### PR TITLE
Lock percussion MIDI channel

### DIFF
--- a/Content.Client/Instruments/UI/ChannelsMenu.xaml.cs
+++ b/Content.Client/Instruments/UI/ChannelsMenu.xaml.cs
@@ -109,8 +109,13 @@ public sealed partial class ChannelsMenu : DefaultWindow
 
         for (int i = 0; i < RobustMidiEvent.MaxChannels; i++)
         {
-            var label = _owner.Loc.GetString("instrument-component-channel-name",
-                ("number", i));
+            var isPercussion = i == RobustMidiEvent.PercussionChannel;
+            var isPercussionLocked = isPercussion && !(instrument?.AllowPercussion ?? true);
+
+            var label = isPercussion
+                ? _owner.Loc.GetString("instrument-component-channel-name-percussion", ("number", i))
+                : _owner.Loc.GetString("instrument-component-channel-name", ("number", i));
+
             if (activeInstrument != null
                 && activeInstrument.Tracks.TryGetValue(i, out var resolvedMidiChannel)
                 && resolvedMidiChannel != null)
@@ -144,7 +149,7 @@ public sealed partial class ChannelsMenu : DefaultWindow
                 }
             }
 
-            var item = ChannelList.AddItem(label, null, true, i);
+            var item = ChannelList.AddItem(label, null, !isPercussionLocked, i);
 
             item.Selected = !instrument?.FilteredChannels[i] ?? false;
         }

--- a/Resources/Locale/en-US/instruments/instruments-component.ftl
+++ b/Resources/Locale/en-US/instruments/instruments-component.ftl
@@ -17,6 +17,7 @@ instruments-component-band-menu = Choose band leader
 instrument-component-band-refresh = Refresh
 instruments-component-channels-menu = MIDI Channel Selection
 instrument-component-channel-name = MIDI Channel {$number}
+instrument-component-channel-name-percussion = MIDI Channel {$number} [Percussion]
 instruments-component-channels-all-button = All
 instruments-component-channels-clear-button = Clear
 instruments-component-channels-track-names-toggle = Show Track Names


### PR DESCRIPTION
## About the PR
Lock the percussion MIDI channel for instruments that do not have it and add a new label for it.

In fact, the percussion channel is already blocked by the server when needed, but it is now clearly displayed in the UI.

## Why / Balance
It's more understandable for players.

## Test plan
See Media

## Media

https://github.com/user-attachments/assets/816aeb38-1751-4b93-88b6-9aa95af6bb7e


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
_I don't think it's important enough for a changelog._