### PR TITLE
Bugfix: Add FixturesComponent to BaseWallmount

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/base_wallmount.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/base_wallmount.yml
@@ -12,6 +12,7 @@
   - type: Rotatable
   - type: Physics
     canCollide: false
+  - type: Fixtures
   - type: Clickable
   - type: WallMount
   - type: InteractionOutline


### PR DESCRIPTION

## About the PR

Oneliner!  Adds the FixturesComponent to BaseWallmount.

Cherry-picked from https://github.com/Space-Wizards-Federation/space-station-14/pull/81

## Why / Balance

You know all those instances of the following in maps on air alarms, APCs, signs...
```yml
- type: Fixtures
  fixtures: {}
```

This removes those!  Resaving bagel.yml, _alone_, reduces its size by 40 kB.  Compound across multiple maps and you're looking at megabytes of needless data cut.

## Technical details

One-line YAML.  Default fixture has no actual fixtures, and offhand I think the PhysicsComponent adds it by default.

## Test plan

Load bagel.
Save bagel.
Compare map size (wow!).

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
no