### PR TITLE
Allow aghosts to open several storage UIs

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -870,6 +870,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
         var uid = args.Target;
         var actor = args.Actor;
         var count = 0;
+        var bypassLimit = _tag.HasTag(actor, _bypassOpenStorageLimitTag)
 
         if (_userQuery.TryComp(actor, out var userComp))
         {
@@ -885,7 +886,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
 
                     count++;
 
-                    if (count >= _openStorageLimit && !_tag.HasTag(actor, _bypassOpenStorageLimitTag))
+                    if (count >= _openStorageLimit && !bypassLimit)
                     {
                         args.Cancel();
                     }

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -84,7 +84,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
     public bool NestedStorage = true;
 
     public static readonly ProtoId<ItemSizePrototype> DefaultStorageMaxItemSize = "Normal";
-    public static readonly ProtoId<TagPrototype> _bypassOpenStorageLimitTag = "BypassOpenStorageLimit";
+    public static readonly ProtoId<TagPrototype> BypassOpenStorageLimitTag = "BypassOpenStorageLimit";
 
     public const float AreaInsertDelayPerItem = 0.075f;
     private static AudioParams _audioParams = AudioParams.Default
@@ -425,7 +425,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
         {
             // If you need something more sophisticated for multi-UI you'll need to code some smarter
             // interactions.
-            if (_openStorageLimit == 1 && !_tag.HasTag(actor, _bypassOpenStorageLimitTag))
+            if (_openStorageLimit == 1 && !_tag.HasTag(actor, BypassOpenStorageLimitTag))
                 UI.CloseUserUis<StorageComponent.StorageUiKey>(actor);
 
             OpenStorageUIInternal(uid, actor, storageComp, silent: silent);
@@ -863,6 +863,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
     {
         if (args.UiKey is not StorageComponent.StorageUiKey.Key ||
             _openStorageLimit == -1 ||
+            _tag.HasTag(args.Actor, BypassOpenStorageLimitTag) ||
             _nestedCheck ||
             args.Message is not OpenBoundInterfaceMessage)
             return;
@@ -870,7 +871,6 @@ public abstract partial class SharedStorageSystem : EntitySystem
         var uid = args.Target;
         var actor = args.Actor;
         var count = 0;
-        var bypassLimit = _tag.HasTag(actor, _bypassOpenStorageLimitTag);
 
         if (_userQuery.TryComp(actor, out var userComp))
         {
@@ -886,7 +886,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
 
                     count++;
 
-                    if (count >= _openStorageLimit && !bypassLimit)
+                    if (count >= _openStorageLimit)
                     {
                         args.Cancel();
                     }

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -870,7 +870,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
         var uid = args.Target;
         var actor = args.Actor;
         var count = 0;
-        var bypassLimit = _tag.HasTag(actor, _bypassOpenStorageLimitTag)
+        var bypassLimit = _tag.HasTag(actor, _bypassOpenStorageLimitTag);
 
         if (_userQuery.TryComp(actor, out var userComp))
         {

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -84,7 +84,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
     public bool NestedStorage = true;
 
     public static readonly ProtoId<ItemSizePrototype> DefaultStorageMaxItemSize = "Normal";
-    private static ProtoId<TagPrototype> _bypassOpenStorageLimitTag = "BypassOpenStorageLimit";
+    public static readonly ProtoId<TagPrototype> _bypassOpenStorageLimitTag = "BypassOpenStorageLimit";
 
     public const float AreaInsertDelayPerItem = 0.075f;
     private static AudioParams _audioParams = AudioParams.Default

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -84,6 +84,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
     public bool NestedStorage = true;
 
     public static readonly ProtoId<ItemSizePrototype> DefaultStorageMaxItemSize = "Normal";
+    private static ProtoId<TagPrototype> _bypassOpenStorageLimitTag = "BypassOpenStorageLimit";
 
     public const float AreaInsertDelayPerItem = 0.075f;
     private static AudioParams _audioParams = AudioParams.Default
@@ -424,7 +425,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
         {
             // If you need something more sophisticated for multi-UI you'll need to code some smarter
             // interactions.
-            if (_openStorageLimit == 1)
+            if (_openStorageLimit == 1 && !_tag.HasTag(actor, _bypassOpenStorageLimitTag))
                 UI.CloseUserUis<StorageComponent.StorageUiKey>(actor);
 
             OpenStorageUIInternal(uid, actor, storageComp, silent: silent);
@@ -884,7 +885,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
 
                     count++;
 
-                    if (count >= _openStorageLimit)
+                    if (count >= _openStorageLimit && !_tag.HasTag(actor, _bypassOpenStorageLimitTag))
                     {
                         args.Cancel();
                     }

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -12,6 +12,7 @@
     - CanPilot
     - BypassInteractionRangeChecks
     - BypassDropChecks
+    - BypassOpenStorageLimit
     - NoConsoleSound
     - SilentStorageUser
     - PreventAccessLogging

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -203,6 +203,9 @@
 - type: Tag
   id: BypassInteractionRangeChecks # Tagged entities don't care about distance or walls when touching things (Aghost).
 
+- type: Tag
+  id: BypassOpenStorageLimit # Tagged entities can open several storage UIs at once (Aghost).
+
 ## C ##
 
 - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Allowed aghosts to open several storage UIs at once.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Annoying to keep track of several storages of a raider for example.

## Technical details
<!-- Summary of code changes for easier review. -->
To keep with the tradition, its a tag that allows them to bypass stuff, just like the interaction limits etc

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Try to open storage as a urist, see only one opens.
2. Try to do the same as an aghost, see several open.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/095124a9-8dfc-4a1c-8786-fea027522d01

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
ADMIN:
- add: Aghosts can now open several storage UIs at once. To bring back previous behaviour remove your "BypassOpenStorageLimit" tag.

<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
