### PR TITLE
Fix illegible FileNotFoundError occurrences when git isn't in path.

### DIFF
--- a/BuildChecker/git_helper.py
+++ b/BuildChecker/git_helper.py
@@ -49,9 +49,6 @@ def update_submodules():
     if os.path.isfile("DISABLE_SUBMODULE_AUTOUPDATE"):
         return
 
-    if shutil.which("git") is None:
-        raise FileNotFoundError("git not found in PATH")
-
     # If the status doesn't match, force VS to reload the solution.
     # status = run_command(["git", "submodule", "status"], capture=True)
     run_command(["git", "submodule", "update", "--init", "--recursive"])
@@ -117,7 +114,14 @@ def check_for_zip_download():
         time.sleep(30)
         exit(1)
 
+def check_path_for_git():
+    if shutil.which("git") is None:
+        print("git not found in PATH. Ensure git is installed and in PATH and run this program again!")
+        time.sleep(30)
+        exit(1)
+
 if __name__ == '__main__':
+    check_path_for_git()
     check_for_zip_download()
     install_hooks()
     update_submodules()

--- a/BuildChecker/git_helper.py
+++ b/BuildChecker/git_helper.py
@@ -115,6 +115,9 @@ def check_for_zip_download():
         exit(1)
 
 def check_path_for_git():
+    """
+    Check git is invokable before trying to invoke it.
+    """
     if shutil.which("git") is None:
         print("git not found in PATH. Ensure git is installed and in PATH and run this program again!")
         time.sleep(30)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Technical details
<!-- Summary of code changes for easier review. -->
Applies to git_helper.py which gets ran by RUN_THIS.py.

Move the check for git to its own function.
Previously this check would not get reached if git wasn't in path because while checking to see if its a zip download,
a call to git is made which in tern raises a FileNotFoundError quite frankly useless for diagnosing this issue.
Also replaced raising FileNotFoundError with a printed string since the traceback isn't needed or helpful here.

Fixes #44074

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
I don't know if this is applicable on Linux.
1: Remove git from your windows path variables.
2: Open command prompt and invoke RUN_THIS.py
3: Observe the git not found message.
4: Readd git to path.
5: Close and reopen command prompt. Rerun RUN_THIS.py
6: Profit.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/f8107e79-9281-4655-aec5-c12cdf46bcc1

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->