### PR TITLE
Fix ToggleRoundEndSummaryWindow requiring two presses.

### DIFF
--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -490,7 +490,7 @@ binds:
   type: State
   key: F8
 - function: ToggleRoundEndSummaryWindow
-  type: Toggle
+  type: State
   key: F9
 - function: OpenSandboxWindow
   type: State


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced Toggle with State for the ToggleRoundEndSummaryWindow keybind.

It appears as though it was being used incorrectly here. Looking at how debug monitors handles it,
the input register is passed an enabled and disabled function to act upon when the button is pressed but that isn't
how the window is doing it. To remain consistent and allow the window to be easier to interface with elsewhere,
I've chosen to just set the type to State.

Fixes #44155

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1: run roundend command.
2: press f9 to close and open the window.
3: observe that you do not need to press the button multiple times.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->