### PR TITLE
Moved dropped event to raise after dropped item is moved

### DIFF
--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -94,7 +94,8 @@ namespace Content.Client.Hands.Systems
             string handId,
             bool doDropInteraction = true,
             bool log = true,
-            EntityCoordinates? targetDropLocation = null)
+            EntityCoordinates? targetDropLocation = null
+        )
         {
             base.DoDrop(ent, handId, doDropInteraction, log, targetDropLocation);
 

--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -15,6 +15,7 @@ using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
+using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 
@@ -92,9 +93,10 @@ namespace Content.Client.Hands.Systems
         public override void DoDrop(Entity<HandsComponent?> ent,
             string handId,
             bool doDropInteraction = true,
-            bool log = true)
+            bool log = true,
+            EntityCoordinates? targetDropLocation = null)
         {
-            base.DoDrop(ent, handId, doDropInteraction, log);
+            base.DoDrop(ent, handId, doDropInteraction, log, targetDropLocation);
 
             if (TryGetHeldItem(ent, handId, out var held) && TryComp(held, out SpriteComponent? sprite))
                 sprite.RenderOrder = EntityManager.CurrentTick.Value;

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -154,17 +154,7 @@ public abstract partial class SharedHandsSystem
 
         // drop the item with heavy calculations from their hands and place it at the calculated interaction range position
         // The DoDrop is handle if there's no drop target
-        DoDrop(ent, handId, doDropInteraction: doDropInteraction);
-
-        // if there's no drop location stop here
-        if (targetDropLocation == null)
-            return true;
-
-        // otherwise, also move dropped item and rotate it properly according to grid/map
-        var (itemPos, itemRot) = TransformSystem.GetWorldPositionRotation(entity.Value);
-        var origin = new MapCoordinates(itemPos, itemXform.MapID);
-        var target = TransformSystem.ToMapCoordinates(targetDropLocation.Value);
-        TransformSystem.SetWorldPositionRotation(entity.Value, GetFinalDropCoordinates(ent, origin, target, entity.Value), itemRot);
+        DoDrop(ent, handId, doDropInteraction: doDropInteraction, targetDropLocation: targetDropLocation);
         return true;
     }
 
@@ -235,7 +225,9 @@ public abstract partial class SharedHandsSystem
     public virtual void DoDrop(Entity<HandsComponent?> ent,
         string handId,
         bool doDropInteraction = true,
-        bool log = true)
+        bool log = true,
+        EntityCoordinates? targetDropLocation = null
+    )
     {
         if (!Resolve(ent, ref ent.Comp, false))
             return;
@@ -253,6 +245,15 @@ public abstract partial class SharedHandsSystem
         {
             Log.Error($"Failed to remove {ToPrettyString(entity)} from users hand container when dropping. User: {ToPrettyString(ent)}. Hand: {handId}.");
             return;
+        }
+
+        if (targetDropLocation != null)
+        {
+            var (itemPos, itemRot) = TransformSystem.GetWorldPositionRotation(entity.Value);
+            // otherwise, also move dropped item and rotate it properly according to grid/map
+            var origin = new MapCoordinates(itemPos, Transform(entity.Value).MapID);
+            var target = TransformSystem.ToMapCoordinates(targetDropLocation.Value);
+            TransformSystem.SetWorldPositionRotation(entity.Value, GetFinalDropCoordinates(ent, origin, target, entity.Value), itemRot);
         }
 
         Dirty(ent);

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -1266,9 +1266,6 @@ namespace Content.Shared.Interaction
             if (IsDeleted(user) || IsDeleted(item))
                 return;
 
-            var dropMsg = new DroppedEvent(user);
-            RaiseLocalEvent(item, dropMsg, true);
-
             // If the dropper is rotated then use their targetrelativerotation as the drop rotation
             var rotation = Angle.Zero;
 
@@ -1278,6 +1275,9 @@ namespace Content.Shared.Interaction
             }
 
             Transform(item).LocalRotation = rotation;
+
+            var dropMsg = new DroppedEvent(user);
+            RaiseLocalEvent(item, dropMsg, true);
         }
         #endregion
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
## About the PR
<!-- What did you change? -->
Currently the DroppedEvent is raised before the entity's location is set to the target location. This moves it after it is moved and rotated.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The dropped event is used for dropping things like beakers so they can break if you slip. Use cases that use the location that an item has been dropped are currently difficult to implement as you can't get that location without some very funky workarounds.
There shouldn't be any cases where this would break anything, and if you need the location of the user which dropped the item, the user entity is sent in the event.
## Technical details
<!-- Summary of code changes for easier review. -->
Moved the code which moves the dropped item into `DoDrop()`
Added `targetDropLocation` input to `DoDrop()`, uses the same logic as before.
Moved `DroppedEvent` to be raised after the rotation of the grid is applied to the entity. Same reasoning as above.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
If there isn't proper integration test coverage for this then there might be an edge case which turns up at some point. Otherwise not much testing is needed.
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer's discretion -->
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`DroppedEvent` is now raised after the dropped entity has been moved and rotated to the grid rotation. If you require the old location, get the transform of the user entity passed into the event.
## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->