### PR TITLE
fixed colours for plant metabolism modifiers in guide

### DIFF
--- a/Content.Shared/EntityEffects/Effects/Botany/PlantAttributes/BasePlantAdjustAttributeEntityEffect.cs
+++ b/Content.Shared/EntityEffects/Effects/Botany/PlantAttributes/BasePlantAdjustAttributeEntityEffect.cs
@@ -32,6 +32,6 @@ public abstract partial class BasePlantAdjustAttribute<T> : EntityEffectBase<T> 
         Loc.GetString("entity-effect-guidebook-plant-attribute",
         ("attribute", Loc.GetString(GuidebookAttributeName)),
         ("amount", Amount.ToString("0.00")),
-        ("positive", GuidebookIsAttributePositive),
+        ("positive", GuidebookIsAttributePositive == Amount > 0f),
         ("chance", Probability));
 }

--- a/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/entity-effects/effects.ftl
@@ -479,8 +479,8 @@ entity-effect-guidebook-plant-attribute =
         [1] Adjusts
         *[other] adjust
     } {$attribute} by {$positive ->
-    [true] [color=red]{$amount}[/color]
-    *[false] [color=green]{$amount}[/color]
+    [false] [color=red]{$amount}[/color]
+    *[true] [color=green]{$amount}[/color]
     }
 
 entity-effect-guidebook-plant-cryoxadone =


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Positive effects are now green
Negitive effects are now red

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Learning botany chems is hard enough as is. The colours not matching the effect only makes this harder. I was very confused by Dylovene adding health when it is red, which gives the impression that it might take away health.

## Technical details
<!-- Summary of code changes for easier review. -->
Flipped the loc bool values because potitive should be green.
Added a check if the chem is adding or taking away the good or bad modifier. 
If the modifier is good but it is removing, then it is actually bad.
If the modifier is bad but it is removing, then it is actually good.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Check the guide for chems with plant metabolism effects.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<details>
<summary>
Dylovene
</summary>

New
<img width="640" height="244" alt="dotnet_P8utHfrgiJ" src="https://github.com/user-attachments/assets/803c9d46-13f0-4356-b0b1-b8b1c9bc42d6" />

Old
<img width="640" height="244" alt="dotnet_yKsxfsfQil" src="https://github.com/user-attachments/assets/451024a3-da3e-44de-a828-b7d8672e4cc6" />
</details>
<details>
<summary>
Cryoxadone
</summary>

New
<img width="640" height="288" alt="dotnet_5wSvQxS6oZ" src="https://github.com/user-attachments/assets/628a947e-54ec-4e9c-a645-fbdc106ed334" />

Old
<img width="640" height="288" alt="dotnet_ciL6yKJ00E" src="https://github.com/user-attachments/assets/1df61e22-0287-440d-8312-c52d59f51c6d" />
</details>
<details>
<summary>
Diethylamine
</summary>

New
<img width="640" height="310" alt="dotnet_aHtYwDwMvw" src="https://github.com/user-attachments/assets/a58aeae9-0c91-4a6b-a8cd-0ca000f0ab08" />

Old
<img width="640" height="310" alt="dotnet_KiTrt9LtUO" src="https://github.com/user-attachments/assets/aff3f67b-74df-4f0e-8b93-3283565b0a8b" />
</details>
<details>
<summary>
Plant-B-gone
</summary>

New
<img width="640" height="288" alt="dotnet_F9h7eXV7uR" src="https://github.com/user-attachments/assets/6fab5525-7e04-403e-94ad-86e147e06e2b" />

Old
<img width="640" height="288" alt="dotnet_EJFMo7JQIC" src="https://github.com/user-attachments/assets/857bcd70-6696-4bba-a28a-5fbddb4aec44" />
</details>



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed modifier color for plant metabolism effects