### PR TITLE
[tweak] detective sign name is now consistent with other signs

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
@@ -1265,7 +1265,7 @@
 - type: entity
   parent: BaseSign
   id: SignDetective
-  name: Detective sign
+  name: detective sign
   description: A sign depicting the detective's office.
   components:
   - type: Sprite


### PR DESCRIPTION
## about the pr
made the sign name lowercase, since all other departmental signs are also lowercase
capitalization is reserved for proper nouns only

## why / balance

it is for consistency

## technical details

D to d

## test plan

spawn any departmental sign, then spawn `SignDetective` and look at it

## media
before
<img width="347" height="158" alt="image" src="https://github.com/user-attachments/assets/9e157250-ed59-45f8-8d83-2a9b33a41b18" />

after
<img width="457" height="284" alt="image" src="https://github.com/user-attachments/assets/9f8f7652-b3cf-4601-b499-025f1cabbb1e" />

## requirements
- [x] i have read and am following the [pull request and changelog guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] i have tested this pull request and written instructions on how to test it
- [x] i have added media to this pr or it does not require an in-game showcase

## changelog

i don't think anyone will notice
