### PR TITLE
Fix shuttle console distance printouts

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -218,14 +218,14 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
             {
                 var gridBounds = grid.Comp.LocalAABB;
 
+                // Display the coordinates of the center of the grid and its distance from the console.
                 var gridCentre = Vector2.Transform(gridBody.LocalCenter, curGridToView);
+                var gridCenterMapCoords = _transform.ToMapCoordinates(new EntityCoordinates(gUid, gridBody.LocalCenter)).Position;
 
-                var gridDistance = (gridBody.LocalCenter - xform.LocalPosition).Length();
+                var gridDistance = (gridCenterMapCoords - mapPos.Position).Length();
                 var labelText = Loc.GetString("shuttle-console-iff-label", ("name", labelName),
                     ("distance", $"{gridDistance:0.0}"));
-
-                var mapCoords = _transform.GetWorldPosition(gUid);
-                var coordsText = $"({mapCoords.X:0.0}, {mapCoords.Y:0.0})";
+                var coordsText = $"({gridCenterMapCoords.X:0.0}, {gridCenterMapCoords.Y:0.0})";
 
                 // yes 1.0 scale is intended here.
                 var labelDimensions = handle.GetDimensions(Font, labelText, 1f);

--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -220,12 +220,12 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
 
                 // Display the coordinates of the center of the grid and its distance from the console.
                 var gridCentre = Vector2.Transform(gridBody.LocalCenter, curGridToView);
-                var gridCenterMapCoords = _transform.ToMapCoordinates(new EntityCoordinates(gUid, gridBody.LocalCenter)).Position;
+                var gridCenterMapPos = _transform.ToWorldPosition(new EntityCoordinates(gUid, gridBody.LocalCenter));
 
-                var gridDistance = (gridCenterMapCoords - mapPos.Position).Length();
+                var gridDistance = (gridCenterMapPos - mapPos.Position).Length();
                 var labelText = Loc.GetString("shuttle-console-iff-label", ("name", labelName),
                     ("distance", $"{gridDistance:0.0}"));
-                var coordsText = $"({gridCenterMapCoords.X:0.0}, {gridCenterMapCoords.Y:0.0})";
+                var coordsText = $"({gridCenterMapPos.X:0.0}, {gridCenterMapPos.Y:0.0})";
 
                 // yes 1.0 scale is intended here.
                 var labelDimensions = handle.GetDimensions(Font, labelText, 1f);


### PR DESCRIPTION
## About the PR

Fixes the distance printed out when using the shuttle console.

## Why / Balance

The distances make no sense as-is - they're effectively relative to the origin for small grids since PhysicsComponent.LocalCenter is in local coordinates, and thus relatively _tiny_.

## Technical details

Little math rejig - converts the center of the target grid into world coords, and uses the previously calculated console world coordinates to get the distance.  Because the distance _is_ to the center, distance to large objects (e.g. VGroids) will still be large when touching them.

## Test plan

1. Hop on a shuttle console.
2. Drive around some grids, see the numbers make sense.
3. Use the cargo shuttle console(?)
4. Drive around some grids, see the numbers make sense - the distance is to the shuttle, not the actual console you are using.

## Media

Before: a geographical oddity, 250 m from everywhere.
<img width="1282" height="759" alt="image" src="https://github.com/user-attachments/assets/5906abba-5c54-4761-ac33-9df90d9205ca" />

After: sensible, sane, predictable
<img width="1282" height="766" alt="image" src="https://github.com/user-attachments/assets/e0c34241-4f1c-4ac3-bf5c-f5311f807e3e" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
Could add a changelog to this, though it's fairly simple.