### PR TITLE
feat: re-add 'c# dev-kit' build task for vscode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,13 +13,35 @@
                 "/consoleloggerparameters:'ForceNoAlign;NoSummary'" // Do not generate summary otherwise it leads to duplicate errors in Problems panel
             ],
             "group": {
-                "kind": "build",
-                "isDefault": true
+                "kind": "build"
             },
             "presentation": {
                 "reveal": "silent"
             },
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "runOptions": {
+                "instanceLimit": 1
+            }
+        },
+        {
+            "label": "build (C# Dev Kit)",
+            "detail": "needs C# Dev Kit extention. use the (build) task instead if you dont have the extention.",
+            "type": "dotnet",
+            "task": "build",
+            "icon": {
+                "id": "build",
+                "color": "terminal.ansiBlue"
+            },
+            "group": {
+                "kind": "build"
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile",
+            "runOptions": {
+                "instanceLimit": 1
+            }
         },
         {
             "label": "build-yaml-linter",


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
After PROPER investigation into details of https://github.com/space-wizards/space-station-14/pull/43862 i agree that having task by itself is nice, and does not hurt dev experience in any shape or form (and as c# dev-kit in general enchances coder experience on vs code).

I am **not** returning manual-only build-before-start because it is a misleading thing - it easily can lead to people making changes and expecting restarted version to include them, while they will not be included. I do understand that building sometimes takes ages, but that is lesser evil.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Dev experience without extension is not diminished.
Steps:
* Disable C# Dev-Kit extension
* remove task from tasks.json
* `Ctrl` + `Shift` + `P` -> `Developer: Reload Window`
* `Ctrl` + `Shift` + `B` -> see list of build options with old build task
* re-add task for tasks.json
* `Ctrl` + `Shift` + `P` -> `Developer: Reload Window`
* `Ctrl` + `Shift` + `B` -> see list of build options with old build task
Result: amount of steps needed to execute build is not different with or without extension (remember to enable extension after finishing  test case :godo:)

2. New task improves dev experience with extension
Steps:
* Make sure C# Dev-Kit extension is enabled
* remove task from tasks.json
* `Ctrl` + `Shift` + `P` -> `Developer: Reload Window`
* `Ctrl` + `Shift` + `B` -> see list of build options with old build task
* re-add task for tasks.json
* `Ctrl` + `Shift` + `P` -> `Developer: Reload Window`
* `Ctrl` + `Shift` + `B` -> see two tasks, new and old one
* in vscode footer toolbar click on 'Debug Any CPU' 
<img width="866" height="33" alt="image" src="https://github.com/user-attachments/assets/518b348b-d701-44a6-b98c-8d0bf50d6da6" />
* Select 'Tools' in configuration dropdown
* Accept reload window (or do `Ctrl` + `Shift` + `P` -> `Developer: Reload Window`)
* `Ctrl` + `Shift` + `B` -> select 'build (C# Dev Kit)' option
Result: Now call for build uses 'Tools' configuration when calling dotnet build. Upon consecutive calls to  `Ctrl` + `Shift` + `B`  first option would be the one that were last used.

3. Launching Server/Client rebuilds project
Steps:
* select Server/Client configuration in Run&Debug section
* click `Start Debugging` button 
Result: Build task is started, after it finishes - Server and client are running and using newly compiled code.

## Technical details
<!-- Summary of code changes for easier review. -->
instanceLimit blocks ability to launch multiple concurrent build actions, which honestly makes a lot of sense to me.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->