### PR TITLE
Made OrganBaseTorso Inedible.

### DIFF
--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -43,7 +43,7 @@
     - Meat
 
 - type: entity
-  parent: OrganBaseOrganic
+  parent: OrganBase
   id: OrganBaseTorso
   name: torso
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I made OrganBaseTorso Inedible.
Closes #44241.
This is my first contribution, so I apologize if I misunderstood the issue and resolved it incorrectly.

## Why / Balance
The reviewer for the PR #44197 stated this was a problem that needed to be fixed.

## Technical details
I changed the  OrganBaseTorso's Parent From OrganBaseOrganic to OrganBase.

## Media
<img width="621" height="584" alt="image" src="https://github.com/user-attachments/assets/b8291401-3537-4e97-8abd-75485ca2ad6e" />

## Test plan
I'm unsure how to test this, as OrganBaseTorso is not actually an item ingame, and its children, such as OrganHumanTorso, is not edible pre-patch, as seen in the media section.


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->



## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed OrganBaseTorso to be Inedible.

