### PR TITLE
Add a species randomizer lock button to the loadout screen

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.BasicInfo.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.BasicInfo.cs
@@ -23,7 +23,14 @@ public sealed partial class HumanoidProfileEditor
 
     private void RandomizeEverything()
     {
-        Profile = HumanoidCharacterProfile.Random();
+        if (SpeciesRandomizerLockButton.Pressed && Profile != null)
+        {
+            Profile = HumanoidCharacterProfile.Random(speciesOverride: Profile.Species);
+        }
+        else
+        {
+            Profile = HumanoidCharacterProfile.Random();
+        }
         SetProfile(Profile, CharacterSlot);
         SetDirty();
     }

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -57,6 +57,13 @@
                                 <BoxContainer HorizontalExpand="True">
                                     <Label Text="{Loc 'humanoid-profile-editor-species-label'}" />
                                     <Control HorizontalExpand="True"/>
+                                    <TextureButton Name="SpeciesRandomizerLockButton"
+                                                   ToggleMode="True"
+                                                   VerticalAlignment="Center"
+                                                   Scale="0.25 0.25"
+                                                   ToolTip="{Loc 'humanoid-profile-editor-species-randomizer-lock-tooltip'}"
+                                    >
+                                    </TextureButton>
                                     <TextureButton Name="SpeciesInfoButton" Scale="0.3 0.3"
                                                    VerticalAlignment="Center"
                                                    ToolTip="{Loc 'humanoid-profile-editor-guidebook-button-tooltip'}"/>

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -200,6 +200,24 @@ namespace Content.Client.Lobby.UI
                 OnSkinColorOnValueChanged();
             };
 
+            {
+                var lockTexture = "/Textures/Interface/VerbIcons/lock.svg.192dpi.png";
+                var unlockTexture = "/Textures/Interface/VerbIcons/unlock.svg.192dpi.png";
+                SpeciesRandomizerLockButton.OnToggled += args =>
+                {
+                    if (args.Pressed)
+                    {
+                        SpeciesRandomizerLockButton.TexturePath = lockTexture;
+                    }
+                    else
+                    {
+                        SpeciesRandomizerLockButton.TexturePath = unlockTexture;
+                    }
+                };
+                SpeciesRandomizerLockButton.TexturePath = unlockTexture;
+                SpeciesRandomizerLockButton.Pressed = false;
+            }
+
             #region Skin
 
             Skin.OnValueChanged += _ =>

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -214,18 +214,25 @@ namespace Content.Shared.Preferences
         }
 
         // TODO: This should eventually not be a visual change only.
-        public static HumanoidCharacterProfile Random(HashSet<string>? ignoredSpecies = null)
+        public static HumanoidCharacterProfile Random(HashSet<string>? ignoredSpecies = null, ProtoId<SpeciesPrototype>? speciesOverride = null)
         {
             var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
             var random = IoCManager.Resolve<IRobustRandom>();
 
-            var species = random.Pick(prototypeManager
+            SpeciesPrototype? speciesProto = null;
+            if (speciesOverride != null)
+            {
+                prototypeManager.TryIndex(speciesOverride, out speciesProto);
+            }
+
+            // use both as a default and a fallback when override fails
+            speciesProto ??= random.Pick(prototypeManager
                 .EnumeratePrototypes<SpeciesPrototype>()
                 .Where(x => ignoredSpecies == null ? x.RoundStart : x.RoundStart && !ignoredSpecies.Contains(x.ID))
                 .ToArray()
-            ).ID;
+            );
 
-            return RandomWithSpecies(species);
+            return RandomWithSpecies(speciesProto.ID);
         }
 
         public static HumanoidCharacterProfile RandomWithSpecies(string? species = null)

--- a/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
@@ -11,6 +11,7 @@ humanoid-profile-editor-sex-unsexed-text = None
 humanoid-profile-editor-age-label = Age:
 humanoid-profile-editor-skin-color-label = Skin color:
 humanoid-profile-editor-species-label = Species:
+humanoid-profile-editor-species-randomizer-lock-tooltip = Prevents selected species from randomizing
 humanoid-profile-editor-pronouns-label = Pronouns:
 humanoid-profile-editor-pronouns-male-text = He / Him
 humanoid-profile-editor-pronouns-female-text = She / Her


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a button to the loadout screen that locks species selection when "randomizing everything".

## Why / Balance
I often start character creation by randomizing everything but in most cases I already have a species in mind. Having no way to lock that down causes a morbiliion clicks to the randomize button.

## Technical details
Added an optional argument to the `Random()` static method of `HumanoidCharacterProfile` that allows to specify species on rolls.

## Test plan
Open dev, go to lobby, char editor, toggle randomize lock and press randomize a bunch of times.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="856" height="613" alt="Screenshot_20260614_001738" src="https://github.com/user-attachments/assets/ed2762b2-2c3a-46ed-b884-7ff6de544583" />
<img width="1017" height="489" alt="Screenshot_20260614_001744" src="https://github.com/user-attachments/assets/b2c8fdb0-3bc8-4599-9468-5bb4ec4f73c8" />


https://github.com/user-attachments/assets/1c8afdf5-c580-4112-b99a-d521d6a00d8b



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added a species randomizer lock button to the loadout screen.
