### PR TITLE
Fix shooting from inside a morgue exploit

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
@@ -34,7 +34,7 @@
         mask:
         - MachineMask
         layer:
-        - HalfWallLayer
+        - MachineLayer
   - type: EntityStorage
     isCollidableWhenOpen: true
     showContents: false
@@ -73,6 +73,7 @@
   - type: AntiRottingContainer
   - type: StaticPrice
     price: 200
+  - type: RequireProjectileTarget
 
 - type: entity
   id: Crematorium
@@ -143,3 +144,4 @@
           False: { visible: false }
   - type: Transform
     anchored: true
+  - type: RequireProjectileTarget


### PR DESCRIPTION
## About the PR
Title.

## Why / Balance
Because the morgue is indestructible, it turns into an overly effective cover for shooting (which is not what a morgue should be used for).

## Technical details
Also added `RequireProjectileTargetComponent` to crematorium for consistency.

## Test plan
See Media

## Media

https://github.com/user-attachments/assets/c68d0f56-4b77-403d-86e1-e126c4647fbc


https://github.com/user-attachments/assets/b93de22d-4c1c-435f-bee7-ed36c4aa6559

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl: B_Kirill
- fix: Fixed shooting from inside a morgue exploit.
