### PR TITLE
Fix: Move belt assembly suffix to name

### DIFF
--- a/Resources/Prototypes/Entities/Structures/conveyor.yml
+++ b/Resources/Prototypes/Entities/Structures/conveyor.yml
@@ -71,8 +71,7 @@
 - type: entity
   id: ConveyorBeltAssembly
   parent: BaseItem
-  name: conveyor belt
-  suffix: assembly
+  name: conveyor belt assembly
   description: A conveyor belt assembly. Used to construct a conveyor belt.
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changes conveyor belt assemblies from having the name 'conveyor belt' with the suffix 'assembly' to just having the name 'conveyor belt assembly'

## Why / Balance
Fixes issue #44069 

## Technical details
2-line YAML change to remove the suffix and add it to the name instead.

## Test plan
Confirm that conveyor belt assemblies are differentiated from conveyor belts, and no longer stack in the context menu.

## Media
<img width="772" height="578" alt="image" src="https://github.com/user-attachments/assets/0735a10d-9f84-4208-abbf-f656999bc152" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
