### PR TITLE
Holoparasite Telepathy

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
@@ -173,6 +173,120 @@ public sealed partial class ChatSystem
             }
     }
 
+    public void SendEntitySpeakForTargets(
+        EntityUid source,
+        string originalMessage,
+        List<EntityUid> targets,
+        string? nameOverride,
+        bool hideLog = false,
+        bool ignoreActionBlocker = false
+    )
+    {
+        Log.Debug("entered SendEntitySpeakForTargets");
+
+        if (!ignoreActionBlocker && !_actionBlocker.CanSpeak(source, originalMessage))
+            return;
+
+        Log.Debug("passed the _actionBlocker check");
+
+        var message = TransformSpeech(source, originalMessage);
+
+        if (message.Length == 0)
+            return;
+
+        Log.Debug("passed the message.Length == 0 check");
+
+        var speech = GetSpeechVerb(source, message);
+
+        Log.Debug("got the speech verb");
+
+        // get the entity's apparent name (if no override provided).
+        string name;
+        if (nameOverride != null)
+        {
+            name = nameOverride;
+        }
+        else
+        {
+            var nameEv = new TransformSpeakerNameEvent(source, Name(source));
+            RaiseLocalEvent(source, nameEv);
+            name = nameEv.VoiceName;
+            // Check for a speech verb override
+            if (nameEv.SpeechVerb != null && _prototypeManager.Resolve(nameEv.SpeechVerb, out var proto))
+                speech = proto;
+        }
+
+        Log.Debug("got the name");
+
+        name = FormattedMessage.EscapeText(name);
+
+        Log.Debug($"name: {name}");
+
+        var wrappedMessage = Loc.GetString(speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message",
+            ("entityName", name),
+            ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
+            ("fontType", speech.FontId),
+            ("fontSize", speech.FontSize),
+            ("message", FormattedMessage.EscapeText(message)));
+
+        Log.Debug($"wrappedMessage: {wrappedMessage}");
+        
+        if (!targets.Contains(source))
+            targets.Add(source);
+
+        var targetClients = targets
+            .Where(HasComp<ActorComponent>)
+            .Select(target => Comp<ActorComponent>(target).PlayerSession.Channel);
+
+        _chatManager.ChatMessageToMany(ChatChannel.Local, message, wrappedMessage, source, false, true, targetClients);
+
+        Log.Debug("message sent!");
+
+        var ev = new EntitySpokeEvent(source, message, null, null);
+        RaiseLocalEvent(source, ev, true);
+
+        Log.Debug("EntitySpokeEvent raised!");
+
+        // To avoid logging any messages sent by entities that are not players, like vendors, cloning, etc.
+        // Also doesn't log if hideLog is true.
+        if (hideLog || !HasComp<ActorComponent>(source))
+            return;
+
+        Log.Debug("passed hide log check");
+
+        var targetsList = "";
+        foreach (var target in targets)
+        {
+            if (targetsList != "")
+                targetsList += ", ";
+
+            targetsList += Name(target);
+        }
+
+        if (originalMessage == message)
+        {
+            if (name != Name(source))
+                _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Say from {source} as {name} to {targetsList}: {originalMessage}.");
+            else
+                _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Say from {source} to {targetsList}: {originalMessage}.");
+        }
+        else
+        {
+            if (name != Name(source))
+            {
+                _adminLogger.Add(LogType.Chat, LogImpact.Low,
+                    $"Say from {source} as {name}, original: {originalMessage} to {targetsList}, transformed: {message}.");
+            }
+            else
+            {
+                _adminLogger.Add(LogType.Chat, LogImpact.Low,
+                    $"Say from {source}, original: {originalMessage} to {targetsList}, transformed: {message}.");
+            }
+        }
+
+        Log.Debug("finished!");
+    }
+
     protected override void SendEntityEmote(
         EntityUid source,
         string action,

--- a/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
@@ -182,23 +182,15 @@ public sealed partial class ChatSystem
         bool ignoreActionBlocker = false
     )
     {
-        Log.Debug("entered SendEntitySpeakForTargets");
-
         if (!ignoreActionBlocker && !_actionBlocker.CanSpeak(source, originalMessage))
             return;
-
-        Log.Debug("passed the _actionBlocker check");
 
         var message = TransformSpeech(source, originalMessage);
 
         if (message.Length == 0)
             return;
 
-        Log.Debug("passed the message.Length == 0 check");
-
         var speech = GetSpeechVerb(source, message);
-
-        Log.Debug("got the speech verb");
 
         // get the entity's apparent name (if no override provided).
         string name;
@@ -216,11 +208,7 @@ public sealed partial class ChatSystem
                 speech = proto;
         }
 
-        Log.Debug("got the name");
-
         name = FormattedMessage.EscapeText(name);
-
-        Log.Debug($"name: {name}");
 
         var wrappedMessage = Loc.GetString(speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message",
             ("entityName", name),
@@ -229,8 +217,6 @@ public sealed partial class ChatSystem
             ("fontSize", speech.FontSize),
             ("message", FormattedMessage.EscapeText(message)));
 
-        Log.Debug($"wrappedMessage: {wrappedMessage}");
-        
         if (!targets.Contains(source))
             targets.Add(source);
 
@@ -240,19 +226,13 @@ public sealed partial class ChatSystem
 
         _chatManager.ChatMessageToMany(ChatChannel.Local, message, wrappedMessage, source, false, true, targetClients);
 
-        Log.Debug("message sent!");
-
         var ev = new EntitySpokeEvent(source, message, null, null);
         RaiseLocalEvent(source, ev, true);
-
-        Log.Debug("EntitySpokeEvent raised!");
 
         // To avoid logging any messages sent by entities that are not players, like vendors, cloning, etc.
         // Also doesn't log if hideLog is true.
         if (hideLog || !HasComp<ActorComponent>(source))
             return;
-
-        Log.Debug("passed hide log check");
 
         var targetsList = "";
         foreach (var target in targets)
@@ -283,8 +263,6 @@ public sealed partial class ChatSystem
                     $"Say from {source}, original: {originalMessage} to {targetsList}, transformed: {message}.");
             }
         }
-
-        Log.Debug("finished!");
     }
 
     protected override void SendEntityEmote(

--- a/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
@@ -21,7 +21,7 @@ public sealed partial class ChatSystem
         bool ignoreActionBlocker = false
         )
     {
-        if (!_actionBlocker.CanSpeak(source) && !ignoreActionBlocker)
+        if (!_actionBlocker.CanSpeak(source, originalMessage) && !ignoreActionBlocker)
             return;
 
         var message = TransformSpeech(source, originalMessage);
@@ -94,7 +94,7 @@ public sealed partial class ChatSystem
         bool ignoreActionBlocker = false
         )
     {
-        if (!_actionBlocker.CanSpeak(source) && !ignoreActionBlocker)
+        if (!_actionBlocker.CanSpeak(source, originalMessage) && !ignoreActionBlocker)
             return;
 
         var message = TransformSpeech(source, FormattedMessage.RemoveMarkupOrThrow(originalMessage));

--- a/Content.Server/Guardian/GuardianComponent.cs
+++ b/Content.Server/Guardian/GuardianComponent.cs
@@ -15,6 +15,12 @@ namespace Content.Server.Guardian
         public EntityUid? Host;
 
         /// <summary>
+        /// If the guardian messages can only be heard by the host while the guardian is not loose
+        /// </summary>
+        [DataField]
+        public bool HostTelepathy = true;
+
+        /// <summary>
         /// Percentage of damage reflected from the guardian to the host
         /// </summary>
         [DataField]

--- a/Content.Server/Guardian/GuardianSystem.cs
+++ b/Content.Server/Guardian/GuardianSystem.cs
@@ -1,5 +1,8 @@
+using Content.Server.Chat.Managers;
+using Content.Server.Chat.Systems;
 using Content.Server.Popups;
 using Content.Shared.Actions;
+using Content.Shared.Chat;
 using Content.Shared.Damage.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -13,9 +16,11 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Mech.EntitySystems;
 using Content.Shared.Mobs;
 using Content.Shared.Popups;
+using Content.Shared.Speech;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
+using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Guardian
@@ -34,6 +39,9 @@ namespace Content.Server.Guardian
         [Dependency] private GibbingSystem _gibbing = default!;
         [Dependency] private SharedContainerSystem _container = default!;
         [Dependency] private SharedTransformSystem _transform = default!;
+        [Dependency] private ChatSystem _chatSystem = default!;
+        [Dependency] private IChatManager _chat = default!;
+        [Dependency] private IRobustRandom _random = default!;
 
         public override void Initialize()
         {
@@ -46,6 +54,7 @@ namespace Content.Server.Guardian
             SubscribeLocalEvent<GuardianComponent, ComponentShutdown>(OnGuardianShutdown);
             SubscribeLocalEvent<GuardianComponent, MoveEvent>(OnGuardianMove);
             SubscribeLocalEvent<GuardianComponent, DamageChangedEvent>(OnGuardianDamaged);
+            SubscribeLocalEvent<GuardianComponent, SpeakAttemptEvent>(OnSpeakAttempt);
             SubscribeLocalEvent<GuardianComponent, PlayerAttachedEvent>(OnGuardianPlayerAttached);
             SubscribeLocalEvent<GuardianComponent, PlayerDetachedEvent>(OnGuardianPlayerDetached);
 
@@ -293,6 +302,38 @@ namespace Content.Server.Guardian
                 interruptsDoAfters: false);
             _popupSystem.PopupEntity(Loc.GetString("guardian-entity-taking-damage"), component.Host.Value, component.Host.Value);
 
+        }
+
+        private void OnSpeakAttempt(Entity<GuardianComponent> entity, ref SpeakAttemptEvent args)
+        {
+            // if guardian is loose, they speech is not blocked
+            if (entity.Comp.GuardianLoose)
+                return;
+
+            // cancel the speech, we gonna send it ourselves only for the host and the guardian
+            args.Cancel();
+
+            if (!TryComp<ActorComponent>(entity, out var guardianActor))
+                return;
+
+            if (!TryComp<ActorComponent>(entity.Comp.Host, out var hostActor))
+                return;
+
+            if (args.Message == null)
+                return;
+
+            // copy pasted from SendEntitySpeak
+            var speech = _chatSystem.GetSpeechVerb(entity, args.Message);
+            var messageWrapped = Loc.GetString(speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message",
+                ("entityName", Name(entity)),
+                ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
+                ("fontType", speech.FontId),
+                ("fontSize", speech.FontSize),
+                ("message", FormattedMessage.EscapeText(args.Message)));
+
+            // send to the host and the guardian (the guardian needs to know what they said)
+            _chat.ChatMessageToOne(ChatChannel.Local, args.Message, messageWrapped, entity, false, hostActor.PlayerSession.Channel);
+            _chat.ChatMessageToOne(ChatChannel.Local, args.Message, messageWrapped, entity, false, guardianActor.PlayerSession.Channel);
         }
 
         /// <summary>

--- a/Content.Server/Guardian/GuardianSystem.cs
+++ b/Content.Server/Guardian/GuardianSystem.cs
@@ -323,9 +323,13 @@ namespace Content.Server.Guardian
                 return;
 
             // copy pasted from SendEntitySpeak
+            var nameEv = new TransformSpeakerNameEvent(entity, Name(entity));
+            RaiseLocalEvent(entity, nameEv);
+            var name = nameEv.VoiceName;
+
             var speech = _chatSystem.GetSpeechVerb(entity, args.Message);
             var messageWrapped = Loc.GetString(speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message",
-                ("entityName", Name(entity)),
+                ("entityName", name),
                 ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
                 ("fontType", speech.FontId),
                 ("fontSize", speech.FontSize),

--- a/Content.Server/Guardian/GuardianSystem.cs
+++ b/Content.Server/Guardian/GuardianSystem.cs
@@ -306,8 +306,8 @@ namespace Content.Server.Guardian
 
         private void OnSpeakAttempt(Entity<GuardianComponent> entity, ref SpeakAttemptEvent args)
         {
-            // if guardian is loose, they speech is not blocked
-            if (entity.Comp.GuardianLoose)
+            // if guardian is loose or they don't have telepathy, they speech is not blocked
+            if (!entity.Comp.HostTelepathy || entity.Comp.GuardianLoose)
                 return;
 
             // cancel the speech, we gonna send it ourselves only for the host and the guardian

--- a/Content.Server/Guardian/GuardianSystem.cs
+++ b/Content.Server/Guardian/GuardianSystem.cs
@@ -316,32 +316,11 @@ namespace Content.Server.Guardian
             // cancel the speech, we gonna send it ourselves only for the host and the guardian
             args.Cancel();
 
-            if (!TryComp<ActorComponent>(entity, out var guardianActor))
+            if (args.Message == null || entity.Comp.Host == null)
                 return;
 
-            if (!TryComp<ActorComponent>(entity.Comp.Host, out var hostActor))
-                return;
-
-            if (args.Message == null)
-                return;
-
-            // copy pasted from SendEntitySpeak
-            var nameEv = new TransformSpeakerNameEvent(entity, Name(entity));
-            RaiseLocalEvent(entity, nameEv);
-            var name = nameEv.VoiceName;
-
-            var speech = _chatSystem.GetSpeechVerb(entity, args.Message);
-            var messageWrapped = Loc.GetString(speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message",
-                ("entityName", name),
-                ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
-                ("fontType", speech.FontId),
-                ("fontSize", speech.FontSize),
-                ("message", FormattedMessage.EscapeText(args.Message)));
-
-            // send to the host and the guardian (the guardian needs to know what they said)
-            _chat.ChatMessageToOne(ChatChannel.Local, args.Message, messageWrapped, entity, false, hostActor.PlayerSession.Channel);
-            _chat.ChatMessageToOne(ChatChannel.Local, args.Message, messageWrapped, entity, false, guardianActor.PlayerSession.Channel);
-            _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Say from {ToPrettyString(entity):player} only to {ToPrettyString(entity.Comp.Host):player}: {args.Message}");
+            // set to ignore action blocker to avoid this method calling OnSpeakAttempt again
+            _chatSystem.SendEntitySpeakForTargets(entity, args.Message, [entity.Comp.Host.Value], null, false, true);
         }
 
         /// <summary>

--- a/Content.Server/Guardian/GuardianSystem.cs
+++ b/Content.Server/Guardian/GuardianSystem.cs
@@ -1,9 +1,11 @@
+using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
 using Content.Server.Chat.Systems;
 using Content.Server.Popups;
 using Content.Shared.Actions;
 using Content.Shared.Chat;
 using Content.Shared.Damage.Systems;
+using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using Content.Shared.Gibbing;
@@ -42,6 +44,7 @@ namespace Content.Server.Guardian
         [Dependency] private ChatSystem _chatSystem = default!;
         [Dependency] private IChatManager _chat = default!;
         [Dependency] private IRobustRandom _random = default!;
+        [Dependency] private IAdminLogManager _adminLogger = default!;
 
         public override void Initialize()
         {
@@ -338,6 +341,7 @@ namespace Content.Server.Guardian
             // send to the host and the guardian (the guardian needs to know what they said)
             _chat.ChatMessageToOne(ChatChannel.Local, args.Message, messageWrapped, entity, false, hostActor.PlayerSession.Channel);
             _chat.ChatMessageToOne(ChatChannel.Local, args.Message, messageWrapped, entity, false, guardianActor.PlayerSession.Channel);
+            _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Say from {ToPrettyString(entity):player} only to {ToPrettyString(entity.Comp.Host):player}: {args.Message}");
         }
 
         /// <summary>

--- a/Content.Server/Vocalization/Systems/VocalizationSystem.cs
+++ b/Content.Server/Vocalization/Systems/VocalizationSystem.cs
@@ -83,7 +83,7 @@ public sealed partial class VocalizationSystem : EntitySystem
 
         // default to local chat if no other system handles the event
         // first check if the entity can speak
-        if (!_actionBlocker.CanSpeak(entity))
+        if (!_actionBlocker.CanSpeak(entity, message))
             return;
 
         // send the message

--- a/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
+++ b/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
@@ -141,10 +141,10 @@ namespace Content.Shared.ActionBlocker
             return !itemEv.Cancelled;
         }
 
-        public bool CanSpeak(EntityUid uid)
+        public bool CanSpeak(EntityUid uid, string? message=null)
         {
             // This one is used as broadcast
-            var ev = new SpeakAttemptEvent(uid);
+            var ev = new SpeakAttemptEvent(uid, message);
             RaiseLocalEvent(uid, ev, true);
 
             return !ev.Cancelled;

--- a/Content.Shared/Speech/SpeakAttemptEvent.cs
+++ b/Content.Shared/Speech/SpeakAttemptEvent.cs
@@ -2,11 +2,13 @@
 {
     public sealed class SpeakAttemptEvent : CancellableEntityEventArgs
     {
-        public SpeakAttemptEvent(EntityUid uid)
+        public SpeakAttemptEvent(EntityUid uid, string? message=null)
         {
             Uid = uid;
+            Message = message;
         }
 
         public EntityUid Uid { get; }
+        public string? Message { get; }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes so when a holoparasite speaks while stored inside the host, only the host can hear their message.
<!-- What did you change? -->

## Why / Balance
When a syndicate pAI whispers to their user, there is no problem cause they are named {person name}'s pAI and not SUPER EVIL PAI

However when a holoparasite whispers, anyone in hear distance will know the person has a holoparasite, and then the host is screwed.

So holoparasites have to be really quiet and wait for their hosts to be alone, which is quite boring.
Also, new players might not know of the implied rule of NOT SPEAKING as a holoparasite when near people and might end up killing their hosts on accident.

This change solves this problem by making so the host can choose when the holoparasite can be heard by other people (just set them loose if you want other people to hear them)

This also makes so the holoparasite act like venom or ryuk (from death note) in the sense they can speak to their hosts and no one else hears so the host looks insane speaking to no them in public.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
made so the chat system and vocalization system send the message to the SpeakAttemptEvent via the CanSpeak method

added a datafield to the GuardianComponent which determines if they can use telepathy with the host.

then i subscribed the GuardianComponent to the SpeakAttemptEvent and if the guardian has telepathy and is not loose, the chat message is canceled and then is sent only to the host and the guardian.
<!-- Summary of code changes for easier review. -->

## Test plan
- Add 3 clients
- Make Client 1 and 3 into urists
- Inject Client 1 with a holoparasite
- Make Client 2 take the holoparasite ghostrole
- Make Client 3 stand near Client 1
- Speak with Client 1
- **All 3 clients should hear that message**
- Speak with Client 3
- **All 3 clients should hear that message**
- Speak with Client 2
- **Only Client 1 and 2 should hear that message**
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
https://github.com/user-attachments/assets/d7e84122-aef6-41fb-aa9c-85d3d7abc24d
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl: Samuka
- tweak: Now only the host can hear their holoparasite when they are not loose!
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
