### PR TITLE
A sound is played when an implanter catastrophically fails

### DIFF
--- a/Content.Shared/Implants/Components/ImplanterComponent.cs
+++ b/Content.Shared/Implants/Components/ImplanterComponent.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Damage;
 using Content.Shared.Whitelist;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -106,6 +107,12 @@ public sealed partial class ImplanterComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public EntProtoId? DeimplantChosen = null;
+
+    /// <summary>
+    /// The sound to be played when an implanter catastrophically fails.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier ImplanterDrawFailSound  = new SoundPathSpecifier("/Audio/Effects/Fluids/splat.ogg");
 
     [ViewVariables]
     public bool UiUpdateNeeded;

--- a/Content.Shared/Implants/SharedImplanterSystem.cs
+++ b/Content.Shared/Implants/SharedImplanterSystem.cs
@@ -12,6 +12,8 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -28,6 +30,7 @@ public abstract partial class SharedImplanterSystem : EntitySystem
     [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private ItemSlotsSystem _itemSlots = default!;
     [Dependency] private SharedAppearanceSystem _appearance = default!;
+    [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedContainerSystem _container = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
@@ -446,6 +449,7 @@ public abstract partial class SharedImplanterSystem : EntitySystem
         var userName = Identity.Entity(user, EntityManager);
         var failedCatastrophicallyMessage = Loc.GetString("implanter-draw-failed-catastrophically", ("user", userName));
         _popup.PopupPredicted(failedCatastrophicallyMessage, user, user, PopupType.MediumCaution);
+        _audio.PlayPredicted(ent.Comp.ImplanterDrawFailSound, ent, user);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
A splat sound is now played when attempting to draw an implanter that isn't there, making it more obvious that the implanter has just spewed cell-damaging slop everywhere. Fixes #44130
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
More of an obvious consequence for bad implant checking
## Technical details
<!-- Summary of code changes for easier review. -->
Honestly I need someone to explain it to me. So the uh, the ImplanterComponent... I added a sound there using a sound specifier... then when the event(?) of catastrophic failure happens I added a `PlayPredicted()` method thing so it plays the sound as one of its effects.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Spawned in an implant extractor and attempted to extract some implants, see below
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
**kinda loud be warned**
https://github.com/user-attachments/assets/afc2bd30-a955-4b81-bc27-d28405ae3ab5


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
