### PR TITLE
Add NU1900 to WarningsNotAsErrors

### DIFF
--- a/MSBuild/Content.props
+++ b/MSBuild/Content.props
@@ -12,6 +12,6 @@
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>CS0618,CS0672,CS0612,CS1062,CS1064,NU1901,NU1902,NU1903,NU1904</WarningsNotAsErrors>
+    <WarningsNotAsErrors>CS0618,CS0672,CS0612,CS1062,CS1064,NU1900,NU1901,NU1902,NU1903,NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## About the PR
NU1900: Error communicating with package source, while getting vulnerability information.
That is, a network error.

## Why / Balance
It dares to annoy me.
