### PR TITLE
Portal preloads

### DIFF
--- a/Content.IntegrationTests/Tests/Teleportation/PortalPvsTest.cs
+++ b/Content.IntegrationTests/Tests/Teleportation/PortalPvsTest.cs
@@ -1,0 +1,79 @@
+using Content.IntegrationTests.Fixtures;
+using Robust.Shared;
+using Content.Shared.CCVar;
+using Content.Shared.Teleportation.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests.Teleportation;
+
+[TestFixture]
+public sealed class PortalPvsTest : GameTest
+{
+    public override PoolSettings PoolSettings => new() { Connected = true, DummyTicker = false };
+
+    [Test]
+    public async Task NearbyPlayerReceivesBothNearestPortalViews()
+    {
+        await Server.WaitPost(() =>
+        {
+            Server.CfgMan.SetCVar(CVars.NetPVS, true);
+            Server.CfgMan.SetCVar(CCVars.PortalMaxPreloaded, 1);
+        });
+        await Pair.RunUntilSynced();
+
+        var map = await Pair.CreateTestMap();
+        EntityUid player = default;
+        EntityUid nearestEntrance = default;
+        EntityUid nearestDestination = default;
+        EntityUid nearestDestinationMarker = default;
+        EntityUid fartherEntrance = default;
+        EntityUid fartherDestination = default;
+        EntityUid fartherDestinationMarker = default;
+
+        await Server.WaitPost(() =>
+        {
+            Assert.That(ServerSession?.AttachedEntity, Is.Not.Null);
+            player = ServerSession!.AttachedEntity!.Value;
+
+            var playerCoords = map.GridCoords.Offset(new(0, 0));
+            var nearestEntranceCoords = map.GridCoords.Offset(new(1, 0));
+            var nearestDestinationCoords = map.GridCoords.Offset(new(80, 0));
+            var fartherEntranceCoords = map.GridCoords.Offset(new(4, 0));
+            var fartherDestinationCoords = map.GridCoords.Offset(new(100, 0));
+
+            nearestEntrance = SEntMan.SpawnAtPosition("PortalRed", nearestEntranceCoords);
+            nearestDestination = SEntMan.SpawnAtPosition("PortalBlue", nearestDestinationCoords);
+            nearestDestinationMarker = SEntMan.SpawnAtPosition("FoodDonkpocket", nearestDestinationCoords.Offset(new(1, 0)));
+
+            fartherEntrance = SEntMan.SpawnAtPosition("PortalRed", fartherEntranceCoords);
+            fartherDestination = SEntMan.SpawnAtPosition("PortalBlue", fartherDestinationCoords);
+            fartherDestinationMarker = SEntMan.SpawnAtPosition("FoodDonkpocket", fartherDestinationCoords.Offset(new(1, 0)));
+
+            var link = SEntMan.System<LinkedEntitySystem>();
+            link.TryLink(nearestEntrance, nearestDestination);
+            link.TryLink(fartherEntrance, fartherDestination);
+
+            SEntMan.System<SharedTransformSystem>().SetCoordinates(player, playerCoords);
+        });
+
+        await Pair.RunUntilSynced();
+
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(ServerSession!.ViewSubscriptions.Contains(nearestEntrance), Is.True, "Nearest entrance portal was not a view subscription.");
+            Assert.That(ServerSession.ViewSubscriptions.Contains(nearestDestination), Is.True, "Nearest linked portal was not a view subscription.");
+            Assert.That(ServerSession.ViewSubscriptions.Contains(fartherEntrance), Is.False, "Farther entrance portal should not be preloaded when the limit is 1.");
+            Assert.That(ServerSession.ViewSubscriptions.Contains(fartherDestination), Is.False, "Farther linked portal should not be preloaded when the limit is 1.");
+        });
+
+        var clientNearestDestination = Pair.ToClientUid(nearestDestination);
+        var clientNearestMarker = Pair.ToClientUid(nearestDestinationMarker);
+
+        await Client.WaitAssertion(() =>
+        {
+            Assert.That(CEntMan.EntityExists(clientNearestDestination), Is.True, "Nearest linked portal destination did not enter client PVS.");
+            Assert.That(CEntMan.EntityExists(clientNearestMarker), Is.True, "Entity near the nearest linked portal did not enter client PVS.");
+        });
+    }
+}

--- a/Content.Server/Teleportation/PortalSystem.cs
+++ b/Content.Server/Teleportation/PortalSystem.cs
@@ -168,7 +168,6 @@ public sealed partial class PortalSystem : SharedPortalSystem
         return views;
     }
 
-    // TODO Move to shared
     protected override void LogTeleport(EntityUid portal, EntityUid subject, EntityCoordinates source,
         EntityCoordinates target)
     {

--- a/Content.Server/Teleportation/PortalSystem.cs
+++ b/Content.Server/Teleportation/PortalSystem.cs
@@ -1,21 +1,178 @@
-﻿using Content.Shared.Administration.Logs;
+using Content.Shared.Administration.Logs;
+using Content.Shared.CCVar;
 using Content.Shared.Database;
 using Content.Shared.Ghost;
 using Content.Shared.Mind.Components;
+using Content.Shared.Teleportation.Components;
 using Content.Shared.Teleportation.Systems;
+using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Player;
 
 namespace Content.Server.Teleportation;
 
 public sealed partial class PortalSystem : SharedPortalSystem
 {
+    [Dependency] private IConfigurationManager _config = default!;
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private SharedViewSubscriberSystem _viewSubscriber = default!;
+
+    [Dependency] private EntityQuery<PortalComponent> _portalQuery = default!;
+    [Dependency] private EntityQuery<MindContainerComponent> _mindContainerQuery = default!;
+    [Dependency] private EntityQuery<GhostComponent> _ghostQuery = default!;
+
+    private readonly Dictionary<ICommonSession, HashSet<EntityUid>> _subscribedViews = new();
+    private readonly Dictionary<ICommonSession, HashSet<EntityUid>> _desiredViews = new();
+    private readonly List<(EntityUid Portal, LinkedEntityComponent Link, float Distance)> _candidatePortals = new();
+    private readonly List<ICommonSession> _sessionsToRemove = new();
+    private readonly List<EntityUid> _viewsToRemove = new();
+    private int _maxPreloadedPortals;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        Subs.CVar(_config, CCVars.PortalMaxPreloaded, value => _maxPreloadedPortals = Math.Max(0, value), true);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        UpdateLinkedViewSubscribers();
+    }
+
+    /// <summary>
+    /// Handles preloading entities through portals so there's less pop-in.
+    /// </summary>
+    private void UpdateLinkedViewSubscribers()
+    {
+        foreach (var desiredViews in _desiredViews.Values)
+        {
+            desiredViews.Clear();
+        }
+
+        if (_maxPreloadedPortals > 0)
+        {
+            var actorQuery = EntityQueryEnumerator<ActorComponent, TransformComponent>();
+            while (actorQuery.MoveNext(out var actorUid, out var actor, out var actorXform))
+            {
+                AddDesiredViewsForPlayer(actor.PlayerSession, actorUid, actorXform);
+            }
+        }
+
+        _sessionsToRemove.Clear();
+        foreach (var (session, subscribedViews) in _subscribedViews)
+        {
+            _desiredViews.TryGetValue(session, out var desiredViews);
+
+            _viewsToRemove.Clear();
+            foreach (var view in subscribedViews)
+            {
+                if (desiredViews?.Contains(view) == true)
+                    continue;
+
+                _viewsToRemove.Add(view);
+            }
+
+            foreach (var view in _viewsToRemove)
+            {
+                _viewSubscriber.RemoveViewSubscriber(view, session);
+                subscribedViews.Remove(view);
+            }
+
+            if (subscribedViews.Count == 0)
+                _sessionsToRemove.Add(session);
+        }
+
+        foreach (var session in _sessionsToRemove)
+            _subscribedViews.Remove(session);
+
+        foreach (var (session, desiredViews) in _desiredViews)
+        {
+            if (desiredViews.Count == 0)
+                continue;
+
+            var subscribedViews = GetSubscribedViews(session);
+
+            foreach (var view in desiredViews)
+            {
+                if (!subscribedViews.Add(view))
+                    continue;
+
+                _viewSubscriber.AddViewSubscriber(view, session);
+            }
+        }
+    }
+
+    private void AddDesiredViewsForPlayer(ICommonSession session, EntityUid player, TransformComponent playerXform)
+    {
+        _candidatePortals.Clear();
+        var playerCoords = _transform.GetMapCoordinates(player, playerXform);
+
+        var portalQuery = EntityQueryEnumerator<PortalComponent, LinkedEntityComponent, TransformComponent>();
+        while (portalQuery.MoveNext(out var portalUid, out var portal, out var link, out var portalXform))
+        {
+            if (portal.LinkedViewSubscriptionRange <= 0f || link.LinkedEntities.Count == 0)
+                continue;
+
+            var portalCoords = _transform.GetMapCoordinates(portalUid, portalXform);
+            if (portalCoords.MapId != playerCoords.MapId)
+                continue;
+
+            var distance = (portalCoords.Position - playerCoords.Position).Length();
+            if (distance > portal.LinkedViewSubscriptionRange)
+                continue;
+
+            _candidatePortals.Add((portalUid, link, distance));
+        }
+
+        if (_candidatePortals.Count == 0)
+            return;
+
+        _candidatePortals.Sort(static (a, b) => a.Distance.CompareTo(b.Distance));
+        var views = GetDesiredViews(session);
+
+        for (var i = 0; i < Math.Min(_maxPreloadedPortals, _candidatePortals.Count); i++)
+        {
+            var (portal, link, _) = _candidatePortals[i];
+            views.Add(portal);
+
+            foreach (var linked in link.LinkedEntities)
+            {
+                if (_portalQuery.HasComp(linked))
+                    views.Add(linked);
+            }
+        }
+    }
+
+    private HashSet<EntityUid> GetDesiredViews(ICommonSession session)
+    {
+        if (_desiredViews.TryGetValue(session, out var views))
+            return views;
+
+        views = new HashSet<EntityUid>();
+        _desiredViews.Add(session, views);
+        return views;
+    }
+
+    private HashSet<EntityUid> GetSubscribedViews(ICommonSession session)
+    {
+        if (_subscribedViews.TryGetValue(session, out var views))
+            return views;
+
+        views = new HashSet<EntityUid>();
+        _subscribedViews.Add(session, views);
+        return views;
+    }
 
     // TODO Move to shared
     protected override void LogTeleport(EntityUid portal, EntityUid subject, EntityCoordinates source,
         EntityCoordinates target)
     {
-        if (HasComp<MindContainerComponent>(subject) && !HasComp<GhostComponent>(subject))
+        if (_mindContainerQuery.HasComp(subject) && !_ghostQuery.HasComp(subject))
             _adminLogger.Add(LogType.Teleport, LogImpact.Low, $"{ToPrettyString(subject):player} teleported via {ToPrettyString(portal)} from {source} to {target}");
     }
 }

--- a/Content.Shared/CCVar/CCVars.Portal.cs
+++ b/Content.Shared/CCVar/CCVars.Portal.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    ///     Maximum number of nearby linked portals to preload per player.
+    ///     Each selected portal subscribes the player to both the portal and its linked portal views.
+    /// </summary>
+    public static readonly CVarDef<int> PortalMaxPreloaded =
+        CVarDef.Create("portal.max_preloaded", 2, CVar.SERVERONLY);
+}

--- a/Content.Shared/Teleportation/Components/PortalComponent.cs
+++ b/Content.Shared/Teleportation/Components/PortalComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Audio;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.Teleportation.Components;
@@ -53,4 +53,11 @@ public sealed partial class PortalComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
     public bool RandomTeleport = true;
+
+    /// <summary>
+    ///     Radius around this portal where players will subscribe to linked portal views.
+    ///     This lets the destination stream in before the player collides with the portal.
+    /// </summary>
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    public float LinkedViewSubscriptionRange = 5f;
 }

--- a/Content.Shared/Teleportation/Components/PortalComponent.cs
+++ b/Content.Shared/Teleportation/Components/PortalComponent.cs
@@ -1,4 +1,4 @@
-using Robust.Shared.Audio;
+﻿using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.Teleportation.Components;
@@ -58,6 +58,6 @@ public sealed partial class PortalComponent : Component
     ///     Radius around this portal where players will subscribe to linked portal views.
     ///     This lets the destination stream in before the player collides with the portal.
     /// </summary>
-    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField, AutoNetworkedField]
     public float LinkedViewSubscriptionRange = 5f;
 }


### PR DESCRIPTION
Gracias to ada for implementing portal prediction properly in the last PR. Now we use viewsubscribers to look into a portal and increase the chances of receiving it in time / reducing pop-in, with a sensible cap so the client doesn't die if there's many together.

Should be no breaking changes or anything of note for forks.

## Changelog
:cl:
- add: Portals will now preload when you get near them and have a higher chance of predicting the teleport.