### PR TITLE
Adding view copy ability

### DIFF
--- a/Content.Client/PDA/PdaMenu.xaml
+++ b/Content.Client/PDA/PdaMenu.xaml
@@ -28,24 +28,32 @@
                       HorizontalExpand="True"
                       MinSize="50 50"
                       Margin="8">
-            <ContainerButton Name="PdaOwnerButton">
+            <ContainerButton Name="PdaOwnerButton" StyleClasses="PdaCopyButton"
+                             ToolTip="{Loc 'comp-pda-ui-copy-tooltip'}">
                 <RichTextLabel Name="PdaOwnerLabel" Access="Public"/>
             </ContainerButton>
-            <ContainerButton Name="IdInfoButton">
+            <ContainerButton Name="IdInfoButton" StyleClasses="PdaCopyButton"
+                             ToolTip="{Loc 'comp-pda-ui-copy-tooltip'}">
                 <RichTextLabel Name="IdInfoLabel" Access="Public"/>
             </ContainerButton>
-            <ContainerButton Name="StationNameButton">
+            <ContainerButton Name="StationNameButton" StyleClasses="PdaCopyButton"
+                             ToolTip="{Loc 'comp-pda-ui-copy-tooltip'}">
                 <RichTextLabel Name="StationNameLabel" Access="Public"/>
             </ContainerButton>
-            <ContainerButton Name="StationAlertLevelButton">
+            <ContainerButton Name="StationAlertLevelButton" StyleClasses="PdaCopyButton"
+                             ToolTip="{Loc 'comp-pda-ui-copy-tooltip'}">
                 <RichTextLabel Name="StationAlertLevelLabel" Access="Public"/>
             </ContainerButton>
-            <ContainerButton Name="StationTimeButton">
+            <ContainerButton Name="StationTimeButton" StyleClasses="PdaCopyButton"
+                             ToolTip="{Loc 'comp-pda-ui-copy-tooltip'}">
                 <RichTextLabel Name="StationTimeLabel" Access="Public"/>
             </ContainerButton>
-            <ContainerButton Name="StationAlertLevelInstructionsButton">
+            <ContainerButton Name="StationAlertLevelInstructionsButton" StyleClasses="PdaCopyButton"
+                             ToolTip="{Loc 'comp-pda-ui-copy-tooltip'}">
                 <RichTextLabel Name="StationAlertLevelInstructions" Access="Public"/>
             </ContainerButton>
+            <Label Name="CopiedLabel" Visible="False" StyleClasses="PdaCopiedLabel"
+                   Text="{Loc 'comp-pda-ui-copied'}" HorizontalAlignment="Right" Margin="0 4 4 0"/>
         </BoxContainer>
         <ScrollContainer HorizontalExpand="True" VerticalExpand="True" HScrollEnabled="True">
             <BoxContainer Orientation="Vertical"

--- a/Content.Client/PDA/PdaMenu.xaml.cs
+++ b/Content.Client/PDA/PdaMenu.xaml.cs
@@ -97,32 +97,38 @@ namespace Content.Client.PDA
             PdaOwnerButton.OnPressed += _ =>
             {
                 _clipboard.SetText(_pdaOwner);
+                ShowCopiedFeedback();
             };
 
             IdInfoButton.OnPressed += _ =>
             {
                 _clipboard.SetText(_owner + ", " + _jobTitle);
+                ShowCopiedFeedback();
             };
 
             StationNameButton.OnPressed += _ =>
             {
                 _clipboard.SetText(_stationName);
+                ShowCopiedFeedback();
             };
 
             StationAlertLevelButton.OnPressed += _ =>
             {
                 _clipboard.SetText(_alertLevel);
+                ShowCopiedFeedback();
             };
 
             StationTimeButton.OnPressed += _ =>
             {
                 var stationTime = _gameTiming.CurTime.Subtract(_gameTicker.RoundStartTimeSpan);
                 _clipboard.SetText((stationTime.ToString("hh\\:mm\\:ss")));
+                ShowCopiedFeedback();
             };
 
             StationAlertLevelInstructionsButton.OnPressed += _ =>
             {
                 _clipboard.SetText(_instructions);
+                ShowCopiedFeedback();
             };
 
 
@@ -326,6 +332,16 @@ namespace Content.Client.PDA
                 Orientation = BoxContainer.LayoutOrientation.Horizontal,
                 HorizontalExpand = true
             };
+        }
+
+        private void ShowCopiedFeedback()
+        {
+            CopiedLabel.Visible = true;
+            Timer.Spawn(1500, () =>
+            {
+                if (!Disposed)
+                    CopiedLabel.Visible = false;
+            });
         }
 
         private void HideAllViews()

--- a/Content.Client/PDA/PdaSheetlet.cs
+++ b/Content.Client/PDA/PdaSheetlet.cs
@@ -77,6 +77,22 @@ public sealed class PdaSheetlet : Sheetlet<NanotrasenStylesheet>
                 .Pseudo(ContainerButton.StylePseudoClassPressed)
                 .Prop(PdaProgramItem.StylePropertyBgColor, Color.FromHex(PdaProgramItem.HoverColor)),
 
+            //PDA - Copy buttons
+            E<ContainerButton>()
+                .Class("PdaCopyButton")
+                .Pseudo(ContainerButton.StylePseudoClassNormal)
+                .Prop(ContainerButton.StylePropertyStyleBox, new StyleBoxFlat(Color.Transparent)),
+
+            E<ContainerButton>()
+                .Class("PdaCopyButton")
+                .Pseudo(ContainerButton.StylePseudoClassHover)
+                .Prop(ContainerButton.StylePropertyStyleBox, new StyleBoxFlat(Color.FromHex("#3a3a42"))),
+
+            E<ContainerButton>()
+                .Class("PdaCopyButton")
+                .Pseudo(ContainerButton.StylePseudoClassPressed)
+                .Prop(ContainerButton.StylePropertyStyleBox, new StyleBoxFlat(Color.FromHex("#4a4a55"))),
+
             //PDA - Text
             E<Label>()
                 .Class("PdaContentFooterText")
@@ -87,6 +103,11 @@ public sealed class PdaSheetlet : Sheetlet<NanotrasenStylesheet>
                 .Class("PdaWindowFooterText")
                 .Prop(Label.StylePropertyFont, sheet.BaseFont.GetFont(10))
                 .Prop(Label.StylePropertyFontColor, Color.FromHex("#333d3b")),
+
+            E<Label>()
+                .Class("PdaCopiedLabel")
+                .Prop(Label.StylePropertyFont, sheet.BaseFont.GetFont(10))
+                .Prop(Label.StylePropertyFontColor, Color.FromHex("#77cc77")),
         ];
     }
 }

--- a/Resources/Locale/en-US/pda/pda-component.ftl
+++ b/Resources/Locale/en-US/pda/pda-component.ftl
@@ -54,3 +54,7 @@ comp-pda-ui-unassigned = Unassigned
 
 pda-notification-message = [font size=12][bold]PDA[/bold] { $header }: [/font]
     "{ $message }"
+
+comp-pda-ui-copy-tooltip = Click to copy
+
+comp-pda-ui-copied = Copied!


### PR DESCRIPTION
## About the PR
The PDA home screen has several info lines (owner, ID, station name, alert level, shift time, alert instructions) that copy their text to the clipboard when clicked — but there was no indication they were interactive. This PR makes them discoverable. Resolve https://github.com/space-wizards/space-station-14/issues/28588

## Why / Balance
Fixes the discoverability issue introduced in #23533. Players had no way to know these lines were clickable buttons that copy text to the clipboard.

## Technical details
- Added a `PdaCopyButton` style class to all six info `ContainerButton`s in `PdaMenu.xaml`, with hover (subtle highlight `#3a3a42`) and press (`#4a4a55`) states defined in `PdaSheetlet.cs`.
- Added a `ToolTip` ("Click to copy") to each button, shown on hover.
- Added a hidden `CopiedLabel` below the info lines that becomes visible for 1.5 seconds after any copy action via `Timer.Spawn`, styled in green (`#77cc77`) via the `PdaCopiedLabel` style class.
- Added two localization strings: `comp-pda-ui-copy-tooltip` and `comp-pda-ui-copied`.

## Test plan
1. Open your PDA in-game.
2. Hover over any info line on the home screen — a highlight background and "Click to copy" tooltip should appear.
3. Click any info line — a green "Copied!" label should appear briefly in the bottom-right of the home view, and the text should be in your clipboard.

## Media
<img width="564" height="219" alt="image" src="https://github.com/user-attachments/assets/ee00e067-1176-4cc8-b995-67a5ac248e50" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- tweak: PDA info lines now show a hover highlight and "Click to copy" tooltip to indicate they are clickable.
- tweak: Clicking a PDA info line now briefly shows a green "Copied!" confirmation label.