### PR TITLE
Toggle dead chat

### DIFF
--- a/Content.Client/Administration/UI/Tabs/ServerTab.xaml
+++ b/Content.Client/Administration/UI/Tabs/ServerTab.xaml
@@ -9,5 +9,6 @@
         <controls:ConfirmButton Name="ServerShutdownButton" Text="{Loc server-shutdown}" />
         <cc:CommandButton Name="SetOocButton" Command="setooc" Text="{Loc server-ooc-toggle}" ToggleMode="True" />
         <cc:CommandButton Name="SetLoocButton" Command="setlooc" Text="{Loc server-looc-toggle}" ToggleMode="True" />
+        <cc:CommandButton Name="SetDeadChatButton" Command="setdeadchat" Text="{Loc server-dead-chat-toggle}" ToggleMode="True" />
     </GridContainer>
 </Control>

--- a/Content.Client/Administration/UI/Tabs/ServerTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/ServerTab.xaml.cs
@@ -20,6 +20,7 @@ namespace Content.Client.Administration.UI.Tabs
 
             _config.OnValueChanged(CCVars.OocEnabled, OocEnabledChanged, true);
             _config.OnValueChanged(CCVars.LoocEnabled, LoocEnabledChanged, true);
+            _config.OnValueChanged(CCVars.DeadChatEnabled, DeadChatEnabledChanged, true);
 
             ServerShutdownButton.OnPressed += _ => _console.ExecuteCommand("shutdown");
         }
@@ -32,6 +33,11 @@ namespace Content.Client.Administration.UI.Tabs
         private void LoocEnabledChanged(bool value)
         {
             SetLoocButton.Pressed = value;
+        }
+
+        private void DeadChatEnabledChanged(bool value)
+        {
+            SetDeadChatButton.Pressed = value;
         }
 
         protected override void Dispose(bool disposing)

--- a/Content.Server/Chat/Commands/SetDeadChatCommand.cs
+++ b/Content.Server/Chat/Commands/SetDeadChatCommand.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Console;
 namespace Content.Server.Chat.Commands;
 
 [AdminCommand(AdminFlags.Server)]
-public sealed class SetDeadChatCommand : LocalizedCommands
+public sealed partial class SetDeadChatCommand : LocalizedCommands
 {
     [Dependency] private IConfigurationManager _configManager = default!;
 

--- a/Content.Server/Chat/Commands/SetDeadChatCommand.cs
+++ b/Content.Server/Chat/Commands/SetDeadChatCommand.cs
@@ -1,0 +1,41 @@
+﻿using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Console;
+
+namespace Content.Server.Chat.Commands;
+
+[AdminCommand(AdminFlags.Server)]
+public sealed class SetDeadChatCommand : LocalizedCommands
+{
+    [Dependency] private IConfigurationManager _configManager = default!;
+
+    public override string Command => "setdeadchat";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length > 1)
+        {
+            shell.WriteError(Loc.GetString("shell-need-between-arguments", ("lower", 0), ("upper", 1)));
+            return;
+        }
+
+        var deadchat = _configManager.GetCVar(CCVars.DeadChatEnabled);
+
+        if (args.Length == 0)
+        {
+            deadchat = !deadchat;
+        }
+
+        if (args.Length == 1 && !bool.TryParse(args[0], out deadchat))
+        {
+            shell.WriteError(Loc.GetString("shell-invalid-bool"));
+            return;
+        }
+
+        _configManager.SetCVar(CCVars.DeadChatEnabled, deadchat);
+
+        shell.WriteLine(Loc.GetString(deadchat ? "cmd-setdeadchat-looc-enabled" : "cmd-setdeadchat-looc-disabled"));
+    }
+}

--- a/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
@@ -234,6 +234,9 @@ public sealed partial class ChatSystem
 
     private void SendDeadChat(EntityUid source, ICommonSession player, string message, bool hideChat)
     {
+        if (!_adminManager.IsAdmin(player) && !_deadChatEnabled)
+            return;
+
         var clients = GetDeadChatClients();
         var playerName = Name(source);
         string wrappedMessage;

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -53,6 +53,8 @@ public sealed partial class ChatSystem : SharedChatSystem
     private bool _critLoocEnabled;
     private readonly bool _adminLoocEnabled = true;
 
+    private bool _deadChatEnabled = true;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -60,6 +62,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         Subs.CVar(_configurationManager, CCVars.LoocEnabled, OnLoocEnabledChanged, true);
         Subs.CVar(_configurationManager, CCVars.DeadLoocEnabled, OnDeadLoocEnabledChanged, true);
         Subs.CVar(_configurationManager, CCVars.CritLoocEnabled, OnCritLoocEnabledChanged, true);
+
+        Subs.CVar(_configurationManager, CCVars.DeadChatEnabled, OnDeadChatEnabledChanged, true);
 
         SubscribeLocalEvent<GameRunLevelChangedEvent>(OnGameChange);
     }
@@ -90,6 +94,16 @@ public sealed partial class ChatSystem : SharedChatSystem
         _critLoocEnabled = val;
         _chatManager.DispatchServerAnnouncement(
             Loc.GetString(val ? "chat-manager-crit-looc-chat-enabled-message" : "chat-manager-crit-looc-chat-disabled-message"));
+    }
+
+    private void OnDeadChatEnabledChanged(bool val)
+    {
+        if (_deadChatEnabled == val)
+            return;
+
+        _deadChatEnabled = val;
+        _chatManager.DispatchServerAnnouncement(
+            Loc.GetString(val ? "chat-manager-dead-chat-enabled-message" : "chat-manager-dead-chat-disabled-message"));
     }
 
     private void OnGameChange(GameRunLevelChangedEvent ev)

--- a/Content.Shared/CCVar/CCVars.Chat.Dead.cs
+++ b/Content.Shared/CCVar/CCVars.Chat.Dead.cs
@@ -1,0 +1,13 @@
+﻿using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    /// True: dead players can send dead chat
+    /// False: dead players can't send dead chat
+    /// </summary>
+    public static readonly CVarDef<bool> DeadChatEnabled =
+        CVarDef.Create("dead_chat.enabled", true, CVar.NOTIFY | CVar.REPLICATED);
+}

--- a/Resources/Locale/en-US/administration/commands/set-dead-chat-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/set-dead-chat-command.ftl
@@ -1,0 +1,4 @@
+cmd-setdeadchat-description = Allows you to enable or disable Dead chat.
+cmd-setdeadchat-help = Usage: setdeadchat OR setdeadchat [value]
+cmd-setdeadchat-looc-enabled = Dead chat has been enabled.
+cmd-setdeadchat-looc-disabled = Dead chat has been disabled.

--- a/Resources/Locale/en-US/administration/ui/tabs/server-tab.ftl
+++ b/Resources/Locale/en-US/administration/ui/tabs/server-tab.ftl
@@ -1,3 +1,4 @@
 server-shutdown = Shutdown
 server-ooc-toggle = Toggle OOC
 server-looc-toggle = Toggle LOOC
+server-dead-chat-toggle = Toggle Dead Chat

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -11,6 +11,8 @@ chat-manager-crit-looc-chat-enabled-message = Crit players can now use LOOC.
 chat-manager-crit-looc-chat-disabled-message = Crit players can no longer use LOOC.
 chat-manager-admin-ooc-chat-enabled-message = Admin OOC chat has been enabled.
 chat-manager-admin-ooc-chat-disabled-message = Admin OOC chat has been disabled.
+chat-manager-dead-chat-enabled-message = Dead players can now use Dead chat.
+chat-manager-dead-chat-disabled-message = Dead players can no longer use Dead chat.
 
 chat-manager-max-message-length-exceeded-message = Your message exceeded {$limit} character limit
 chat-manager-no-headset-on-message = You don't have a headset on!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Add a toggle dead chat button to the admin server tab

As the name implies, this button toggles the ability of dead players to send messages on the dead channel.
Admins of course can still send messages in dead chat regardless.
<!-- What did you change? -->

## Why / Balance
Admins want to abuse players idk. /j

This can be used to stop malding, copypasta or other high flood of messages in dead chat. similar of what can happen in ooc or looc.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
New cvar, `DeadLoocEnabled`, when the cvar is changed it toggles `_deadChatEnabled` from the chat system
if `_deadChatEnabled` is false then non-admin players can't send dead chat.

Added a new command, `setdeadchat`, which is used to set the value of `DeadLoocEnabled`.
Added a new button of the server tab that calls `setdeadchat`.
<!-- Summary of code changes for easier review. -->

## Test plan
- Join with 2 clients
- Deadmin with client 2
- Make sure both clients are ghosts and are set to speak in dead chat
- Send message with client 2
- **See that the message was sent sucessfully**
- With client 1, do one of the following:
- - Change the cvar with `> cvar dead_chat.enabled False`
- - Toggle dead chat with `setdeadchat False`
- - Press the **Toggle dead chat** button in the server tab of the admin menu (open with F7)
- Send message with client 1
- **See that the message was sent sucessfully**
- Send message with client 2
- **See that the message wasn't sent**
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
https://github.com/user-attachments/assets/3c3cbf20-b88e-4e85-9cef-d077d3b98316

<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl: Samuka
ADMIN:
- add: Added a new button to the server tab which toggles dead chat!
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
