### PR TITLE
Bugfix: Fix DrawDepth subfloor gap width, add gap for mapping subfloor layers

### DIFF
--- a/Content.Client/SubFloor/SubFloorHideSystem.cs
+++ b/Content.Client/SubFloor/SubFloorHideSystem.cs
@@ -1,4 +1,5 @@
 using Content.Client.UserInterface.Systems.Sandbox;
+using Content.Shared.DrawDepth;
 using Content.Shared.SubFloor;
 using Robust.Client.GameObjects;
 using Robust.Client.UserInterface;
@@ -91,7 +92,8 @@ public sealed partial class SubFloorHideSystem : SharedSubFloorHideSystem
         {
             // Allows sandbox mode to make wires visible over other stuff.
             component.OriginalDrawDepth ??= args.Sprite.DrawDepth;
-            _sprite.SetDrawDepth((uid, args.Sprite), (int)Shared.DrawDepth.DrawDepth.Overdoors);
+            var drawDepthDifference = Shared.DrawDepth.DrawDepth.ThickPipe - (Shared.DrawDepth.DrawDepth.Overdoors + 1);
+            _sprite.SetDrawDepth((uid, args.Sprite), args.Sprite.DrawDepth - drawDepthDifference);
         }
         else if (scannerRevealed)
         {
@@ -99,8 +101,8 @@ public sealed partial class SubFloorHideSystem : SharedSubFloorHideSystem
             if (component.OriginalDrawDepth is not null)
                 return;
             component.OriginalDrawDepth = args.Sprite.DrawDepth;
-            var drawDepthDifference = Shared.DrawDepth.DrawDepth.ThickPipe - Shared.DrawDepth.DrawDepth.Puddles;
-            _sprite.SetDrawDepth((uid, args.Sprite), args.Sprite.DrawDepth - (drawDepthDifference - 1));
+            var drawDepthDifference = Shared.DrawDepth.DrawDepth.ThickPipe - (Shared.DrawDepth.DrawDepth.Puddles + 1);
+            _sprite.SetDrawDepth((uid, args.Sprite), args.Sprite.DrawDepth - drawDepthDifference);
         }
         else if (component.OriginalDrawDepth.HasValue)
         {

--- a/Content.Client/SubFloor/SubFloorHideSystem.cs
+++ b/Content.Client/SubFloor/SubFloorHideSystem.cs
@@ -1,5 +1,4 @@
 using Content.Client.UserInterface.Systems.Sandbox;
-using Content.Shared.DrawDepth;
 using Content.Shared.SubFloor;
 using Robust.Client.GameObjects;
 using Robust.Client.UserInterface;

--- a/Content.Shared/DrawDepth/DrawDepth.cs
+++ b/Content.Shared/DrawDepth/DrawDepth.cs
@@ -1,133 +1,137 @@
 using Robust.Shared.Serialization;
 using DrawDepthTag = Robust.Shared.GameObjects.DrawDepth;
 
-namespace Content.Shared.DrawDepth
+namespace Content.Shared.DrawDepth;
+
+[ConstantsFor(typeof(DrawDepthTag))]
+public enum DrawDepth
 {
-    [ConstantsFor(typeof(DrawDepthTag))]
-    public enum DrawDepth
-    {
-        /// <summary>
-        ///     This is for sub-floors, the floors you see after prying off a tile.
-        /// </summary>
-        LowFloors = DrawDepthTag.Default - 20,
+    /// <summary>
+    ///     This is for sub-floors, the floors you see after prying off a tile.
+    /// </summary>
+    LowFloors = DrawDepthTag.Default - 22,
 
-        // various entity types that require different
-        // draw depths, as to avoid hiding
-        #region SubfloorEntities
-        ThickPipe = DrawDepthTag.Default - 19,
-        ThickWire = DrawDepthTag.Default - 18,
-        ThinPipeAlt2 = DrawDepthTag.Default - 17,
-        ThinPipeAlt1 = DrawDepthTag.Default - 16,
-        ThinPipe = DrawDepthTag.Default - 15,
-        ThinWire = DrawDepthTag.Default - 14,
-        #endregion
+    // various entity types that require different
+    // draw depths, as to avoid hiding
+    // If updating this set, update the gaps above Puddles and Overdoors.
+    #region SubfloorEntities
+    ThickPipe = DrawDepthTag.Default - 21,
+    ThickWire = DrawDepthTag.Default - 20,
+    ThinPipeAlt2 = DrawDepthTag.Default - 19,
+    ThinPipeAlt1 = DrawDepthTag.Default - 18,
+    ThinPipe = DrawDepthTag.Default - 17,
+    ThinWire = DrawDepthTag.Default - 16,
+    #endregion
 
-        /// <summary>
-        ///     Things that are beneath regular floors.
-        /// </summary>
-        BelowFloor = DrawDepthTag.Default - 13,
+    /// <summary>
+    ///     Things that are beneath regular floors.
+    /// </summary>
+    BelowFloor = DrawDepthTag.Default - 15,
 
-        /// <summary>
-        ///     Used for entities like carpets.
-        /// </summary>
-        FloorTiles = DrawDepthTag.Default - 12,
+    /// <summary>
+    ///     Used for entities like carpets.
+    /// </summary>
+    FloorTiles = DrawDepthTag.Default - 14,
 
-        /// <summary>
-        ///     Things that are actually right on the floor, like ice crust or atmos devices. This does not mean objects like
-        ///     tables, even though they are technically "on the floor".
-        /// </summary>
-        FloorObjects = DrawDepthTag.Default - 11,
+    /// <summary>
+    ///     Things that are actually right on the floor, like ice crust or atmos devices. This does not mean objects like
+    ///     tables, even though they are technically "on the floor".
+    /// </summary>
+    FloorObjects = DrawDepthTag.Default - 13,
 
-        /// <summary>
-        //     Discrete drawdepth to avoid z-fighting with other FloorObjects but also above floor entities.
-        /// </summary>
-        Puddles = DrawDepthTag.Default - 10,
+    /// <summary>
+    //     Discrete drawdepth to avoid z-fighting with other FloorObjects but also above floor entities.
+    /// </summary>
+    Puddles = DrawDepthTag.Default - 12,
 
-        // There's a gap for subfloor entities to retain relative draw depth when revealed by a t-ray scanner.
-        /// <summary>
-        //     Objects that are on the floor, but should render above puddles. This includes kudzu, holopads, telepads and levers.
-        /// </summary>
-        HighFloorObjects = DrawDepthTag.Default - 5,
+    // NOTE: There's a gap for subfloor entities to retain relative draw depth when revealed by a t-ray scanner (need 6 layers in between).
 
-        DeadMobs = DrawDepthTag.Default - 4,
+    /// <summary>
+    //     Objects that are on the floor, but should render above puddles. This includes kudzu, holopads, telepads and levers.
+    /// </summary>
+    HighFloorObjects = DrawDepthTag.Default - 5,
 
-        /// <summary>
-        ///     Allows small mobs like mice and drones to render under tables and chairs but above puddles and vents
-        /// </summary>
-        SmallMobs = DrawDepthTag.Default - 3,
+    DeadMobs = DrawDepthTag.Default - 4,
 
-        Walls = DrawDepthTag.Default - 2,
+    /// <summary>
+    ///     Allows small mobs like mice and drones to render under tables and chairs but above puddles and vents
+    /// </summary>
+    SmallMobs = DrawDepthTag.Default - 3,
 
-        /// <summary>
-        ///     Used for windows (grilles use walls) and misc signage. Useful if you want to have an APC in the middle
-        ///     of some wall-art or something.
-        /// </summary>
-        WallTops = DrawDepthTag.Default - 1,
+    Walls = DrawDepthTag.Default - 2,
 
-        /// <summary>
-        ///     Furniture, crates, tables. etc. If an entity should be drawn on top of a table, it needs a draw depth
-        ///     that is higher than this.
-        /// </summary>
-        Objects = DrawDepthTag.Default,
+    /// <summary>
+    ///     Used for windows (grilles use walls) and misc signage. Useful if you want to have an APC in the middle
+    ///     of some wall-art or something.
+    /// </summary>
+    WallTops = DrawDepthTag.Default - 1,
 
-        /// <summary>
-        ///     In-between an furniture and an item. Useful for entities that need to appear on top of tables, but are
-        ///     not items. E.g., power cell chargers. Also useful for pizza boxes, which appear above crates, but not
-        ///     above the pizza itself.
-        /// </summary>
-        SmallObjects = DrawDepthTag.Default + 1,
+    /// <summary>
+    ///     Furniture, crates, tables. etc. If an entity should be drawn on top of a table, it needs a draw depth
+    ///     that is higher than this.
+    /// </summary>
+    Objects = DrawDepthTag.Default,
 
-        /// <summary>
-        ///     Posters, APCs, air alarms, etc. This also includes most lights & lamps.
-        /// </summary>
-        WallMountedItems = DrawDepthTag.Default + 2,
+    /// <summary>
+    ///     In-between an furniture and an item. Useful for entities that need to appear on top of tables, but are
+    ///     not items. E.g., power cell chargers. Also useful for pizza boxes, which appear above crates, but not
+    ///     above the pizza itself.
+    /// </summary>
+    SmallObjects = DrawDepthTag.Default + 1,
 
-        /// <summary>
-        ///     To use for objects that would usually fall under SmallObjects, but appear taller than 1 tile. For example: Reagent Grinder
-        /// </summary>
-        LargeObjects = DrawDepthTag.Default + 3,
+    /// <summary>
+    ///     Posters, APCs, air alarms, etc. This also includes most lights & lamps.
+    /// </summary>
+    WallMountedItems = DrawDepthTag.Default + 2,
 
-        /// <summary>
-        ///     Generic items. Things that should be above crates & tables, but underneath mobs.
-        /// </summary>
-        Items = DrawDepthTag.Default + 4,
-        /// <summary>
-        /// Stuff that should be drawn below mobs, but on top of items. Like muzzle flash.
-        /// </summary>
-        BelowMobs = DrawDepthTag.Default + 5,
+    /// <summary>
+    ///     To use for objects that would usually fall under SmallObjects, but appear taller than 1 tile. For example: Reagent Grinder
+    /// </summary>
+    LargeObjects = DrawDepthTag.Default + 3,
 
-        Mobs = DrawDepthTag.Default + 6,
+    /// <summary>
+    ///     Generic items. Things that should be above crates & tables, but underneath mobs.
+    /// </summary>
+    Items = DrawDepthTag.Default + 4,
+    /// <summary>
+    /// Stuff that should be drawn below mobs, but on top of items. Like muzzle flash.
+    /// </summary>
+    BelowMobs = DrawDepthTag.Default + 5,
 
-        OverMobs = DrawDepthTag.Default + 7,
+    Mobs = DrawDepthTag.Default + 6,
 
-        Doors = DrawDepthTag.Default + 8,
+    OverMobs = DrawDepthTag.Default + 7,
 
-        /// <summary>
-        /// Blast doors and shutters which go over the usual doors.
-        /// </summary>
-        BlastDoors = DrawDepthTag.Default + 9,
+    Doors = DrawDepthTag.Default + 8,
 
-        /// <summary>
-        /// Stuff that needs to draw over most things, but not effects, like Kudzu.
-        /// </summary>
-        Overdoors = DrawDepthTag.Default + 10,
+    /// <summary>
+    /// Blast doors and shutters which go over the usual doors.
+    /// </summary>
+    BlastDoors = DrawDepthTag.Default + 9,
 
-        /// <summary>
-        ///     Visible atmos gas.
-        /// </summary>
-        Gasses = DrawDepthTag.Default + 11,
+    /// <summary>
+    /// Stuff that needs to draw over most things, but not effects, like Kudzu.
+    /// </summary>
+    Overdoors = DrawDepthTag.Default + 10,
 
-        /// <summary>
-        ///     Explosions, fire, melee swings. Whatever.
-        /// </summary>
-        Effects = DrawDepthTag.Default + 12,
+    // NOTE: There's a gap here for subfloor layers in mapping mode (need 6 layers in between)
 
-        Ghosts = DrawDepthTag.Default + 13,
+    /// <summary>
+    ///     Visible atmos gas.
+    /// </summary>
+    Gasses = DrawDepthTag.Default + 17,
 
-        /// <summary>
-        ///    Use this selectively if it absolutely needs to be drawn above (almost) everything else. Examples include
-        ///    the pointing arrow, the drag & drop ghost-entity, and some debug tools.
-        /// </summary>
-        Overlays = DrawDepthTag.Default + 14,
-    }
+    /// <summary>
+    ///     Explosions, fire, melee swings. Whatever.
+    /// </summary>
+    Effects = DrawDepthTag.Default + 18,
+
+    Ghosts = DrawDepthTag.Default + 19,
+
+    /// <summary>
+    ///    Use this selectively if it absolutely needs to be drawn above (almost) everything else. Examples include
+    ///    the pointing arrow, the drag & drop ghost-entity, and some debug tools.
+    /// </summary>
+    Overlays = DrawDepthTag.Default + 20,
 }
+

--- a/Content.Shared/DrawDepth/DrawDepth.cs
+++ b/Content.Shared/DrawDepth/DrawDepth.cs
@@ -3,7 +3,6 @@ using DrawDepthTag = Robust.Shared.GameObjects.DrawDepth;
 
 namespace Content.Shared.DrawDepth
 {
-
     [ConstantsFor(typeof(DrawDepthTag))]
     public enum DrawDepth
     {

--- a/Content.Shared/DrawDepth/DrawDepth.cs
+++ b/Content.Shared/DrawDepth/DrawDepth.cs
@@ -1,137 +1,138 @@
 using Robust.Shared.Serialization;
 using DrawDepthTag = Robust.Shared.GameObjects.DrawDepth;
 
-namespace Content.Shared.DrawDepth;
-
-[ConstantsFor(typeof(DrawDepthTag))]
-public enum DrawDepth
+namespace Content.Shared.DrawDepth
 {
-    /// <summary>
-    ///     This is for sub-floors, the floors you see after prying off a tile.
-    /// </summary>
-    LowFloors = DrawDepthTag.Default - 22,
 
-    // various entity types that require different
-    // draw depths, as to avoid hiding
-    // If updating this set, update the gaps above Puddles and Overdoors.
-    #region SubfloorEntities
-    ThickPipe = DrawDepthTag.Default - 21,
-    ThickWire = DrawDepthTag.Default - 20,
-    ThinPipeAlt2 = DrawDepthTag.Default - 19,
-    ThinPipeAlt1 = DrawDepthTag.Default - 18,
-    ThinPipe = DrawDepthTag.Default - 17,
-    ThinWire = DrawDepthTag.Default - 16,
-    #endregion
+    [ConstantsFor(typeof(DrawDepthTag))]
+    public enum DrawDepth
+    {
+        /// <summary>
+        ///     This is for sub-floors, the floors you see after prying off a tile.
+        /// </summary>
+        LowFloors = DrawDepthTag.Default - 22,
 
-    /// <summary>
-    ///     Things that are beneath regular floors.
-    /// </summary>
-    BelowFloor = DrawDepthTag.Default - 15,
+        // various entity types that require different
+        // draw depths, as to avoid hiding
+        // If updating this set, update the gaps above Puddles and Overdoors.
+        #region SubfloorEntities
+        ThickPipe = DrawDepthTag.Default - 21,
+        ThickWire = DrawDepthTag.Default - 20,
+        ThinPipeAlt2 = DrawDepthTag.Default - 19,
+        ThinPipeAlt1 = DrawDepthTag.Default - 18,
+        ThinPipe = DrawDepthTag.Default - 17,
+        ThinWire = DrawDepthTag.Default - 16,
+        #endregion
 
-    /// <summary>
-    ///     Used for entities like carpets.
-    /// </summary>
-    FloorTiles = DrawDepthTag.Default - 14,
+        /// <summary>
+        ///     Things that are beneath regular floors.
+        /// </summary>
+        BelowFloor = DrawDepthTag.Default - 15,
 
-    /// <summary>
-    ///     Things that are actually right on the floor, like ice crust or atmos devices. This does not mean objects like
-    ///     tables, even though they are technically "on the floor".
-    /// </summary>
-    FloorObjects = DrawDepthTag.Default - 13,
+        /// <summary>
+        ///     Used for entities like carpets.
+        /// </summary>
+        FloorTiles = DrawDepthTag.Default - 14,
 
-    /// <summary>
-    //     Discrete drawdepth to avoid z-fighting with other FloorObjects but also above floor entities.
-    /// </summary>
-    Puddles = DrawDepthTag.Default - 12,
+        /// <summary>
+        ///     Things that are actually right on the floor, like ice crust or atmos devices. This does not mean objects like
+        ///     tables, even though they are technically "on the floor".
+        /// </summary>
+        FloorObjects = DrawDepthTag.Default - 13,
 
-    // NOTE: There's a gap for subfloor entities to retain relative draw depth when revealed by a t-ray scanner (need 6 layers in between).
+        /// <summary>
+        //     Discrete drawdepth to avoid z-fighting with other FloorObjects but also above floor entities.
+        /// </summary>
+        Puddles = DrawDepthTag.Default - 12,
 
-    /// <summary>
-    //     Objects that are on the floor, but should render above puddles. This includes kudzu, holopads, telepads and levers.
-    /// </summary>
-    HighFloorObjects = DrawDepthTag.Default - 5,
+        // NOTE: There's a gap for subfloor entities to retain relative draw depth when revealed by a t-ray scanner (need 6 layers in between).
 
-    DeadMobs = DrawDepthTag.Default - 4,
+        /// <summary>
+        //     Objects that are on the floor, but should render above puddles. This includes kudzu, holopads, telepads and levers.
+        /// </summary>
+        HighFloorObjects = DrawDepthTag.Default - 5,
 
-    /// <summary>
-    ///     Allows small mobs like mice and drones to render under tables and chairs but above puddles and vents
-    /// </summary>
-    SmallMobs = DrawDepthTag.Default - 3,
+        DeadMobs = DrawDepthTag.Default - 4,
 
-    Walls = DrawDepthTag.Default - 2,
+        /// <summary>
+        ///     Allows small mobs like mice and drones to render under tables and chairs but above puddles and vents
+        /// </summary>
+        SmallMobs = DrawDepthTag.Default - 3,
 
-    /// <summary>
-    ///     Used for windows (grilles use walls) and misc signage. Useful if you want to have an APC in the middle
-    ///     of some wall-art or something.
-    /// </summary>
-    WallTops = DrawDepthTag.Default - 1,
+        Walls = DrawDepthTag.Default - 2,
 
-    /// <summary>
-    ///     Furniture, crates, tables. etc. If an entity should be drawn on top of a table, it needs a draw depth
-    ///     that is higher than this.
-    /// </summary>
-    Objects = DrawDepthTag.Default,
+        /// <summary>
+        ///     Used for windows (grilles use walls) and misc signage. Useful if you want to have an APC in the middle
+        ///     of some wall-art or something.
+        /// </summary>
+        WallTops = DrawDepthTag.Default - 1,
 
-    /// <summary>
-    ///     In-between an furniture and an item. Useful for entities that need to appear on top of tables, but are
-    ///     not items. E.g., power cell chargers. Also useful for pizza boxes, which appear above crates, but not
-    ///     above the pizza itself.
-    /// </summary>
-    SmallObjects = DrawDepthTag.Default + 1,
+        /// <summary>
+        ///     Furniture, crates, tables. etc. If an entity should be drawn on top of a table, it needs a draw depth
+        ///     that is higher than this.
+        /// </summary>
+        Objects = DrawDepthTag.Default,
 
-    /// <summary>
-    ///     Posters, APCs, air alarms, etc. This also includes most lights & lamps.
-    /// </summary>
-    WallMountedItems = DrawDepthTag.Default + 2,
+        /// <summary>
+        ///     In-between an furniture and an item. Useful for entities that need to appear on top of tables, but are
+        ///     not items. E.g., power cell chargers. Also useful for pizza boxes, which appear above crates, but not
+        ///     above the pizza itself.
+        /// </summary>
+        SmallObjects = DrawDepthTag.Default + 1,
 
-    /// <summary>
-    ///     To use for objects that would usually fall under SmallObjects, but appear taller than 1 tile. For example: Reagent Grinder
-    /// </summary>
-    LargeObjects = DrawDepthTag.Default + 3,
+        /// <summary>
+        ///     Posters, APCs, air alarms, etc. This also includes most lights & lamps.
+        /// </summary>
+        WallMountedItems = DrawDepthTag.Default + 2,
 
-    /// <summary>
-    ///     Generic items. Things that should be above crates & tables, but underneath mobs.
-    /// </summary>
-    Items = DrawDepthTag.Default + 4,
-    /// <summary>
-    /// Stuff that should be drawn below mobs, but on top of items. Like muzzle flash.
-    /// </summary>
-    BelowMobs = DrawDepthTag.Default + 5,
+        /// <summary>
+        ///     To use for objects that would usually fall under SmallObjects, but appear taller than 1 tile. For example: Reagent Grinder
+        /// </summary>
+        LargeObjects = DrawDepthTag.Default + 3,
 
-    Mobs = DrawDepthTag.Default + 6,
+        /// <summary>
+        ///     Generic items. Things that should be above crates & tables, but underneath mobs.
+        /// </summary>
+        Items = DrawDepthTag.Default + 4,
+        /// <summary>
+        /// Stuff that should be drawn below mobs, but on top of items. Like muzzle flash.
+        /// </summary>
+        BelowMobs = DrawDepthTag.Default + 5,
 
-    OverMobs = DrawDepthTag.Default + 7,
+        Mobs = DrawDepthTag.Default + 6,
 
-    Doors = DrawDepthTag.Default + 8,
+        OverMobs = DrawDepthTag.Default + 7,
 
-    /// <summary>
-    /// Blast doors and shutters which go over the usual doors.
-    /// </summary>
-    BlastDoors = DrawDepthTag.Default + 9,
+        Doors = DrawDepthTag.Default + 8,
 
-    /// <summary>
-    /// Stuff that needs to draw over most things, but not effects, like Kudzu.
-    /// </summary>
-    Overdoors = DrawDepthTag.Default + 10,
+        /// <summary>
+        /// Blast doors and shutters which go over the usual doors.
+        /// </summary>
+        BlastDoors = DrawDepthTag.Default + 9,
 
-    // NOTE: There's a gap here for subfloor layers in mapping mode (need 6 layers in between)
+        /// <summary>
+        /// Stuff that needs to draw over most things, but not effects, like Kudzu.
+        /// </summary>
+        Overdoors = DrawDepthTag.Default + 10,
 
-    /// <summary>
-    ///     Visible atmos gas.
-    /// </summary>
-    Gasses = DrawDepthTag.Default + 17,
+        // NOTE: There's a gap here for subfloor layers in mapping mode (need 6 layers in between)
 
-    /// <summary>
-    ///     Explosions, fire, melee swings. Whatever.
-    /// </summary>
-    Effects = DrawDepthTag.Default + 18,
+        /// <summary>
+        ///     Visible atmos gas.
+        /// </summary>
+        Gasses = DrawDepthTag.Default + 17,
 
-    Ghosts = DrawDepthTag.Default + 19,
+        /// <summary>
+        ///     Explosions, fire, melee swings. Whatever.
+        /// </summary>
+        Effects = DrawDepthTag.Default + 18,
 
-    /// <summary>
-    ///    Use this selectively if it absolutely needs to be drawn above (almost) everything else. Examples include
-    ///    the pointing arrow, the drag & drop ghost-entity, and some debug tools.
-    /// </summary>
-    Overlays = DrawDepthTag.Default + 20,
+        Ghosts = DrawDepthTag.Default + 19,
+
+        /// <summary>
+        ///    Use this selectively if it absolutely needs to be drawn above (almost) everything else. Examples include
+        ///    the pointing arrow, the drag & drop ghost-entity, and some debug tools.
+        /// </summary>
+        Overlays = DrawDepthTag.Default + 20,
+    }
 }
-


### PR DESCRIPTION
## About the PR

Fixes DrawDepth values so that subfloor entities are drawn correctly when using the t-ray or in mapping mode.

Currently, in mapping mode, all of the subfloor entities are drawn on _one layer_, so you often end up with disposals blocking the view of everything else, which shouldn't happen.

Cherry-picked from https://github.com/Space-Wizards-Federation/space-station-14/pull/70

## Why / Balance

It is very frustrating to have every subfloor entity drawing on the same layer when mapping.  The t-ray did this right, and had a solution that works.  This adds another gap to the DrawDepth enum for that reason.

The gap for subfloor layers was previously four, but was not increased with the new alternative pipe layers, so the top few cable layers will collide with the layers above the gap.  This PR resolves this issue.

Resolves https://github.com/space-wizards/space-station-14/issues/36322

## Technical details

Fixes the existing DrawDepth gap for t-ray subfloor layers from 4 to 6 layers wide (two new alt pipe layers).

Adds a new DrawDepth gap for mapping subfloor layers above the Overdoors layer.

Moved a magic +/-1 from the difference (why?) to "the layer after this one" (slightly more intuitive)

Added comments stating the width of the gaps, and added an instruction above the subfloor layers to adjust the gaps if adding extra layers to it.

## Test plan

Turn on t-ray.  Dead mobs and holopads should consistently show up above LV cables.
Turn on mapping mode, load up Bagel station.  The disposals, HV cables, MV cables and atmos pipes should all be distinctly visible, on their own layers, as if using a t-ray.

## Media

Mapping mode on Bagel.  Note that the disposals pipes are not fighting with the MV/LV cables.
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/e9219151-ef83-42b9-89a8-daeb42bbc11f" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

DrawDepth enum values at or below Puddles and at or above Gasses have changed.  Forks adding additional layers will need to adjust their added values locally.

## Changelog
no