### PR TITLE
Fix ReagentDispensor not focusing, slow use delay

### DIFF
--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
@@ -44,7 +44,8 @@
         </BoxContainer>
         <SplitContainer Orientation="Vertical"
                         HorizontalExpand="True"
-                        VerticalExpand="True">
+                        VerticalExpand="True"
+                        MouseFilter="Ignore">
             <ScrollContainer HScrollEnabled="False"
                              HorizontalExpand="True"
                              VerticalExpand="True"

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -55,6 +55,8 @@
     maxItemSize: Large
     grid:
     - 0,0,15,11
+  - type: UseDelay
+    delay: 0
   - type: ReagentDispenser
     beakerSlot:
       whitelistFailPopup: reagent-dispenser-component-cannot-put-entity-message


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Improves chemical dispenser UI/UX by making the 'dead space' on the UI focus the window, and removes the UseDelay on opening the UI.

## Why / Balance
Fixes #44184 
Fixes #44185

## Technical details
Added a MouseFilter "Ignore" tag to the SplitContainer on the chem dispenser's UI, and added an explicit UseDelay component to the base Reagent Dispenser prototype to override the default UseDelay introduced by the Storage component dependency.

## Test plan

1. Spam open and close the reagent dispenser UI to your heart's content
2. Open another non-dispenser window, and click the dead space in the reagent dispenser to bring the dispenser window into focus.

## Media
[Screencast_20260603_121213.webm](https://github.com/user-attachments/assets/de741466-fb5b-4aff-bc82-fe78b2422816)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes


## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
