### PR TITLE
Serialization content changes

### DIFF
--- a/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
+++ b/Content.IntegrationTests/Tests/PrototypeSaveTest.cs
@@ -74,7 +74,7 @@ public sealed class PrototypeSaveTest : GameTest
             prototypes.Add(prototype);
         }
 
-        var context = new TestEntityUidContext();
+        var context = new TestEntityUidContext(seriMan);
 
         await server.WaitAssertion(() =>
         {
@@ -168,9 +168,9 @@ public sealed class PrototypeSaveTest : GameTest
         public string WritingComponent = string.Empty;
         public EntityPrototype? Prototype;
 
-        public TestEntityUidContext()
+        public TestEntityUidContext(ISerializationManager ser)
         {
-            SerializerProvider = new();
+            SerializerProvider = new(ser);
             SerializerProvider.RegisterSerializer(this);
         }
 

--- a/Content.IntegrationTests/Tests/PrototypeTests/PrototypeTests.cs
+++ b/Content.IntegrationTests/Tests/PrototypeTests/PrototypeTests.cs
@@ -18,9 +18,9 @@ public sealed class PrototypeTests : GameTest
     [Test]
     public async Task TestAllServerPrototypesAreSerializable()
     {
-        var pair = Pair;
-        var context = new PrototypeSaveTest.TestEntityUidContext();
-        await SaveThenValidatePrototype(pair.Server, "server", context);
+        var ser = Pair.Server.ResolveDependency<ISerializationManager>();
+        var context = new PrototypeSaveTest.TestEntityUidContext(ser);
+        await SaveThenValidatePrototype(Pair.Server, "server", context);
     }
 
     /// <summary>
@@ -30,9 +30,9 @@ public sealed class PrototypeTests : GameTest
     [Test]
     public async Task TestAllClientPrototypesAreSerializable()
     {
-        var pair = Pair;
-        var context = new PrototypeSaveTest.TestEntityUidContext();
-        await SaveThenValidatePrototype(pair.Client, "client", context);
+        var ser = Pair.Server.ResolveDependency<ISerializationManager>();
+        var context = new PrototypeSaveTest.TestEntityUidContext(ser);
+        await SaveThenValidatePrototype(Pair.Client, "client", context);
     }
 
     public async Task SaveThenValidatePrototype(RobustIntegrationTest.IntegrationInstance instance, string instanceId,
@@ -68,9 +68,9 @@ public sealed class PrototypeTests : GameTest
     [Test]
     public async Task ServerPrototypeSaveLoadSaveTest()
     {
-        var pair = Pair;
-        var context = new PrototypeSaveTest.TestEntityUidContext();
-        await SaveLoadSavePrototype(pair.Server, context);
+        var ser = Pair.Server.ResolveDependency<ISerializationManager>();
+        var context = new PrototypeSaveTest.TestEntityUidContext(ser);
+        await SaveLoadSavePrototype(Pair.Server, context);
     }
 
     /// <summary>
@@ -79,9 +79,9 @@ public sealed class PrototypeTests : GameTest
     [Test]
     public async Task ClientPrototypeSaveLoadSaveTest()
     {
-        var pair = Pair;
-        var context = new PrototypeSaveTest.TestEntityUidContext();
-        await SaveLoadSavePrototype(pair.Client, context);
+        var ser = Pair.Server.ResolveDependency<ISerializationManager>();
+        var context = new PrototypeSaveTest.TestEntityUidContext(ser);
+        await SaveLoadSavePrototype(Pair.Client, context);
     }
 
     private async Task SaveLoadSavePrototype(

--- a/Content.Shared/Cloning/CloningSettingsPrototype.cs
+++ b/Content.Shared/Cloning/CloningSettingsPrototype.cs
@@ -17,7 +17,7 @@ public sealed partial class CloningSettingsPrototype : IPrototype, IInheritingPr
     public string ID { get; private set; } = default!;
 
     /// <inheritdoc/>
-    [ParentDataField(typeof(PrototypeIdArraySerializer<CloningSettingsPrototype>))]
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<CloningSettingsPrototype>))]
     public string[]? Parents { get; private set; }
 
     /// <inheritdoc/>

--- a/Content.Shared/Humanoid/Prototypes/RandomHumanoidSettingsPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/RandomHumanoidSettingsPrototype.cs
@@ -11,7 +11,7 @@ public sealed partial class RandomHumanoidSettingsPrototype : IPrototype, IInher
 {
     [IdDataField] public string ID { get; private set; } = default!;
 
-    [ParentDataField(typeof(PrototypeIdArraySerializer<RandomHumanoidSettingsPrototype>))]
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<RandomHumanoidSettingsPrototype>))]
     public string[]? Parents { get; private set; }
 
     [AbstractDataField]

--- a/Content.Shared/Mech/Equipment/Systems/MechSoundboardSystem.cs
+++ b/Content.Shared/Mech/Equipment/Systems/MechSoundboardSystem.cs
@@ -24,7 +24,7 @@ public sealed partial class MechSoundboardSystem : EntitySystem
     private void OnUiStateReady(EntityUid uid, MechSoundboardComponent comp, MechEquipmentUiStateReadyEvent args)
     {
         // you have to specify a collection so it must exist probably
-        var sounds = comp.Sounds.Select(sound => sound.Collection!);
+        var sounds = comp.Sounds.Select(sound => sound.Collection!.Value);
         var state = new MechSoundboardUiState
         {
             Sounds = sounds.ToList()

--- a/Content.Shared/Mech/Equipment/Systems/MechSoundboardSystem.cs
+++ b/Content.Shared/Mech/Equipment/Systems/MechSoundboardSystem.cs
@@ -24,7 +24,7 @@ public sealed partial class MechSoundboardSystem : EntitySystem
     private void OnUiStateReady(EntityUid uid, MechSoundboardComponent comp, MechEquipmentUiStateReadyEvent args)
     {
         // you have to specify a collection so it must exist probably
-        var sounds = comp.Sounds.Select(sound => sound.Collection!.Value);
+        var sounds = comp.Sounds.Select(sound => sound.Collection!);
         var state = new MechSoundboardUiState
         {
             Sounds = sounds.ToList()

--- a/Content.Shared/Mech/MechUI.cs
+++ b/Content.Shared/Mech/MechUI.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.Serialization;
+using Robust.Shared.Audio;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Mech;
 
@@ -122,5 +123,5 @@ public sealed class MechGrabberUiState : BoundUserInterfaceState
 [Serializable, NetSerializable]
 public sealed class MechSoundboardUiState : BoundUserInterfaceState
 {
-    public List<string> Sounds = new();
+    public List<ProtoId<SoundCollectionPrototype>> Sounds = new();
 }

--- a/Content.Shared/Mech/MechUI.cs
+++ b/Content.Shared/Mech/MechUI.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Mech;


### PR DESCRIPTION
- changed mech soundboard state to use protoid
- added seriMan to TestEntityUidContext constructor
- replaced the only 2 PrototypeIdArraySerializer uses with the abstract one

requires https://github.com/space-wizards/RobustToolbox/pull/6674