### PR TITLE
voice activate lathes, kinda

### DIFF
--- a/Content.IntegrationTests/Tests/Lathe/VoiceCommandRecipeAmbiguityTest.cs
+++ b/Content.IntegrationTests/Tests/Lathe/VoiceCommandRecipeAmbiguityTest.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.IntegrationTests.Fixtures;
+using Content.Shared.Lathe;
+using Content.Shared.Prototypes;
+using Content.Shared.Trigger;
+using Content.Shared.Trigger.Components.Triggers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Lathe;
+
+[TestFixture]
+public sealed class VoiceCommandRecipeAmbiguityTest : GameTest
+{
+    [Test]
+    public void LocalizedQuantityWordsMatchTest()
+    {
+        var locMan = Pair.Server.ResolveDependency<ILocalizationManager>();
+        var digits = VoiceCommandMatcher.BuildSpokenDigits(id => locMan.GetString(id));
+        var five = digits.FirstOrDefault(kvp => kvp.Value == 5).Key;
+        Assert.That(five, Is.Not.Empty, "Localized quantity words must include a word for 5.");
+
+        var triggers = new Dictionary<string, string>
+        {
+            ["popcorn"] = "FoodPopcorn",
+        };
+        var comp = new VoiceCommandsComponent
+        {
+            Triggers = triggers,
+            Candidates = VoiceCommandMatcher.BuildVoiceCommandCandidates(triggers),
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(VoiceCommandMatcher.TryMatchVoiceCommand(comp, $"{five} popcorn", digits, out var tag, out var quantity), Is.True);
+            Assert.That(tag, Is.EqualTo("FoodPopcorn"));
+            Assert.That(quantity, Is.EqualTo(5));
+
+            Assert.That(VoiceCommandMatcher.TryMatchVoiceCommand(comp, $"{five}, popcorn", digits, out tag, out quantity), Is.True);
+            Assert.That(tag, Is.EqualTo("FoodPopcorn"));
+            Assert.That(quantity, Is.EqualTo(5));
+        });
+    }
+
+    // Every recipe a voice lathe registers should resolve back to itself.
+    [Test]
+    public async Task RecipeNamesSelfResolveTest()
+    {
+        var locMan = Server.ResolveDependency<ILocalizationManager>();
+        var latheSystem = Server.System<SharedLatheSystem>();
+        var digits = VoiceCommandMatcher.BuildSpokenDigits(id => locMan.GetString(id));
+
+        var map = await Pair.CreateTestMap();
+
+        var voiceLatheProtos = SProtoMan.EnumeratePrototypes<EntityPrototype>()
+            .Where(p => !p.Abstract)
+            .Where(p => !Pair.IsTestPrototype(p))
+            .Where(p => p.HasComponent<LatheComponent>() && p.HasComponent<VoiceCommandsComponent>())
+            .ToList();
+
+        Assert.That(voiceLatheProtos, Is.Not.Empty, "No voice-command lathe prototypes found to test.");
+
+        // Spawn each lathe via the tracked helper; mutation runs on the server thread and cleans up after.
+        var lathes = new List<(string Id, EntityUid Uid)>();
+        foreach (var proto in voiceLatheProtos)
+            lathes.Add((proto.ID, await SpawnAtPosition(proto.ID, map.GridCoords)));
+
+        var failures = new List<string>();
+
+        foreach (var (id, uid) in lathes)
+        {
+            // Candidates come from the provider path on MapInit.
+            var comp = SComp<VoiceCommandsComponent>(uid);
+            if (comp.Candidates.Count == 0)
+                failures.Add($"{id}: voice lathe contributes no recipe triggers");
+            else
+                CheckLathe(id, latheSystem, comp, digits, failures);
+        }
+
+        Assert.That(failures, Is.Empty, $"{failures.Count} voice recipe command failure(s):\n{string.Join('\n', failures)}");
+    }
+
+    private static void CheckLathe(string latheId, SharedLatheSystem latheSystem, VoiceCommandsComponent comp, IReadOnlyDictionary<string, int> digits, List<string> failures)
+    {
+        foreach (var candidate in comp.Candidates)
+        {
+            // The registered phrase is the recipe's display name.
+            var phrase = latheSystem.GetRecipeName(candidate.Tag).Trim();
+            if (!VoiceCommandMatcher.TryMatchVoiceCommand(comp, phrase, digits, out var got, out _))
+                failures.Add($"{latheId}: \"{phrase}\" ({candidate.Tag}) matched nothing");
+            else if (got != candidate.Tag)
+                failures.Add($"{latheId}: \"{phrase}\" ({candidate.Tag}) cross-matched {got} (\"{latheSystem.GetRecipeName(got).Trim()}\")");
+        }
+    }
+}

--- a/Content.IntegrationTests/Tests/Lathe/VoiceCommandRecipeAmbiguityTest.cs
+++ b/Content.IntegrationTests/Tests/Lathe/VoiceCommandRecipeAmbiguityTest.cs
@@ -54,30 +54,40 @@ public sealed class VoiceCommandRecipeAmbiguityTest : GameTest
 
         var map = await Pair.CreateTestMap();
 
-        var voiceLatheProtos = SProtoMan.EnumeratePrototypes<EntityPrototype>()
-            .Where(p => !p.Abstract)
-            .Where(p => !Pair.IsTestPrototype(p))
-            .Where(p => p.HasComponent<LatheComponent>() && p.HasComponent<VoiceCommandsComponent>())
-            .ToList();
+        // HasComponent resolves the component factory via IoC, so enumerate on the server thread.
+        var latheIds = new List<string>();
+        await Server.WaitPost(() =>
+        {
+            latheIds = SProtoMan.EnumeratePrototypes<EntityPrototype>()
+                .Where(p => !p.Abstract)
+                .Where(p => !Pair.IsTestPrototype(p))
+                .Where(p => p.HasComponent<LatheComponent>() && p.HasComponent<VoiceCommandsComponent>())
+                .Select(p => p.ID)
+                .ToList();
+        });
 
-        Assert.That(voiceLatheProtos, Is.Not.Empty, "No voice-command lathe prototypes found to test.");
+        Assert.That(latheIds, Is.Not.Empty, "No voice-command lathe prototypes found to test.");
 
         // Spawn each lathe via the tracked helper; mutation runs on the server thread and cleans up after.
         var lathes = new List<(string Id, EntityUid Uid)>();
-        foreach (var proto in voiceLatheProtos)
-            lathes.Add((proto.ID, await SpawnAtPosition(proto.ID, map.GridCoords)));
+        foreach (var id in latheIds)
+            lathes.Add((id, await SpawnAtPosition(id, map.GridCoords)));
 
         var failures = new List<string>();
 
-        foreach (var (id, uid) in lathes)
+        // Reads only; recipe-name resolution needs the server thread's IoC context.
+        await Server.WaitAssertion(() =>
         {
-            // Candidates come from the provider path on MapInit.
-            var comp = SComp<VoiceCommandsComponent>(uid);
-            if (comp.Candidates.Count == 0)
-                failures.Add($"{id}: voice lathe contributes no recipe triggers");
-            else
-                CheckLathe(id, latheSystem, comp, digits, failures);
-        }
+            foreach (var (id, uid) in lathes)
+            {
+                // Candidates come from the provider path on MapInit.
+                var comp = SComp<VoiceCommandsComponent>(uid);
+                if (comp.Candidates.Count == 0)
+                    failures.Add($"{id}: voice lathe contributes no recipe triggers");
+                else
+                    CheckLathe(id, latheSystem, comp, digits, failures);
+            }
+        });
 
         Assert.That(failures, Is.Empty, $"{failures.Count} voice recipe command failure(s):\n{string.Join('\n', failures)}");
     }

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -10,6 +10,9 @@ using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Radio.EntitySystems;
 using Content.Server.Stack;
+using Content.Shared.Trigger;
+using Content.Shared.Trigger.Components.Triggers;
+using Content.Shared.Trigger.Systems;
 using Content.Shared.Atmos;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
@@ -56,11 +59,16 @@ namespace Content.Server.Lathe
         [Dependency] private StackSystem _stack = default!;
         [Dependency] private TransformSystem _transform = default!;
         [Dependency] private RadioSystem _radio = default!;
+        [Dependency] private TriggerSystem _trigger = default!;
 
         /// <summary>
         /// Per-tick cache
         /// </summary>
         private readonly List<GasMixture> _environments = new();
+
+        // EmaggedComponent is added after GotEmaggedEvent fires, so emag recipes aren't visible yet
+        // during OnLatheEmagged; defer the voice-trigger rebuild to Update so it sees them.
+        private readonly HashSet<EntityUid> _voiceRebuilds = new();
 
         public override void Initialize()
         {
@@ -83,9 +91,16 @@ namespace Content.Server.Lathe
             SubscribeLocalEvent<TechnologyDatabaseComponent, LatheGetRecipesEvent>(OnGetRecipes);
             SubscribeLocalEvent<EmagLatheRecipesComponent, LatheGetRecipesEvent>(GetEmagLatheRecipes);
             SubscribeLocalEvent<LatheHeatProducingComponent, LatheStartPrintingEvent>(OnHeatStartPrinting);
+            SubscribeLocalEvent<LatheComponent, VoiceCommandMatchedEvent>(OnLatheVoiceCommand);
+            SubscribeLocalEvent<LatheComponent, VoiceCommandsGetTriggersEvent>(OnLatheGetVoiceTriggers);
+            SubscribeLocalEvent<LatheComponent, GotEmaggedEvent>(OnLatheEmagged);
         }
         public override void Update(float frameTime)
         {
+            foreach (var uid in _voiceRebuilds)
+                RefreshVoiceTriggers(uid);
+            _voiceRebuilds.Clear();
+
             var query = EntityQueryEnumerator<LatheProducingComponent, LatheComponent>();
             while (query.MoveNext(out var uid, out var comp, out var lathe))
             {
@@ -368,6 +383,14 @@ namespace Content.Server.Lathe
         private void OnDatabaseModified(EntityUid uid, LatheComponent component, ref TechnologyDatabaseModifiedEvent args)
         {
             UpdateUserInterfaceState(uid, component);
+            RefreshVoiceTriggers(uid);
+        }
+
+        private void RefreshVoiceTriggers(EntityUid uid)
+        {
+            if (!TryComp<VoiceCommandsComponent>(uid, out var voice))
+                return;
+            _trigger.RebuildVoiceCommandLookup((uid, voice));
         }
 
         private void OnTechnologyDatabaseModified(Entity<LatheAnnouncingComponent> ent, ref TechnologyDatabaseModifiedEvent args)
@@ -415,6 +438,7 @@ namespace Content.Server.Lathe
         private void OnResearchRegistrationChanged(EntityUid uid, LatheComponent component, ref ResearchRegistrationChangedEvent args)
         {
             UpdateUserInterfaceState(uid, component);
+            RefreshVoiceTriggers(uid);
         }
 
         protected override bool HasRecipe(EntityUid uid, LatheRecipePrototype recipe, LatheComponent component)
@@ -603,6 +627,51 @@ namespace Content.Server.Lathe
             component.CurrentRecipe = null;
             FinishProducing(uid, component);
         }
+        #endregion
+
+        #region Voice Activated Lathes
+
+        private void OnLatheEmagged(Entity<LatheComponent> ent, ref GotEmaggedEvent args)
+        {
+            _voiceRebuilds.Add(ent.Owner);
+        }
+
+        private void OnLatheGetVoiceTriggers(Entity<LatheComponent> ent, ref VoiceCommandsGetTriggersEvent args)
+        {
+            foreach (var recipeId in GetAvailableRecipes(ent, ent.Comp))
+            {
+                if (!_proto.TryIndex(recipeId, out var recipe))
+                    continue;
+                var phrase = GetRecipeName(recipe).Trim();
+                if (string.IsNullOrEmpty(phrase))
+                    continue;
+                if (!args.Triggers.TryAdd(phrase, recipe.ID))
+                    Log.Warning($"Lathe {ToPrettyString(ent)} voice trigger '{phrase}' already taken by '{args.Triggers[phrase]}'; skipped '{recipe.ID}'.");
+            }
+        }
+
+        private void OnLatheVoiceCommand(Entity<LatheComponent> ent, ref VoiceCommandMatchedEvent args)
+        {
+            if (!this.IsPowered(ent, EntityManager))
+                return;
+
+            if (!_proto.TryIndex<LatheRecipePrototype>(args.Tag, out var recipe)
+                || !GetAvailableRecipes(ent, ent.Comp).Contains(recipe.ID))
+            {
+                _popup.PopupEntity(Loc.GetString("lathe-voice-recipe-not-found"), ent, args.Source);
+                return;
+            }
+
+            var name = GetRecipeName(recipe);
+
+            if (!TryAddToQueue(ent, recipe, args.Quantity, ent.Comp))
+                return;
+
+            _popup.PopupEntity(Loc.GetString("lathe-voice-fabricating", ("item", name)), ent, args.Source);
+            TryStartProducing(ent, ent.Comp);
+            UpdateUserInterfaceState(ent, ent.Comp);
+        }
+
         #endregion
     }
 }

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -667,6 +667,10 @@ namespace Content.Server.Lathe
             if (!TryAddToQueue(ent, recipe, args.Quantity, ent.Comp))
                 return;
 
+            _adminLogger.Add(LogType.Action,
+                LogImpact.Low,
+                $"{ToPrettyString(args.Source):player} voice-queued {args.Quantity} {name} at {ToPrettyString(ent):lathe}");
+
             _popup.PopupEntity(Loc.GetString("lathe-voice-fabricating", ("item", name)), ent, args.Source);
             TryStartProducing(ent, ent.Comp);
             UpdateUserInterfaceState(ent, ent.Comp);

--- a/Content.Shared/Trigger/Components/Triggers/TriggerOnVoiceComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/TriggerOnVoiceComponent.cs
@@ -34,6 +34,24 @@ public sealed partial class TriggerOnVoiceComponent : BaseTriggerOnXComponent
     public int ListenRange = 4;
 
     /// <summary>
+    /// Match the keyphrase approximately so accents and stutters still trigger it.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool FuzzyMatch;
+
+    /// <summary>
+    /// Minimum trigram overlap score required for a fuzzy keyphrase match.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float FuzzyMatchThreshold = 0.5f;
+
+    /// <summary>
+    /// Cached trigram form of <see cref="KeyPhrase"/> for fuzzy matching.
+    /// </summary>
+    [ViewVariables]
+    public List<VoiceCommandCandidate> KeyPhraseCandidates = new();
+
+    /// <summary>
     /// Whether we are currently recording a new keyphrase.
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Trigger/Components/Triggers/VoiceCommandCandidate.cs
+++ b/Content.Shared/Trigger/Components/Triggers/VoiceCommandCandidate.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// A voice trigger's tag and its precomputed trigrams.
+/// </summary>
+public sealed class VoiceCommandCandidate
+{
+    public string Tag = string.Empty;
+
+    public HashSet<string> Trigrams = new();
+}

--- a/Content.Shared/Trigger/Components/Triggers/VoiceCommandsComponent.cs
+++ b/Content.Shared/Trigger/Components/Triggers/VoiceCommandsComponent.cs
@@ -1,0 +1,22 @@
+namespace Content.Shared.Trigger.Components.Triggers;
+
+/// <summary>
+/// Fuzzy-matches heard phrases against registered triggers and raises <see cref="VoiceCommandMatchedEvent"/>.
+/// Requires <see cref="TriggerOnVoiceComponent"/>.
+/// </summary>
+// Not networked; only read server-side during ListenEvent.
+[RegisterComponent]
+public sealed partial class VoiceCommandsComponent : Component
+{
+    /// <summary>Spoken phrase to tag.</summary>
+    [DataField]
+    public Dictionary<string, string> Triggers = new();
+
+    /// <summary>Trigram overlap threshold in [0, 1]. Lower is more permissive.</summary>
+    [DataField]
+    public float MatchThreshold = 0.5f;
+
+    /// <summary>Matchable form of every trigger.</summary>
+    [ViewVariables]
+    public List<VoiceCommandCandidate> Candidates = new();
+}

--- a/Content.Shared/Trigger/Systems/TriggerSystem.Voice.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.Voice.cs
@@ -25,6 +25,7 @@ public sealed partial class TriggerSystem
             Dirty(ent);
         }
 
+        RebuildKeyPhraseCandidate(ent.Comp);
         UpdateListening(ent);
     }
 
@@ -57,7 +58,7 @@ public sealed partial class TriggerSystem
                 return;
 
             if (message.Length >= component.MinLength && message.Length <= component.MaxLength)
-                FinishRecording(ent, args.Source, args.Message);
+                FinishRecording(ent, args.Source, message);
             else if (message.Length > component.MaxLength)
                 _popup.PopupEntity(Loc.GetString("trigger-on-voice-record-failed-too-long"), ent);
             else if (message.Length < component.MinLength)
@@ -66,16 +67,29 @@ public sealed partial class TriggerSystem
             return;
         }
 
-        if (!string.IsNullOrWhiteSpace(component.KeyPhrase) && message.IndexOf(component.KeyPhrase, StringComparison.InvariantCultureIgnoreCase) is var index and >= 0)
+        if (string.IsNullOrWhiteSpace(component.KeyPhrase))
+            return;
+
+        if (!VoiceCommandMatcher.TryExtractKeyphrase(message, component.KeyPhrase, component.KeyPhraseCandidates, component.FuzzyMatch, component.FuzzyMatchThreshold, out var messageWithoutPhrase))
+            return;
+
+        // VoiceCommands handles its own dispatch; plain triggers use the keyed path.
+        if (!HasComp<VoiceCommandsComponent>(ent))
         {
             _adminLogger.Add(LogType.Trigger, LogImpact.Medium,
-                    $"A voice-trigger on {ToPrettyString(ent):entity} was triggered by {ToPrettyString(args.Source):speaker} speaking the key-phrase {component.KeyPhrase}.");
+                $"A voice-trigger on {ToPrettyString(ent):entity} was triggered by {ToPrettyString(args.Source):speaker} speaking the key-phrase {component.KeyPhrase}.");
             Trigger(ent, args.Source, ent.Comp.KeyOut);
-
-            var messageWithoutPhrase = message.Remove(index, component.KeyPhrase.Length).Trim();
-            var voice = new VoiceTriggeredEvent(args.Source, message, messageWithoutPhrase);
-            RaiseLocalEvent(ent, ref voice);
         }
+
+        var voice = new VoiceTriggeredEvent(args.Source, message, messageWithoutPhrase);
+        RaiseLocalEvent(ent, ref voice);
+    }
+
+    private static void RebuildKeyPhraseCandidate(TriggerOnVoiceComponent comp)
+    {
+        comp.KeyPhraseCandidates = string.IsNullOrWhiteSpace(comp.KeyPhrase)
+            ? new()
+            : VoiceCommandMatcher.BuildVoiceCommandCandidates(new Dictionary<string, string> { [comp.KeyPhrase] = string.Empty });
     }
 
     private void OnVoiceGetAltVerbs(Entity<TriggerOnVoiceComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
@@ -173,6 +187,7 @@ public sealed partial class TriggerSystem
         ent.Comp.KeyPhrase = message;
         ent.Comp.IsRecording = false;
         Dirty(ent);
+        RebuildKeyPhraseCandidate(ent.Comp);
 
         _adminLogger.Add(LogType.Trigger, LogImpact.Low,
                 $"A voice-trigger on {ToPrettyString(ent):entity} has recorded a new keyphrase: '{ent.Comp.KeyPhrase}'. Recorded from {ToPrettyString(source):speaker}");
@@ -188,6 +203,7 @@ public sealed partial class TriggerSystem
         ent.Comp.KeyPhrase = null;
         ent.Comp.IsRecording = false;
         Dirty(ent);
+        RebuildKeyPhraseCandidate(ent.Comp);
         RemComp<ActiveListenerComponent>(ent);
     }
 
@@ -202,6 +218,7 @@ public sealed partial class TriggerSystem
         ent.Comp.KeyPhrase = Loc.GetString(ent.Comp.DefaultKeyPhrase);
         ent.Comp.IsRecording = false;
         Dirty(ent);
+        RebuildKeyPhraseCandidate(ent.Comp);
         UpdateListening(ent);
 
         _adminLogger.Add(LogType.Trigger, LogImpact.Low,

--- a/Content.Shared/Trigger/Systems/TriggerSystem.VoiceCommands.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.VoiceCommands.cs
@@ -1,0 +1,51 @@
+using Content.Shared.Database;
+using Content.Shared.Trigger.Components.Triggers;
+
+namespace Content.Shared.Trigger.Systems;
+
+public sealed partial class TriggerSystem
+{
+    private Dictionary<string, int>? _spokenDigits;
+
+    private void InitializeVoiceCommands()
+    {
+        SubscribeLocalEvent<VoiceCommandsComponent, MapInitEvent>(OnVoiceCommandsMapInit);
+        SubscribeLocalEvent<VoiceCommandsComponent, VoiceTriggeredEvent>(OnVoiceCommandsHeard);
+    }
+
+    private void OnVoiceCommandsMapInit(Entity<VoiceCommandsComponent> ent, ref MapInitEvent args)
+    {
+        RebuildVoiceCommandLookup(ent);
+    }
+
+    public void RebuildVoiceCommandLookup(Entity<VoiceCommandsComponent> ent)
+    {
+        var getEv = new VoiceCommandsGetTriggersEvent();
+        RaiseLocalEvent(ent, ref getEv);
+        foreach (var (phrase, tag) in ent.Comp.Triggers)
+            getEv.Triggers[phrase] = tag;
+
+        ent.Comp.Candidates = VoiceCommandMatcher.BuildVoiceCommandCandidates(getEv.Triggers);
+    }
+
+    private void OnVoiceCommandsHeard(Entity<VoiceCommandsComponent> ent, ref VoiceTriggeredEvent args)
+    {
+        if (string.IsNullOrWhiteSpace(args.MessageWithoutPhrase))
+            return;
+
+        _spokenDigits ??= VoiceCommandMatcher.BuildSpokenDigits(id => Loc.GetString(id));
+
+        if (!VoiceCommandMatcher.TryMatchVoiceCommand(ent.Comp, args.MessageWithoutPhrase, _spokenDigits, out var tag, out var quantity))
+        {
+            _adminLogger.Add(LogType.Trigger, LogImpact.Low,
+                $"A voice command on {ToPrettyString(ent):entity} from {ToPrettyString(args.Source):speaker} matched no command: '{args.MessageWithoutPhrase}'.");
+            return;
+        }
+
+        _adminLogger.Add(LogType.Trigger, LogImpact.Medium,
+            $"A voice command on {ToPrettyString(ent):entity} from {ToPrettyString(args.Source):speaker} resolved to '{tag}' (x{quantity}).");
+
+        var matched = new VoiceCommandMatchedEvent(args.Source, tag, quantity);
+        RaiseLocalEvent(ent, ref matched);
+    }
+}

--- a/Content.Shared/Trigger/Systems/TriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.cs
@@ -59,6 +59,7 @@ public sealed partial class TriggerSystem : EntitySystem
         InitializeTimer();
         InitializeSpawn();
         InitializeVoice();
+        InitializeVoiceCommands();
     }
 
     /// <summary>

--- a/Content.Shared/Trigger/VoiceCommandMatchedEvent.cs
+++ b/Content.Shared/Trigger/VoiceCommandMatchedEvent.cs
@@ -1,0 +1,25 @@
+namespace Content.Shared.Trigger;
+
+/// <summary>
+/// Raised when a spoken phrase matched a registered voice command.
+/// </summary>
+/// <param name="Source">The entity that spoke.</param>
+/// <param name="Tag">The opaque tag the matched phrase maps to.</param>
+/// <param name="Quantity">Always >= 1.</param>
+[ByRefEvent]
+public readonly record struct VoiceCommandMatchedEvent(EntityUid Source, string Tag, int Quantity);
+
+/// <summary>
+/// Raised during a rebuild to collect phrase -> tag entries from subscribers. Static triggers take priority.
+/// Pull-based, so a subscriber whose triggers change must call <c>RebuildVoiceCommandLookup</c> itself.
+/// </summary>
+[ByRefEvent]
+public struct VoiceCommandsGetTriggersEvent
+{
+    public readonly Dictionary<string, string> Triggers;
+
+    public VoiceCommandsGetTriggersEvent()
+    {
+        Triggers = new();
+    }
+}

--- a/Content.Shared/Trigger/VoiceCommandMatcher.cs
+++ b/Content.Shared/Trigger/VoiceCommandMatcher.cs
@@ -1,0 +1,353 @@
+using System.Text;
+using Content.Shared.Trigger.Components.Triggers;
+
+namespace Content.Shared.Trigger;
+
+/// <summary>
+/// Trigram matching for spoken voice commands and keyphrases.
+/// </summary>
+public static class VoiceCommandMatcher
+{
+    public const string VoiceCommandQuantityWordsLoc = "voice-command-quantity-words";
+
+    public static List<VoiceCommandCandidate> BuildVoiceCommandCandidates(IReadOnlyDictionary<string, string> triggers)
+    {
+        var candidates = new List<VoiceCommandCandidate>(triggers.Count);
+        foreach (var (phrase, tag) in triggers)
+        {
+            var trigrams = Trigrams(NormalizePhrase(phrase));
+            if (trigrams.Count == 0)
+                continue;
+
+            candidates.Add(new VoiceCommandCandidate
+            {
+                Tag = tag,
+                Trigrams = trigrams,
+            });
+        }
+        return candidates;
+    }
+
+    // Matches spoken text to a tag, pulling a leading count into quantity (default 1).
+    public static bool TryMatchVoiceCommand(VoiceCommandsComponent comp, string message, IReadOnlyDictionary<string, int> spokenDigits, out string tag, out int quantity)
+    {
+        tag = string.Empty;
+        quantity = 1;
+
+        if (comp.Candidates.Count == 0)
+            return false;
+
+        var tokens = message.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0)
+            return false;
+
+        var phraseStart = 0;
+        if (tokens.Length > 1 && TryParseCount(tokens[0], spokenDigits, out var count))
+        {
+            if (count <= 0)
+                return false;
+
+            quantity = count;
+            phraseStart = 1;
+        }
+
+        var threshold = ClampMatchThreshold(comp.MatchThreshold);
+
+        var match = MatchPhrase(comp.Candidates, tokens[phraseStart..], threshold);
+        if (match == null)
+        {
+            quantity = 1;
+            return false;
+        }
+
+        tag = match.Tag;
+        return true;
+    }
+
+    // Strips the keyphrase out, fuzzily if enabled, leaving the command text.
+    public static bool TryExtractKeyphrase(string message, string keyphrase, List<VoiceCommandCandidate> keyphraseCandidates, bool fuzzyMatch, float threshold, out string remainder)
+    {
+        var index = message.IndexOf(keyphrase, StringComparison.InvariantCultureIgnoreCase);
+        if (index >= 0)
+        {
+            remainder = TrimCommandRemainder(message.Remove(index, keyphrase.Length));
+            return true;
+        }
+
+        if (fuzzyMatch && keyphraseCandidates.Count > 0
+            && TryFuzzyExtractKeyphrase(message, keyphrase, keyphraseCandidates, threshold, out var fuzzy))
+        {
+            remainder = TrimCommandRemainder(fuzzy);
+            return true;
+        }
+
+        remainder = string.Empty;
+        return false;
+    }
+
+    // Builds the candidate inline, for tests and one-offs.
+    public static bool TryExtractKeyphrase(string message, string keyphrase, bool fuzzyMatch, float threshold, out string remainder)
+    {
+        var candidates = fuzzyMatch
+            ? BuildVoiceCommandCandidates(new Dictionary<string, string> { [keyphrase] = string.Empty })
+            : new List<VoiceCommandCandidate>();
+        return TryExtractKeyphrase(message, keyphrase, candidates, fuzzyMatch, threshold, out remainder);
+    }
+
+    public static Dictionary<string, int> BuildSpokenDigits(Func<string, string> getString)
+    {
+        return BuildSpokenDigitsFromWords(getString(VoiceCommandQuantityWordsLoc));
+    }
+
+    private static bool TryFuzzyExtractKeyphrase(string message, string keyphrase, List<VoiceCommandCandidate> candidates, float threshold, out string remainder)
+    {
+        remainder = string.Empty;
+
+        var keyTokens = keyphrase.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var msgTokens = message.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (keyTokens.Length == 0 || msgTokens.Length < keyTokens.Length)
+            return false;
+
+        var minScore = ClampMatchThreshold(threshold);
+        for (var start = 0; start <= msgTokens.Length - keyTokens.Length; start++)
+        {
+            if (MatchPhrase(candidates, msgTokens[start..(start + keyTokens.Length)], minScore) == null)
+                continue;
+
+            var kept = new List<string>(msgTokens.Length - keyTokens.Length);
+            for (var i = 0; i < msgTokens.Length; i++)
+            {
+                if (i < start || i >= start + keyTokens.Length)
+                    kept.Add(msgTokens[i]);
+            }
+            remainder = string.Join(' ', kept);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string TrimCommandRemainder(string remainder)
+    {
+        var start = 0;
+        while (start < remainder.Length && !char.IsLetterOrDigit(remainder[start]))
+            start++;
+
+        var end = remainder.Length;
+        while (end > start && !char.IsLetterOrDigit(remainder[end - 1]))
+            end--;
+
+        return remainder[start..end];
+    }
+
+    private static VoiceCommandCandidate? MatchPhrase(
+        List<VoiceCommandCandidate> candidates,
+        IReadOnlyList<string> phraseTokens,
+        float threshold)
+    {
+        if (phraseTokens.Count == 0)
+            return null;
+
+        var phrase = NormalizePhrase(string.Join(' ', phraseTokens));
+        if (phrase.Length == 0)
+            return null;
+
+        var variants = GetPhraseTrigrams(phrase);
+        if (variants.Count == 0)
+            return null;
+
+        // Prefer triggers the speaker said in full, then fall back to triggers that contain the speech.
+        return BestMatch(candidates, variants, threshold, allowPartialTrigger: false)
+               ?? BestMatch(candidates, variants, threshold, allowPartialTrigger: true);
+    }
+
+    private static VoiceCommandCandidate? BestMatch(
+        List<VoiceCommandCandidate> candidates,
+        List<HashSet<string>> messageTrigramVariants,
+        float threshold,
+        bool allowPartialTrigger)
+    {
+        VoiceCommandCandidate? best = null;
+        var bestCovered = -1f;
+        var bestSaid = -1f;
+
+        foreach (var candidate in candidates)
+        {
+            var said = 0f;
+            var covered = 0f;
+            foreach (var v in messageTrigramVariants)
+            {
+                var s = TrigramOverlap(candidate.Trigrams, v);
+                if (s > said) said = s;
+                var c = TrigramOverlap(v, candidate.Trigrams);
+                if (c > covered) covered = c;
+            }
+
+            var gate = allowPartialTrigger ? covered : said;
+            if (gate < threshold)
+                continue;
+
+            // Rank by coverage, then by how fully the trigger was said, then by shortest, so
+            // "beaker" wins over the superset "large beaker".
+            if (best == null
+                || covered > bestCovered
+                || (covered == bestCovered && said > bestSaid)
+                || (covered == bestCovered && said == bestSaid && candidate.Trigrams.Count < best.Trigrams.Count))
+            {
+                best = candidate;
+                bestCovered = covered;
+                bestSaid = said;
+            }
+        }
+
+        return best;
+    }
+
+    private static Dictionary<string, int> BuildSpokenDigitsFromWords(string localizedWords)
+    {
+        var words = localizedWords
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var map = new Dictionary<string, int>(words.Length);
+        for (var i = 0; i < words.Length; i++)
+            map[words[i].ToLowerInvariant()] = i + 1;
+        return map;
+    }
+
+    private static bool TryParseCount(string token, IReadOnlyDictionary<string, int> spokenDigits, out int count)
+    {
+        // Speech-to-text leaves punctuation stuck to the count, e.g. "five, popcorn".
+        var end = token.Length;
+        while (end > 0 && !char.IsLetterOrDigit(token[end - 1]))
+            end--;
+        token = token[..end];
+
+        if (int.TryParse(token, out count))
+            return true;
+        return spokenDigits.TryGetValue(token.ToLowerInvariant(), out count);
+    }
+
+    // Pads with spaces so trigrams catch word boundaries.
+    private static string NormalizePhrase(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return string.Empty;
+
+        var sb = new StringBuilder(input.Length + 2);
+        sb.Append(' ');
+        var prevSpace = true;
+        foreach (var c in input)
+        {
+            char next;
+            if (char.IsLetterOrDigit(c))
+                next = char.ToLowerInvariant(c);
+            else
+                next = ' ';
+
+            if (next == ' ')
+            {
+                if (prevSpace)
+                    continue;
+                prevSpace = true;
+            }
+            else
+            {
+                prevSpace = false;
+            }
+            sb.Append(next);
+        }
+        if (!prevSpace)
+            sb.Append(' ');
+
+        return sb.Length <= 2 ? string.Empty : sb.ToString();
+    }
+
+    // Expects an already normalized, padded string.
+    private static HashSet<string> Trigrams(string padded)
+    {
+        if (padded.Length < 3)
+            return new HashSet<string>();
+
+        var set = new HashSet<string>(padded.Length - 2);
+        for (var i = 0; i <= padded.Length - 3; i++)
+            set.Add(padded.Substring(i, 3));
+        return set;
+    }
+
+    private static List<HashSet<string>> GetPhraseTrigrams(string normalized)
+    {
+        var t1 = Trigrams(normalized);
+        if (t1.Count == 0)
+            return [];
+
+        var variants = new List<HashSet<string>>(2) { t1 };
+
+        var singular = SingularizeNormalizedPhrase(normalized);
+        if (singular != normalized)
+        {
+            var t2 = Trigrams(singular);
+            if (t2.Count > 0 && !t2.SetEquals(t1))
+                variants.Add(t2);
+        }
+
+        return variants;
+    }
+
+    private static string SingularizeNormalizedPhrase(string normalized)
+    {
+        var words = normalized.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length == 0)
+            return normalized;
+
+        var changed = false;
+        for (var i = 0; i < words.Length; i++)
+        {
+            var singular = SingularizeWord(words[i]);
+            if (singular == words[i])
+                continue;
+
+            words[i] = singular;
+            changed = true;
+        }
+
+        return changed ? $" {string.Join(' ', words)} " : normalized;
+    }
+
+    private static string SingularizeWord(string word)
+    {
+        if (word.Length > 3 && word.EndsWith("ies", StringComparison.Ordinal))
+            return word[..^3] + "y";
+
+        // Plural added "es" to a consonant cluster.
+        if (word.Length > 4
+            && (word.EndsWith("ches", StringComparison.Ordinal)
+                || word.EndsWith("shes", StringComparison.Ordinal)
+                || word.EndsWith("xes", StringComparison.Ordinal)))
+        {
+            return word[..^2];
+        }
+
+        // Plain "s" plural. Length > 3 so short words (eggs, peas) still singularize, skip "ss" (glass) so it isn't mangled.
+        if (word.Length > 3 && word.EndsWith('s') && !word.EndsWith("ss", StringComparison.Ordinal))
+            return word[..^1];
+
+        return word;
+    }
+
+    // A 0 threshold would let a zero-overlap candidate match anything, so floor it.
+    private static float ClampMatchThreshold(float threshold) => Math.Clamp(threshold, float.Epsilon, 1f);
+
+    // Overlap coefficient, not Jaccard: fraction of reference present in candidate.
+    private static float TrigramOverlap(HashSet<string> reference, HashSet<string> candidate)
+    {
+        if (reference.Count == 0)
+            return 0f;
+        var intersect = 0;
+        foreach (var tri in reference)
+        {
+            if (candidate.Contains(tri))
+                intersect++;
+        }
+        return (float) intersect / reference.Count;
+    }
+}

--- a/Content.Tests/Shared/Trigger/VoiceCommandMatcherTest.cs
+++ b/Content.Tests/Shared/Trigger/VoiceCommandMatcherTest.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using Content.Shared.Trigger;
+using Content.Shared.Trigger.Components.Triggers;
+using NUnit.Framework;
+
+namespace Content.Tests.Shared.Trigger;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public sealed class VoiceCommandMatcherTest
+{
+    private static VoiceCommandsComponent Build(float threshold = 0.5f, params (string phrase, string tag)[] triggers)
+    {
+        var dict = new Dictionary<string, string>();
+        foreach (var (p, t) in triggers)
+            dict[p] = t;
+
+        return new VoiceCommandsComponent
+        {
+            Triggers = dict,
+            MatchThreshold = threshold,
+            Candidates = VoiceCommandMatcher.BuildVoiceCommandCandidates(dict),
+        };
+    }
+
+    private static readonly Dictionary<string, int> NoSpokenDigits = [];
+
+    private static void AssertMatch(VoiceCommandsComponent comp, string spoken, string tag, int quantity = 1)
+    {
+        Assert.That(VoiceCommandMatcher.TryMatchVoiceCommand(comp, spoken, NoSpokenDigits, out var matchedTag, out var matchedQty), Is.True, $"\"{spoken}\" did not match");
+        Assert.That(matchedTag, Is.EqualTo(tag), $"\"{spoken}\" tag");
+        Assert.That(matchedQty, Is.EqualTo(quantity), $"\"{spoken}\" quantity");
+    }
+
+    private static void AssertNoMatch(VoiceCommandsComponent comp, string spoken)
+    {
+        Assert.That(VoiceCommandMatcher.TryMatchVoiceCommand(comp, spoken, NoSpokenDigits, out _, out _), Is.False, $"\"{spoken}\" unexpectedly matched");
+    }
+
+    [Test]
+    public void SurfaceNoiseStillMatches()
+    {
+        var comp = Build(triggers: ("popcorn", "FoodPopcorn"));
+        Assert.Multiple(() =>
+        {
+            AssertMatch(comp, "popcorn", "FoodPopcorn");
+            AssertMatch(comp, "POPCORN", "FoodPopcorn");
+            AssertMatch(comp, "popcorn!", "FoodPopcorn");
+            AssertMatch(comp, "can I get some popcorn please", "FoodPopcorn");
+        });
+    }
+
+    [Test]
+    public void QuantityExtraction()
+    {
+        var comp = Build(triggers: ("popcorn", "FoodPopcorn"));
+        Assert.Multiple(() =>
+        {
+            AssertMatch(comp, "5 popcorn", "FoodPopcorn", 5);
+            AssertMatch(comp, "500 popcorn", "FoodPopcorn", 500); // big counts go through digits
+            AssertMatch(comp, "2 popcorn 5", "FoodPopcorn", 2);
+            AssertNoMatch(comp, "-3 popcorn");
+        });
+    }
+
+    [Test]
+    public void NumberInItemNameIsNotEatenAsQuantity()
+    {
+        // "B-52" orders one B-52, not 52 "b"'s.
+        var comp = Build(triggers: ("b 52", "DrinkB52"));
+        Assert.Multiple(() =>
+        {
+            AssertMatch(comp, "b 52", "DrinkB52", 1);
+            AssertMatch(comp, "5 b 52", "DrinkB52", 5);
+        });
+    }
+
+    [Test]
+    public void RejectsNonCommands()
+    {
+        var comp = Build(triggers: ("popcorn", "FoodPopcorn"));
+        AssertNoMatch(comp, "   ");
+        AssertNoMatch(comp, "5"); // a bare count with no item
+    }
+
+    [Test]
+    public void NoTriggersNeverMatches()
+    {
+        AssertNoMatch(Build(), "popcorn");
+    }
+
+    [Test]
+    public void RanksMostSpecificTrigger()
+    {
+        var comp = Build(triggers: new[] { ("apple", "FoodApple"), ("apple juice", "DrinkAppleJuice") });
+        Assert.Multiple(() =>
+        {
+            AssertMatch(comp, "apple juice", "DrinkAppleJuice");
+            AssertMatch(comp, "apple", "FoodApple");
+        });
+    }
+
+    [Test]
+    public void MatchesOnPartialOverlap()
+    {
+        Assert.Multiple(() =>
+        {
+            // Spoken phrase contains more of the longer trigger.
+            var fried = Build(triggers: new[] { ("chicken", "FoodChicken"), ("southern fried chicken", "FoodFriedChicken") });
+            AssertMatch(fried, "fried chicken", "FoodFriedChicken");
+
+            // Spoken phrase fits inside a longer trigger.
+            var pizza = Build(triggers: new[] { ("arnolds pizza", "FoodPizzaArnold"), ("popcorn", "FoodPopcorn") });
+            AssertMatch(pizza, "pizza", "FoodPizzaArnold");
+
+            // Plural of a word inside a multi-word trigger.
+            var beer = Build(triggers: ("beer can", "DrinkBeerCan"));
+            AssertMatch(beer, "beers", "DrinkBeerCan");
+        });
+    }
+
+    [Test]
+    public void ThresholdGating()
+    {
+        Assert.Multiple(() =>
+        {
+            // "acorn" overlaps "popcorn" but well below 0.9.
+            AssertNoMatch(Build(threshold: 0.9f, triggers: ("popcorn", "FoodPopcorn")), "acorn");
+
+            // Threshold > 1 is clamped; an exact (1.0) match still passes.
+            AssertMatch(Build(threshold: 5f, triggers: ("popcorn", "FoodPopcorn")), "popcorn", "FoodPopcorn");
+
+            // Threshold 0 must not become a catch-all: unrelated speech still fails.
+            AssertNoMatch(Build(threshold: 0f, triggers: ("popcorn", "FoodPopcorn")), "supercalifragilisticexpialidocious");
+        });
+    }
+
+    [Test]
+    public void PaddingKeepsShortTriggersDistinct()
+    {
+        // Unpadded, "s"'s trigrams would be a subset of "screwdriver" and match it.
+        AssertNoMatch(Build(triggers: ("s", "ItemS")), "screwdriver");
+    }
+
+    [Test]
+    public void FuzzyKeyphraseExtraction()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(VoiceCommandMatcher.TryExtractKeyphrase("autolathe, ten crowbars", "autolathe", false, 0.5f, out var exact), Is.True);
+            Assert.That(exact, Is.EqualTo("ten crowbars"));
+
+            // OwO accent works.
+            Assert.That(VoiceCommandMatcher.TryExtractKeyphrase("computew popcown", "computer", true, 0.5f, out var owo), Is.True);
+            Assert.That(owo, Is.EqualTo("popcown"));
+
+            // Stutter works.
+            Assert.That(VoiceCommandMatcher.TryExtractKeyphrase("c-c-omputer popcorn", "computer", true, 0.5f, out var stutter), Is.True);
+            Assert.That(stutter, Does.Contain("popcorn"));
+        });
+    }
+}

--- a/Resources/Locale/en-US/lathe/lathesystem.ftl
+++ b/Resources/Locale/en-US/lathe/lathesystem.ftl
@@ -1,4 +1,6 @@
 lathe-popup-material-not-used = This material is not used in this machine.
+lathe-voice-recipe-not-found = Unable to comply. Recipe not found.
+lathe-voice-fabricating = Fabricating { $item }...
 lathe-unlock-recipe-radio-broadcast = This lathe is now capable of producing the following recipes: {$items}
 lathe-unlock-recipe-radio-broadcast-overflow = This lathe is now capable of producing {$count} new recipes, including: {$items}
 lathe-unlock-recipe-radio-broadcast-item = [bold]{$item}[/bold]

--- a/Resources/Locale/en-US/speech/speech-triggers.ftl
+++ b/Resources/Locale/en-US/speech/speech-triggers.ftl
@@ -1,1 +1,17 @@
 key-phrase-gadget = go go gadget
+key-phrase-autolathe = autolathe
+key-phrase-protolathe = protolathe
+key-phrase-circuit-imprinter = circuit imprinter
+key-phrase-exosuit-fabricator = exosuit fabricator
+key-phrase-biofabricator = biofabricator
+key-phrase-security-techfab = security techfab
+key-phrase-ammo-techfab = ammo techfab
+key-phrase-medical-techfab = medical techfab
+key-phrase-uniform-printer = uniform printer
+key-phrase-biogenerator = biogenerator
+key-phrase-ore-processor = ore processor
+key-phrase-sheetifier = sheetifier
+key-phrase-cutter = cutter
+
+# Position sets the value, so keep them ordered.
+voice-command-quantity-words = one, two, three, four, five, six, seven, eight, nine, ten

--- a/Resources/Prototypes/Entities/Debugging/voice_lathe.yml
+++ b/Resources/Prototypes/Entities/Debugging/voice_lathe.yml
@@ -1,0 +1,102 @@
+# Debug-only voice variants of every lathe, used to exercise the voice-command matcher.
+- type: entity
+  abstract: true
+  id: BaseVoiceLatheDebug
+  categories: [ Debug ]
+  suffix: DEBUG
+  components:
+  - type: TriggerOnVoice
+    fuzzyMatch: true
+    listenRange: 8
+  - type: VoiceCommands
+
+- type: entity
+  parent: [ Autolathe, BaseVoiceLatheDebug ]
+  id: AutolatheVoiceDebug
+  components:
+  - type: TriggerOnVoice
+    defaultKeyPhrase: key-phrase-autolathe
+
+- type: entity
+  parent: [ Protolathe, BaseVoiceLatheDebug ]
+  id: ProtolatheVoiceDebug
+  components:
+  - type: TriggerOnVoice
+    defaultKeyPhrase: key-phrase-protolathe
+
+- type: entity
+  parent: [ CircuitImprinter, BaseVoiceLatheDebug ]
+  id: CircuitImprinterVoiceDebug
+  components:
+  - type: TriggerOnVoice
+    defaultKeyPhrase: key-phrase-circuit-imprinter
+
+- type: entity
+  parent: [ ExosuitFabricator, BaseVoiceLatheDebug ]
+  id: ExosuitFabricatorVoiceDebug
+  components:
+  - type: TriggerOnVoice
+    defaultKeyPhrase: key-phrase-exosuit-fabricator
+
+- type: entity
+  parent: [ Biofabricator, BaseVoiceLatheDebug ]
+  id: BiofabricatorVoiceDebug
+  components:
+  - type: TriggerOnVoice
+    defaultKeyPhrase: key-phrase-biofabricator
+
+- type: entity
+  parent: [ SecurityTechFab, BaseVoiceLatheDebug ]
+  id: SecurityTechFabVoiceDebug
+  components:
+  - type: TriggerOnVoice
+    defaultKeyPhrase: key-phrase-security-techfab
+
+- type: entity
+  parent: [ AmmoTechFab, BaseVoiceLatheDebug ]
+  id: AmmoTechFabVoiceDebug
+  components:
+  - type: TriggerOnVoice
+    defaultKeyPhrase: key-phrase-ammo-techfab
+
+- type: entity
+  parent: [ MedicalTechFab, BaseVoiceLatheDebug ]
+  id: MedicalTechFabVoiceDebug
+  components:
+  - type: TriggerOnVoice
+    defaultKeyPhrase: key-phrase-medical-techfab
+
+- type: entity
+  parent: [ UniformPrinter, BaseVoiceLatheDebug ]
+  id: UniformPrinterVoiceDebug
+  components:
+  - type: TriggerOnVoice
+    defaultKeyPhrase: key-phrase-uniform-printer
+
+- type: entity
+  parent: [ Biogenerator, BaseVoiceLatheDebug ]
+  id: BiogeneratorVoiceDebug
+  components:
+  - type: TriggerOnVoice
+    defaultKeyPhrase: key-phrase-biogenerator
+
+- type: entity
+  parent: [ OreProcessor, BaseVoiceLatheDebug ]
+  id: OreProcessorVoiceDebug
+  components:
+  - type: TriggerOnVoice
+    defaultKeyPhrase: key-phrase-ore-processor
+
+- type: entity
+  parent: [ Sheetifier, BaseVoiceLatheDebug ]
+  id: SheetifierVoiceDebug
+  components:
+  - type: TriggerOnVoice
+    defaultKeyPhrase: key-phrase-sheetifier
+
+- type: entity
+  parent: [ CutterMachine, BaseVoiceLatheDebug ]
+  id: CutterMachineVoiceDebug
+  components:
+  - type: TriggerOnVoice
+    defaultKeyPhrase: key-phrase-cutter


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added debug voice activated lathes and text parsing for same.

Required by https://github.com/space-wizards/space-station-14/pull/43363

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

No player-facing balance impact this cut. The goal is to split the larger food replicator work into a reviewable infrastructure PR first.

## Technical details
<!-- Summary of code changes for easier review. -->

It's a little hacky because I can't touch chat code due to the freeze, otherwise I'd just grab the unaccented command word and it'd be a lot less complicated.

```mermaid
flowchart TD
    A[Player speaks near listener] --> B[TriggerOnVoice hears speech]
    B --> C{Keyphrase matched?}
    C -- No --> D[Ignore]
    C -- Yes --> E[Strip keyphrase from message]
    E --> F[VoiceCommands receives command text]
    F --> G[Parse optional quantity]
    G --> H[Fuzzy match command against candidates]
    H --> I{Command matched?}
    I -- No --> J[Admin log trigger no match]
    I -- Yes --> K[Admin log trigger resolved tag and quantity]
    K --> L[Raise VoiceCommandMatchedEvent]
    L --> M[Lathe validates recipe is available]
    M --> N{Can queue recipe?}
    N -- No --> O[Do nothing]
    N -- Yes --> P[Queue recipe]
    P --> Q[Admin log action voice queued]
    Q --> R[Show fabricating popup]
    R --> S[Start production]
    S --> T[Update lathe UI]
```

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Tests are baked in, there's also debug versions of lathes you can try out.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/bffd06a0-3f37-42f6-8bd1-bb1443179265


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->