### PR TITLE
Remove instances of the broken Caution style class

### DIFF
--- a/Content.Client/Holopad/HolopadWindow.xaml.cs
+++ b/Content.Client/Holopad/HolopadWindow.xaml.cs
@@ -1,4 +1,5 @@
 using Content.Client.Popups;
+using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Controls;
 using Content.Shared.Access.Systems;
 using Content.Shared.Holopad;
@@ -61,8 +62,8 @@ public sealed partial class HolopadWindow : FancyWindow
 
         // XML formatting
         AnswerCallButton.AddStyleClass("ButtonAccept");
-        EndCallButton.AddStyleClass("Caution");
-        StartBroadcastButton.AddStyleClass("Caution");
+        EndCallButton.AddStyleClass(StyleClass.Negative);
+        StartBroadcastButton.AddStyleClass(StyleClass.Negative);
 
         HolopadContactListPanel.PanelOverride = new StyleBoxFlat
         {

--- a/Content.Client/Lathe/UI/LatheMenu.xaml
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml
@@ -120,7 +120,7 @@
                             HorizontalAlignment="Right"
                             ToolTip="{Loc 'lathe-menu-delete-fabricating-tooltip'}">
                             <Button.StyleClasses>
-                                <system:String>Caution</system:String>
+                                <system:String>negative</system:String>
                                 <system:String>OpenLeft</system:String>
                             </Button.StyleClasses>
                         </Button>

--- a/Content.Client/Lathe/UI/QueuedRecipeControl.xaml
+++ b/Content.Client/Lathe/UI/QueuedRecipeControl.xaml
@@ -27,7 +27,7 @@
             Text="✖"
             ToolTip="{Loc 'lathe-menu-delete-item-tooltip'}">
             <Button.StyleClasses>
-                <system:String>Caution</system:String>
+                <system:String>negative</system:String>
                 <system:String>OpenLeft</system:String>
             </Button.StyleClasses>
         </Button>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Removes any instances of the broken Caution button class.  Affects the holopad and lathe UI.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Buttons that were once red are now no longer red since the introduction of stylesheets.

Do you remember when these buttons were red?  I remember.

## Technical details
<!-- Summary of code changes for easier review. -->

Search and replace ops.

Constant used for C# instances.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Spawn and open holopad.  Emergency broadcast button should be red.
2. Spawn another holopad.  Call it from the open one.  The End Call button should be red.
3. Spawn an autolathe and a bunch of steel.  Insert the steel into the lathe and open the UI.
4. Start printing a big batch of objects.  Both X buttons on the right should be red.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before fix:
<img width="682" height="458" alt="image" src="https://github.com/user-attachments/assets/cdadacc6-e8b5-437f-a728-8ae98478e5f9" />
<img width="360" height="492" alt="image" src="https://github.com/user-attachments/assets/b92cf6a7-4571-4113-ad52-48f188b189ca" />
(Did not get a picture of the end call button, but it is also blue)

After fix:
<img width="681" height="458" alt="image" src="https://github.com/user-attachments/assets/c11c49cc-82ea-4368-bf23-84a76e7c3527" />
<img width="723" height="488" alt="image" src="https://github.com/user-attachments/assets/8119e671-67a5-4fbf-9ced-eb16b844672e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Negligible fix, no real game impact.