### PR TITLE
Construction Cache Reload

### DIFF
--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -45,6 +45,7 @@ namespace Content.Client.Construction
             WarmupRecipesCache();
 
             UpdatesOutsidePrediction = true;
+            SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypeReload);
             SubscribeLocalEvent<LocalPlayerAttachedEvent>(HandlePlayerAttached);
             SubscribeNetworkEvent<AckStructureConstructionMessage>(HandleAckStructure);
             SubscribeNetworkEvent<ResponseConstructionGuide>(OnConstructionGuideReceived);
@@ -76,8 +77,16 @@ namespace Content.Client.Construction
             return false;
         }
 
+        private void OnPrototypeReload(PrototypesReloadedEventArgs obj)
+        {
+            if (obj.WasModified<ConstructionPrototype>())
+                WarmupRecipesCache();
+        }
+
         private void WarmupRecipesCache()
         {
+            _recipesMetadataCache.Clear();
+
             foreach (var constructionProto in PrototypeManager.EnumeratePrototypes<ConstructionPrototype>())
             {
                 if (!PrototypeManager.Resolve(constructionProto.Graph, out var graphProto))


### PR DESCRIPTION
## About the PR
Adds client-side cache invalidation for construction recipes when construction prototypes are reloaded. Previously, after a prototype reload (e.g., admin changes or hotfixes), the client's construction menu would continue showing stale data until a full game restart or rejoin. Now the cache is rebuilt automatically.

## Why / Balance
This improves developer and admin quality of life during live testing and hotfixes. When construction prototypes are updated on the fly, clients will immediately see the changes without needing to reconnect. This is particularly useful for debugging construction graphs or applying urgent fixes on live servers.

## Technical details
Subscribes to `PrototypesReloadedEventArgs` in `ConstructionSystem` (client-side) and checks if any `ConstructionPrototype` was modified. If so, calls `WarmupRecipesCache()` to rebuild the internal `_recipesMetadataCache` dictionary using the updated prototype data.

#### Testing:
1. Use `loadprototypes` in admin console.
2. Open the construction menu.
3. Verify that the constructions updates instantly without rejoining.
4. Confirm no errors appear in client logs.

## Media
No media required - no visual changes.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

## Changelog
:cl:
ADMIN:
- fix: Construction menu now updates immediately after reloading construction prototypes.