### PR TITLE
Recyclers: spill without valid solutions

### DIFF
--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -219,10 +219,14 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
         TransformComponent? xform = null,
         PhysicalCompositionComponent? composition = null)
     {
-        if (!Resolve(reclaimer, ref reclaimerComponent, ref xform) || reclaimerComponent.SolutionContainerId == null)
+        if (!Resolve(reclaimer, ref reclaimerComponent, ref xform))
             return;
 
         efficiency *= reclaimerComponent.Efficiency;
+
+        // Solution will be empty, nothing to do.
+        if (efficiency <= 0)
+            return;
 
         var totalChemicals = new Solution();
 
@@ -254,9 +258,10 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
             }
         }
 
-        if (!_solutionContainer.TryGetSolution(reclaimer, reclaimerComponent.SolutionContainerId, out var outputSolution) ||
-            !_solutionContainer.TryTransferSolution(outputSolution.Value, totalChemicals, totalChemicals.Volume) ||
-            totalChemicals.Volume > 0)
+        if (totalChemicals.Volume > 0 &&
+            (reclaimerComponent.SolutionContainerId == null ||
+            !_solutionContainer.TryGetSolution(reclaimer, reclaimerComponent.SolutionContainerId, out var outputSolution) ||
+            !_solutionContainer.TryTransferSolution(outputSolution.Value, totalChemicals, totalChemicals.Volume)))
         {
             _puddle.TrySpillAt(reclaimer, totalChemicals, out _, sound, transformComponent: xform);
         }

--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -258,10 +258,13 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
             }
         }
 
-        if (totalChemicals.Volume > 0 &&
-            (reclaimerComponent.SolutionContainerId == null ||
+        // Transfer or spill the solution if there's anything to move.
+        if (totalChemicals.Volume <= 0)
+            return;
+
+        if (reclaimerComponent.SolutionContainerId == null ||
             !_solutionContainer.TryGetSolution(reclaimer, reclaimerComponent.SolutionContainerId, out var outputSolution) ||
-            !_solutionContainer.TryTransferSolution(outputSolution.Value, totalChemicals, totalChemicals.Volume)))
+            !_solutionContainer.TryTransferSolution(outputSolution.Value, totalChemicals, totalChemicals.Volume))
         {
             _puddle.TrySpillAt(reclaimer, totalChemicals, out _, sound, transformComponent: xform);
         }


### PR DESCRIPTION
## About the PR

Restores the behaviour of recyclers spilling the contents of drainable solutions.

Cherry-picked from https://github.com/Space-Wizards-Federation/space-station-14/pull/139

## Why / Balance

Regression introduced by https://github.com/space-wizards/space-station-14/pull/43412

The null check at the beginning of the function prevented the recycler from spilling reagents.

## Technical details

Rewrite of `MaterialReclaimerSystem.SpawnChemicalsFromComposition`.

The null check that was added to the top of the function has been removed.

Added a few conditions to avoid creating a solution if it won't be spilled at all.

Rewrote the spill condition: puddle volume first (no reagents, no problem), then solution lookup.

## Test plan
1. Throw bottles into a running recycler.  They should spill.
2. Throw a watermelon into a running recycler.  It should not spill.
3. If desired, check out d74f891288fb7063d8a2d9774b202564afa6ac5c and retry steps 1 and 2.  The results should be the same.
4. Check out master, retry steps 1 and 2.  The bottles should not spill.

## Media

A small video showing this PR in action.  Three different things are thrown into a recycler - a BBQ sauce bottle, a wine bottle, and a watermelon.  The watermelon does not spill onto the floor (it is not drainable, it is extractable), but the other two do.

https://github.com/user-attachments/assets/c3301a3a-32d2-4981-982f-185534ae9fee


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
:cl:
- fix: The recycler now spills again when reclaiming drainable items.
