### PR TITLE
Revert " build task configuration fix "

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,8 +270,6 @@ __pycache__/
 !.vscode/extensions.json
 !.vscode/launch.json
 !.vscode/tasks.json
-# Visual Studio Code C# Dev kit cache files.
-*.csproj.lscache
 
 # Release package files go here:
 release/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,6 +49,7 @@
                 "Server",
                 "Client"
             ],
+            "preLaunchTask": "build"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,27 +4,6 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "build (C# Dev Kit)",
-            "detail": "needs C# Dev Kit extention. use the (build) task instead if you dont have the extention.",
-            "type": "dotnet",
-            "task": "build",
-            "icon": {
-                "id": "build",
-                "color": "terminal.ansiBlue"
-            },
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "presentation": {
-                "reveal": "silent"
-            },
-            "problemMatcher": "$msCompile",
-            "runOptions": {
-                "instanceLimit": 1
-            }
-        },
-        {
             "label": "build",
             "command": "dotnet",
             "type": "shell",
@@ -34,15 +13,13 @@
                 "/consoleloggerparameters:'ForceNoAlign;NoSummary'" // Do not generate summary otherwise it leads to duplicate errors in Problems panel
             ],
             "group": {
-                "kind": "build"
+                "kind": "build",
+                "isDefault": true
             },
             "presentation": {
                 "reveal": "silent"
             },
-            "problemMatcher": "$msCompile",
-            "runOptions": {
-                "instanceLimit": 1
-            }
+            "problemMatcher": "$msCompile"
         },
         {
             "label": "build-yaml-linter",


### PR DESCRIPTION
Reverts space-wizards/space-station-14#43862

It does not build the game anymore at all, it just launches the last one you build before.
So any changes you made won't get applied unless you build manually first.

Also the lscache files were already in the gitignore, so they are now twice in there.