### PR TITLE
Admin log silicon laws

### DIFF
--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -3,7 +3,9 @@ using Content.Server.Administration;
 using Content.Server.Chat.Managers;
 using Content.Server.Station.Systems;
 using Content.Shared.Administration;
+using Content.Shared.Administration.Logs;
 using Content.Shared.Chat;
+using Content.Shared.Database;
 using Content.Shared.Emag.Systems;
 using Content.Shared.GameTicking;
 using Content.Shared.Mind;
@@ -33,6 +35,7 @@ public sealed partial class SiliconLawSystem : SharedSiliconLawSystem
     [Dependency] private StationSystem _station = default!;
     [Dependency] private UserInterfaceSystem _userInterface = default!;
     [Dependency] private EmagSystem _emag = default!;
+    [Dependency] private ISharedAdminLogManager _adminLogger = default!;
 
     private static readonly ProtoId<SiliconLawsetPrototype> DefaultCrewLawset = "Crewsimov";
 
@@ -81,6 +84,8 @@ public sealed partial class SiliconLawSystem : SharedSiliconLawSystem
 
     private void OnLawProviderMindAdded(Entity<SiliconLawProviderComponent> ent, ref MindAddedMessage args)
     {
+        _adminLogger.Add(LogType.SiliconLaw, LogImpact.Low, $"{ent.Owner} laws at MindAdded are [{ent.Comp.Lawset?.LoggingString()}]");
+
         if (!ent.Comp.Subverted)
             return;
         EnsureSubvertedSiliconRole(args.Mind);
@@ -248,6 +253,10 @@ public sealed partial class SiliconLawSystem : SharedSiliconLawSystem
     public override void NotifyLawsChanged(EntityUid uid, SoundSpecifier? cue = null)
     {
         base.NotifyLawsChanged(uid, cue);
+
+        if (!TryComp<SiliconLawProviderComponent>(uid, out var lawProvider))
+            return;
+        _adminLogger.Add(LogType.SiliconLaw, LogImpact.Low, $"{uid} laws changed to [{lawProvider.Lawset?.LoggingString()}]");
 
         if (!TryComp<ActorComponent>(uid, out var actor))
             return;

--- a/Content.Shared.Database/LogType.cs
+++ b/Content.Shared.Database/LogType.cs
@@ -483,4 +483,9 @@ public enum LogType
     /// Events related to players connecting/disconnecting.
     /// </summary>
     Connection = 104,
+
+    /// <summary>
+    /// Silicon law changes.
+    /// </summary>
+    SiliconLaw = 105,
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
When a mind is added to a LawProvider, the current laws get admin logged. When laws are changed (and a mind is present, so NotifyLawsChanged gets called (I would hope)), the new laws are logged.

## Why / Balance
Why wasn't this already a thing?

## Technical details
It's a pretty basic pr. I also added SiliconLaw LogType so you can filter out IonStorm spamming the logs if there are a bunch of borgs.

## It works I think
Take control of borg, ion storm, look at admin logs.
<img width="1092" height="354" alt="image" src="https://github.com/user-attachments/assets/e5798a6d-025d-4a94-ba57-e6e965daa318" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

## Changelog
:cl:
- add: Silicon laws are now admin logged.