### PR TITLE
Fixes an error when RCD ammo is deleted

### DIFF
--- a/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.RCD.Components;
+using Robust.Shared.Network;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.RCD.Systems;
@@ -13,6 +14,7 @@ public sealed partial class RCDAmmoSystem : EntitySystem
     [Dependency] private SharedChargesSystem _sharedCharges = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private INetManager _net = default!;
 
     public override void Initialize()
     {
@@ -57,7 +59,7 @@ public sealed partial class RCDAmmoSystem : EntitySystem
         Dirty(uid, comp);
 
         // prevent having useless ammo with 0 charges
-        if (comp.Charges <= 0)
+        if (comp.Charges <= 0 && _net.IsServer)
             QueueDel(uid);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When RCD ammo was deleted from the game via `QueueDel()`, it would throw a huge error on the client.

This PR fixes that.

```
[ERRO] root: Predicting the queued deletion of a networked entity: compressed matter (938/n4557, RCDAmmo). Trace:    at System.Environment.get_StackTrace()
   at Robust.Client.GameObjects.ClientEntityManager.QueueDeleteEntity(Nullable`1 uid) in C:\Dev\WizDen\RobustToolbox\Robust.Client\GameObjects\ClientEntityManager.cs:line 95
   at Content.Shared.RCD.Systems.RCDAmmoSystem.OnAfterInteract(EntityUid uid, RCDAmmoComponent comp, AfterInteractEvent args) in C:\Dev\WizDen\Content.Shared\RCD\Systems\RCDAmmoSystem.cs:line 61
   at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalOrdered(EntityUid uid, Type eventType, EventData subs, Unit& unitRef, Boolean broadcast) in C:\Dev\WizDen\RobustToolbox\Robust.Shared\GameObjects\EntityEventBus.Ordering.cs:line 43
   at Robust.Shared.GameObjects.EntitySystem.RaiseLocalEvent[TEvent](EntityUid uid, TEvent args, Boolean broadcast) in C:\Dev\WizDen\RobustToolbox\Robust.Shared\GameObjects\EntitySystem.cs:line 222
   at Content.Shared.Interaction.SharedInteractionSystem.InteractDoAfter(EntityUid user, EntityUid used, Nullable`1 target, EntityCoordinates clickLocation, Boolean canReach, Boolean checkDeletion) in C:\Dev\WizDen\Content.Shared\Interaction\SharedInteractionSystem.cs:line 1093
   at Content.Shared.Interaction.SharedInteractionSystem.InteractUsing(EntityUid user, EntityUid used, EntityUid target, EntityCoordinates clickLocation, Boolean checkCanInteract, Boolean checkCanUse) in C:\Dev\WizDen\Content.Shared\Interaction\SharedInteractionSystem.cs:line 1067
   at Content.Shared.Interaction.SharedInteractionSystem.UserInteraction(EntityUid user, EntityCoordinates coordinates, Nullable`1 target, Boolean altInteract, Boolean checkCanInteract, Boolean checkAccess, Boolean checkCanUse) in C:\Dev\WizDen\Content.Shared\Interaction\SharedInteractionSystem.cs:line 457
   at Content.Shared.Interaction.SharedInteractionSystem.HandleUseInteraction(ICommonSession session, EntityCoordinates coords, EntityUid uid) in C:\Dev\WizDen\Content.Shared\Interaction\SharedInteractionSystem.cs:line 331
   at Robust.Shared.Input.Binding.PointerInputCmdHandler.<>c__DisplayClass5_0.<.ctor>b__0(PointerInputCmdArgs& args) in C:\Dev\WizDen\RobustToolbox\Robust.Shared\Input\Binding\InputCmdHandler.cs:line 97
   at Robust.Shared.Input.Binding.PointerInputCmdHandler.HandleCmdMessage(IEntityManager entManager, ICommonSession session, IFullInputCmdMessage message) in C:\Dev\WizDen\RobustToolbox\Robust.Shared\Input\Binding\InputCmdHandler.cs:line 114
   at Robust.Client.GameObjects.InputSystem.HandleInputCommand(ICommonSession session, BoundKeyFunction function, IFullInputCmdMessage message, Boolean replay) in C:\Dev\WizDen\RobustToolbox\Robust.Client\GameObjects\EntitySystems\InputSystem.cs:line 79
   at Content.Client.Gameplay.GameplayStateBase.OnKeyBindStateChanged(ViewportBoundKeyEventArgs args) in C:\Dev\WizDen\Content.Client\Gameplay\GameplayStateBase.cs:line 262
   at Robust.Client.Input.InputManager.ViewportKeyEvent(Control viewport, BoundKeyEventArgs eventArgs) in C:\Dev\WizDen\RobustToolbox\Robust.Client\Input\InputManager.cs:line 455
   at Robust.Client.UserInterface.UserInterfaceManager._doGuiInput(Control control, GUIBoundKeyEventArgs guiEvent, Action`2 action, Boolean ignoreStop) in C:\Dev\WizDen\RobustToolbox\Robust.Client\UserInterface\UserInterfaceManager.Input.cs:line 313
   at Robust.Client.UserInterface.UserInterfaceManager.KeyBindDown(BoundKeyEventArgs args) in C:\Dev\WizDen\RobustToolbox\Robust.Client\UserInterface\UserInterfaceManager.Input.cs:line 110
   at Robust.Client.Input.InputManager.SetBindState(KeyBinding binding, BoundKeyState state, Boolean uiOnly, Boolean isRepeat) in C:\Dev\WizDen\RobustToolbox\Robust.Client\Input\InputManager.cs:line 435
   at Robust.Client.Input.InputManager.DownBind(KeyBinding binding, Boolean uiOnly, Boolean isRepeat) in C:\Dev\WizDen\RobustToolbox\Robust.Client\Input\InputManager.cs:line 373
   at Robust.Client.Input.InputManager.KeyDown(KeyEventArgs args) in C:\Dev\WizDen\RobustToolbox\Robust.Client\Input\InputManager.cs:line 293
   at Robust.Client.GameController.KeyDown(KeyEventArgs keyEvent) in C:\Dev\WizDen\RobustToolbox\Robust.Client\GameController\GameController.Input.cs:line 12
   at Robust.Client.Graphics.Clyde.Clyde.DispatchSingleEvent(DEventBase ev) in C:\Dev\WizDen\RobustToolbox\Robust.Client\Graphics\Clyde\Clyde.Events.cs:line 47
   at Robust.Client.Graphics.Clyde.Clyde.DispatchEvents() in C:\Dev\WizDen\RobustToolbox\Robust.Client\Graphics\Clyde\Clyde.Events.cs:line 31
   at Robust.Client.GameController.Input(FrameEventArgs frameEventArgs) in C:\Dev\WizDen\RobustToolbox\Robust.Client\GameController\GameController.cs:line 572
   at Robust.Shared.Timing.GameLoop.Run() in C:\Dev\WizDen\RobustToolbox\Robust.Shared\Timing\GameLoop.cs:line 195
   at Robust.Client.GameController.ContinueStartupAndLoop(DisplayMode mode) in C:\Dev\WizDen\RobustToolbox\Robust.Client\GameController\GameController.Standalone.cs:line 169
   at Robust.Client.GameController.GameThreadMain(DisplayMode mode) in C:\Dev\WizDen\RobustToolbox\Robust.Client\GameController\GameController.Standalone.cs:line 152
   at Robust.Client.GameController.<>c__DisplayClass119_0.<Run>b__0() in C:\Dev\WizDen\RobustToolbox\Robust.Client\GameController\GameController.Standalone.cs:line 111
   at System.Threading.Thread.StartCallback()
```

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix. I found this error by accident.

## Technical details
<!-- Summary of code changes for easier review. -->
I am not very familiar with how prediction works, but from what I can parse from the stack trace this is a prediction based error.

Referencing this comment in `RobustToolbox\Robust.Client\GameObjects\ClientEntityManager.cs`:
```
// Client-side entity deletion is not supported and will cause errors.
```

I am guessing that deleting stuff when it's predicted is bad, so the deletion here needs a guard to check "hey, is this the server? Ok cool you can delete it". Removing the deletion entirely wouldn't be desired behaviour, as the desired behaviour is to have the ammo get "consumed" (deleted) when it hits zero charges.

To fix the error, I added a `IsServer()` check here:
```csharp
        // prevent having useless ammo with 0 charges
        if (comp.Charges <= 0 && _net.IsServer)
            QueueDel(uid);
```

If there's a better way to implement this guard, I'd be happy to learn :>

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Open the game to any map - I used the dev map
2. Spawn `RCDEmpty` and pick it up
3. Spawn `RCDAmmo` and pick it up
4. Put the RCD ammo into the empty RCD
5. Observe as no giant stack trace error appears in the console with this PR applied

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/45107ebc-dd93-4e6c-bd61-11eab219b813

fig. 1 - Demonstrating the test plan described above. No error.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Should be none.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: CawsForConcern
- fix: RCD ammo no longer throws an error when all of its charges are depleted.
