### PR TITLE
Fixes MiningWindowDiagonal having the wrong parent

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Windows/mining.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/mining.yml
@@ -47,7 +47,7 @@
     price: 100
 
 - type: entity
-  parent: ShuttleWindow
+  parent: MiningWindow
   id: MiningWindowDiagonal
   suffix: diagonal
   placement:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`MiningWindowDiagonal`'s parent was `ShuttleWindow` instead of `MiningWindow`. This made it inherit the wrong values as well as show up in the spawn menu named as 'shuttle window [diagonal].

This PR fixes the parent of `MiningWindowDiagonal`, setting it to `MiningWindow` as expected.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed the `parent` of `MiningWindowDiagonal` from `ShuttleWindow` to `MiningWindow`.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Open spawn menu
2. Observe that `MiningWindowDiagonal` is named "mining window [diagonal]" instead of "shuttle window [diagonal]"
3. Hit the `MiningWindowDiagonal` with a weapon and observe that it's no longer as tough as a `shuttle window`.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="374" height="420" alt="image" src="https://github.com/user-attachments/assets/c082fd71-e1f1-41cc-85be-b0e50afda30b" />

fig. 1 - As seen in the spawn menu after the fix.

<img width="319" height="342" alt="image" src="https://github.com/user-attachments/assets/05c11d9c-632e-41a8-8bd7-dee46d059083" />

fig. 2 - I hit each of the windows here with an e-sword twice to show the window's health values are now as expected.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

