### PR TITLE
Fix infinite board dupe in television/telescreen construction graphs.

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_telemonitors.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_telemonitors.yml
@@ -48,9 +48,6 @@
             - !type:GivePrototype
               prototype: CableApcStack1
               amount: 5
-            - !type:GivePrototype
-              prototype: SurveillanceCameraMonitorCircuitboard
-              amount: 1
           steps:
             - tool: Cutting
               doAfter: 2
@@ -70,8 +67,8 @@
         - to: Wired
           completed:
             - !type:GivePrototype
-              prototype: SheetGlass1
-              amount: 2
+              prototype: SurveillanceCameraMonitorCircuitboard
+              amount: 1
           steps:
             - tool: Prying
               doAfter: 2
@@ -81,9 +78,15 @@
       entity: WallmountTelescreen
       edges:
         - to: Screen
+          completed:
+            - !type:GivePrototype
+              prototype: SheetGlass1
+              amount: 2
           steps:
             - tool: Screwing
-              doAfter: 3
+              doAfter: 2
+            - tool: Prying
+              doAfter: 2
 
 # TVs
 
@@ -130,16 +133,13 @@
               name: construction-graph-tag-television-board
               icon:
                 sprite: Objects/Misc/module.rsi
-                state: cpuboard
+                state: cpu_security
 
         - to: TelevisionFrame
           completed:
             - !type:GivePrototype
               prototype: CableApcStack1
               amount: 5
-            - !type:GivePrototype
-              prototype: ComputerTelevisionCircuitboard
-              amount: 1
           steps:
             - tool: Cutting
               doAfter: 2
@@ -159,8 +159,8 @@
         - to: Wired
           completed:
             - !type:GivePrototype
-              prototype: SheetGlass1
-              amount: 2
+              prototype: ComputerTelevisionCircuitboard
+              amount: 1
           steps:
             - tool: Prying
               doAfter: 2
@@ -170,7 +170,13 @@
       entity: WallmountTelevision
       edges:
         - to: Screen
+          completed:
+            - !type:GivePrototype
+              prototype: SheetGlass1
+              amount: 2
           steps:
             - tool: Screwing
-              doAfter: 3
+              doAfter: 2
+            - tool: Prying
+              doAfter: 2
 

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_telemonitors.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/wallmount_telemonitors.yml
@@ -41,7 +41,7 @@
               name: construction-graph-tag-surveillance-camera-monitor-board
               icon:
                 sprite: Objects/Misc/module.rsi
-                state: cpuboard
+                state: cpu_security
 
         - to: TelescreenFrame
           completed:
@@ -133,7 +133,7 @@
               name: construction-graph-tag-television-board
               icon:
                 sprite: Objects/Misc/module.rsi
-                state: cpu_security
+                state: cpuboard
 
         - to: TelevisionFrame
           completed:


### PR DESCRIPTION
## About the PR

Fixes an issue in the television and telescreen construction graphs where you could duplicate infinite security camera monitor boards.

To reproduce the issue, start constructing a telescreen.  Insert the steel, then the wires, then snip the wires.  You get a free board.  Repeat.

Makes the first step in deconstructing the telescreen and television involve both an unscrewing and prying step, closer to how computers are deconstructed.

If you'd like the YAML indentation in the file fixed, I can do that as well, though I didn't touch it as-is.

## Why / Balance

Bugfix.

## Technical details

Graph changes:
- All steps that returned materials (SpawnPrototype, GivePrototype) moved to the step afterwards the step where the materials were used.
- First deconstruction step for telescreens/wallmount TVs is unscrewing, then prying, and that prying outputs the glass.  This is closer to computer behaviour.
- Sprite for security camera monitor board changed to the red security CPU board.

## Test plan

Construct and deconstruct a telescreen, it should work as written, you should get no extra materials.
Deconstruct a wallmount television, follow the deconstruction steps, they should be the same as for the telescreen.

## Media

Reproducing the original issue - add steel, add wires, snip wires, get board.

https://github.com/user-attachments/assets/95d469bc-0de5-4dbe-8e51-f4cebe9f8c99

Going through the construction and deconstruction steps for the telescreen.  The dupe is attempted afterwards, and fails to occur - the LV cables are slowly split apart into stacks of five, but no new boards are created from thin air.  Note the red board in the telescreen construction steps in the construction window.

https://github.com/user-attachments/assets/7b0d5a1a-76f6-4440-93d5-b0d90248cfcb