### PR TITLE
fix: Plasma reaction no longer deletes O2

### DIFF
--- a/Content.IntegrationTests/Tests/Atmos/AtmosTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/AtmosTest.cs
@@ -108,15 +108,14 @@ public abstract class AtmosTest : InteractionTest
     /// <summary>
     /// Sums every gas species across all tiles into a single mixture.
     /// </summary>
-    protected static GasMixture GetGridComposition(Entity<GridAtmosphereComponent> grid)
+    protected GasMixture GetGridComposition(Entity<GridAtmosphereComponent> grid)
     {
         var total = new GasMixture();
         foreach (var tile in grid.Comp.Tiles.Values)
         {
             if (tile.Air == null)
                 continue;
-            for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
-                total.AdjustMoles((Gas)i, tile.Air.GetMoles((Gas)i));
+            SAtmos.Merge(total, tile.Air);
         }
 
         return total;

--- a/Content.IntegrationTests/Tests/Atmos/AtmosTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/AtmosTest.cs
@@ -106,6 +106,23 @@ public abstract class AtmosTest : InteractionTest
     }
 
     /// <summary>
+    /// Sums every gas species across all tiles into a single mixture.
+    /// </summary>
+    protected static GasMixture GetGridComposition(Entity<GridAtmosphereComponent> grid)
+    {
+        var total = new GasMixture();
+        foreach (var tile in grid.Comp.Tiles.Values)
+        {
+            if (tile.Air == null)
+                continue;
+            for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
+                total.AdjustMoles((Gas)i, tile.Air.GetMoles((Gas)i));
+        }
+
+        return total;
+    }
+
+    /// <summary>
     /// Asserts that test grid has this many moles, within tolerance percentage.
     /// </summary>
     protected void AssertGridMoles(float moles, float tolerance)

--- a/Content.IntegrationTests/Tests/Atmos/TileAtmosphereTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/TileAtmosphereTest.cs
@@ -89,6 +89,8 @@ public abstract class TileAtmosphereTest : AtmosTest
         sourceMix.AdjustMoles(Gas.Oxygen, Moles - Moles / 10);
         sourceMix.Temperature = Atmospherics.FireMinimumTemperatureToExist - 10;
 
+        var before = GetGridComposition(RelevantAtmos);
+
         Assert.Multiple(() =>
         {
             Assert.That(SAtmos.IsHotspotActive(MapData.Grid, sourceXY), Is.False);
@@ -121,7 +123,29 @@ public abstract class TileAtmosphereTest : AtmosTest
         });
 
         AssertMixMoles(mix1, mix2, Tolerance);
-        AssertGridMoles(Moles, Tolerance);
+
+        var after = GetGridComposition(RelevantAtmos);
+
+        var plasmaConsumed = before.GetMoles(Gas.Plasma) - after.GetMoles(Gas.Plasma);
+        var oxygenConsumed = before.GetMoles(Gas.Oxygen) - after.GetMoles(Gas.Oxygen);
+        var co2Produced = after.GetMoles(Gas.CarbonDioxide) - before.GetMoles(Gas.CarbonDioxide);
+
+        // Set up can't produce Tritium, moles aren't conserved in Tritium Fires.
+        Assert.Multiple(() =>
+        {
+            Assert.That(plasmaConsumed, Is.GreaterThan(1f), "Plasma should be meaningfully consumed");
+            // oxygenBurnRate = OxygenBurnRateBase - temperatureScale, temperatureScale in (0,1]
+            Assert.That(oxygenConsumed, Is.InRange(0.4f * plasmaConsumed, 1.4f * plasmaConsumed),
+                "Oxygen consumption within oxygenBurnRate bounds");
+            Assert.That(after.GetMoles(Gas.Tritium), Is.Zero, "No tritium below supersaturation threshold");
+            Assert.That(after.GetMoles(Gas.WaterVapor), Is.Zero, "No TritiumFire");
+            Assert.That(co2Produced,
+                Is.EqualTo(plasmaConsumed + oxygenConsumed).Within(1e-3f),
+                "PlasmaFire conserves moles");
+            Assert.That(after.TotalMoles,
+                Is.EqualTo(before.TotalMoles).Within(1e-3f),
+                "Grid moles conserved");
+        });
     }
 }
 

--- a/Content.IntegrationTests/Tests/Atmos/TileAtmosphereTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/TileAtmosphereTest.cs
@@ -133,18 +133,18 @@ public abstract class TileAtmosphereTest : AtmosTest
         // Set up can't produce Tritium, moles aren't conserved in Tritium Fires.
         Assert.Multiple(() =>
         {
-            Assert.That(plasmaConsumed, Is.GreaterThan(1f), "Plasma should be meaningfully consumed");
+            Assert.That(plasmaConsumed, Is.GreaterThan(1f), "Plasma was not meaningfully consumed");
             // oxygenBurnRate = OxygenBurnRateBase - temperatureScale, temperatureScale in (0,1]
             Assert.That(oxygenConsumed, Is.InRange(0.4f * plasmaConsumed, 1.4f * plasmaConsumed),
-                "Oxygen consumption within oxygenBurnRate bounds");
-            Assert.That(after.GetMoles(Gas.Tritium), Is.Zero, "No tritium below supersaturation threshold");
-            Assert.That(after.GetMoles(Gas.WaterVapor), Is.Zero, "No TritiumFire");
+                "Oxygen consumption outside oxygenBurnRate bounds");
+            Assert.That(after.GetMoles(Gas.Tritium), Is.Zero, "Tritium was produced below supersaturation threshold");
+            Assert.That(after.GetMoles(Gas.WaterVapor), Is.Zero, "Water vapor was produced by a TritiumFire");
             Assert.That(co2Produced,
                 Is.EqualTo(plasmaConsumed + oxygenConsumed).Within(1e-3f),
-                "PlasmaFire conserves moles");
+                "PlasmaFire did not conserve moles");
             Assert.That(after.TotalMoles,
                 Is.EqualTo(before.TotalMoles).Within(1e-3f),
-                "Grid moles conserved");
+                "Grid moles were not conserved");
         });
     }
 }

--- a/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/PlasmaFireReaction.cs
@@ -54,9 +54,9 @@ namespace Content.Server.Atmos.Reactions
                     mixture.SetMoles(Gas.Plasma, initialPlasmaMoles - plasmaBurnRate);
                     mixture.SetMoles(Gas.Oxygen, initialOxygenMoles - plasmaBurnRate * oxygenBurnRate);
 
-                    // supersaturation adjusts the ratio of produced tritium to unwanted CO2
+                    // supersaturation adjusts the ratio of produced tritium to CO2; oxygenBurnRate moles of oxygen also become CO2
                     mixture.AdjustMoles(Gas.Tritium, plasmaBurnRate * supersaturation);
-                    mixture.AdjustMoles(Gas.CarbonDioxide, plasmaBurnRate * (1.0f - supersaturation));
+                    mixture.AdjustMoles(Gas.CarbonDioxide, plasmaBurnRate * (1.0f - supersaturation + oxygenBurnRate));
 
                     energyReleased += Atmospherics.FirePlasmaEnergyReleased * plasmaBurnRate;
                     energyReleased /= heatScale; // adjust energy to make sure speedup doesn't cause mega temperature rise


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed the Plasma reaction, it no longer deletes O2, but instead converts it to CO2.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Plasma fires will be a little harder to start given CO2's heat capacity, but in testing I didn't see much difference.
My refactor of atmos was failing this test because it changed how "fast" reactions happened tripping the assertion I changed. It's out of scope for the refactor to touch reactions so here's this PR.
## Technical details
<!-- Summary of code changes for easier review. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
dotnet test?
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Plasma reactions convert O2 to CO2, conserving total moles.
