### PR TITLE
constructed toilets no longer can spawn items

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -24,7 +24,7 @@
           False: { state: dispover-ready, visible: true }
       enum.PowerDeviceVisuals.Powered:
         enum.DisposalUnitVisualLayers.OverlayCharging:
-          False: { visible: false } 
+          False: { visible: false }
       enum.AnchorVisuals.Anchored:
         enum.DisposalUnitVisualLayers.Base:
           True: { state: disposal }
@@ -81,7 +81,6 @@
         - MachineMask
         layer:
         - None
-  - type: PlungerUse
   - type: Appearance
   - type: SecretStash
     secretStashName: secret-stash-toilet
@@ -100,17 +99,9 @@
     interfaces:
       enum.DisposalUnitUiKey.Key:
         type: DisposalUnitBoundUserInterface
-  - type: Rummageable
-    table: !type:NestedSelector
-      tableId: RatKingLoot
   - type: SolutionManager
     solutions:
     - SolutionDrainNormal
-  - type: SolutionRegeneration
-    generated:
-      reagents:
-      - ReagentId: Water
-        Quantity: 1
   - type: DrainableSolution
     solution: tank
   - type: ReagentTank
@@ -124,14 +115,31 @@
 
 - type: entity
   parent: BaseToilet
+  id: ConstructedToilet
+  name: toilet
+  description: The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably clean.
+  suffix: Constructed
+  components:
+    - type: Construction
+      graph: Toilet
+      node: toilet
+
+- type: entity
+  parent: ConstructedToilet
   id: ToiletEmpty
   name: toilet
   description: The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably clean.
   suffix: Empty
   components:
-  - type: Construction
-    graph: Toilet
-    node: toilet
+  - type: PlungerUse
+  - type: Rummageable
+    table: !type:NestedSelector
+      tableId: RatKingLoot
+  - type: SolutionRegeneration
+    generated:
+      reagents:
+      - ReagentId: Water
+        Quantity: 1
 
 # so theres not actually any way to replenish the gastrotoxin / gold in these.
 # I wouldn't add it to the solutionregeneration comp because that doesn't make a lot of sense imo.
@@ -201,6 +209,15 @@
           IngotGold1:
             min: 5
             max: 5
+  - type: PlungerUse
+  - type: Rummageable
+    table: !type:NestedSelector
+      tableId: RatKingLoot
+  - type: SolutionRegeneration
+    generated:
+      reagents:
+      - ReagentId: Water
+        Quantity: 1
 
 - type: entity
   parent: ToiletGoldenEmpty

--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -113,19 +113,20 @@
     destroyOnEmpty: false
     utensil: Spoon
 
+# constructed toilets don't come with Rummageable or plungeruse component to avoid infinite item spawning.
 - type: entity
   parent: BaseToilet
   id: ConstructedToilet
   name: toilet
   description: The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably clean.
-  suffix: Constructed
+  suffix: Constructed, Unplungable
   components:
     - type: Construction
       graph: Toilet
       node: toilet
 
 - type: entity
-  parent: ConstructedToilet
+  parent: BaseToilet
   id: ToiletEmpty
   name: toilet
   description: The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably clean.

--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -126,9 +126,9 @@
   description: The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably clean.
   suffix: Constructed, Unplungable
   components:
-    - type: Construction
-      graph: Toilet
-      node: toilet
+  - type: Construction
+    graph: Toilet
+    node: toilet
 
 - type: entity
   parent: BaseToilet

--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -112,6 +112,11 @@
     solution: tank
     destroyOnEmpty: false
     utensil: Spoon
+  - type: SolutionRegeneration
+    generated:
+      reagents:
+      - ReagentId: Water
+        Quantity: 1
 
 # constructed toilets don't come with Rummageable or plungeruse component to avoid infinite item spawning.
 - type: entity
@@ -136,11 +141,6 @@
   - type: Rummageable
     table: !type:NestedSelector
       tableId: RatKingLoot
-  - type: SolutionRegeneration
-    generated:
-      reagents:
-      - ReagentId: Water
-        Quantity: 1
 
 # so theres not actually any way to replenish the gastrotoxin / gold in these.
 # I wouldn't add it to the solutionregeneration comp because that doesn't make a lot of sense imo.
@@ -214,11 +214,6 @@
   - type: Rummageable
     table: !type:NestedSelector
       tableId: RatKingLoot
-  - type: SolutionRegeneration
-    generated:
-      reagents:
-      - ReagentId: Water
-        Quantity: 1
 
 - type: entity
   parent: ToiletGoldenEmpty

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/toilet.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/toilet.yml
@@ -12,7 +12,7 @@
               amount: 5
               doAfter: 1
     - node: toilet
-      entity: ToiletEmpty
+      entity: ConstructedToilet
       edges:
         - to: start
           completed:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
made constructed toilets not come with the plunger use or rummablge components.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Closes #44208 and also stops infinite rat king grinding using a similar method.

## Technical details
<!-- Summary of code changes for easier review. -->
made a new prototype just for constructed toilets.
removed the relevant components from the base toilet
added them back to gold and empty toilet prototype directly.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Spawn every toilet
build one new toilet
See which ones can be plunged

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="806" height="366" alt="image" src="https://github.com/user-attachments/assets/72a4a02e-763d-43d7-b3ab-20502533524d" />

<img width="616" height="346" alt="image" src="https://github.com/user-attachments/assets/e9986a9d-083f-4b74-bbef-33195fe7a15c" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

- Maps using the "BaseToilet" Prototype won't be clogged. Replace with "ToiletEmpty" to restore function. (Should not happen because BaseToilet is abstract at this point)
- New Toilet Prototypes will also break and should add the components again to themselves.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: You can no longer generate infinite items from constructing toilets.

