### PR TITLE
Bugfix: Banana cream pies stun when target is already creamed

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/SharedCreamPieSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SharedCreamPieSystem.cs
@@ -118,12 +118,17 @@ public abstract partial class SharedCreamPieSystem : EntitySystem
 
     private void OnCreamPiedHitBy(Entity<CreamPiedComponent> creamPied, ref ThrowHitByEvent args)
     {
-        if (creamPied.Comp.CreamPied || !Exists(args.Thrown) || !TryComp<CreamPieComponent>(args.Thrown, out var creamPie))
+        if (!Exists(args.Thrown) || !TryComp<CreamPieComponent>(args.Thrown, out var creamPie))
+            return;
+
+        _stunSystem.TryUpdateParalyzeDuration(creamPied.Owner, creamPie.ParalyzeTime);
+
+        // Already creamed, no need to spam popups.
+        if (creamPied.Comp.CreamPied)
             return;
 
         // TODO: Check if they even have a head that can be hit.
         SetCreamPied(creamPied.AsNullable(), true);
-        _stunSystem.TryUpdateParalyzeDuration(creamPied.Owner, creamPie.ParalyzeTime);
 
         // Throwing is not predicted, so the thrower is not equal to the client predicting the collision, so we cannot pass in a user.
         // TODO: Make the popup API sane.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

When hit by a banana cream pie, fixes a condition that would prevent you from being stunned if you have pie on your face.

The popup that says "you have been creamed by a banana cream pie" will only appear when it has been applied to your face.  Further hits will not display this text (they may happen in quick succession, this seems unnecessary).

Worth note that with these changes, each pie will cause knockdown.  If it would be reasonable, a knockdown/stun cooldown could be added, but that has not been added.  Getting hit with another pie 2 minutes from the first should stun you for sure - should getting hit with another pie 2 seconds from now stun you?

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes #44195.  Makes reasonable sense.  Pointed out the problem, might as well write the fix.

## Technical details
<!-- Summary of code changes for easier review. -->

Simple C# condition change.  The check for the target being pied was moved below the paralyze attempt.

Stunlock may be undesirable, but is possible with this (so long as you have more pies).

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Spawn a Urist and a bunch of pies.
2. Throw pie at Urist.  You should see a popup, they should have pie on their face, and they should fall to the ground.
3. Throw pie at Urist.  They should fall to the ground, but there should be no popup.
4. Throw pie at Urist while they are on the ground.  Their recovery refreshes, but there should be no popup.
5. Wash the pie off of the Urist with a fire extinguisher.
6. Throw pie at Urist.  You should see a popup, they should have pie on their face, and they should fall to the ground.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/65c6b93b-3e06-425c-8fec-b06164bffa01

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
effect seems minor, but sure
:cl:
- fix: Banana cream pies now stun targets that already have pie on their face.