### PR TITLE
Adds events for Chasm falling start+stop

### DIFF
--- a/Content.Client/Chasm/ChasmFallingVisualsSystem.cs
+++ b/Content.Client/Chasm/ChasmFallingVisualsSystem.cs
@@ -13,7 +13,10 @@ public sealed partial class ChasmFallingVisualsSystem : EntitySystem
     [Dependency] private AnimationPlayerSystem _anim = default!;
     [Dependency] private SpriteSystem _sprite = default!;
 
-    private readonly string _chasmFallAnimationKey = "chasm_fall";
+    [Dependency] private EntityQuery<AnimationPlayerComponent> _animationPlayerQuery;
+    [Dependency] private EntityQuery<SpriteComponent> _spriteQuery;
+
+    private const string ChasmFallAnimationKey = "chasm_fall";
 
     public override void Initialize()
     {
@@ -23,60 +26,62 @@ public sealed partial class ChasmFallingVisualsSystem : EntitySystem
         SubscribeLocalEvent<ChasmFallingComponent, ComponentRemove>(OnComponentRemove);
     }
 
-    private void OnComponentInit(EntityUid uid, ChasmFallingComponent component, ComponentInit args)
+    private void OnComponentInit(Entity<ChasmFallingComponent> entity, ref ComponentInit args)
     {
-        if (!TryComp<SpriteComponent>(uid, out var sprite) ||
-            TerminatingOrDeleted(uid))
+        if (!_spriteQuery.TryComp(entity, out var sprite) ||
+            TerminatingOrDeleted(entity))
         {
             return;
         }
 
-        component.OriginalScale = sprite.Scale;
+        entity.Comp.OriginalScale = sprite.Scale;
 
-        if (!TryComp<AnimationPlayerComponent>(uid, out var player))
-            return;
-
-        if (_anim.HasRunningAnimation(player, _chasmFallAnimationKey))
-            return;
-
-        _anim.Play((uid, player), GetFallingAnimation(component), _chasmFallAnimationKey);
-    }
-
-    private void OnComponentRemove(EntityUid uid, ChasmFallingComponent component, ComponentRemove args)
-    {
-        if (!TryComp<SpriteComponent>(uid, out var sprite))
-            return;
-
-        _sprite.SetScale((uid, sprite), component.OriginalScale);
-
-        if (!TryComp<AnimationPlayerComponent>(uid, out var player))
-            return;
-
-        if (_anim.HasRunningAnimation(player, _chasmFallAnimationKey))
-            _anim.Stop((uid, player), _chasmFallAnimationKey);
-    }
-
-    private Animation GetFallingAnimation(ChasmFallingComponent component)
-    {
-        var length = component.AnimationTime;
-
-        return new Animation()
+        if (!_animationPlayerQuery.TryComp(entity, out var player) ||
+            _anim.HasRunningAnimation(player, ChasmFallAnimationKey))
         {
-            Length = length,
+            return;
+        }
+
+        _anim.Play((entity, player), GetFallingAnimation(entity.Comp), ChasmFallAnimationKey);
+    }
+
+    private void OnComponentRemove(Entity<ChasmFallingComponent> entity, ref ComponentRemove args)
+    {
+        if (!_spriteQuery.TryComp(entity, out var sprite))
+        {
+            return;
+        }
+
+        _sprite.SetScale((entity, sprite), entity.Comp.OriginalScale);
+
+        if (!_animationPlayerQuery.TryComp(entity, out var player) ||
+            !_anim.HasRunningAnimation(player, ChasmFallAnimationKey))
+        {
+            return;
+        }
+
+        _anim.Stop((entity, player), ChasmFallAnimationKey);
+    }
+
+    private static Animation GetFallingAnimation(ChasmFallingComponent component)
+    {
+        return new Animation
+        {
+            Length = component.AnimationTime,
             AnimationTracks =
             {
-                new AnimationTrackComponentProperty()
+                new AnimationTrackComponentProperty
                 {
                     ComponentType = typeof(SpriteComponent),
                     Property = nameof(SpriteComponent.Scale),
                     KeyFrames =
                     {
                         new AnimationTrackProperty.KeyFrame(component.OriginalScale, 0.0f),
-                        new AnimationTrackProperty.KeyFrame(component.AnimationScale, length.Seconds),
+                        new AnimationTrackProperty.KeyFrame(component.AnimationScale, component.AnimationTime.Seconds),
                     },
-                    InterpolationMode = AnimationInterpolationMode.Cubic
-                }
-            }
+                    InterpolationMode = AnimationInterpolationMode.Cubic,
+                },
+            },
         };
     }
 }

--- a/Content.Shared/Chasm/ChasmComponent.cs
+++ b/Content.Shared/Chasm/ChasmComponent.cs
@@ -12,6 +12,30 @@ public sealed partial class ChasmComponent : Component
     /// <summary>
     ///     Sound that should be played when an entity falls into the chasm
     /// </summary>
-    [DataField("fallingSound")]
+    [DataField]
     public SoundSpecifier FallingSound = new SoundPathSpecifier("/Audio/Effects/falling.ogg");
 }
+
+/// <summary>
+/// This event is raised on an entity when it begins falling into <paramref name="FallingInto"/>.
+/// </summary>
+[ByRefEvent]
+public readonly record struct StartedFallingIntoChasmEvent(Entity<ChasmComponent> FallingInto);
+
+/// <summary>
+/// This event is raised on a chasm when <paramref name="Faller"/> begins falling into it.
+/// </summary>
+[ByRefEvent]
+public readonly record struct EntityStartedFallingIntoChasmEvent(Entity<ChasmFallingComponent> Faller);
+
+/// <summary>
+/// This event is raised on an entity when it has finished falling into <paramref name="FellInto"/>, just before it is deleted.
+/// </summary>
+[ByRefEvent]
+public readonly record struct CompletedFallingIntoChasmEvent(Entity<ChasmComponent> FellInto);
+
+/// <summary>
+/// This event is raised on a chasm when <paramref name="Faller"/> has finished falling into it, just before it is deleted.
+/// </summary>
+[ByRefEvent]
+public readonly record struct EntityCompletedFallingIntoChasmEvent(Entity<ChasmFallingComponent> Faller);

--- a/Content.Shared/Chasm/ChasmFallingComponent.cs
+++ b/Content.Shared/Chasm/ChasmFallingComponent.cs
@@ -7,22 +7,28 @@ namespace Content.Shared.Chasm;
 /// <summary>
 ///     Added to entities which have started falling into a chasm.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class ChasmFallingComponent : Component
 {
     /// <summary>
+    ///     The entity with <see cref="ChasmComponent"/> that this entity is falling into.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid FallingInto;
+
+    /// <summary>
     ///     Time it should take for the falling animation (scaling down) to complete.
     /// </summary>
-    [DataField("animationTime")]
+    [DataField]
     public TimeSpan AnimationTime = TimeSpan.FromSeconds(1.5f);
 
     /// <summary>
     ///     Time it should take in seconds for the entity to actually delete
     /// </summary>
-    [DataField("deletionTime")]
+    [DataField]
     public TimeSpan DeletionTime = TimeSpan.FromSeconds(1.8f);
 
-    [DataField("nextDeletionTime", customTypeSerializer:typeof(TimeOffsetSerializer))]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoPausedField]
     public TimeSpan NextDeletionTime = TimeSpan.Zero;
 
@@ -34,5 +40,5 @@ public sealed partial class ChasmFallingComponent : Component
     /// <summary>
     ///     Scale that the animation should bring entities to.
     /// </summary>
-    public Vector2 AnimationScale = new Vector2(0.01f, 0.01f);
+    public Vector2 AnimationScale = new(0.01f, 0.01f);
 }

--- a/Content.Shared/Chasm/ChasmSystem.cs
+++ b/Content.Shared/Chasm/ChasmSystem.cs
@@ -69,10 +69,14 @@ public sealed partial class ChasmSystem : EntitySystem
     /// <summary>
     /// Causes <paramref name="tripper"/> to fall into <paramref name="chasm"/>: starts a falling animation, optionally
     /// plays a sound, and eventually deletes <paramref name="tripper"/>.
+    /// If <paramref name="chasm"/> does not have a <see cref="ChasmComponent"/> component, does nothing.
     /// </summary>
     [PublicAPI]
-    public void StartFalling(Entity<ChasmComponent> chasm, EntityUid tripper, bool playSound = true)
+    public void StartFalling(Entity<ChasmComponent?> chasm, EntityUid tripper, bool playSound = true)
     {
+        if (!_chasmQuery.Resolve(chasm, ref chasm.Comp, logMissing: false))
+            return;
+
         var falling = AddComp<ChasmFallingComponent>(tripper);
         falling.FallingInto = chasm;
 

--- a/Content.Shared/Chasm/ChasmSystem.cs
+++ b/Content.Shared/Chasm/ChasmSystem.cs
@@ -2,9 +2,10 @@
 using Content.Shared.Movement.Events;
 using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Weapons.Misc;
+using JetBrains.Annotations;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Network;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Chasm;
 
@@ -15,9 +16,11 @@ public sealed partial class ChasmSystem : EntitySystem
 {
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private ActionBlockerSystem _blocker = default!;
-    [Dependency] private INetManager _net = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedGrapplingGunSystem _grapple = default!;
+
+    [Dependency] private EntityQuery<ChasmComponent> _chasmQuery;
+    [Dependency] private EntityQuery<ChasmFallingComponent> _chasmFallingQuery;
 
     public override void Initialize()
     {
@@ -32,41 +35,62 @@ public sealed partial class ChasmSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        // don't predict queuedels on client
-        if (_net.IsClient)
-            return;
-
         var query = EntityQueryEnumerator<ChasmFallingComponent>();
         while (query.MoveNext(out var uid, out var chasm))
         {
             if (_timing.CurTime < chasm.NextDeletionTime)
                 continue;
 
-            QueueDel(uid);
+            var chasmEvent = new EntityCompletedFallingIntoChasmEvent((uid, chasm));
+            RaiseLocalEvent(chasm.FallingInto, ref chasmEvent);
+            if (_chasmQuery.TryComp(chasm.FallingInto, out var chasmComp))
+            {
+                var tripperEvent = new CompletedFallingIntoChasmEvent((chasm.FallingInto, chasmComp));
+                RaiseLocalEvent(uid, ref tripperEvent);
+            }
+            else
+            {
+                DebugTools.Assert($"{ToPrettyString(chasm.FallingInto)} is missing {nameof(ChasmComponent)}");
+            }
+
+            PredictedQueueDel(uid);
         }
     }
 
-    private void OnStepTriggered(EntityUid uid, ChasmComponent component, ref StepTriggeredOffEvent args)
+    private void OnStepTriggered(Entity<ChasmComponent> entity, ref StepTriggeredOffEvent args)
     {
         // already doomed
-        if (HasComp<ChasmFallingComponent>(args.Tripper))
+        if (_chasmFallingQuery.HasComp(args.Tripper))
             return;
 
-        StartFalling(uid, component, args.Tripper);
+        StartFalling(entity, args.Tripper);
     }
 
-    public void StartFalling(EntityUid chasm, ChasmComponent component, EntityUid tripper, bool playSound = true)
+    /// <summary>
+    /// Causes <paramref name="tripper"/> to fall into <paramref name="chasm"/>: starts a falling animation, optionally
+    /// plays a sound, and eventually deletes <paramref name="tripper"/>.
+    /// </summary>
+    [PublicAPI]
+    public void StartFalling(Entity<ChasmComponent> chasm, EntityUid tripper, bool playSound = true)
     {
         var falling = AddComp<ChasmFallingComponent>(tripper);
+        falling.FallingInto = chasm;
 
         falling.NextDeletionTime = _timing.CurTime + falling.DeletionTime;
         _blocker.UpdateCanMove(tripper);
 
         if (playSound)
-            _audio.PlayPredicted(component.FallingSound, chasm, tripper);
+            _audio.PlayPredicted(chasm.Comp.FallingSound, chasm, tripper);
+
+        var chasmEvent = new EntityStartedFallingIntoChasmEvent((tripper, falling));
+        RaiseLocalEvent(chasm, ref chasmEvent);
+        var tripperEvent = new StartedFallingIntoChasmEvent(chasm);
+        RaiseLocalEvent(tripper, ref tripperEvent);
+
+        Dirty(tripper, falling);
     }
 
-    private void OnStepTriggerAttempt(EntityUid uid, ChasmComponent component, ref StepTriggerAttemptEvent args)
+    private void OnStepTriggerAttempt(Entity<ChasmComponent> entity, ref StepTriggerAttemptEvent args)
     {
         if (_grapple.IsEntityHooked(args.Tripper))
         {
@@ -77,7 +101,7 @@ public sealed partial class ChasmSystem : EntitySystem
         args.Continue = true;
     }
 
-    private void OnUpdateCanMove(EntityUid uid, ChasmFallingComponent component, UpdateCanMoveEvent args)
+    private static void OnUpdateCanMove(Entity<ChasmFallingComponent> entity, ref UpdateCanMoveEvent args)
     {
         args.Cancel();
     }

--- a/Content.Shared/Chasm/ChasmSystem.cs
+++ b/Content.Shared/Chasm/ChasmSystem.cs
@@ -63,19 +63,26 @@ public sealed partial class ChasmSystem : EntitySystem
         if (_chasmFallingQuery.HasComp(args.Tripper))
             return;
 
-        StartFalling(entity, args.Tripper);
+        StartFalling(entity.AsNullable(), args.Tripper);
     }
 
     /// <summary>
     /// Causes <paramref name="tripper"/> to fall into <paramref name="chasm"/>: starts a falling animation, optionally
     /// plays a sound, and eventually deletes <paramref name="tripper"/>.
-    /// If <paramref name="chasm"/> does not have a <see cref="ChasmComponent"/> component, does nothing.
+    /// If <paramref name="chasm"/> does not have a <see cref="ChasmComponent"/> component, does nothing and returns null.
     /// </summary>
+    /// <returns>
+    /// <paramref name="tripper"/> with its new <see cref="ChasmFallingComponent"/>, if the entity did start falling. Null otherwise.
+    /// </returns>
     [PublicAPI]
-    public void StartFalling(Entity<ChasmComponent?> chasm, EntityUid tripper, bool playSound = true)
+    public Entity<ChasmFallingComponent>? StartFalling(
+        Entity<ChasmComponent?> chasm,
+        EntityUid tripper,
+        bool playSound = true
+    )
     {
         if (!_chasmQuery.Resolve(chasm, ref chasm.Comp, logMissing: false))
-            return;
+            return null;
 
         var falling = AddComp<ChasmFallingComponent>(tripper);
         falling.FallingInto = chasm;
@@ -88,10 +95,12 @@ public sealed partial class ChasmSystem : EntitySystem
 
         var chasmEvent = new EntityStartedFallingIntoChasmEvent((tripper, falling));
         RaiseLocalEvent(chasm, ref chasmEvent);
-        var tripperEvent = new StartedFallingIntoChasmEvent(chasm);
+        var tripperEvent = new StartedFallingIntoChasmEvent((chasm, chasm.Comp));
         RaiseLocalEvent(tripper, ref tripperEvent);
 
-        Dirty(tripper, falling);
+        Entity<ChasmFallingComponent> ret = (tripper, falling);
+        Dirty(ret);
+        return ret;
     }
 
     private void OnStepTriggerAttempt(Entity<ChasmComponent> entity, ref StepTriggerAttemptEvent args)

--- a/Content.Shared/Chasm/ChasmSystem.cs
+++ b/Content.Shared/Chasm/ChasmSystem.cs
@@ -1,12 +1,9 @@
 ﻿using Content.Shared.ActionBlocker;
-using Content.Shared.Item;
 using Content.Shared.Movement.Events;
-using Content.Shared.Popups;
 using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Weapons.Misc;
 using JetBrains.Annotations;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Network;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -25,9 +22,6 @@ public sealed partial class ChasmSystem : EntitySystem
     [Dependency] private EntityQuery<ChasmComponent> _chasmQuery;
     [Dependency] private EntityQuery<ChasmFallingComponent> _chasmFallingQuery;
 
-    [Dependency] private SharedPopupSystem _p = default!;
-    [Dependency] private INetManager _n = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -35,29 +29,6 @@ public sealed partial class ChasmSystem : EntitySystem
         SubscribeLocalEvent<ChasmComponent, StepTriggeredOffEvent>(OnStepTriggered);
         SubscribeLocalEvent<ChasmComponent, StepTriggerAttemptEvent>(OnStepTriggerAttempt);
         SubscribeLocalEvent<ChasmFallingComponent, UpdateCanMoveEvent>(OnUpdateCanMove);
-
-        // Server check guards are to prevent predicted replay spamming popups.
-        SubscribeLocalEvent<ItemComponent, StartedFallingIntoChasmEvent>((ent, ref args) =>
-        {
-            if (!_n.IsServer) return;
-            _p.PopupEntity($"\nEnt start fall into {ToPrettyString(args.FallingInto)} ({args.FallingInto.Comp})", args.FallingInto);
-        });
-        SubscribeLocalEvent<ChasmComponent, EntityStartedFallingIntoChasmEvent>((ent, ref args) =>
-        {
-            if (!_n.IsServer) return;
-            _p.PopupEntity($"Chasm starts fall for {ToPrettyString(args.Faller)} ({args.Faller.Comp})\n", ent);
-        });
-
-        SubscribeLocalEvent<ItemComponent, CompletedFallingIntoChasmEvent>((ent, ref args) =>
-        {
-            if (!_n.IsServer) return;
-            _p.PopupEntity($"\nEnt completes fall into {ToPrettyString(args.FellInto)} ({args.FellInto.Comp})", args.FellInto);
-        });
-        SubscribeLocalEvent<ChasmComponent, EntityCompletedFallingIntoChasmEvent>((ent, ref args) =>
-        {
-            if (!_n.IsServer) return;
-            _p.PopupEntity($"Chasm completes fall for {ToPrettyString(args.Faller)} ({args.Faller.Comp})\n", ent);
-        });
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/Chasm/ChasmSystem.cs
+++ b/Content.Shared/Chasm/ChasmSystem.cs
@@ -1,9 +1,12 @@
 ﻿using Content.Shared.ActionBlocker;
+using Content.Shared.Item;
 using Content.Shared.Movement.Events;
+using Content.Shared.Popups;
 using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Weapons.Misc;
 using JetBrains.Annotations;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -22,6 +25,9 @@ public sealed partial class ChasmSystem : EntitySystem
     [Dependency] private EntityQuery<ChasmComponent> _chasmQuery;
     [Dependency] private EntityQuery<ChasmFallingComponent> _chasmFallingQuery;
 
+    [Dependency] private SharedPopupSystem _p = default!;
+    [Dependency] private INetManager _n = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -29,6 +35,29 @@ public sealed partial class ChasmSystem : EntitySystem
         SubscribeLocalEvent<ChasmComponent, StepTriggeredOffEvent>(OnStepTriggered);
         SubscribeLocalEvent<ChasmComponent, StepTriggerAttemptEvent>(OnStepTriggerAttempt);
         SubscribeLocalEvent<ChasmFallingComponent, UpdateCanMoveEvent>(OnUpdateCanMove);
+
+        // Server check guards are to prevent predicted replay spamming popups.
+        SubscribeLocalEvent<ItemComponent, StartedFallingIntoChasmEvent>((ent, ref args) =>
+        {
+            if (!_n.IsServer) return;
+            _p.PopupEntity($"\nEnt start fall into {ToPrettyString(args.FallingInto)} ({args.FallingInto.Comp})", args.FallingInto);
+        });
+        SubscribeLocalEvent<ChasmComponent, EntityStartedFallingIntoChasmEvent>((ent, ref args) =>
+        {
+            if (!_n.IsServer) return;
+            _p.PopupEntity($"Chasm starts fall for {ToPrettyString(args.Faller)} ({args.Faller.Comp})\n", ent);
+        });
+
+        SubscribeLocalEvent<ItemComponent, CompletedFallingIntoChasmEvent>((ent, ref args) =>
+        {
+            if (!_n.IsServer) return;
+            _p.PopupEntity($"\nEnt completes fall into {ToPrettyString(args.FellInto)} ({args.FellInto.Comp})", args.FellInto);
+        });
+        SubscribeLocalEvent<ChasmComponent, EntityCompletedFallingIntoChasmEvent>((ent, ref args) =>
+        {
+            if (!_n.IsServer) return;
+            _p.PopupEntity($"Chasm completes fall for {ToPrettyString(args.Faller)} ({args.Faller.Comp})\n", ent);
+        });
     }
 
     public override void Update(float frameTime)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title, plus modernization of Chasm implementation.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's purely a refactor with no player-facing changes.
I need the events for a downstream feature and figure that this is a nice, clean, small improvement to provide here.

## Technical details
<!-- Summary of code changes for easier review. -->
Uhhhhhhhhhhhhh the modernization stuff is just cleaning up lint warnings, changing subscriptions to use event by reference, changing to use Component queries, etc.

The events are just dinky "A thing started falling", "A thing started falling into you" type events, `ByRefEvents`.
Should be really easy to understand.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Add testing only changes (check 1cc3e437e2faf5195fc7df7694d20cb998783bcc in this PR)
Start client+server
Spawn chasm
Yeet shit into chasm
Observe event handlers reacting

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


https://github.com/user-attachments/assets/8c4ce3bd-31ea-47bb-ad9f-4cfbb1ef76af

Includes the testing-only changes from 1cc3e437e2faf5195fc7df7694d20cb998783bcc to make the popups appear.
One line of the popup is handling the event directed at the item, the other is the event directed at the chasm, demonstrating that both work.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- `ChasmSystem.StartFalling` now takes an `Entity<ChasmComponent>` instead of separated entity and component.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
N/A, not player facing.
