### PR TITLE
[BUGFIX] Janitorial Winter Coat in-hand sprite fix

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -432,7 +432,7 @@
       left:
       - state: JANI-inhand-left
       right:
-      - state: CHEF-inhand-right
+      - state: JANI-inhand-right
   - type: Clothing
     sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
     clothingVisuals:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Janitorial winter coat uses the correct sprite when holding it in the 'right' hand

## Why / Balance
It used to be a chef winter coat, but now it isn't

## Technical details
<img width="270" height="148" alt="image" src="https://github.com/user-attachments/assets/6b4f73f3-4f81-42f3-8781-a0d12a65796a" />

<img width="255" height="149" alt="image" src="https://github.com/user-attachments/assets/c8e4b5b7-d585-41c9-b47d-f5f35b309de1" />

## Test plan
Spawn a `ClothingOuterWinterJani`, hold it in your right hand.

## Media
BEFORE:
<img width="536" height="775" alt="image" src="https://github.com/user-attachments/assets/1645f25f-e314-4333-a946-fca441c2335d" />

AFTER:
<img width="399" height="653" alt="image" src="https://github.com/user-attachments/assets/0ebe5ede-d180-4acc-8db5-4d42ceeb1505" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
- fix: Fixed janitorial winter coat in-hand sprite.
