### PR TITLE
Mark more tests as disconnected

### DIFF
--- a/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
+++ b/Content.IntegrationTests/Tests/Access/AccessReaderTest.cs
@@ -13,6 +13,8 @@ namespace Content.IntegrationTests.Tests.Access
     [TestOf(typeof(AccessReaderComponent))]
     public sealed class AccessReaderTest : GameTest
     {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
         [TestPrototypes]
         private const string Prototypes = @"
 - type: entity

--- a/Content.IntegrationTests/Tests/Atmos/AlarmThresholdTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/AlarmThresholdTest.cs
@@ -8,6 +8,8 @@ namespace Content.IntegrationTests.Tests.Atmos
     [TestOf(typeof(AtmosAlarmThreshold))]
     public sealed class AlarmThresholdTest : GameTest
     {
+        public override PoolSettings PoolSettings => PsDisconnected;
+
         private const string AlarmThresholdTestDummyId = "AlarmThresholdTestDummy";
 
         [TestPrototypes]

--- a/Content.IntegrationTests/Tests/Atmos/ConstantsTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/ConstantsTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.IntegrationTests.Fixtures;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.Atmos;
@@ -9,6 +9,8 @@ namespace Content.IntegrationTests.Tests.Atmos;
 [TestOf(typeof(Atmospherics))]
 public sealed class ConstantsTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     [Test]
     public async Task TotalGasesTest()
     {

--- a/Content.IntegrationTests/Tests/Atmos/GasArrayTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/GasArrayTest.cs
@@ -11,6 +11,8 @@ namespace Content.IntegrationTests.Tests.Atmos;
 [TestOf(typeof(Atmospherics))]
 public sealed class GasArrayTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     private const string GasTankTestDummyId = "GasTankTestDummy";
 
     private const string GasTankLegacyTestDummyId = "GasTankLegacyTestDummy";

--- a/Content.IntegrationTests/Tests/Atmos/GasMixtureTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/GasMixtureTest.cs
@@ -1,4 +1,4 @@
-﻿using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures;
 using Content.Server.Atmos;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.Atmos;
@@ -10,6 +10,8 @@ namespace Content.IntegrationTests.Tests.Atmos
     [TestOf(typeof(GasMixture))]
     public sealed class GasMixtureTest : GameTest
     {
+        public override PoolSettings PoolSettings => PsDisconnected;
+
         [Test]
         public async Task TestMerge()
         {

--- a/Content.IntegrationTests/Tests/Atmos/GridJoinTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/GridJoinTest.cs
@@ -9,6 +9,8 @@ namespace Content.IntegrationTests.Tests.Atmos;
 [TestFixture]
 public sealed class GridJoinTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     private const string CanisterProtoId = "AirCanister";
 
     [Test]

--- a/Content.IntegrationTests/Tests/Chemistry/ReagentDataTest.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/ReagentDataTest.cs
@@ -11,6 +11,8 @@ namespace Content.IntegrationTests.Tests.Chemistry;
 [TestOf(typeof(ReagentData))]
 public sealed class ReagentDataTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     [Test]
     public async Task ReagentDataIsSerializable()
     {

--- a/Content.IntegrationTests/Tests/Chemistry/SolutionPurgeRegenerationTests.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/SolutionPurgeRegenerationTests.cs
@@ -14,6 +14,8 @@ namespace Content.IntegrationTests.Tests.Chemistry;
 [TestOf(typeof(SolutionPurgeSystem))]
 public sealed class SolutionPurgeRegenerationTests : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     private static readonly EntProtoId AdvancedMop = "AdvMopItem";
     private static readonly ProtoId<ReagentPrototype> Water = "Water";
     private static readonly ProtoId<ReagentPrototype> NotWater = "DexalinPlus";

--- a/Content.IntegrationTests/Tests/Chemistry/SolutionRoundingTest.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/SolutionRoundingTest.cs
@@ -12,6 +12,8 @@ namespace Content.IntegrationTests.Tests.Chemistry;
 [TestOf(typeof(ChemicalReactionSystem))]
 public sealed class SolutionRoundingTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     // This test tests two things:
     // * A rounding error in reaction code while I was making chloral hydrate
     // * An assert with solution heat capacity calculations that I found a repro for while testing the above.

--- a/Content.IntegrationTests/Tests/Chemistry/SolutionSystemTests.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/SolutionSystemTests.cs
@@ -17,6 +17,8 @@ namespace Content.IntegrationTests.Tests.Chemistry;
 [TestOf(typeof(SharedSolutionContainerSystem))]
 public sealed class SolutionSystemTests : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     [TestPrototypes]
     private const string Prototypes = @"
 - type: entity

--- a/Content.IntegrationTests/Tests/Chemistry/SprayVaporTests.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/SprayVaporTests.cs
@@ -21,6 +21,8 @@ namespace Content.IntegrationTests.Tests.Chemistry;
 [TestOf(typeof(VaporSystem))]
 public sealed class SprayVaporTests : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     private static readonly ProtoId<ReagentPrototype> Blood = "Blood";
     private static readonly EntProtoId SprayBottleSpaceCleaner = "SprayBottleSpaceCleaner";
     private const string BloodPuddle = "SprayVaporTestBloodPuddle";

--- a/Content.IntegrationTests/Tests/Chemistry/TryAllReactionsTest.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/TryAllReactionsTest.cs
@@ -15,6 +15,8 @@ namespace Content.IntegrationTests.Tests.Chemistry
     [TestOf(typeof(ReactionPrototype))]
     public sealed class TryAllReactionsTest : GameTest
     {
+        public override PoolSettings PoolSettings => PsDisconnected;
+
         [TestPrototypes]
         private const string Prototypes = @"
 - type: entity

--- a/Content.IntegrationTests/Tests/Cloning/CloningSettingsPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Cloning/CloningSettingsPrototypeTest.cs
@@ -5,6 +5,8 @@ namespace Content.IntegrationTests.Tests.Cloning;
 
 public sealed class CloningSettingsPrototypeTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     /// <summary>
     /// Checks that the components named in every <see cref="CloningSettingsPrototype"/> are valid components known to the server.
     /// This is used instead of <see cref="ComponentNameSerializer"/> because we only care if the components are registered with the server,

--- a/Content.IntegrationTests/Tests/ConfigPresetTests.cs
+++ b/Content.IntegrationTests/Tests/ConfigPresetTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using Content.IntegrationTests.Fixtures;
 using Content.Server.Entry;
@@ -10,6 +10,8 @@ namespace Content.IntegrationTests.Tests;
 [TestFixture]
 public sealed class ConfigPresetTests : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     [Test]
     public async Task TestLoadAll()
     {

--- a/Content.IntegrationTests/Tests/Construction/ConstructionActionValid.cs
+++ b/Content.IntegrationTests/Tests/Construction/ConstructionActionValid.cs
@@ -10,6 +10,8 @@ namespace Content.IntegrationTests.Tests.Construction
     [TestFixture]
     public sealed class ConstructionActionValid : GameTest
     {
+        public override PoolSettings PoolSettings => PsDisconnected;
+
         private bool IsValid(IGraphAction action, IPrototypeManager protoMan, out string prototype)
         {
             switch (action)

--- a/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Construction/ConstructionPrototypeTest.cs
@@ -10,6 +10,8 @@ namespace Content.IntegrationTests.Tests.Construction
     [TestFixture]
     public sealed class ConstructionPrototypeTest : GameTest
     {
+        public override PoolSettings PoolSettings => PsDisconnected;
+
         // discount linter for construction graphs
         // TODO: Create serialization validators for these?
         // Top test definitely can be but writing a serializer takes ages.

--- a/Content.IntegrationTests/Tests/Damageable/DamageAllPrototypes.cs
+++ b/Content.IntegrationTests/Tests/Damageable/DamageAllPrototypes.cs
@@ -17,6 +17,8 @@ namespace Content.IntegrationTests.Tests.Damageable;
 [TestOf(typeof(DamageableSystem))]
 public sealed class DamageAllPrototypesTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     [SidedDependency(Side.Server)] private readonly DamageableSystem _damageableSystem = default!;
 
     private static string[] _damageables = GameDataScrounger.EntitiesWithComponent("Damageable");

--- a/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/DamageableTest.cs
@@ -15,6 +15,8 @@ namespace Content.IntegrationTests.Tests.Damageable
     [TestOf(typeof(DamageableSystem))]
     public sealed class DamageableTest : GameTest
     {
+        public override PoolSettings PoolSettings => PsDisconnected;
+
         private const string TestDamageableEntityId = "TestDamageableEntityId";
         private const string TestGroup1 = "TestGroup1";
         private const string TestGroup2 = "TestGroup2";

--- a/Content.IntegrationTests/Tests/Damageable/MobThresholdsTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/MobThresholdsTest.cs
@@ -7,6 +7,8 @@ namespace Content.IntegrationTests.Tests.Damageable;
 
 public sealed class MobThresholdsTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     private static string[] _entitiesWithThresholds = GameDataScrounger.EntitiesWithComponent("MobThresholds");
 
     [Test]

--- a/Content.IntegrationTests/Tests/Damageable/StaminaComponentTest.cs
+++ b/Content.IntegrationTests/Tests/Damageable/StaminaComponentTest.cs
@@ -8,6 +8,8 @@ namespace Content.IntegrationTests.Tests.Damageable;
 
 public sealed class StaminaComponentTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     private static string[] _entitiesWithStamina = GameDataScrounger.EntitiesWithComponent("Stamina");
 
     [Test]

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDamageGroupTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDamageGroupTest.cs
@@ -16,6 +16,8 @@ namespace Content.IntegrationTests.Tests.Destructible
     [TestOf(typeof(AndTrigger))]
     public sealed class DestructibleDamageGroupTest : GameTest
     {
+        public override PoolSettings PoolSettings => PsDisconnected;
+
         [Test]
         public async Task AndTest()
         {

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDamageTypeTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDamageTypeTest.cs
@@ -15,6 +15,8 @@ namespace Content.IntegrationTests.Tests.Destructible
     [TestOf(typeof(AndTrigger))]
     public sealed class DestructibleDamageTypeTest : GameTest
     {
+        public override PoolSettings PoolSettings => PsDisconnected;
+
         [Test]
         public async Task Test()
         {

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleDestructionTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleDestructionTest.cs
@@ -13,6 +13,8 @@ namespace Content.IntegrationTests.Tests.Destructible
 {
     public sealed class DestructibleDestructionTest : GameTest
     {
+        public override PoolSettings PoolSettings => PsDisconnected;
+
         [Test]
         public async Task Test()
         {

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleOverkillTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleOverkillTest.cs
@@ -17,6 +17,8 @@ namespace Content.IntegrationTests.Tests.Destructible;
 /// </summary>
 public sealed class DestructibleOverkillTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     [SidedDependency(Side.Server)] private DamageableSystem _sDamageableSystem = default!;
     [SidedDependency(Side.Server)] private TestDestructibleListenerSystem _sDestructibleListenerSystem = default!;
 

--- a/Content.IntegrationTests/Tests/Destructible/DestructibleThresholdActivationTest.cs
+++ b/Content.IntegrationTests/Tests/Destructible/DestructibleThresholdActivationTest.cs
@@ -22,6 +22,8 @@ namespace Content.IntegrationTests.Tests.Destructible
     [TestOf(typeof(DamageThreshold))]
     public sealed class DestructibleThresholdActivationTest : GameTest
     {
+        public override PoolSettings PoolSettings => PsDisconnected;
+
         [Test]
         public async Task Test()
         {

--- a/Content.IntegrationTests/Tests/Explosion/ExplosionPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Explosion/ExplosionPrototypeTest.cs
@@ -6,6 +6,8 @@ namespace Content.IntegrationTests.Tests.Explosion;
 
 public sealed class ExplosionPrototypeTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     private static string[] _explosionKinds = GameDataScrounger.PrototypesOfKind<ExplosionPrototype>();
 
     [Test]

--- a/Content.IntegrationTests/Tests/GameTestTests/DependencyTests.cs
+++ b/Content.IntegrationTests/Tests/GameTestTests/DependencyTests.cs
@@ -14,6 +14,11 @@ namespace Content.IntegrationTests.Tests.GameTestTests;
 [TestOf(typeof(SidedDependencyAttribute))]
 public sealed class DependencyTests : GameTest
 {
+    public override PoolSettings PoolSettings => new()
+    {
+        Connected = true,
+    };
+
     [SidedDependency(Side.Server)] private readonly SharedGameTicker _sGameTicker = null!;
     [SidedDependency(Side.Client)] private readonly SharedGameTicker _cGameTicker = null!;
     [SidedDependency(Side.Server)] private readonly EntityQuery<TransformComponent> _sXformQuery = default!;

--- a/Content.IntegrationTests/Tests/Humanoid/HideablePrototypeValidation.cs
+++ b/Content.IntegrationTests/Tests/Humanoid/HideablePrototypeValidation.cs
@@ -11,6 +11,8 @@ namespace Content.IntegrationTests.Tests.Humanoid;
 [TestFixture]
 public sealed class HideablePrototypeValidation : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     [Test]
     public async Task NoOrgansWithoutClothing()
     {

--- a/Content.IntegrationTests/Tests/Linter/StaticFieldValidationTest.cs
+++ b/Content.IntegrationTests/Tests/Linter/StaticFieldValidationTest.cs
@@ -14,6 +14,8 @@ namespace Content.IntegrationTests.Tests.Linter;
 [TestFixture]
 public sealed class StaticFieldValidationTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     [Test]
     public async Task TestStaticFieldValidation()
     {

--- a/Content.IntegrationTests/Tests/Localization/EntityPrototypeLocalizationTest.cs
+++ b/Content.IntegrationTests/Tests/Localization/EntityPrototypeLocalizationTest.cs
@@ -6,6 +6,8 @@ namespace Content.IntegrationTests.Tests.Localization;
 
 public sealed class EntityPrototypeLocalizationTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     /// <summary>
     /// An explanation of why LocIds should not be used for entity prototype names/descriptions.
     /// Appended to the error message when the test is failed.

--- a/Content.IntegrationTests/Tests/Localization/LocalizedDatasetPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Localization/LocalizedDatasetPrototypeTest.cs
@@ -9,6 +9,8 @@ namespace Content.IntegrationTests.Tests.Localization;
 [TestFixture]
 public sealed class LocalizedDatasetPrototypeTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     [Test]
     public async Task ValidProtoIdsTest()
     {

--- a/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
+++ b/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
@@ -29,6 +29,8 @@ namespace Content.IntegrationTests.Tests;
 [TestFixture]
 public sealed class MaterialArbitrageTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     // These sets are for selectively excluding recipes from arbitrage.
     // You should NOT be adding to these. They exist here for downstreams and potential future issues.
     private readonly HashSet<string> _destructionArbitrageIgnore = [];

--- a/Content.IntegrationTests/Tests/Materials/MaterialTests.cs
+++ b/Content.IntegrationTests/Tests/Materials/MaterialTests.cs
@@ -17,6 +17,8 @@ namespace Content.IntegrationTests.Tests.Materials
     [TestOf(typeof(MaterialPrototype))]
     public sealed class MaterialPrototypeSpawnsStackMaterialTest : GameTest
     {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
         [Test]
         public async Task MaterialPrototypeSpawnsStackMaterial()
         {

--- a/Content.IntegrationTests/Tests/Minds/RoleTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/RoleTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.IntegrationTests.Fixtures;
 using Content.Shared.Roles.Components;
 using Robust.Shared.GameObjects;
@@ -9,6 +9,8 @@ namespace Content.IntegrationTests.Tests.Minds;
 [TestFixture]
 public sealed class RoleTests : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     /// <summary>
     /// Check that any prototype with a <see cref="MindRoleComponent"/> is properly configured
     /// </summary>

--- a/Content.IntegrationTests/Tests/Physics/AnchorPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Physics/AnchorPrototypeTest.cs
@@ -9,6 +9,8 @@ namespace Content.IntegrationTests.Tests.Physics;
 [TestFixture]
 public sealed class AnchorPrototypeTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     /// <summary>
     /// Asserts that entityprototypes marked as anchored are also static physics bodies.
     /// </summary>

--- a/Content.IntegrationTests/Tests/Power/PowerStatePrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Power/PowerStatePrototypeTest.cs
@@ -11,6 +11,8 @@ namespace Content.IntegrationTests.Tests.Power;
 [TestFixture, TestOf(typeof(SharedPowerStateSystem))]
 public sealed class PowerStatePrototypeTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     /// <summary>
     /// Asserts that the <see cref="SharedApcPowerReceiverComponent"/>'s load is the same
     /// as the idle or working power draw from <see cref="PowerStateComponent"/>,

--- a/Content.IntegrationTests/Tests/Power/PowerStateTest.cs
+++ b/Content.IntegrationTests/Tests/Power/PowerStateTest.cs
@@ -11,6 +11,8 @@ namespace Content.IntegrationTests.Tests.Power;
 [TestFixture]
 public sealed class PowerStateTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     [TestPrototypes]
     private const string Prototypes = @"
 - type: entity

--- a/Content.IntegrationTests/Tests/ResearchTest.cs
+++ b/Content.IntegrationTests/Tests/ResearchTest.cs
@@ -11,6 +11,8 @@ namespace Content.IntegrationTests.Tests;
 [TestFixture]
 public sealed class ResearchTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     [Test]
     public async Task DisciplineValidTierPrerequesitesTest()
     {

--- a/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
+++ b/Content.IntegrationTests/Tests/Serialization/SerializationTest.cs
@@ -11,6 +11,8 @@ namespace Content.IntegrationTests.Tests.Serialization;
 [TestFixture]
 public sealed partial class SerializationTest : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     /// <summary>
     /// Check that serializing generic enums works as intended. This should really be in engine, but engine
     /// integrations tests block reflection and I am lazy..

--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -16,6 +16,8 @@ namespace Content.IntegrationTests.Tests;
 [TestFixture]
 public sealed class StoreTests : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
 
     [TestPrototypes]
     private const string Prototypes = @"

--- a/Content.IntegrationTests/Tests/Tag/TagTest.cs
+++ b/Content.IntegrationTests/Tests/Tag/TagTest.cs
@@ -13,6 +13,8 @@ namespace Content.IntegrationTests.Tests.Tag
     [TestOf(typeof(TagComponent))]
     public sealed class TagTest : GameTest
     {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
         private const string TagEntityId = "TagTestDummy";
 
         // Register these three into the prototype manager

--- a/Content.IntegrationTests/Tests/Utility/EntityWhitelistTest.cs
+++ b/Content.IntegrationTests/Tests/Utility/EntityWhitelistTest.cs
@@ -9,6 +9,8 @@ namespace Content.IntegrationTests.Tests.Utility
     [TestOf(typeof(EntityWhitelist))]
     public sealed class EntityWhitelistTest : GameTest
     {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
         private const string InvalidComponent = "Sprite";
         private const string ValidComponent = "Physics";
 

--- a/Content.IntegrationTests/Tests/WizdenContentFreeze/WizdenContentFreeze.cs
+++ b/Content.IntegrationTests/Tests/WizdenContentFreeze/WizdenContentFreeze.cs
@@ -8,6 +8,8 @@ namespace Content.IntegrationTests.Tests.WizdenContentFreeze;
 /// </summary>
 public sealed class WizdenContentFreeze : GameTest
 {
+    public override PoolSettings PoolSettings => PsDisconnected;
+
     /// <summary>
     /// This freeze prohibits the addition of new microwave recipes.
     /// The maintainers decided that the mechanics of cooking food in the microwave should be removed,


### PR DESCRIPTION
GameTest is weird and having 2 different test pools built on top of robust's integration test is also weird.

Anyway these are the tests that I could see being safely marked as disconnected. I have no idea if it even makes things faster but in an ideal world it should as the client should be ignorable.