### PR TITLE
Clarify clone/respawn/spawn here admin actions

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -137,6 +137,7 @@ namespace Content.Server.Administration.Systems
                     args.Verbs.Add(new Verb()
                     {
                         Text = Loc.GetString("admin-player-actions-spawn"),
+                        Message = Loc.GetString("admin-player-actions-spawn-message"),
                         Category = VerbCategory.Admin,
                         Act = () =>
                         {
@@ -163,6 +164,7 @@ namespace Content.Server.Administration.Systems
                     args.Verbs.Add(new Verb()
                     {
                         Text = Loc.GetString("admin-player-actions-clone"),
+                        Message = Loc.GetString("admin-player-actions-clone-message"),
                         Category = VerbCategory.Admin,
                         Act = () =>
                         {
@@ -213,6 +215,7 @@ namespace Content.Server.Administration.Systems
                     args.Verbs.Add(new Verb
                     {
                         Text = Loc.GetString("admin-player-actions-respawn"),
+                        Message = Loc.GetString("admin-player-actions-respawn-message"),
                         Category = VerbCategory.Admin,
                         Act = () =>
                         {

--- a/Resources/Locale/en-US/administration/ui/actions.ftl
+++ b/Resources/Locale/en-US/administration/ui/actions.ftl
@@ -4,11 +4,14 @@ admin-player-actions-notes = Notes
 admin-player-actions-kick = Kick
 admin-player-actions-ban = Ban
 admin-player-actions-ahelp = AHelp
-admin-player-actions-respawn = Respawn
+admin-player-actions-respawn = Respawn To Lobby
+admin-player-actions-respawn-message = Return the player to the lobby, allowing them to respawn as a new character at will.
 admin-player-actions-spawn = Spawn here
+admin-player-actions-spawn-message = Spawns a new copy of this character and immediately transfers their mind to it.
 admin-player-spawn-failed = Failed to find valid coordinates
 admin-player-actions-player-panel = Open Player Panel
 
 admin-player-actions-clone = Clone
+admin-player-actions-clone-message = Spawn a copy of this character, without transferring their mind.
 admin-player-actions-follow = Follow
 admin-player-actions-confirm = Are you sure?


### PR DESCRIPTION
Fixes https://github.com/space-wizards/space-station-14/issues/44304

:cl:
ADMIN:
- tweak: "Respawn" admin action has been renamed to "return to lobby." Similar related actions have had tooltips added to clarify behavior.