### PR TITLE
Fix ConfigurationComponent spawn cost

### DIFF
--- a/Content.Shared/Configurable/ConfigurationComponent.cs
+++ b/Content.Shared/Configurable/ConfigurationComponent.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Content.Shared.Prototypes;
 using Content.Shared.Tools;
 using Content.Shared.Tools.Systems;
 using Robust.Shared.GameStates;
@@ -32,7 +33,7 @@ namespace Content.Shared.Configurable
         /// Validate tags in <see cref="Config"/>.
         /// </summary>
         [DataField]
-        public Regex Validation = new("^[a-zA-Z0-9 ]*$", RegexOptions.Compiled);
+        public ProtoId<RegexPrototype> Validation = "ConfigurationValidation";
 
         /// <summary>
         ///     Message data sent from client to server when the device configuration is updated.

--- a/Content.Shared/Configurable/SharedConfigurationSystem.cs
+++ b/Content.Shared/Configurable/SharedConfigurationSystem.cs
@@ -47,7 +47,7 @@ public abstract partial class SharedConfigurationSystem : EntitySystem
         {
             var value = args.Config.GetValueOrDefault(key);
 
-            if (string.IsNullOrWhiteSpace(value) || validation.Regex.IsMatch(value))
+            if (string.IsNullOrWhiteSpace(value) || !validation.Regex.IsMatch(value))
                 continue;
 
             component.Config[key] = value;

--- a/Content.Shared/Configurable/SharedConfigurationSystem.cs
+++ b/Content.Shared/Configurable/SharedConfigurationSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Interaction;
 using Content.Shared.Tools.Systems;
 using Robust.Shared.Containers;
+using Robust.Shared.Prototypes;
 using static Content.Shared.Configurable.ConfigurationComponent;
 
 namespace Content.Shared.Configurable;
@@ -10,6 +11,7 @@ namespace Content.Shared.Configurable;
 /// </summary>
 public abstract partial class SharedConfigurationSystem : EntitySystem
 {
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
     [Dependency] private SharedUserInterfaceSystem _uiSystem = default!;
     [Dependency] private SharedToolSystem _toolSystem = default!;
 
@@ -36,11 +38,16 @@ public abstract partial class SharedConfigurationSystem : EntitySystem
 
     private void OnUpdate(EntityUid uid, ConfigurationComponent component, ConfigurationUpdatedMessage args)
     {
+        if (!_protoMan.Resolve(component.Validation, out var validation))
+        {
+            return;
+        }
+
         foreach (var key in component.Config.Keys)
         {
             var value = args.Config.GetValueOrDefault(key);
 
-            if (string.IsNullOrWhiteSpace(value) || component.Validation != null && !component.Validation.IsMatch(value))
+            if (string.IsNullOrWhiteSpace(value) || validation.Regex.IsMatch(value))
                 continue;
 
             component.Config[key] = value;

--- a/Content.Shared/Prototypes/RegexPrototype.cs
+++ b/Content.Shared/Prototypes/RegexPrototype.cs
@@ -1,0 +1,17 @@
+using System.Text.RegularExpressions;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Prototypes;
+
+/// <summary>
+/// Static reference to Regex that avoids the runtime cost of instantiating them.
+/// </summary>
+[Prototype]
+public sealed partial class RegexPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    [DataField(required: true)]
+    public Regex Regex = new("", RegexOptions.Compiled);
+}

--- a/Resources/Prototypes/regex.yml
+++ b/Resources/Prototypes/regex.yml
@@ -1,0 +1,3 @@
+- type: regex
+  id: ConfigurationValidation
+  regex: "^[a-zA-Z0-9 ]*$"


### PR DESCRIPTION
Make it use a dedicated prototype so we don't slam compiled regexes out. Minor runtime cost but big big entity init cost.

Profile:
<img width="1584" height="486" alt="image" src="https://github.com/user-attachments/assets/9b989195-3572-4b90-acac-415bdb65e0e7" />

BC:
ConfigurationComponent now uses a dedicated RegexPrototype for validation rather than an inline Regex.