### PR TITLE
Make NumberObjective Max inclusive

### DIFF
--- a/Content.Server/Objectives/Components/NumberObjectiveComponent.cs
+++ b/Content.Server/Objectives/Components/NumberObjectiveComponent.cs
@@ -16,13 +16,13 @@ public sealed partial class NumberObjectiveComponent : Component
     public int Target;
 
     /// <summary>
-    /// Minimum number for target to roll.
+    /// Minimum number for target to roll. (Inclusive)
     /// </summary>
     [DataField(required: true)]
     public int Min;
 
     /// <summary>
-    /// Maximum number for target to roll.
+    /// Maximum number for target to roll. (Inclusive)
     /// </summary>
     [DataField(required: true)]
     public int Max;

--- a/Content.Server/Objectives/Systems/NumberObjectiveSystem.cs
+++ b/Content.Server/Objectives/Systems/NumberObjectiveSystem.cs
@@ -23,7 +23,7 @@ public sealed partial class NumberObjectiveSystem : EntitySystem
 
     private void OnAssigned(EntityUid uid, NumberObjectiveComponent comp, ref ObjectiveAssignedEvent args)
     {
-        comp.Target = _random.Next(comp.Min, comp.Max+1);
+        comp.Target = _random.Next(comp.Min, comp.Max + 1);
     }
 
     private void OnAfterAssign(EntityUid uid, NumberObjectiveComponent comp, ref ObjectiveAfterAssignEvent args)

--- a/Content.Server/Objectives/Systems/NumberObjectiveSystem.cs
+++ b/Content.Server/Objectives/Systems/NumberObjectiveSystem.cs
@@ -23,7 +23,7 @@ public sealed partial class NumberObjectiveSystem : EntitySystem
 
     private void OnAssigned(EntityUid uid, NumberObjectiveComponent comp, ref ObjectiveAssignedEvent args)
     {
-        comp.Target = _random.Next(comp.Min, comp.Max);
+        comp.Target = _random.Next(comp.Min, comp.Max+1);
     }
 
     private void OnAfterAssign(EntityUid uid, NumberObjectiveComponent comp, ref ObjectiveAfterAssignEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made the NumberObjectiveComponent.Max value be inclusive.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Feels unintended. We have a few cases of objectives rolling 3-4, but because its not inclusive it always returns 3.
We also have objectives that roll 3-3, which is what probably should be used if we only want a specific number

## Technical details
<!-- Summary of code changes for easier review. -->
Just added +1 to the random.Next()
I checked all uses of NumberObjectiveComponent and it doesnt seem to cause any issues anywhere.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Get traitor
2. Give yourself crit anomaly objective 6 or 7 times.
3. Notice its sometimes 3 and sometimes 4
4. Become changeling
5. Give yourself the devour objective 6 or 7 times
6. Notice its sometimes 3 sometimes 4

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="396" height="140" alt="image" src="https://github.com/user-attachments/assets/c6705462-346e-4eb8-bf18-5b0b719099ac" />
<img width="385" height="129" alt="image" src="https://github.com/user-attachments/assets/de831ad1-90c6-4e94-ac12-83978d498d5e" />
<img width="375" height="99" alt="image" src="https://github.com/user-attachments/assets/47af1af0-52fa-4e1b-8a98-c2dce0bf6b84" />
<img width="386" height="107" alt="image" src="https://github.com/user-attachments/assets/b46fc69a-f936-470a-8e4c-d6060af58299" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
`NumberObjectiveComponent.Max` is now inclusive

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The "Crit Anomalies" objective will now correctly randomize the number of anomalies to crit.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
