### PR TITLE
Attempt to fix AFK heisentest

### DIFF
--- a/Content.IntegrationTests/Tests/Afk/AfkSystemTest.cs
+++ b/Content.IntegrationTests/Tests/Afk/AfkSystemTest.cs
@@ -77,9 +77,11 @@ public sealed class AfkSystemTest : GameTest
         await Server.WaitAssertion(() =>
         {
             session = GetSession();
-            _cfg.SetCVar(CCVars.AfkConfirmTimeout, 0.01f);
 
-            Assert.That(_afkConfirm.TryStartConfirmation(session), Is.True);
+            _afkConfirm.AddConfirmationForTest(session, TimeSpan.Zero);
+            Assert.That(_afkConfirm.HasConfirmation(session), Is.True);
+
+            _afkConfirm.Update(0);
         });
 
         await RunTicksSync(5);


### PR DESCRIPTION
Update alone should fix it but this at least avoids any session based cruff if its status is cooked.