### PR TITLE
Fix portal different grids

### DIFF
--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -7,7 +7,6 @@ using Content.Shared.Popups;
 using Content.Shared.Teleportation.Components;
 using Content.Shared.Teleportation.Systems;
 using Robust.Server.Audio;
-using Robust.Server.GameObjects;
 
 namespace Content.Server.Teleportation;
 
@@ -27,6 +26,16 @@ public sealed partial class HandTeleporterSystem : EntitySystem
     {
         SubscribeLocalEvent<HandTeleporterComponent, UseInHandEvent>(OnUseInHand);
         SubscribeLocalEvent<HandTeleporterComponent, TeleporterDoAfterEvent>(OnDoAfter);
+        SubscribeLocalEvent<GridSplitEvent>(OnGridSplit);
+    }
+
+    private void OnGridSplit(ref GridSplitEvent args)
+    {
+        var teleporterQuery = EntityQueryEnumerator<HandTeleporterComponent>();
+        while (teleporterQuery.MoveNext(out var uid, out var teleporter))
+        {
+            CheckPortals((uid, teleporter));
+        }
     }
 
     private void OnDoAfter(EntityUid uid, HandTeleporterComponent component, DoAfterEvent args)
@@ -150,7 +159,7 @@ public sealed partial class HandTeleporterSystem : EntitySystem
         }
     }
 
-    private void FizzlePortals(EntityUid uid, HandTeleporterComponent component, EntityUid user, bool instability)
+    private void FizzlePortals(EntityUid uid, HandTeleporterComponent component, EntityUid? user, bool instability)
     {
         // Logging
         var portalStrings = "";

--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -85,7 +85,7 @@ public sealed partial class HandTeleporterSystem : EntitySystem
 
     /// <summary>
     /// Checks if both portals of a teleporter are on same grid/map
-    /// and if the teleporter allows that. if the portals are in a illegal state, it fizzles them.
+    /// and if the teleporter allows that. if the portals are in an illegal state, it fizzles them.
     /// </summary>
     private void CheckPortals(Entity<HandTeleporterComponent> entity)
     {
@@ -100,7 +100,7 @@ public sealed partial class HandTeleporterSystem : EntitySystem
         var sameMap = portal1Xform.MapID == portal2Xform.MapID;
 
         if (!sameGrid && !entity.Comp.AllowPortalsOnDifferentGrids || !sameMap && !entity.Comp.AllowPortalsOnDifferentMaps)
-            FizzlePortals(entity.Owner, entity.Comp, null, false);
+            FizzlePortals(entity, null, false);
     }
 
     /// <summary>
@@ -138,7 +138,7 @@ public sealed partial class HandTeleporterSystem : EntitySystem
             if (!component.AllowPortalsOnDifferentGrids && xform.ParentUid != Transform(component.FirstPortal!.Value).ParentUid)
             {
                 // Whoops. Fizzle time. Crime time too because yippee I'm not refactoring this logic right now (I started to, I'm not going to.)
-                FizzlePortals(uid, component, user, true);
+                FizzlePortals((uid, component), user, true);
                 return;
             }
 
@@ -155,37 +155,43 @@ public sealed partial class HandTeleporterSystem : EntitySystem
         }
         else
         {
-            FizzlePortals(uid, component, user, false);
+            FizzlePortals((uid, component), user, false);
         }
     }
 
-    private void FizzlePortals(EntityUid uid, HandTeleporterComponent component, EntityUid? user, bool instability)
+    /// <summary>
+    /// Deletes both portals of a teleporter
+    /// </summary>
+    /// <param name="entity">the teleporter entity</param>
+    /// <param name="user">who deleted the portals</param>
+    /// <param name="instability">if it should send an "instability" popup to the user</param>
+    private void FizzlePortals(Entity<HandTeleporterComponent> entity, EntityUid? user, bool instability)
     {
         // Logging
         var portalStrings = "";
-        portalStrings += ToPrettyString(component.FirstPortal);
+        portalStrings += ToPrettyString(entity.Comp.FirstPortal);
         if (portalStrings != "")
             portalStrings += " and ";
-        portalStrings += ToPrettyString(component.SecondPortal);
+        portalStrings += ToPrettyString(entity.Comp.SecondPortal);
         if (portalStrings != "")
         {
             if (user != null)
-                _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{ToPrettyString(user):player} closed {portalStrings} with {ToPrettyString(uid)}");
+                _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{ToPrettyString(user):player} closed {portalStrings} with {ToPrettyString(entity)}");
             else
                 _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{portalStrings} were closed");
         }
 
         // Clear both portals
-        if (!Deleted(component.FirstPortal))
-            QueueDel(component.FirstPortal.Value);
-        if (!Deleted(component.SecondPortal))
-            QueueDel(component.SecondPortal.Value);
+        if (!Deleted(entity.Comp.FirstPortal))
+            QueueDel(entity.Comp.FirstPortal.Value);
+        if (!Deleted(entity.Comp.SecondPortal))
+            QueueDel(entity.Comp.SecondPortal.Value);
 
-        component.FirstPortal = null;
-        component.SecondPortal = null;
-        _audio.PlayPvs(component.ClearPortalsSound, uid);
+        entity.Comp.FirstPortal = null;
+        entity.Comp.SecondPortal = null;
+        _audio.PlayPvs(entity.Comp.ClearPortalsSound, entity);
 
         if (instability && user != null)
-            _popup.PopupEntity(Loc.GetString("handheld-teleporter-instability-fizzle"), uid, user.Value, PopupType.MediumCaution);
+            _popup.PopupEntity(Loc.GetString("handheld-teleporter-instability-fizzle"), entity, user.Value, PopupType.MediumCaution);
     }
 }

--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -74,6 +74,25 @@ public sealed partial class HandTeleporterSystem : EntitySystem
         args.Handled = true;
     }
 
+    /// <summary>
+    /// Checks if both portals of a teleporter are on same grid/map
+    /// and if the teleporter allows that. if the portals are in a illegal state, it fizzles them.
+    /// </summary>
+    private void CheckPortals(Entity<HandTeleporterComponent> entity)
+    {
+        // no need to check nothing if there aren't 2 portals
+        if (Deleted(entity.Comp.FirstPortal) || Deleted(entity.Comp.SecondPortal))
+            return;
+
+        var portal1Xform = Transform(entity.Comp.FirstPortal!.Value);
+        var portal2Xform = Transform(entity.Comp.SecondPortal!.Value);
+
+        var sameGrid = portal1Xform.GridUid == portal2Xform.GridUid;
+        var sameMap = portal1Xform.MapID == portal2Xform.MapID;
+
+        if (!sameGrid && !entity.Comp.AllowPortalsOnDifferentGrids || !sameMap && !entity.Comp.AllowPortalsOnDifferentMaps)
+            FizzlePortals(entity.Owner, entity.Comp, null, false);
+    }
 
     /// <summary>
     ///     Creates or removes a portal given the state of the hand teleporter.

--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -140,7 +140,12 @@ public sealed partial class HandTeleporterSystem : EntitySystem
             portalStrings += " and ";
         portalStrings += ToPrettyString(component.SecondPortal);
         if (portalStrings != "")
-            _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{ToPrettyString(user):player} closed {portalStrings} with {ToPrettyString(uid)}");
+        {
+            if (user != null)
+                _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{ToPrettyString(user):player} closed {portalStrings} with {ToPrettyString(uid)}");
+            else
+                _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{portalStrings} were closed");
+        }
 
         // Clear both portals
         if (!Deleted(component.FirstPortal))
@@ -152,7 +157,7 @@ public sealed partial class HandTeleporterSystem : EntitySystem
         component.SecondPortal = null;
         _audio.PlayPvs(component.ClearPortalsSound, uid);
 
-        if (instability)
-            _popup.PopupEntity(Loc.GetString("handheld-teleporter-instability-fizzle"), uid, user, PopupType.MediumCaution);
+        if (instability && user != null)
+            _popup.PopupEntity(Loc.GetString("handheld-teleporter-instability-fizzle"), uid, user.Value, PopupType.MediumCaution);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made so when a grid is split, it checks all portals to see if they should fizzle or not

old PR: https://github.com/space-wizards/space-station-14/pull/44129
<!-- What did you change? -->

## Why / Balance
Before this you could place 2 portals, one in cargo and another in a shittle that is still attached to the station, then you would split the shittle from the station and the portals would keep existing so you bypassed the AllowPortalsOnDifferentGrids of the teleporter.

this PR fixes this by fizzling both portals if the grid is split 
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Added a CheckPortals method that simply checks if the 2 portals of a teleporter are on different grids or different maps, and fizzles them if the teleporter doesn't allow one of the two.

Then called said method on all teleporters once a grid is split.
<!-- Summary of code changes for easier review. -->

## Test plan
- Make sure physics.grid_splitting is set to true with `> cvar physics.grid_splitting True`
- Place 2 portals on the same grid
- Cut the grid in a way that the 2 portals remain on the same side
- the portals should not fizzle
- Cut the grid in a way that the 2 portals are in different grids
- the portals should fizzle
- make sure the grids are truly split by turning on griddrag and trying to move the 2 split grids apart
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
https://github.com/user-attachments/assets/e05310ba-326c-493f-807b-bef4ccc589b5

<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl: Samuka
- fix: RD's teleporter can no longer be used to create portals in different grids by placing both portals in the same grid then spliting the grid.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->