### PR TITLE
Bugfix: Prevent delay stacking on (Un)AnchorAttemptEvent

### DIFF
--- a/Content.Shared/Construction/Components/AnchorableComponent.cs
+++ b/Content.Shared/Construction/Components/AnchorableComponent.cs
@@ -15,13 +15,11 @@ namespace Content.Shared.Construction.Components
         public AnchorableFlags Flags = AnchorableFlags.Anchorable | AnchorableFlags.Unanchorable;
 
         [DataField]
-        [ViewVariables(VVAccess.ReadWrite)]
         public bool Snap { get; private set; } = true;
 
         /// <summary>
         /// Base delay to use for anchoring.
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
         [DataField]
         public float Delay = 1f;
     }

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Examine;
 using Content.Shared.Construction.Components;

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -89,7 +89,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         if (!Resolve(usingUid, ref usingTool))
             return;
 
-        if (!Valid(uid, userUid, usingUid, false, out var failMessage))
+        if (!Valid(uid, userUid, usingUid, false, out var failMessage, out var actualDelay))
         {
             if (failMessage != null)
                 _popup.PopupClient(failMessage, uid, userUid);
@@ -99,7 +99,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         // Log unanchor attempt (server only)
         _adminLogger.Add(LogType.Anchor, LogImpact.Low, $"{ToPrettyString(userUid):user} is trying to unanchor {ToPrettyString(uid):entity} from {transform.Coordinates:targetlocation}");
 
-        _tool.UseTool(usingUid, userUid, uid, anchorable.Delay, usingTool.Qualities, new TryUnanchorCompletedEvent());
+        _tool.UseTool(usingUid, userUid, uid, actualDelay, usingTool.Qualities, new TryUnanchorCompletedEvent());
     }
 
     private void OnInteractUsing(EntityUid uid, AnchorableComponent anchorable, InteractUsingEvent args)
@@ -244,7 +244,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         if (!Resolve(usingUid, ref usingTool))
             return;
 
-        if (!Valid(uid, userUid, usingUid, true, out var failMessage, anchorable, usingTool))
+        if (!Valid(uid, userUid, usingUid, true, out var failMessage, out var actualDelay, anchorable, usingTool))
         {
             if (failMessage != null)
                 _popup.PopupClient(Loc.GetString(failMessage), uid, userUid);
@@ -263,18 +263,32 @@ public sealed partial class AnchorableSystem : EntitySystem
             return;
         }
 
-        _tool.UseTool(usingUid, userUid, uid, anchorable.Delay, usingTool.Qualities, new TryAnchorCompletedEvent());
+        _tool.UseTool(usingUid, userUid, uid, actualDelay, usingTool.Qualities, new TryAnchorCompletedEvent());
     }
 
+    /// <summary>
+    /// Checks if a given entity can be (un)anchored by a particular user and tool.
+    /// </summary>
+    /// <param name="uid">The target entity to be (un)anchored.</param>
+    /// <param name="userUid">The user attempting to anchor it.</param>
+    /// <param name="usingUid">The tool being used to (un)anchor the target entity.</param>
+    /// <param name="anchoring">True if the target will be anchored, false if unanchored.</param>
+    /// <param name="failMessage">On failure, may contain a message stating why the target could not be (un)anchored.</param>
+    /// <param name="actualDelay">On success, contains the actual delay that the entity should take to anchor.</param>
+    /// <param name="anchorable">The AnchorableComponent of the target.</param>
+    /// <param name="usingTool">The ToolComponent of the tool.</param>
+    /// <returns>true if the target can be (un)anchored, false otherwise.</returns>
     private bool Valid(
         EntityUid uid,
         EntityUid userUid,
         EntityUid usingUid,
         bool anchoring,
         out string? failMessage,
+        out float actualDelay,
         AnchorableComponent? anchorable = null,
         ToolComponent? usingTool = null)
     {
+        actualDelay = 0f;
         failMessage = null;
 
         if (!Resolve(uid, ref anchorable))
@@ -298,7 +312,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         else
             RaiseLocalEvent(uid, (UnanchorAttemptEvent)attempt);
 
-        anchorable.Delay += attempt.Delay;
+        actualDelay = anchorable.Delay + attempt.Delay;
 
         failMessage = attempt.FailMessage;
 

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -274,7 +274,7 @@ public sealed partial class AnchorableSystem : EntitySystem
     /// <param name="usingUid">The tool being used to (un)anchor the target entity.</param>
     /// <param name="anchoring">True if the target will be anchored, false if unanchored.</param>
     /// <param name="failMessage">On failure, may contain a message stating why the target could not be (un)anchored.</param>
-    /// <param name="actualDelay">On success, contains the actual delay that the entity should take to anchor.</param>
+    /// <param name="actualDelay">On success, contains the actual delay that the entity should take to anchor, in seconds.</param>
     /// <param name="anchorable">The AnchorableComponent of the target.</param>
     /// <param name="usingTool">The ToolComponent of the tool.</param>
     /// <returns>true if the target can be (un)anchored, false otherwise.</returns>


### PR DESCRIPTION
## About the PR

Fixes anchorable delay stacking from AnchorAttemptEvent/UnanchorAttemptEvent.

An alternative to #39553 with a smaller diff and no major changes to flow.

Documented AnchorableSystem.Valid since it was changed in the diff.

## Why / Balance

Bugfix.

Fixes #22546

## Technical details

Adds an extra output parameter to AnchorableSystem.Valid that contains the actual time instead of modifying the component's state - that delay is supposed to be the base.

Cleanup: removed a few redundant VVAccess attributes in AnchorableComponent (DataField already ReadWrite), removed an unused using from AnchorableSystem.

## Test plan

Replicate the test video.
1. Spawn on the dev map, wander over to the atmos section.
2. Turn on the N2/O2 pumps to max, turn the mixer to 500 kPa.
3. Unanchor the pipe.
4. Anchor the pipe.
5. Repeat steps 3 and 4.  The unanchor should take the same time.
6. Check the AnchorableComponent on the pipe being unanchored.  Its Delay should stay at 1 second.

## Media

The above test plan shown in-game.  A pipe is unanchored and reanchored while full of high pressure gas.  The amount of time it takes to unanchor does not change between each attempt.  The AnchorableComponent of the pipe is examined, and the Delay is still at 1 second after the test.

https://github.com/user-attachments/assets/f1f34b2d-3637-43c4-87fb-a61750a2f471

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
Can't figure out something that's both terse and straightforward.
:cl:
- fix: Pipes no longer take longer to reanchor after unanchoring while at high pressure.