### PR TITLE
Pathfindingsystem minor optimisation

### DIFF
--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -136,7 +136,7 @@ public sealed partial class PathfindingSystem
 
             // TODO: Inflate grid bounds slightly and get chunks.
             // This is for map <> grid pathfinding
-            
+
             // Without parallel this is roughly 3x slower on my desktop.
             Parallel.For(0, dirt.Length, options, i =>
             {

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -136,14 +136,11 @@ public sealed partial class PathfindingSystem
 
             // TODO: Inflate grid bounds slightly and get chunks.
             // This is for map <> grid pathfinding
-            var sw = new Stopwatch();
-            sw.Start();
             // Without parallel this is roughly 3x slower on my desktop.
             Parallel.For(0, dirt.Length, options, i =>
             {
                 BuildBreadcrumbs(dirt[i], (uid, mapGridComp));
             });
-            Log.Error($"Built breadcrumbs in {sw.Elapsed.TotalMilliseconds}ms.......");
             const int Division = 4;
 
             // You can safely do this in parallel as long as no neighbor chunks are being touched in the same iteration.
@@ -512,10 +509,7 @@ public sealed partial class PathfindingSystem
                                 {
                                     continue;
                                 }
-                                if (!_fixtures.TestPoint(
-                                        fixture.Shape,
-                                        new Transform(xform.LocalPosition, xform.LocalRotation),
-                                        localPos))
+                                if (!_fixtures.TestPoint(fixture.Shape, new Transform(xform.LocalPosition, xform.LocalRotation), localPos))
                                 {
                                     continue;
                                 }
@@ -525,7 +519,7 @@ public sealed partial class PathfindingSystem
                                 colliding = true;
                             }
 
-                            if(!colliding)
+                            if (!colliding)
                                 continue;
 
                             if (_accessReaderQuery.HasComponent(ent))
@@ -548,6 +542,14 @@ public sealed partial class PathfindingSystem
                                 damage += _destructible.DestroyedAt(ent, damageable).Float();
                             }
                         }
+
+                        /*This is causing too many issues and I'd rather just ignore it until pathfinder refactor
+                          to just get tiles at runtime.
+                        if ((flags & PathfindingBreadcrumbFlag.Space) != 0x0)
+                        {
+                            // DebugTools.Assert(tileEntities.Count == 0);
+                        }
+                        */
 
                         var crumb = new PathfindingBreadcrumb()
                         {
@@ -635,7 +637,7 @@ public sealed partial class PathfindingSystem
             }
         }
 
-        //Log.Debug($"Built breadcrumbs in {sw.Elapsed.TotalMilliseconds}ms");
+        // Log.Debug($"Built breadcrumbs in {sw.Elapsed.TotalMilliseconds}ms");
         SendBreadcrumbs(chunk, grid);
     }
 

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -136,8 +136,8 @@ public sealed partial class PathfindingSystem
 
             // TODO: Inflate grid bounds slightly and get chunks.
             // This is for map <> grid pathfinding
+            
             // Without parallel this is roughly 3x slower on my desktop.
-
             Parallel.For(0, dirt.Length, options, i =>
             {
                 BuildBreadcrumbs(dirt[i], (uid, mapGridComp));

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -137,10 +137,12 @@ public sealed partial class PathfindingSystem
             // TODO: Inflate grid bounds slightly and get chunks.
             // This is for map <> grid pathfinding
             // Without parallel this is roughly 3x slower on my desktop.
+
             Parallel.For(0, dirt.Length, options, i =>
             {
                 BuildBreadcrumbs(dirt[i], (uid, mapGridComp));
             });
+
             const int Division = 4;
 
             // You can safely do this in parallel as long as no neighbor chunks are being touched in the same iteration.
@@ -422,7 +424,6 @@ public sealed partial class PathfindingSystem
         {
             for (var y = 0; y < ChunkSize; y++)
             {
-
                 // Tile
                 var tilePos = new Vector2i(x, y) + gridOrigin;
                 tilePolys.Clear();
@@ -495,7 +496,9 @@ public sealed partial class PathfindingSystem
                                     continue;
                                 }
 
+                                // Do an AABB check first as it's probably faster, then do an actual point check.
                                 var intersects = false;
+
                                 foreach (var proxy in fixture.Proxies)
                                 {
                                     if (!proxy.AABB.Contains(localPos))
@@ -509,6 +512,7 @@ public sealed partial class PathfindingSystem
                                 {
                                     continue;
                                 }
+                                
                                 if (!_fixtures.TestPoint(fixture.Shape, new Transform(xform.LocalPosition, xform.LocalRotation), localPos))
                                 {
                                     continue;

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -512,7 +512,7 @@ public sealed partial class PathfindingSystem
                                 {
                                     continue;
                                 }
-                                
+
                                 if (!_fixtures.TestPoint(fixture.Shape, new Transform(xform.LocalPosition, xform.LocalRotation), localPos))
                                 {
                                     continue;
@@ -523,6 +523,7 @@ public sealed partial class PathfindingSystem
                                 colliding = true;
                             }
 
+                            // If entity doesn't intersect this node (e.g. thindows) then ignore it.
                             if (!colliding)
                                 continue;
 

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -8,6 +8,7 @@ using Robust.Shared.Collections;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -135,13 +136,14 @@ public sealed partial class PathfindingSystem
 
             // TODO: Inflate grid bounds slightly and get chunks.
             // This is for map <> grid pathfinding
-
+            var sw = new Stopwatch();
+            sw.Start();
             // Without parallel this is roughly 3x slower on my desktop.
             Parallel.For(0, dirt.Length, options, i =>
             {
                 BuildBreadcrumbs(dirt[i], (uid, mapGridComp));
             });
-
+            Log.Error($"Built breadcrumbs in {sw.Elapsed.TotalMilliseconds}ms.......");
             const int Division = 4;
 
             // You can safely do this in parallel as long as no neighbor chunks are being touched in the same iteration.
@@ -400,11 +402,13 @@ public sealed partial class PathfindingSystem
 
     private void BuildBreadcrumbs(GridPathfindingChunk chunk, Entity<MapGridComponent> grid)
     {
-        var sw = new Stopwatch();
-        sw.Start();
+        //var sw = new Stopwatch();
+        //sw.Start();
         var points = chunk.Points;
         var gridOrigin = chunk.Origin * ChunkSize;
-        var tileEntities = new ValueList<EntityUid>();
+        var tileEntities = new ValueList<Entity<FixturesComponent>>();
+        var fixtureList = new ValueList<(EntityUid, TransformComponent, ValueList<Fixture>)>();
+
         var chunkPolys = chunk.BufferPolygons;
 
         for (var i = 0; i < chunkPolys.Length; i++)
@@ -421,6 +425,7 @@ public sealed partial class PathfindingSystem
         {
             for (var y = 0; y < ChunkSize; y++)
             {
+
                 // Tile
                 var tilePos = new Vector2i(x, y) + gridOrigin;
                 tilePolys.Clear();
@@ -449,7 +454,24 @@ public sealed partial class PathfindingSystem
                         continue;
                     }
 
-                    tileEntities.Add(ent);
+                    tileEntities.Add((ent, fixtures));
+                }
+
+                // Cache fixtures list so we resolve everything once.
+                fixtureList.Clear();
+                foreach (var ent in tileEntities)
+                {
+                    if(!TryComp(ent, out TransformComponent? xform))
+                        continue;
+
+                    var entFixtures = new ValueList<Fixture>();
+                    foreach (var fixture in ent.Comp.Fixtures.Values)
+                    {
+                        if (fixture.Hard)
+                            entFixtures.Add(fixture);
+                    }
+
+                    fixtureList.Add((ent.Owner, xform, entFixtures));
                 }
 
                 for (var subX = 0; subX < SubStep; subX++)
@@ -465,26 +487,18 @@ public sealed partial class PathfindingSystem
                         var collisionLayer = 0x0;
                         var damage = 0f;
 
-                        foreach (var ent in tileEntities)
+                        foreach (var (ent, xform, fixtures) in fixtureList)
                         {
-                            if (!_fixturesQuery.TryGetComponent(ent, out var fixtures))
-                                continue;
-
                             var colliding = false;
-
-                            foreach (var fixture in fixtures.Fixtures.Values)
+                            foreach (var fixture in fixtures)
                             {
-                                // Don't need to re-do it.
-                                if (!fixture.Hard ||
-                                    (collisionMask & fixture.CollisionMask) == fixture.CollisionMask &&
+                                if ((collisionMask & fixture.CollisionMask) == fixture.CollisionMask &&
                                     (collisionLayer & fixture.CollisionLayer) == fixture.CollisionLayer)
                                 {
                                     continue;
                                 }
 
-                                // Do an AABB check first as it's probably faster, then do an actual point check.
                                 var intersects = false;
-
                                 foreach (var proxy in fixture.Proxies)
                                 {
                                     if (!proxy.AABB.Contains(localPos))
@@ -493,13 +507,14 @@ public sealed partial class PathfindingSystem
                                     intersects = true;
                                 }
 
-                                if (!intersects ||
-                                    !TryComp(ent, out TransformComponent? xform))
+                                if (!intersects)
                                 {
                                     continue;
                                 }
-
-                                if (!_fixtures.TestPoint(fixture.Shape, new Transform(xform.LocalPosition, xform.LocalRotation), localPos))
+                                if (!_fixtures.TestPoint(
+                                        fixture.Shape,
+                                        new Transform(xform.LocalPosition, xform.LocalRotation),
+                                        localPos))
                                 {
                                     continue;
                                 }
@@ -509,8 +524,7 @@ public sealed partial class PathfindingSystem
                                 colliding = true;
                             }
 
-                            // If entity doesn't intersect this node (e.g. thindows) then ignore it.
-                            if (!colliding)
+                            if(!colliding)
                                 continue;
 
                             if (_accessReaderQuery.HasComponent(ent))
@@ -533,14 +547,6 @@ public sealed partial class PathfindingSystem
                                 damage += _destructible.DestroyedAt(ent, damageable).Float();
                             }
                         }
-
-                        /*This is causing too many issues and I'd rather just ignore it until pathfinder refactor
-                          to just get tiles at runtime.
-                        if ((flags & PathfindingBreadcrumbFlag.Space) != 0x0)
-                        {
-                            // DebugTools.Assert(tileEntities.Count == 0);
-                        }
-                        */
 
                         var crumb = new PathfindingBreadcrumb()
                         {
@@ -628,7 +634,7 @@ public sealed partial class PathfindingSystem
             }
         }
 
-        // Log.Debug($"Built breadcrumbs in {sw.Elapsed.TotalMilliseconds}ms");
+        //Log.Debug($"Built breadcrumbs in {sw.Elapsed.TotalMilliseconds}ms");
         SendBreadcrumbs(chunk, grid);
     }
 

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Grid.cs
@@ -505,6 +505,7 @@ public sealed partial class PathfindingSystem
                                         continue;
 
                                     intersects = true;
+                                    break;
                                 }
 
                                 if (!intersects)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Refactored a part of the `BuildBreadcrumbs` for `PathfindingSystem.Grid`. 
I'll look at some more of it later on.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Noticed a lot of the code was only needed for the entity, but was being duplicated for every fixture of that entity. So I pulled it into one loop in a prepass which has a bunch of early filtering.

I also ran a test with building the prepass cache in the forloop just before where we build the tileEntities list. It was better for the quantiles up to the median, but after that it was noticeably worse. The q99 was actually higher than before the change.

## Technical details
<!-- Summary of code changes for easier review. -->
Pulls a bunch of duplicated code into a prepass.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Not the most scientific of tests... 
Was way too convoluted to run a benchmark on the method itself, so I did a Stopwatch check before and after the `Parallel.ForEach` that runs the BuildBreadcrumbs. I wrote a python script to read the logs of the output after a few minutes of gameplay, parse for the stopwatch logging and calculate some metrics attached below.
I repeated the test a few times to get an overall Before and After set. The worst cases are significantly reduced and we're more consistent across the board.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Refactor
<img width="186" height="373" alt="image" src="https://github.com/user-attachments/assets/1c30d0f6-9225-4c94-bb0c-da1a704ac9cf" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
