### PR TITLE
Fix: Screens on Serpentcrest now properly show evac timers

### DIFF
--- a/Resources/Maps/Shuttles/emergency_syndicate.yml
+++ b/Resources/Maps/Shuttles/emergency_syndicate.yml
@@ -194,6 +194,12 @@ entities:
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: DeviceNetwork
+      deviceNetId: Wireless
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
+    - type: NavMap
     - type: ExplosionAirtightGrid
 - proto: AirlockCargoGlassLocked
   entities:


### PR DESCRIPTION
## About the PR
This PR fixes the Serpentcrest evac shuttle to properly broadcast its evac time tables. This enables screens on the station itself, the evac shuttle, and central command to be able to see countdowns properly.

## Why / Balance
Because knowing when evac is arriving at a reasonable glance is good for players, and AI players  won't go rampant from being requested for evac times for the 27th time in a round. 
This PR exists because I had to fix a similar issue on a downstream map and became aware of Serpentcrest needing a similar fix. 

Resolves: https://github.com/space-wizards/space-station-14/issues/44158

## Technical details
Modified the yml of `emergency_syndicate.yml` to add the following.
```
    - type: DeviceNetwork
      deviceNetId: Wireless
      configurators: []
      deviceLists: []
      transmitFrequencyId: ShuttleTimer
    - type: NavMap
```
Used Box's shuttle for comparison and added the missing components and metadata for the DeviceNetwork component.

## Test plan
1. Start up a Release version of the dev env server and client.
2. enter the  console command `forcemap serpentcrest`. Join and start the round.
3. Navigate to evac (has the most screens) 
4. F7 -> (Re)Call Shuttle -> Call the shuttle
5. Screens will display evac timers.

## Media
<img width="1152" height="652" alt="image" src="https://github.com/user-attachments/assets/4c6fb9b1-d0ef-4aee-9c7b-ea7e4b496b56" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

## Changelog
:cl:
MAPS:
- fix: On Serpentcrest, wall screens now show evacuation timers properly.
