### PR TITLE
Fix Organs being Unedible

### DIFF
--- a/Resources/Prototypes/Body/Animals/animal.yml
+++ b/Resources/Prototypes/Body/Animals/animal.yml
@@ -6,7 +6,7 @@
     metabolizerTypes: [ Animal ]
 
 - type: entity
-  parent: OrganBase
+  parent: OrganBaseOrganic
   id: OrganAnimal
   abstract: true
   suffix: Animal

--- a/Resources/Prototypes/Body/Species/arachnid.yml
+++ b/Resources/Prototypes/Body/Species/arachnid.yml
@@ -144,7 +144,7 @@
       state: creampie_arachnid
 
 - type: entity
-  parent: OrganBase
+  parent: OrganBaseOrganic
   id: OrganArachnid
   abstract: true
   suffix: Arachnid

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -172,7 +172,7 @@
   - type: Rootable
 
 - type: entity
-  parent: OrganBase
+  parent: OrganBaseOrganic
   id: OrganDiona
   abstract: true
   suffix: Diona

--- a/Resources/Prototypes/Body/Species/dwarf.yml
+++ b/Resources/Prototypes/Body/Species/dwarf.yml
@@ -69,7 +69,7 @@
     speechSounds: Bass
 
 - type: entity
-  parent: OrganBase
+  parent: OrganBaseOrganic
   id: OrganDwarf
   abstract: true
   suffix: Dwarf

--- a/Resources/Prototypes/Body/Species/gingerbread.yml
+++ b/Resources/Prototypes/Body/Species/gingerbread.yml
@@ -79,7 +79,7 @@
     proto: gingerbread
 
 - type: entity
-  parent: OrganBase
+  parent: OrganBaseOrganic
   id: OrganGingerbread
   abstract: true
   suffix: gingerbread

--- a/Resources/Prototypes/Body/Species/human.yml
+++ b/Resources/Prototypes/Body/Species/human.yml
@@ -99,7 +99,7 @@
       amount: 5
 
 - type: entity
-  parent: OrganBase
+  parent: OrganBaseOrganic
   id: OrganHuman
   abstract: true
   suffix: human

--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -200,7 +200,7 @@
       250: 0.7
 
 - type: entity
-  parent: OrganBase
+  parent: OrganBaseOrganic
   id: OrganMoth
   abstract: true
   suffix: Moth

--- a/Resources/Prototypes/Body/Species/reptilian.yml
+++ b/Resources/Prototypes/Body/Species/reptilian.yml
@@ -172,7 +172,7 @@
   - type: Wagging
 
 - type: entity
-  parent: OrganBase
+  parent: OrganBaseOrganic
   id: OrganReptilian
   abstract: true
   suffix: Reptilian

--- a/Resources/Prototypes/Body/Species/skeleton.yml
+++ b/Resources/Prototypes/Body/Species/skeleton.yml
@@ -185,7 +185,7 @@
     messagePerceivedByOthers: hugging-success-generic-others
 
 - type: entity
-  parent: OrganBase
+  parent: OrganBaseOrganic
   id: OrganSkeletonPerson
   abstract: true
   suffix: SkeletonPerson

--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -175,7 +175,7 @@
     maxSaturation: 15
 
 - type: entity
-  parent: OrganBase
+  parent: OrganBaseOrganic
   id: OrganSlimePerson
   abstract: true
   suffix: slime person

--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -258,7 +258,7 @@
   - type: Wagging
 
 - type: entity
-  parent: OrganBase
+  parent: OrganBaseOrganic
   id: OrganVox
   abstract: true
   suffix: Vox

--- a/Resources/Prototypes/Body/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Body/Species/vulpkanin.yml
@@ -213,7 +213,7 @@
       state: creampie_vulpkanin
 
 - type: entity
-  parent: OrganBase
+  parent: OrganBaseOrganic
   id: OrganVulpkanin
   abstract: true
   suffix: vulpkanin

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -26,7 +26,7 @@
   id: OrganBase
   name: organ
   abstract: true
-  parent: [OrganBaseUnEdible, SolutionFood]
+  parent: [ OrganBaseUnEdible, SolutionFood, SolutionSmall ]
   components:
   - type: FlavorProfile
     flavors:

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -15,7 +15,7 @@
       nudityDefault: [ UndergarmentBottomBoxers ]
 
 - type: entity
-  id: OrganBaseUnEdible
+  id: OrganBase
   name: organ
   abstract: true
   parent: BaseItem
@@ -23,10 +23,10 @@
   - type: Organ
 
 - type: entity
-  id: OrganBase
+  id: OrganBaseOrganic
   name: organ
   abstract: true
-  parent: [ OrganBaseUnEdible, SolutionFood, SolutionSmall ]
+  parent: [ OrganBase, SolutionFood, SolutionSmall ]
   components:
   - type: FlavorProfile
     flavors:
@@ -39,7 +39,7 @@
         Quantity: 20
 
 - type: entity
-  parent: OrganBase
+  parent: OrganBaseOrganic
   id: OrganBaseTorso
   name: torso
   abstract: true

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -26,7 +26,7 @@
   id: OrganBaseOrganic
   name: organ
   abstract: true
-  parent: [ OrganBase, SolutionFood, SolutionSmall ]
+  parent: [ OrganBase, SolutionFood, SolutionTiny ]
   components:
   - type: FlavorProfile
     flavors:

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -37,6 +37,10 @@
       reagents:
       - ReagentId: UncookedAnimalProteins
         Quantity: 20
+  - type: Tag # I am nearing my limit of tolerance for TagComponent.
+    tags:
+    - Raw
+    - Meat
 
 - type: entity
   parent: OrganBaseOrganic

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -15,12 +15,28 @@
       nudityDefault: [ UndergarmentBottomBoxers ]
 
 - type: entity
-  id: OrganBase
+  id: OrganBaseUnEditable
   name: organ
   abstract: true
   parent: BaseItem
   components:
   - type: Organ
+
+- type: entity
+  id: OrganBase
+  name: organ
+  abstract: true
+  parent: [OrganBaseUnEditable, SolutionFood]
+  components:
+  - type: FlavorProfile
+    flavors:
+    - chicken # INTRODUCING OUR NEW EVERY-MEAT BURRITO, IT'S GOT EVERY MEAT!
+  - type: Edible
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: UncookedAnimalProteins
+        Quantity: 20
 
 - type: entity
   parent: OrganBase
@@ -255,6 +271,13 @@
   - type: Examiner
   - type: BlockMovement
   - type: BadFood
+  - type: Solution
+    solution:
+      reagents:
+      - ReagentId: UncookedAnimalProteins
+        Quantity: 15
+      - ReagentId: GreyMatter
+        Quantity: 10
   - type: FoodSequenceElement
     entries:
       Burger: Brain

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -15,7 +15,7 @@
       nudityDefault: [ UndergarmentBottomBoxers ]
 
 - type: entity
-  id: OrganBaseUnEditable
+  id: OrganBaseUnEdible
   name: organ
   abstract: true
   parent: BaseItem
@@ -26,7 +26,7 @@
   id: OrganBase
   name: organ
   abstract: true
-  parent: [OrganBaseUnEditable, SolutionFood]
+  parent: [OrganBaseUnEdible, SolutionFood]
   components:
   - type: FlavorProfile
     flavors:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I made organs Editable again
Resolves #43383

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Casualty of Nubody, also brains get grey matter because thats how it was like before.
## Technical details
<!-- Summary of code changes for easier review. -->
YAML
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
go ingame, spawn entities in, smite them, eat their organs
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/1942f20e-36c2-4724-9143-d7e876ed48a5


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Organic Species now have their organs parent off of `OrganBaseOrganic` instead of `OrganBase`

## Changelog
🆑 
- fix: Organs are edible again