### PR TITLE
Fix SmartFridge bug where it appears empty, even when it's not

### DIFF
--- a/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
+++ b/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
@@ -81,7 +81,7 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
 
     private void OnItemInserted(Entity<SmartFridgeComponent> ent, ref EntInsertedIntoContainerMessage args)
     {
-        if (args.Container.ID != ent.Comp.Container || _timing.ApplyingState)
+        if (args.Container.ID != ent.Comp.Container)
             return;
 
         var key = new SmartFridgeEntry(Identity.Name(args.Entity, EntityManager));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This is an attempt to fix the problem in issue #44247. It fixes a bug where the smart fridge UI shows the smart fridge has 0 items, even when items are inside.

## Why / Balance
This bug makes it seem like all the items in a Smart Fridge were deleted, which is confusing. Fixing it should improve Smart Fridge UX.

## Technical details
This seems to be an issue on the client-side. When the SmartFridge leaves the PVS (Potential Visible Set), the items get deleted by `SharedSmartFridgeSystem#OnItemRemoved`. However, when it goes back into the PVS, the items don't get re-added due to a timing check in `SharedSmartFridgeSystem#OnItemInserted`.

I removed the check. **This is a draft PR because I am not sure this was a good idea!** It seems to work in-game, but I would appreciate if someone more experienced could look.

## Test plan
You can test this manually with the following procedure:
1. Go into the sandbox.
2. Place down a SmartFridge.
3. Place items inside.
4. Walk far enough away that the SmartFridge leaves the PVS (Potential Visible Set).
5. Return and open the SmartFridge to see what's inside.

## Media
Demonstration of the bug (before):

https://github.com/user-attachments/assets/eea5be3e-db6f-4d90-83ce-d8b9b0916e78

Demonstration of the fixed SmartFridge (after):

https://github.com/user-attachments/assets/4d31bc9d-f361-472b-ab54-f2bfa51535f9


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- fix: Fixed a bug where the SmartFridge UI would show the SmartFridge as empty, even when it was not.
