### PR TITLE
itemIconStyle: BigAction, added to the three purchasable revenant act…

### DIFF
--- a/Resources/Prototypes/Actions/revenant.yml
+++ b/Resources/Prototypes/Actions/revenant.yml
@@ -13,6 +13,7 @@
   - type: Action
     useDelay: 15
     icon: Interface/Actions/defile.png
+    itemIconStyle: BigAction
   - type: InstantAction
     event: !type:RevenantDefileActionEvent
 
@@ -25,6 +26,7 @@
   - type: Action
     icon: Interface/Actions/overloadlight.png
     useDelay: 20
+    itemIconStyle: BigAction
   - type: InstantAction
     event: !type:RevenantOverloadLightsActionEvent
 
@@ -49,5 +51,6 @@
   - type: Action
     icon: Interface/Actions/malfunction.png
     useDelay: 20
+    itemIconStyle: BigAction
   - type: InstantAction
     event: !type:RevenantMalfunctionActionEvent


### PR DESCRIPTION
## About the PR
Adds `itemIconStyle: BigAction` to the three purchasable revenant actions (Defile, Overload Lights, Malfunction) in `Resources/Prototypes/Actions/revenant.yml`. This makes their icons fill the action button instead of rendering small in the corner.

## Why / Balance
So the revenant store listings in `revenant_catalog.yml` set `productAction` without `applyToMob`, so `StoreSystem` adds the purchased action to the mind entity rather than the mob. Because that container is a different entity from the player's body, `EntityIcon` ends up non-null. When `EntityIcon` is set and the style is left at the default `ItemIconStyle.BigItem`, the button shrinks the action icon into the corner instead of filling the box.

In this case, setting `BigAction` renders the action icon large and any item icon small, which is the layout these buttons should have. This fixes #44054.

## Technical details
One added line per action: `itemIconStyle: BigAction` on the Defile, Overload Lights, and Malfunction prototypes in `Resources/Prototypes/Actions/revenant.yml`. No code changes.

This is the conservative, UI-only fix: it corrects the rendering while leaving the actions on the mind entity. An alternative would be setting `applyToMob: true` on the catalog listings to move the actions onto the mob, but that changes behavior beyond the visual bug, so I kept the change scoped to the icon style.

## Test plan
1. Start a round and become a revenant.
2. Open the revenant shop and buy Defile, Overload Lights, and Malfunction.
3. Check that each purchased action's icon now fills its button instead of sitting small in the corner.

## Media
**Before**
<img width="248" height="120" alt="image" src="https://github.com/user-attachments/assets/161fa620-3404-413f-9fef-396e785ea5f4" />

**After:**
<img width="154" height="356" alt="image" src="https://github.com/user-attachments/assets/ac0df64d-eaa1-4959-9229-123de8fcd425" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

## Changelog
:cl:
- fix: Revenant ability icons now fill their action buttons.