### PR TITLE
fix remaining butcherable components

### DIFF
--- a/Resources/Locale/en-US/kitchen/components/butcherable-component.ftl
+++ b/Resources/Locale/en-US/kitchen/components/butcherable-component.ftl
@@ -1,2 +1,0 @@
-butcherable-need-knife = Use a sharp object to butcher { THE($target) }.
-butcherable-knife-butchered-success = You butcher { THE($target) } with { THE($knife) }.

--- a/Resources/Locale/en-US/kitchen/components/butcherable-component.ftl
+++ b/Resources/Locale/en-US/kitchen/components/butcherable-component.ftl
@@ -1,0 +1,2 @@
+butcherable-need-knife = Use a sharp object to butcher { THE($target) }.
+butcherable-knife-butchered-success = You butcher { THE($target) } with { THE($knife) }.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -834,7 +834,7 @@
     sprite: Clothing/OuterClothing/WinterCoats/coatnomi.rsi
 
 - type: entity
-  parent: ClothingOuterWinterCoatToggleable
+  parent: [ClothingOuterWinterCoatToggleable, BaseSlicingRefinable]
   id: ClothingOuterWinterWeb
   name: web winter coat
   description: Feels like the inside of a cocoon, not that this would make you less afraid of being in one.
@@ -857,8 +857,8 @@
   - type: Construction
     graph: WebObjects
     node: coat
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: MaterialWebSilk1
       amount: 5
   - type: FlavorProfile

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -176,7 +176,7 @@
     sprite: Clothing/Shoes/Boots/winterbootssyndicate.rsi
 
 - type: entity
-  parent: ClothingShoesBaseWinterBoots
+  parent: [ClothingShoesBaseWinterBoots, BaseSlicingRefinable]
   id: ClothingShoesBootsWinterWeb
   name: web winter boots
   description: Boots made out of dense webbing to help survive even the coldest of winters.
@@ -195,8 +195,8 @@
       reagents:
       - ReagentId: Fiber
         Quantity: 20
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: MaterialWebSilk1
       amount: 2
   - type: Construction

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1131,7 +1131,7 @@
 
 - type: entity
   abstract: true
-  parent: BaseMobRuminant
+  parent: [BaseMobRuminant, BaseSlicingRefinable]
   id: MobSheepBase
   name: sheepBase
   description: A sheep.
@@ -1214,8 +1214,8 @@
     solution: wool
     requiresSpecialDigestion: true
     requireDead: false
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: FoodMeat
       amount: 4
   - type: Grammar

--- a/Resources/Prototypes/Entities/Mobs/NPCs/argocyte.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/argocyte.yml
@@ -51,7 +51,7 @@
     group: GenericNumber
 
 - type: entity
-  parent: BaseMobArgocyte
+  parent: [BaseMobArgocyte, BaseSlicingRefinable]
   id: MobArgocyteSlurva
   name: slurva
   description: A pathetic creature, incapable of doing much.
@@ -73,8 +73,8 @@
     thresholds:
       0: Alive
       30: Dead
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: FoodMeatXeno
       amount: 1
   - type: MovementSpeedModifier
@@ -86,7 +86,7 @@
         Blunt: 3
 
 - type: entity
-  parent: BaseMobArgocyte
+  parent: [BaseMobArgocyte, BaseSlicingRefinable]
   id: MobArgocyteBarrier
   name: barrier
   components:
@@ -107,8 +107,8 @@
     thresholds:
       0: Alive
       30: Dead
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: FoodMeatXeno
       amount: 1
   - type: Fixtures
@@ -128,7 +128,7 @@
         Blunt: 3
 
 - type: entity
-  parent: BaseMobArgocyte
+  parent: [BaseMobArgocyte, BaseSlicingRefinable]
   id: MobArgocyteSkitter
   name: skitter
   description: A devious little alien... Make sure they don't run off with your rations!
@@ -147,8 +147,8 @@
     thresholds:
       0: Alive
       30: Dead
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: FoodMeatXeno
       amount: 1
   - type: Fixtures
@@ -168,7 +168,7 @@
         Slash: 3
 
 - type: entity
-  parent: BaseMobArgocyte
+  parent: [BaseMobArgocyte, BaseSlicingRefinable]
   id: MobArgocyteSwiper
   name: swiper
   description: Where did that stack of steel go?
@@ -187,15 +187,15 @@
     thresholds:
       0: Alive
       60: Dead
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: FoodMeatXeno
       amount: 2
   - type: MovementSpeedModifier
     baseSprintSpeed : 5
 
 - type: entity
-  parent: BaseMobArgocyte
+  parent: [BaseMobArgocyte, BaseSlicingRefinable]
   id: MobArgocyteMolder
   name: molder
   components:
@@ -213,8 +213,8 @@
     thresholds:
       0: Alive
       100: Dead
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: FoodMeatXeno
       amount: 2
   - type: MovementSpeedModifier
@@ -222,7 +222,7 @@
     baseWalkSpeed : 3.5
 
 - type: entity
-  parent: BaseMobArgocyte
+  parent: [BaseMobArgocyte, BaseSlicingRefinable]
   id: MobArgocytePouncer
   name: pouncer
   components:
@@ -240,8 +240,8 @@
     thresholds:
       0: Alive
       100: Dead
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: FoodMeatXeno
       amount: 2
   - type: MeleeWeapon
@@ -251,7 +251,7 @@
         Slash: 7.5
 
 - type: entity
-  parent: BaseMobArgocyte
+  parent: [BaseMobArgocyte, BaseSlicingRefinable]
   id: MobArgocyteGlider
   name: glider
   components:
@@ -269,8 +269,8 @@
     thresholds:
       0: Alive
       100: Dead
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: FoodMeatXeno
       amount: 2
   - type: MeleeWeapon
@@ -283,7 +283,7 @@
     baseWalkSpeed: 4.5
 
 - type: entity
-  parent: BaseMobArgocyte
+  parent: [BaseMobArgocyte, BaseSlicingRefinable]
   id: MobArgocyteHarvester
   name: harvester
   components:
@@ -301,8 +301,8 @@
     thresholds:
       0: Alive
       150: Dead
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: FoodMeatXeno
       amount: 2
   - type: MeleeWeapon
@@ -313,7 +313,7 @@
         Structural: 5
 
 - type: entity
-  parent: BaseMobArgocyte
+  parent: [BaseMobArgocyte, BaseSlicingRefinable]
   id: MobArgocyteCrawler
   name: crawler
   description: Deadly, pack-animals that maul unsuspecting travelers.
@@ -332,8 +332,8 @@
     thresholds:
       0: Alive
       150: Dead
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: FoodMeatXeno
       amount: 2
   - type: MeleeWeapon
@@ -347,7 +347,7 @@
     baseWalkSpeed: 5
 
 - type: entity
-  parent: BaseMobArgocyte
+  parent: [BaseMobArgocyte, BaseSlicingRefinable]
   id: MobArgocyteEnforcer
   name: enforcer
   components:
@@ -365,8 +365,8 @@
     thresholds:
       0: Alive
       300: Dead
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: FoodMeatXeno
       amount: 3
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -206,54 +206,54 @@
 
 - type: entity
   name: sharkminnow
-  parent: [ BaseMobBloodsucker, BaseMobCarp ]
+  parent: [ BaseMobBloodsucker, BaseMobCarp, BaseSlicingRefinable ]
   id: MobShark
   description: A dangerous shark from the blackness of endless space, who loves to drink blood.
   components:
-    - type: Sprite
-      sprite: Mobs/Aliens/Carps/sharkminnow.rsi
-      layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-      - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
-        state: mouth
-        shader: unshaded
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape:
-            !type:PhysShapeCircle
-            radius: 0.40
-          density: 100
-          mask:
-            - FlyingMobMask
-          layer:
-            - FlyingMobLayer
-    - type: MobThresholds
-      thresholds:
-        0: Alive
-        82: Dead # Might seem random, but this brings up the hits to kill with a crusher mark to 3
-    - type: Stamina
-      baseCritThreshold: 150
-    - type: DamageStateVisuals
-      states:
-        Alive:
-          Base: alive
-          BaseUnshaded: mouth
-        Dead:
-          Base: dead
-          BaseUnshaded: dead_mouth
-    - type: Butcherable
-      spawned:
-        - id: FoodMeatFish
-          amount: 4
-        - id: MaterialToothSharkminnow1
-          amount: 3
-    - type: MeleeWeapon
-      damage:
-        types:
-          Slash: 10
-          Bloodloss: 5
+  - type: Sprite
+    sprite: Mobs/Aliens/Carps/sharkminnow.rsi
+    layers:
+    - map: [ "enum.DamageStateVisualLayers.Base" ]
+      state: alive
+    - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
+      state: mouth
+      shader: unshaded
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.40
+        density: 100
+        mask:
+        - FlyingMobMask
+        layer:
+        - FlyingMobLayer
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      82: Dead # Might seem random, but this brings up the hits to kill with a crusher mark to 3
+  - type: Stamina
+    baseCritThreshold: 150
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: alive
+        BaseUnshaded: mouth
+      Dead:
+        Base: dead
+        BaseUnshaded: dead_mouth
+  - type: ToolRefinable
+    refineResult:
+    - id: FoodMeatFish
+      amount: 4
+    - id: MaterialToothSharkminnow1
+      amount: 3
+  - type: MeleeWeapon
+    damage:
+      types:
+        Slash: 10
+        Bloodloss: 5
 
 - type: entity
   id: MobSharkSalvage

--- a/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   name: watcher
   id: MobWatcherBase
-  parent: [ SimpleSpaceMobBase, FlyingMobBase ]
+  parent: [ SimpleSpaceMobBase, FlyingMobBase, BaseSlicingRefinable ]
   abstract: true
   description: It's like it's staring right through you.
   components:
@@ -43,8 +43,8 @@
     thresholds:
       0: Alive
       50: Dead
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: DiamondOre1
       amount: 1
   - type: MovementSpeedModifier

--- a/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: mimic
   id: MobMimic
-  parent: [ SimpleMobBase, MobCombat ]
+  parent: [ SimpleMobBase, MobCombat, BaseSlicingRefinable ]
   description: Surprise. # When this gets a proper write this should use the object's actual description >:)
   components:
   - type: Tag
@@ -40,7 +40,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed : 1
     baseSprintSpeed : 1
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: DrinkChangelingStingCan
       amount: 1

--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: laser raptor
   id: MobLaserRaptor
-  parent: SimpleMobBase
+  parent: [SimpleMobBase, BaseSlicingRefinable]
   description: From the Viking age.
   components:
     - type: NpcFactionMember
@@ -37,8 +37,8 @@
       thresholds:
         0: Alive
         100: Dead
-    - type: Butcherable
-      spawned:
+    - type: ToolRefinable
+      refineResult:
       - id: FoodMeatChicken
         amount: 2
     - type: MovementSpeedModifier

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -124,7 +124,7 @@
 - type: entity
   name: space kangaroo
   id: MobKangarooSpace
-  parent: [MobSpaceBasic, StripableInventoryBase]
+  parent: [MobSpaceBasic, StripableInventoryBase, BaseSlicingRefinable]
   description: It looks friendly. Why don't you give it a hug?
   components:
   - type: Sprite
@@ -167,8 +167,8 @@
       Unsexed: Kangaroo
   - type: ReplacementAccent
     accent: kangaroo
-  - type: Butcherable
-    spawned:
+  - type: ToolRefinable
+    refineResult:
     - id: FoodMeat
       amount: 1
   - type: MobThresholds

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/cottonburger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/cottonburger.yml
@@ -1,7 +1,7 @@
 # Cotton Bun
 
 - type: entity
-  parent: FoodBreadSliceBase
+  parent: [FoodBreadSliceBase, BaseSlicingRefinable]
   id: FoodCottonBun
   name: cotton bun
   description: A cotton hamburger bun. Soft, round and convenient to hold.
@@ -19,9 +19,9 @@
         Quantity: 5
       - ReagentId: Fiber
         Quantity: 5
-  - type: Butcherable
-    butcherDelay: 1
-    spawned:
+  - type: ToolRefinable
+    refineTime: 1
+    refineResult:
     - id: FoodCottonBunTop
       amount: 1
     - id: FoodCottonBunBottom


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fixed a bunch of entities to use toolrefinable instead of butcherable. namely:
- cotton buns
- web winter coat and boots
- all the argocytes (except leviathing and founder)
- sheep, watchers, mimics, space kangaroos, sharkminnows, laser raptors 

## Why / Balance
#36895 forgot to cover these, presumably because it's a PR from april 2025 and the game has updated since
this should be on par with butchery behavior before: only humanoid species, xenos, monkeys, scurrets, kobolds, founders, and leviathings should be spikeable now

## Technical details
<!-- Summary of code changes for easier review. -->
replaced a bunch of `Butcherable` components with `ToolRefinable` and added the `BaseSlicingRefinable` parent, as per original PR's breaking changes

added a localization file

## Test plan
- ensure cotton buns can be sliced with a knife into top and bottom buns
- ensure web winter coat and web winter boots can be sliced into silk 
- all argocytes except founder and leviathing should be butchered with knives instead of meat spikes
- sheep, watchers, mimics, space kangaroos, sharkminnows, and laser raptors should be butcherable with knives

## Media
some of these are rotted because i fucked around too long. sorry. it did butcher fresh
<img width="516" height="420" alt="image" src="https://github.com/user-attachments/assets/0639142e-357a-4275-b035-cc6c79744909" />
<img width="743" height="512" alt="image" src="https://github.com/user-attachments/assets/ee2ff4d3-22c5-47da-8afd-fb91d2d537da" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

nope?

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: A couple of broken messages related to meatspiking have been fixed.
- fix: Cotton buns, web winter coats, and web winter boots are now sliceable again.
- fix: A bunch of mobs that erroneously required a meat spike no longer need to do so. The only mobs that should need meatspiking to butcher are humanoid species, monkeys, kobolds, scurrets, and xenos.
