### PR TITLE
Fix `GameTest.CTryComp` using the server entity manager

### DIFF
--- a/Content.IntegrationTests/Fixtures/GameTest.Entities.cs
+++ b/Content.IntegrationTests/Fixtures/GameTest.Entities.cs
@@ -100,12 +100,12 @@ public abstract partial class GameTest
     }
 
     /// <summary>
-    ///     Attempts to retrieve the given component from an entity on the server.
+    ///     Attempts to retrieve the given component from an entity on the client.
     /// </summary>
     public bool CTryComp<T>(EntityUid? target, [NotNullWhen(true)] out T? component)
         where T : IComponent
     {
-        return SEntMan.TryGetComponent(target, out component);
+        return CEntMan.TryGetComponent(target, out component);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`GameTest.CTryComp<T>` now tries to retrieve the component from the client entity manager, rather than the server.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Micro bugfix of a typo.

## Technical details
<!-- Summary of code changes for easier review. -->
Literal one-character fix. Fixed the xmldoc summary too.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Use `CTryComp<SpriteComponent>` and observe that it no longer throws a `KeyNotFoundException` due to `SpriteComponent` not being registered on the server.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->