### PR TITLE
Fix powercelldraw

### DIFF
--- a/Content.Shared/PowerCell/PowerCellSystem.cs
+++ b/Content.Shared/PowerCell/PowerCellSystem.cs
@@ -137,6 +137,23 @@ public sealed partial class PowerCellSystem : EntitySystem
     {
         if (ent.Comp.Enabled)
             args.NewChargeRate -= ent.Comp.DrawRate;
+        else
+            return;
+
+        // If PowerCellDraw is enabled. then it should set the charge cooldown on the self recharging battery
+
+        if (!TryComp<PowerCellSlotComponent>(ent, out var powerCellSlotComponent))
+            return;
+
+        if (!TryGetBatteryFromSlot((ent, powerCellSlotComponent), out var battery))
+            return;
+
+        if (!TryComp<BatterySelfRechargerComponent>(battery, out var selfRechargerComp))
+            return;
+
+        var batterySelfRecharge = (battery.Value.Owner, selfRechargerComp);
+
+        _battery.TrySetChargeCooldown(batterySelfRecharge);
     }
 
     private void OnDrawStartup(Entity<PowerCellDrawComponent> ent, ref ComponentStartup args)

--- a/Content.Shared/PowerCell/PowerCellSystem.cs
+++ b/Content.Shared/PowerCell/PowerCellSystem.cs
@@ -148,12 +148,7 @@ public sealed partial class PowerCellSystem : EntitySystem
         if (!TryGetBatteryFromSlot((ent, powerCellSlotComponent), out var battery))
             return;
 
-        if (!TryComp<BatterySelfRechargerComponent>(battery, out var selfRechargerComp))
-            return;
-
-        var batterySelfRecharge = (battery.Value.Owner, selfRechargerComp);
-
-        _battery.TrySetChargeCooldown(batterySelfRecharge);
+        _battery.TrySetChargeCooldown(battery.Value.Owner);
     }
 
     private void OnDrawStartup(Entity<PowerCellDrawComponent> ent, ref ComponentStartup args)

--- a/Content.Shared/PowerCell/PowerCellSystem.cs
+++ b/Content.Shared/PowerCell/PowerCellSystem.cs
@@ -142,10 +142,7 @@ public sealed partial class PowerCellSystem : EntitySystem
 
         // If PowerCellDraw is enabled. then it should set the charge cooldown on the self recharging battery
 
-        if (!TryComp<PowerCellSlotComponent>(ent, out var powerCellSlotComponent))
-            return;
-
-        if (!TryGetBatteryFromSlot((ent, powerCellSlotComponent), out var battery))
+        if (!TryGetBatteryFromSlot(ent.Owner, out var battery))
             return;
 
         _battery.TrySetChargeCooldown(battery.Value.Owner);

--- a/Content.Shared/PowerCell/PowerCellSystem.cs
+++ b/Content.Shared/PowerCell/PowerCellSystem.cs
@@ -135,13 +135,12 @@ public sealed partial class PowerCellSystem : EntitySystem
 
     private void OnDrawRefreshChargeRate(Entity<PowerCellDrawComponent> ent, ref RefreshChargeRateEvent args)
     {
-if (!ent.Comp.Enabled)
-     return;
+        if (!ent.Comp.Enabled)
+            return;
 
-args.NewChargeRate -= ent.Comp.DrawRate;
+        args.NewChargeRate -= ent.Comp.DrawRate;
 
         // If PowerCellDraw is enabled. then it should set the charge cooldown on the self recharging battery
-
         if (!TryGetBatteryFromSlot(ent.Owner, out var battery))
             return;
 

--- a/Content.Shared/PowerCell/PowerCellSystem.cs
+++ b/Content.Shared/PowerCell/PowerCellSystem.cs
@@ -135,10 +135,10 @@ public sealed partial class PowerCellSystem : EntitySystem
 
     private void OnDrawRefreshChargeRate(Entity<PowerCellDrawComponent> ent, ref RefreshChargeRateEvent args)
     {
-        if (ent.Comp.Enabled)
-            args.NewChargeRate -= ent.Comp.DrawRate;
-        else
-            return;
+if (!ent.Comp.Enabled)
+     return;
+
+args.NewChargeRate -= ent.Comp.DrawRate;
 
         // If PowerCellDraw is enabled. then it should set the charge cooldown on the self recharging battery
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
There is a bug that makes so devices with power cell draw don't set the cooldown for powercells with self recharge. so it means that if the powercell has a larger self-recharge rate than the powercell draw, that device will never run out of power, even if the powercell should have a cooldown before charging

Example: cloaking device and super cloaking device. they last forever right now even though they should only recharge when turned off and after a certain cooldown

old PR: https://github.com/space-wizards/space-station-14/pull/42431
<!-- What did you change? -->

## Why / Balance
bug fix good
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
in OnDrawRefreshChargeRate of the PowerCellSystem. it checks if the battery has the BatterySelfRechargerComponent and then if it does it tries to set the charge cooldown
<!-- Summary of code changes for easier review. -->

## Test plan
- Spawn a PowerCellSmallNuclear (that has BatterySelfRechargerComp and a AutoRechargePauseTime)
- place it on a device that consumes less than 36W (the recharge rate of that battery)
- Because of the AutoRechargePauseTime, the device should discharge the battery
- wait the AutoRechargePauseTime while the device is turned off
- check to see the battery recharge to full
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
no need
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Samuka
- fix: Cloaking device from xenoborgs no longer lasts forever.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
