### PR TITLE
Cleanup: ProtoMan Part 2 - remove Client and Server EntitySystem IPrototypeManager instances

### DIFF
--- a/Content.Client/Access/Systems/JobStatusSystem.cs
+++ b/Content.Client/Access/Systems/JobStatusSystem.cs
@@ -10,7 +10,6 @@ public sealed partial class JobStatusSystem : SharedJobStatusSystem
 {
     [Dependency] private ShowJobIconsSystem _showJobIcons = default!;
     [Dependency] private ShowCrewIconsSystem _showCrewIcons = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
 
     private static readonly ProtoId<SecurityIconPrototype> CrewBorderIcon = "CrewBorderIcon";
     private static readonly ProtoId<SecurityIconPrototype> CrewUncertainBorderIcon = "CrewUncertainBorderIcon";
@@ -26,14 +25,14 @@ public sealed partial class JobStatusSystem : SharedJobStatusSystem
     private void OnGetStatusIconsEvent(Entity<JobStatusComponent> ent, ref GetStatusIconsEvent ev)
     {
         if (_showJobIcons.IsActive && ent.Comp.JobStatusIcon != null)
-            ev.StatusIcons.Add(_prototype.Index(ent.Comp.JobStatusIcon));
+            ev.StatusIcons.Add(ProtoMan.Index(ent.Comp.JobStatusIcon));
 
         if (_showCrewIcons.IsActive)
         {
             if (_showCrewIcons.UncertainCrewBorder)
-                ev.StatusIcons.Add(_prototype.Index(CrewUncertainBorderIcon));
+                ev.StatusIcons.Add(ProtoMan.Index(CrewUncertainBorderIcon));
             else if (ent.Comp.IsCrew)
-                ev.StatusIcons.Add(_prototype.Index(CrewBorderIcon));
+                ev.StatusIcons.Add(ProtoMan.Index(CrewBorderIcon));
         }
     }
 }

--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -17,7 +17,6 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Sequence;
 using Robust.Shared.Serialization.Markdown.Value;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using YamlDotNet.RepresentationModel;
 
@@ -30,7 +29,6 @@ namespace Content.Client.Actions
 
         [Dependency] private SharedChargesSystem _sharedCharges = default!;
         [Dependency] private IPlayerManager _playerManager = default!;
-        [Dependency] private IPrototypeManager _proto = default!;
         [Dependency] private IResourceManager _resources = default!;
         [Dependency] private MetaDataSystem _metaData = default!;
         [Dependency] private ISerializationManager _serialization = default!;
@@ -257,7 +255,7 @@ namespace Content.Client.Actions
                 else if (map.TryGet<ValueDataNode>("entity", out var entityNode))
                 {
                     var id = new EntProtoId(entityNode.Value);
-                    var proto = _proto.Index(id);
+                    var proto = ProtoMan.Index(id);
                     actionId = Spawn(MappingEntityAction);
                     SetIcon(actionId, new SpriteSpecifier.EntityPrototype(id));
                     SetEvent(actionId, new StartPlacementActionEvent()
@@ -270,7 +268,7 @@ namespace Content.Client.Actions
                 else if (map.TryGet<ValueDataNode>("tileId", out var tileNode))
                 {
                     var id = new ProtoId<ContentTileDefinition>(tileNode.Value);
-                    var proto = _proto.Index(id);
+                    var proto = ProtoMan.Index(id);
                     actionId = Spawn(MappingEntityAction);
                     if (proto.Sprite is {} sprite)
                         SetIcon(actionId, new SpriteSpecifier.Texture(sprite));

--- a/Content.Client/Administration/AdminQuickInfoSystem.cs
+++ b/Content.Client/Administration/AdminQuickInfoSystem.cs
@@ -39,7 +39,6 @@ internal sealed partial class AdminQuickInfoCommand : LocalizedEntityCommands
 internal sealed partial class AdminQuickInfoSystem : EntitySystem
 {
     [Dependency] private AdminSystem _adminSystem = null!;
-    [Dependency] private IPrototypeManager _prototypeManager = null!;
 
     public event Action<QuickInfoShared.SingleEntityInfo>? EntityResponseReceived;
 
@@ -152,7 +151,7 @@ internal sealed partial class AdminQuickInfoSystem : EntitySystem
 
                 sb.AppendMarkupLine(Loc.GetString("admin-quick-info-job", ("job", _playerInfo.StartingJob)));
 
-                if (_playerInfo.RoleProto is { } roleId && _system._prototypeManager.Resolve(roleId, out var role))
+                if (_playerInfo.RoleProto is { } roleId && _system.ProtoMan.Resolve(roleId, out var role))
                 {
                     var roleColor = role.Color.ToHex();
                     var symbol = _playerInfo.Antag ? role.Symbol : "";

--- a/Content.Client/Administration/Systems/AdminSystem.Overlay.cs
+++ b/Content.Client/Administration/Systems/AdminSystem.Overlay.cs
@@ -4,7 +4,6 @@ using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Administration.Systems
 {
@@ -18,7 +17,6 @@ namespace Content.Client.Administration.Systems
         [Dependency] private IUserInterfaceManager _userInterfaceManager = default!;
         [Dependency] private IConfigurationManager _configurationManager = default!;
         [Dependency] private SharedRoleSystem _roles = default!;
-        [Dependency] private IPrototypeManager _proto = default!;
 
         private AdminNameOverlay _adminNameOverlay = default!;
 
@@ -36,7 +34,7 @@ namespace Content.Client.Administration.Systems
                 _userInterfaceManager,
                 _configurationManager,
                 _roles,
-                _proto);
+                ProtoMan);
             _adminManager.AdminStatusUpdated += OnAdminStatusUpdated;
         }
 

--- a/Content.Client/Alerts/ClientAlertsSystem.cs
+++ b/Content.Client/Alerts/ClientAlertsSystem.cs
@@ -15,7 +15,6 @@ public sealed partial class ClientAlertsSystem : AlertsSystem
     public AlertOrderPrototype? AlertOrder { get; set; }
 
     [Dependency] private IPlayerManager _playerManager = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IUserInterfaceManager _ui = default!;
 
     public event EventHandler? ClearAlerts;
@@ -39,7 +38,7 @@ public sealed partial class ClientAlertsSystem : AlertsSystem
     {
         base.LoadPrototypes();
 
-        AlertOrder = _prototypeManager.EnumeratePrototypes<AlertOrderPrototype>().FirstOrDefault();
+        AlertOrder = ProtoMan.EnumeratePrototypes<AlertOrderPrototype>().FirstOrDefault();
         if (AlertOrder == null)
             Log.Error("No alertOrder prototype found, alerts will be in random order");
     }

--- a/Content.Client/Atmos/AlignAtmosPipeLayers.cs
+++ b/Content.Client/Atmos/AlignAtmosPipeLayers.cs
@@ -6,7 +6,6 @@ using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Placement;
 using Robust.Client.Placement.Modes;
-using Robust.Client.Utility;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -169,7 +168,7 @@ public sealed partial class AlignAtmosPipeLayers : SnapgridCenter
         if (!_protoManager.TryIndex<EntityPrototype>(pManager.CurrentPermission.EntityType, out var currentProto))
             return;
 
-        if (!currentProto.TryGetComponent<AtmosPipeLayersComponent>(out var atmosPipeLayers, _entityManager.ComponentFactory))
+        if (!currentProto.TryComp<AtmosPipeLayersComponent>(out var atmosPipeLayers, _entityManager.ComponentFactory))
             return;
 
         if (!_pipeLayersSystem.TryGetAlternativePrototype(atmosPipeLayers, layer, out var newProtoId))
@@ -181,7 +180,7 @@ public sealed partial class AlignAtmosPipeLayers : SnapgridCenter
             pManager.CurrentPermission.EntityType = newProtoId;
 
             // Update the appearance of the ghost sprite
-            if (newProto.TryGetComponent<SpriteComponent>(out var sprite, _entityManager.ComponentFactory))
+            if (newProto.TryComp<SpriteComponent>(out var sprite, _entityManager.ComponentFactory))
             {
                 var textures = new List<IDirectionalTextureProvider>();
 

--- a/Content.Client/Atmos/EntitySystems/GasCanisterAppearanceSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/GasCanisterAppearanceSystem.cs
@@ -1,7 +1,6 @@
 using Content.Shared.Atmos.Piping.Unary.Components;
 using Content.Shared.SprayPainter.Prototypes;
 using Robust.Client.GameObjects;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Atmos.EntitySystems;
 
@@ -10,14 +9,12 @@ namespace Content.Client.Atmos.EntitySystems;
 /// </summary>
 public sealed partial class GasCanisterAppearanceSystem : VisualizerSystem<GasCanisterComponent>
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, GasCanisterComponent component, ref AppearanceChangeEvent args)
     {
         if (!AppearanceSystem.TryGetData<string>(uid, PaintableVisuals.Prototype, out var protoName, args.Component) || args.Sprite is not { } old)
             return;
 
-        if (!_prototypeManager.HasIndex(protoName))
+        if (!ProtoMan.HasIndex(protoName))
             return;
 
         // Create the given prototype and get its first layer.

--- a/Content.Client/Audio/ContentAudioSystem.AmbientMusic.cs
+++ b/Content.Client/Audio/ContentAudioSystem.AmbientMusic.cs
@@ -24,7 +24,6 @@ public sealed partial class ContentAudioSystem
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private ILogManager _logManager = default!;
     [Dependency] private IPlayerManager _player = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IStateManager _state = default!;
     [Dependency] private RulesSystem _rules = default!;
@@ -106,7 +105,7 @@ public sealed partial class ContentAudioSystem
     private void SetupAmbientSounds()
     {
         _ambientSounds.Clear();
-        foreach (var ambience in _proto.EnumeratePrototypes<AmbientMusicPrototype>())
+        foreach (var ambience in ProtoMan.EnumeratePrototypes<AmbientMusicPrototype>())
         {
             var tracks = _ambientSounds.GetOrNew(ambience.ID);
             RefreshTracks(ambience.Sound, tracks, null);
@@ -131,7 +130,7 @@ public sealed partial class ContentAudioSystem
                 if (collection.Collection == null)
                     break;
 
-                var slothCud = _proto.Index<SoundCollectionPrototype>(collection.Collection);
+                var slothCud = ProtoMan.Index<SoundCollectionPrototype>(collection.Collection);
                 tracks.AddRange(slothCud.PickFiles);
                 break;
             case SoundPathSpecifier path:
@@ -167,7 +166,7 @@ public sealed partial class ContentAudioSystem
         {
             var player = _player.LocalSession?.AttachedEntity;
 
-            if (player == null || _musicProto == null || !_rules.IsTrue(player.Value, _proto.Index<RulesPrototype>(_musicProto.Rules)))
+            if (player == null || _musicProto == null || !_rules.IsTrue(player.Value, ProtoMan.Index<RulesPrototype>(_musicProto.Rules)))
             {
                 FadeOut(_ambientMusicStream, duration: AmbientMusicFadeTime);
                 _musicProto = null;
@@ -241,12 +240,12 @@ public sealed partial class ContentAudioSystem
         if (ev.Cancelled)
             return null;
 
-        var ambiences = _proto.EnumeratePrototypes<AmbientMusicPrototype>().ToList();
+        var ambiences = ProtoMan.EnumeratePrototypes<AmbientMusicPrototype>().ToList();
         ambiences.Sort((x, y) => y.Priority.CompareTo(x.Priority));
 
         foreach (var amb in ambiences)
         {
-            if (!_rules.IsTrue(player.Value, _proto.Index<RulesPrototype>(amb.Rules)))
+            if (!_rules.IsTrue(player.Value, ProtoMan.Index<RulesPrototype>(amb.Rules)))
                 continue;
 
             return amb;

--- a/Content.Client/Audio/Jukebox/JukeboxSystem.cs
+++ b/Content.Client/Audio/Jukebox/JukeboxSystem.cs
@@ -8,7 +8,6 @@ namespace Content.Client.Audio.Jukebox;
 
 public sealed partial class JukeboxSystem : SharedJukeboxSystem
 {
-    [Dependency] private IPrototypeManager _protoManager = default!;
     [Dependency] private AnimationPlayerSystem _animationPlayer = default!;
     [Dependency] private SharedAppearanceSystem _appearanceSystem = default!;
     [Dependency] private SharedUserInterfaceSystem _uiSystem = default!;
@@ -21,13 +20,13 @@ public sealed partial class JukeboxSystem : SharedJukeboxSystem
         SubscribeLocalEvent<JukeboxComponent, AnimationCompletedEvent>(OnAnimationCompleted);
         SubscribeLocalEvent<JukeboxComponent, AfterAutoHandleStateEvent>(OnJukeboxAfterState);
 
-        _protoManager.PrototypesReloaded += OnProtoReload;
+        ProtoMan.PrototypesReloaded += OnProtoReload;
     }
 
     public override void Shutdown()
     {
         base.Shutdown();
-        _protoManager.PrototypesReloaded -= OnProtoReload;
+        ProtoMan.PrototypesReloaded -= OnProtoReload;
     }
 
     private void OnProtoReload(PrototypesReloadedEventArgs obj)

--- a/Content.Client/BarSign/BarSignVisualizerSystem.cs
+++ b/Content.Client/BarSign/BarSignVisualizerSystem.cs
@@ -1,14 +1,11 @@
 using Content.Shared.BarSign;
 using Content.Shared.Power;
 using Robust.Client.GameObjects;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.BarSign;
 
 public sealed partial class BarSignVisualizerSystem : VisualizerSystem<BarSignComponent>
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
-
     protected override void OnAppearanceChange(EntityUid uid, BarSignComponent component, ref AppearanceChangeEvent args)
     {
         AppearanceSystem.TryGetData<bool>(uid, PowerDeviceVisuals.Powered, out var powered, args.Component);
@@ -16,7 +13,7 @@ public sealed partial class BarSignVisualizerSystem : VisualizerSystem<BarSignCo
 
         if (powered
             && currentSign != null
-            && _prototypeManager.Resolve<BarSignPrototype>(currentSign, out var proto))
+            && ProtoMan.Resolve<BarSignPrototype>(currentSign, out var proto))
         {
             SpriteSystem.LayerSetSprite((uid, args.Sprite), 0, proto.Icon);
             args.Sprite?.LayerSetShader(0, "unshaded");

--- a/Content.Client/Body/VisualBodySystem.cs
+++ b/Content.Client/Body/VisualBodySystem.cs
@@ -7,7 +7,6 @@ using Content.Shared.Humanoid;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Configuration;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Content.Client.Body;
@@ -15,7 +14,6 @@ namespace Content.Client.Body;
 public sealed partial class VisualBodySystem : SharedVisualBodySystem
 {
     [Dependency] private IConfigurationManager _cfg = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private DisplacementMapSystem _displacement = default!;
     [Dependency] private MarkingManager _marking = default!;
     [Dependency] private SpriteSystem _sprite = default!;
@@ -149,7 +147,7 @@ public sealed partial class VisualBodySystem : SharedVisualBodySystem
         if (!censorNudity)
             yield break;
 
-        var group = _prototype.Index(ent.Comp.MarkingData.Group);
+        var group = ProtoMan.Index(ent.Comp.MarkingData.Group);
         foreach (var layer in ent.Comp.MarkingData.Layers)
         {
             if (!group.Limits.TryGetValue(layer, out var layerLimits))

--- a/Content.Client/Chat/TypingIndicator/TypingIndicatorVisualizerSystem.cs
+++ b/Content.Client/Chat/TypingIndicator/TypingIndicatorVisualizerSystem.cs
@@ -1,13 +1,11 @@
 ﻿using Content.Shared.Chat.TypingIndicator;
 using Robust.Client.GameObjects;
-using Robust.Shared.Prototypes;
 using Content.Shared.Inventory;
 
 namespace Content.Client.Chat.TypingIndicator;
 
 public sealed partial class TypingIndicatorVisualizerSystem : VisualizerSystem<TypingIndicatorComponent>
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private InventorySystem _inventory = default!;
 
     protected override void OnAppearanceChange(EntityUid uid, TypingIndicatorComponent component, ref AppearanceChangeEvent args)
@@ -27,7 +25,7 @@ public sealed partial class TypingIndicatorVisualizerSystem : VisualizerSystem<T
         if (overrideIndicator != null)
             currentTypingIndicator = overrideIndicator.Value;
 
-        if (!_prototypeManager.Resolve(currentTypingIndicator, out var proto))
+        if (!ProtoMan.Resolve(currentTypingIndicator, out var proto))
         {
             Log.Error($"Unknown typing indicator id: {component.TypingIndicatorPrototype}");
             return;

--- a/Content.Client/Chemistry/EntitySystems/ChemistryGuideDataSystem.cs
+++ b/Content.Client/Chemistry/EntitySystems/ChemistryGuideDataSystem.cs
@@ -15,6 +15,7 @@ namespace Content.Client.Chemistry.EntitySystems;
 /// <inheritdoc/>
 public sealed partial class ChemistryGuideDataSystem : SharedChemistryGuideDataSystem
 {
+    [Dependency] private IComponentFactory _factory = default!;
     [Dependency] private SharedSolutionContainerSystem _solutionContainer = default!;
 
     private static readonly ProtoId<MixingCategoryPrototype> DefaultMixingCategory = "DummyMix";
@@ -89,15 +90,15 @@ public sealed partial class ChemistryGuideDataSystem : SharedChemistryGuideDataS
             if (entProto.Abstract || usedNames.Contains(entProto.Name))
                 continue;
 
-            if (!entProto.TryGetComponent<ExtractableComponent>(out var extractableComponent, EntityManager.ComponentFactory))
+            if (!entProto.TryComp(out ExtractableComponent? extractableComponent, EntityManager.ComponentFactory))
                 continue;
 
             //these bloat the hell out of blood/fat
-            if (entProto.HasComponent<OrganComponent>())
+            if (entProto.HasComp<OrganComponent>(_factory))
                 continue;
 
             //these feel obvious...
-            if (entProto.HasComponent<PillComponent>())
+            if (entProto.HasComp<PillComponent>(_factory))
                 continue;
 
             if (extractableComponent.JuiceSolution is { } juiceSolution)

--- a/Content.Client/Chemistry/EntitySystems/ChemistryGuideDataSystem.cs
+++ b/Content.Client/Chemistry/EntitySystems/ChemistryGuideDataSystem.cs
@@ -7,7 +7,6 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reaction;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Kitchen.Components;
-using Content.Shared.Prototypes;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client.Chemistry.EntitySystems;
@@ -15,7 +14,6 @@ namespace Content.Client.Chemistry.EntitySystems;
 /// <inheritdoc/>
 public sealed partial class ChemistryGuideDataSystem : SharedChemistryGuideDataSystem
 {
-    [Dependency] private IComponentFactory _factory = default!;
     [Dependency] private SharedSolutionContainerSystem _solutionContainer = default!;
 
     private static readonly ProtoId<MixingCategoryPrototype> DefaultMixingCategory = "DummyMix";
@@ -90,15 +88,15 @@ public sealed partial class ChemistryGuideDataSystem : SharedChemistryGuideDataS
             if (entProto.Abstract || usedNames.Contains(entProto.Name))
                 continue;
 
-            if (!entProto.TryComp(out ExtractableComponent? extractableComponent, EntityManager.ComponentFactory))
+            if (!entProto.TryComp(out ExtractableComponent? extractableComponent, Factory))
                 continue;
 
             //these bloat the hell out of blood/fat
-            if (entProto.HasComp<OrganComponent>(_factory))
+            if (entProto.HasComp<OrganComponent>(Factory))
                 continue;
 
             //these feel obvious...
-            if (entProto.HasComp<PillComponent>(_factory))
+            if (entProto.HasComp<PillComponent>(Factory))
                 continue;
 
             if (extractableComponent.JuiceSolution is { } juiceSolution)

--- a/Content.Client/Chemistry/EntitySystems/InjectorStatusControlSystem.cs
+++ b/Content.Client/Chemistry/EntitySystems/InjectorStatusControlSystem.cs
@@ -2,19 +2,16 @@
 using Content.Client.Items;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Chemistry.EntitySystems;
 
 public sealed partial class InjectorStatusControlSystem : EntitySystem
 {
     [Dependency] private SharedSolutionContainerSystem _solutionContainers = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
-
 
     public override void Initialize()
     {
         base.Initialize();
-        Subs.ItemStatus<InjectorComponent>(injector => new InjectorStatusControl(injector, _solutionContainers, _prototypeManager));
+        Subs.ItemStatus<InjectorComponent>(injector => new InjectorStatusControl(injector, _solutionContainers, ProtoMan));
     }
 }

--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
@@ -8,13 +8,11 @@ using Content.Shared.Hands;
 using Content.Shared.Item;
 using Content.Shared.Rounding;
 using Robust.Client.GameObjects;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Chemistry.Visualizers;
 
 public sealed partial class SolutionContainerVisualsSystem : VisualizerSystem<SolutionContainerVisualsComponent>
 {
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private ItemSystem _itemSystem = default!;
 
     public override void Initialize()
@@ -131,7 +129,7 @@ public sealed partial class SolutionContainerVisualsSystem : VisualizerSystem<So
                 args.Component))
             return null;
 
-        var reagentProto = _prototype.Index<ReagentPrototype>(baseOverride);
+        var reagentProto = ProtoMan.Index<ReagentPrototype>(baseOverride);
 
         if (SpriteSystem.LayerMapTryGet(ent, component.OverlayLayer, out var overlayLayer, false))
             SpriteSystem.LayerSetVisible(ent, overlayLayer, reagentProto.MetamorphicSprite is not null);

--- a/Content.Client/Clothing/Systems/ChameleonClothingSystem.cs
+++ b/Content.Client/Clothing/Systems/ChameleonClothingSystem.cs
@@ -1,8 +1,6 @@
-﻿using System.Linq;
-using Content.Client.PDA;
+﻿using Content.Client.PDA;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.EntitySystems;
-using Content.Shared.Inventory;
 using Robust.Client.GameObjects;
 using Robust.Shared.Prototypes;
 
@@ -35,14 +33,14 @@ public sealed class ChameleonClothingSystem : SharedChameleonClothingSystem
     {
         base.UpdateSprite(uid, proto);
         if (TryComp(uid, out SpriteComponent? sprite)
-            && proto.TryGetComponent(out SpriteComponent? otherSprite, Factory))
+            && proto.TryComp(out SpriteComponent? otherSprite, Factory))
         {
             sprite.CopyFrom(otherSprite);
         }
 
         // Edgecase for PDAs to include visuals when UI is open
         if (TryComp(uid, out PdaBorderColorComponent? borderColor)
-            && proto.TryGetComponent(out PdaBorderColorComponent? otherBorderColor, Factory))
+            && proto.TryComp(out PdaBorderColorComponent? otherBorderColor, Factory))
         {
             borderColor.BorderColor = otherBorderColor.BorderColor;
             borderColor.AccentHColor = otherBorderColor.AccentHColor;

--- a/Content.Client/Clothing/UI/ChameleonBoundUserInterface.cs
+++ b/Content.Client/Clothing/UI/ChameleonBoundUserInterface.cs
@@ -48,7 +48,7 @@ public sealed partial class ChameleonBoundUserInterface : BoundUserInterface
                 if (string.IsNullOrEmpty(target) || !_proto.Resolve(target, out EntityPrototype? proto))
                     continue;
 
-                if (!proto.TryGetComponent(out TagComponent? tag, EntMan.ComponentFactory) || !_tag.HasTag(tag, st.RequiredTag))
+                if (!proto.TryComp(out TagComponent? tag, EntMan.ComponentFactory) || !_tag.HasTag(tag, st.RequiredTag))
                     continue;
 
                 newTargets.Add(target);

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -300,7 +300,7 @@ namespace Content.Client.Construction
 
             var sprite = Comp<SpriteComponent>(ghost.Value);
 
-            if (targetProto.TryGetComponent(out IconComponent? icon, EntityManager.ComponentFactory))
+            if (targetProto.TryComp(out IconComponent? icon, EntityManager.ComponentFactory))
             {
                 _sprite.AddBlankLayer((ghost.Value, sprite), 0);
                 _sprite.LayerSetSprite((ghost.Value, sprite), 0, icon.Icon);

--- a/Content.Client/Construction/FlatpackSystem.cs
+++ b/Content.Client/Construction/FlatpackSystem.cs
@@ -28,7 +28,7 @@ public sealed partial class FlatpackSystem : SharedFlatpackSystem
         if (!ProtoMan.TryIndex<EntityPrototype>(machineBoardId, out var machineBoardPrototype))
             return;
 
-        if (!machineBoardPrototype.TryGetComponent<SpriteComponent>(out var sprite, EntityManager.ComponentFactory))
+        if (!machineBoardPrototype.TryComp(out SpriteComponent? sprite, EntityManager.ComponentFactory))
             return;
 
         Color? color = null;

--- a/Content.Client/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Client/CrewManifest/CrewManifestSystem.cs
@@ -6,8 +6,6 @@ namespace Content.Client.CrewManifest;
 
 public sealed partial class CrewManifestSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
-
     private Dictionary<string, Dictionary<string, int>> _jobDepartmentLookup = new();
     private HashSet<string> _departments = new();
 
@@ -40,7 +38,7 @@ public sealed partial class CrewManifestSystem : EntitySystem
     {
         _jobDepartmentLookup.Clear();
         _departments.Clear();
-        foreach (var department in _prototypeManager.EnumeratePrototypes<DepartmentPrototype>())
+        foreach (var department in ProtoMan.EnumeratePrototypes<DepartmentPrototype>())
         {
             _departments.Add(department.ID);
 

--- a/Content.Client/Damage/DamageVisualsSystem.cs
+++ b/Content.Client/Damage/DamageVisualsSystem.cs
@@ -28,7 +28,6 @@ namespace Content.Client.Damage;
 /// </summary>
 public sealed partial class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponent>
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private DamageableSystem _damageable = default!;
 
     public override void Initialize()
@@ -153,7 +152,7 @@ public sealed partial class DamageVisualsSystem : VisualizerSystem<DamageVisuals
         // If the damage container on our entity's DamageableComponent
         // is not null, we can try to check through its groups.
         if (injurableComponent.DamageContainer != null
-            && _prototypeManager.Resolve<DamageContainerPrototype>(injurableComponent.DamageContainer, out var damageContainer))
+            && ProtoMan.Resolve<DamageContainerPrototype>(injurableComponent.DamageContainer, out var damageContainer))
         {
             // Are we using damage overlay sprites by group?
             // Check if the container matches the supported groups,
@@ -189,7 +188,7 @@ public sealed partial class DamageVisualsSystem : VisualizerSystem<DamageVisuals
         // Ditto above, but instead we go through every group.
         else // oh boy! time to enumerate through every single group!
         {
-            var damagePrototypeIdList = _prototypeManager.EnumeratePrototypes<DamageGroupPrototype>()
+            var damagePrototypeIdList = ProtoMan.EnumeratePrototypes<DamageGroupPrototype>()
                 .Select((p, _) => p.ID)
                 .ToList();
             if (damageVisComp.DamageOverlayGroups != null)
@@ -524,7 +523,7 @@ public sealed partial class DamageVisualsSystem : VisualizerSystem<DamageVisuals
             if (!damageVisComp.Overlay && damageGroup != damageVisComp.DamageGroup)
                 continue;
 
-            if (!_prototypeManager.TryIndex<DamageGroupPrototype>(damageGroup, out var damageGroupPrototype)
+            if (!ProtoMan.TryIndex<DamageGroupPrototype>(damageGroup, out var damageGroupPrototype)
                 || !damage.TryGetDamageInGroup(damageGroupPrototype, out var damageTotal))
                 continue;
 

--- a/Content.Client/Decals/DecalPlacementSystem.cs
+++ b/Content.Client/Decals/DecalPlacementSystem.cs
@@ -19,7 +19,6 @@ public sealed partial class DecalPlacementSystem : EntitySystem
 {
     [Dependency] private IInputManager _inputManager = default!;
     [Dependency] private IOverlayManager _overlay = default!;
-    [Dependency] private IPrototypeManager _protoMan = default!;
     [Dependency] private InputSystem _inputSystem = default!;
     [Dependency] private MetaDataSystem _metaData = default!;
     [Dependency] private SharedActionsSystem _actions = default!;
@@ -42,7 +41,7 @@ public sealed partial class DecalPlacementSystem : EntitySystem
     public (DecalPrototype? Decal, bool Snap, Angle Angle, Color Color) GetActiveDecal()
     {
         return _active && _decalId != null ?
-            (_protoMan.Index<DecalPrototype>(_decalId), _snap, _decalAngle, _decalColor) :
+            (ProtoMan.Index<DecalPrototype>(_decalId), _snap, _decalAngle, _decalColor) :
             (null, false, Angle.Zero, Color.Wheat);
     }
 
@@ -143,7 +142,7 @@ public sealed partial class DecalPlacementSystem : EntitySystem
         if (ev.Action != null)
             return;
 
-        if (_decalId == null || !_protoMan.TryIndex<DecalPrototype>(_decalId, out var decalProto))
+        if (_decalId == null || !ProtoMan.TryIndex<DecalPrototype>(_decalId, out var decalProto))
             return;
 
         var actionEvent = new PlaceDecalActionEvent()

--- a/Content.Client/Delivery/DeliveryVisualizerSystem.cs
+++ b/Content.Client/Delivery/DeliveryVisualizerSystem.cs
@@ -8,7 +8,6 @@ namespace Content.Client.Delivery;
 public sealed partial class DeliveryVisualizerSystem : VisualizerSystem<DeliveryComponent>
 {
     [Dependency] private SharedAppearanceSystem _appearance = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
 
     private static readonly ProtoId<JobIconPrototype> UnknownIcon = "JobIconUnknown";
 
@@ -22,9 +21,9 @@ public sealed partial class DeliveryVisualizerSystem : VisualizerSystem<Delivery
         if (string.IsNullOrEmpty(job))
             job = UnknownIcon;
 
-        if (!_prototype.TryIndex<JobIconPrototype>(job, out var icon))
+        if (!ProtoMan.TryIndex<JobIconPrototype>(job, out var icon))
         {
-            SpriteSystem.LayerSetTexture((uid, args.Sprite), DeliveryVisualLayers.JobStamp, SpriteSystem.Frame0(_prototype.Index(UnknownIcon).Icon));
+            SpriteSystem.LayerSetTexture((uid, args.Sprite), DeliveryVisualLayers.JobStamp, SpriteSystem.Frame0(ProtoMan.Index(UnknownIcon).Icon));
             return;
         }
 

--- a/Content.Client/DoAfter/DoAfterSystem.cs
+++ b/Content.Client/DoAfter/DoAfterSystem.cs
@@ -1,9 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Shared.DoAfter;
-using Content.Shared.Hands.Components;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.DoAfter;
 
@@ -15,13 +13,12 @@ public sealed partial class DoAfterSystem : SharedDoAfterSystem
 {
     [Dependency] private IOverlayManager _overlay = default!;
     [Dependency] private IPlayerManager _player = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private MetaDataSystem _metadata = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-        _overlay.AddOverlay(new DoAfterOverlay(EntityManager, _prototype, GameTiming, _player));
+        _overlay.AddOverlay(new DoAfterOverlay(EntityManager, ProtoMan, GameTiming, _player));
     }
 
     public override void Shutdown()

--- a/Content.Client/Doors/DoorSystem.cs
+++ b/Content.Client/Doors/DoorSystem.cs
@@ -9,7 +9,6 @@ namespace Content.Client.Doors;
 public sealed partial class DoorSystem : SharedDoorSystem
 {
     [Dependency] private AnimationPlayerSystem _animationSystem = default!;
-    [Dependency] private IComponentFactory _componentFactory = default!;
     [Dependency] private SpriteSystem _sprite = default!;
 
     public override void Initialize()
@@ -210,7 +209,7 @@ public sealed partial class DoorSystem : SharedDoorSystem
         if (!ProtoMan.Resolve(targetProto, out var target))
             return;
 
-        if (!target.TryComp(out SpriteComponent? targetSprite, _componentFactory))
+        if (!target.TryComp(out SpriteComponent? targetSprite, Factory))
             return;
 
         _sprite.SetBaseRsi(sprite.AsNullable(), targetSprite.BaseRSI);

--- a/Content.Client/Doors/DoorSystem.cs
+++ b/Content.Client/Doors/DoorSystem.cs
@@ -3,7 +3,6 @@ using Content.Shared.Doors.Systems;
 using Content.Shared.SprayPainter.Prototypes;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Doors;
 
@@ -11,7 +10,6 @@ public sealed partial class DoorSystem : SharedDoorSystem
 {
     [Dependency] private AnimationPlayerSystem _animationSystem = default!;
     [Dependency] private IComponentFactory _componentFactory = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private SpriteSystem _sprite = default!;
 
     public override void Initialize()
@@ -209,10 +207,10 @@ public sealed partial class DoorSystem : SharedDoorSystem
 
     private void UpdateSpriteLayers(Entity<SpriteComponent> sprite, string targetProto)
     {
-        if (!_prototypeManager.Resolve(targetProto, out var target))
+        if (!ProtoMan.Resolve(targetProto, out var target))
             return;
 
-        if (!target.TryGetComponent(out SpriteComponent? targetSprite, _componentFactory))
+        if (!target.TryComp(out SpriteComponent? targetSprite, _componentFactory))
             return;
 
         _sprite.SetBaseRsi(sprite.AsNullable(), targetSprite.BaseRSI);

--- a/Content.Client/Explosion/ExplosionOverlaySystem.cs
+++ b/Content.Client/Explosion/ExplosionOverlaySystem.cs
@@ -4,7 +4,6 @@ using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Shared.GameStates;
 using Robust.Shared.Graphics.RSI;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Explosion;
 
@@ -14,7 +13,6 @@ namespace Content.Client.Explosion;
 /// </summary>
 public sealed partial class ExplosionOverlaySystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _protoMan = default!;
     [Dependency] private IResourceCache _resCache = default!;
     [Dependency] private IOverlayManager _overlayMan = default!;
     [Dependency] private SharedPointLightSystem _lights = default!;
@@ -61,7 +59,7 @@ public sealed partial class ExplosionOverlaySystem : EntitySystem
     {
         EnsureComp<ExplosionVisualsTexturesComponent>(uid);
 
-        if (!_protoMan.TryIndex(component.ExplosionType, out ExplosionPrototype? type) ||
+        if (!ProtoMan.TryIndex(component.ExplosionType, out ExplosionPrototype? type) ||
             !TryComp(uid, out ExplosionVisualsTexturesComponent? textures))
         {
             return;

--- a/Content.Client/Holopad/HolopadSystem.cs
+++ b/Content.Client/Holopad/HolopadSystem.cs
@@ -2,7 +2,6 @@ using Content.Shared.Chat.TypingIndicator;
 using Content.Shared.Holopad;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using System.Linq;
 using System.Numerics;
@@ -12,7 +11,6 @@ namespace Content.Client.Holopad;
 
 public sealed partial class HolopadSystem : SharedHolopadSystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SpriteSystem _sprite = default!;
 
@@ -120,7 +118,7 @@ public sealed partial class HolopadSystem : SharedHolopadSystem
         // Find the texture height of the largest layer
         float texHeight = sprite.AllLayers.Max(x => x.PixelSize.Y);
 
-        var instance = _prototypeManager.Index<ShaderPrototype>(holopadHologram.ShaderName).InstanceUnique();
+        var instance = ProtoMan.Index<ShaderPrototype>(holopadHologram.ShaderName).InstanceUnique();
         instance.SetParameter("color1", new Vector3(holopadHologram.Color1.R, holopadHologram.Color1.G, holopadHologram.Color1.B));
         instance.SetParameter("color2", new Vector3(holopadHologram.Color2.R, holopadHologram.Color2.G, holopadHologram.Color2.B));
         instance.SetParameter("alpha", holopadHologram.Alpha);

--- a/Content.Client/Interaction/DragDropSystem.cs
+++ b/Content.Client/Interaction/DragDropSystem.cs
@@ -37,7 +37,6 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
     [Dependency] private IInputManager _inputManager = default!;
     [Dependency] private IEyeManager _eyeManager = default!;
     [Dependency] private IPlayerManager _playerManager = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IConfigurationManager _cfgMan = default!;
     [Dependency] private InteractionOutlineSystem _outline = default!;
     [Dependency] private SharedInteractionSystem _interactionSystem = default!;
@@ -112,8 +111,8 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
 
         Subs.CVar(_cfgMan, CCVars.DragDropDeadZone, SetDeadZone, true);
 
-        _dropTargetInRangeShader = _prototypeManager.Index(ShaderDropTargetInRange).Instance();
-        _dropTargetOutOfRangeShader = _prototypeManager.Index(ShaderDropTargetOutOfRange).Instance();
+        _dropTargetInRangeShader = ProtoMan.Index(ShaderDropTargetInRange).Instance();
+        _dropTargetOutOfRangeShader = ProtoMan.Index(ShaderDropTargetOutOfRange).Instance();
         // needs to fire on mouseup and mousedown so we can detect a drag / drop
         CommandBinds.Builder
             .BindBefore(EngineKeyFunctions.Use, new PointerInputCmdHandler(OnUse, false, true), new[] { typeof(SharedInteractionSystem) })

--- a/Content.Client/Machines/EntitySystems/MultipartMachineSystem.cs
+++ b/Content.Client/Machines/EntitySystems/MultipartMachineSystem.cs
@@ -21,9 +21,8 @@ public sealed partial class MultipartMachineSystem : SharedMultipartMachineSyste
     private readonly Color _partiallyTransparent = new Color(255, 255, 255, 180);
 
     [Dependency] private SpriteSystem _sprite = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private MetaDataSystem _metaData = default!;
-    [Dependency] private ISerializationManager _serialization= default!;
+    [Dependency] private ISerializationManager _serialization = default!;
 
     public override void Initialize()
     {
@@ -70,7 +69,7 @@ public sealed partial class MultipartMachineSystem : SharedMultipartMachineSyste
             if (part.GhostProto == null)
                 continue;
 
-            var entProto = _prototype.Index(part.GhostProto.Value);
+            var entProto = ProtoMan.Index(part.GhostProto.Value);
             if (!entProto.Components.TryGetComponent("Sprite", out var s) || s is not SpriteComponent protoSprite)
                 return;
 

--- a/Content.Client/MapText/MapTextSystem.cs
+++ b/Content.Client/MapText/MapTextSystem.cs
@@ -5,7 +5,6 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.RichText;
 using Robust.Shared.Configuration;
 using Robust.Shared.GameStates;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Content.Client.MapText;
@@ -17,7 +16,6 @@ public sealed partial class MapTextSystem : SharedMapTextSystem
     [Dependency] private IUserInterfaceManager _uiManager = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private IResourceCache _resourceCache = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IOverlayManager _overlayManager = default!;
 
     private MapTextOverlay _overlay = default!;
@@ -28,18 +26,18 @@ public sealed partial class MapTextSystem : SharedMapTextSystem
         SubscribeLocalEvent<MapTextComponent, ComponentStartup>(OnComponentStartup);
         SubscribeLocalEvent<MapTextComponent, ComponentHandleState>(HandleCompState);
 
-        _overlay = new MapTextOverlay(_configManager, EntityManager, _uiManager, _transform, _resourceCache, _prototypeManager);
+        _overlay = new MapTextOverlay(_configManager, EntityManager, _uiManager, _transform, _resourceCache, ProtoMan);
         _overlayManager.AddOverlay(_overlay);
 
         // TODO move font prototype to robust.shared, then use ProtoId<FontPrototype>
-        DebugTools.Assert(_prototypeManager.HasIndex<FontPrototype>(SharedMapTextComponent.DefaultFont));
+        DebugTools.Assert(ProtoMan.HasIndex<FontPrototype>(SharedMapTextComponent.DefaultFont));
     }
 
     private void OnComponentStartup(Entity<MapTextComponent> ent, ref ComponentStartup args)
     {
         CacheText(ent.Comp);
         // TODO move font prototype to robust.shared, then use ProtoId<FontPrototype>
-        DebugTools.Assert(_prototypeManager.HasIndex<FontPrototype>(ent.Comp.FontId));
+        DebugTools.Assert(ProtoMan.HasIndex<FontPrototype>(ent.Comp.FontId));
     }
 
     private void HandleCompState(Entity<MapTextComponent> ent, ref ComponentHandleState args)
@@ -65,12 +63,12 @@ public sealed partial class MapTextSystem : SharedMapTextSystem
             ? Loc.GetString(component.LocText)
             : component.Text;
 
-        if (!_prototypeManager.TryIndex<FontPrototype>(component.FontId, out var fontPrototype))
+        if (!ProtoMan.TryIndex<FontPrototype>(component.FontId, out var fontPrototype))
         {
             component.CachedText = Loc.GetString("map-text-font-error");
             component.Color = Color.Red;
 
-            if(_prototypeManager.TryIndex<FontPrototype>(SharedMapTextComponent.DefaultFont, out var @default))
+            if (ProtoMan.TryIndex<FontPrototype>(SharedMapTextComponent.DefaultFont, out var @default))
                 component.CachedFont = new VectorFont(_resourceCache.GetResource<FontResource>(@default.Path), 14);
             return;
         }

--- a/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
+++ b/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
@@ -10,8 +10,6 @@ public sealed partial class FloorOcclusionSystem : SharedFloorOcclusionSystem
 {
     private static readonly ProtoId<ShaderPrototype> HorizontalCut = "HorizontalCut";
 
-    [Dependency] private IPrototypeManager _proto = default!;
-
     [Dependency] private EntityQuery<SpriteComponent> _spriteQuery = default!;
 
     public override void Initialize()
@@ -48,7 +46,7 @@ public sealed partial class FloorOcclusionSystem : SharedFloorOcclusionSystem
         if (!_spriteQuery.Resolve(sprite.Owner, ref sprite.Comp, false))
             return;
 
-        var shader = _proto.Index(HorizontalCut).Instance();
+        var shader = ProtoMan.Index(HorizontalCut).Instance();
 
         if (sprite.Comp.PostShader is not null && sprite.Comp.PostShader != shader)
             return;

--- a/Content.Client/Outline/TargetOutlineSystem.cs
+++ b/Content.Client/Outline/TargetOutlineSystem.cs
@@ -23,7 +23,6 @@ public sealed partial class TargetOutlineSystem : EntitySystem
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private IInputManager _inputManager = default!;
     [Dependency] private IPlayerManager _playerManager = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private SharedInteractionSystem _interactionSystem = default!;
     [Dependency] private EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private SharedTransformSystem _transformSystem = default!;
@@ -83,8 +82,8 @@ public sealed partial class TargetOutlineSystem : EntitySystem
     {
         base.Initialize();
 
-        _shaderTargetValid = _prototypeManager.Index(ShaderTargetValid).InstanceUnique();
-        _shaderTargetInvalid = _prototypeManager.Index(ShaderTargetInvalid).InstanceUnique();
+        _shaderTargetValid = ProtoMan.Index(ShaderTargetValid).InstanceUnique();
+        _shaderTargetInvalid = ProtoMan.Index(ShaderTargetInvalid).InstanceUnique();
     }
 
     public void Disable()

--- a/Content.Client/Overlays/ShowCriminalRecordIconsSystem.cs
+++ b/Content.Client/Overlays/ShowCriminalRecordIconsSystem.cs
@@ -1,15 +1,11 @@
 using Content.Shared.Overlays;
 using Content.Shared.Security.Components;
-using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Overlays;
 
 public sealed partial class ShowCriminalRecordIconsSystem : EquipmentHudSystem<ShowCriminalRecordIconsComponent>
 {
-    [Dependency] private IPrototypeManager _prototype = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -22,7 +18,7 @@ public sealed partial class ShowCriminalRecordIconsSystem : EquipmentHudSystem<S
         if (!IsActive)
             return;
 
-        if (_prototype.Resolve(component.StatusIcon, out var iconPrototype))
+        if (ProtoMan.Resolve(component.StatusIcon, out var iconPrototype))
             ev.StatusIcons.Add(iconPrototype);
     }
 }

--- a/Content.Client/Overlays/ShowHealthBarsSystem.cs
+++ b/Content.Client/Overlays/ShowHealthBarsSystem.cs
@@ -1,7 +1,6 @@
 using Content.Shared.Inventory.Events;
 using Content.Shared.Overlays;
 using Robust.Client.Graphics;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Overlays;
 
@@ -11,7 +10,6 @@ namespace Content.Client.Overlays;
 public sealed partial class ShowHealthBarsSystem : EquipmentHudSystem<ShowHealthBarsComponent>
 {
     [Dependency] private IOverlayManager _overlayMan = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
 
     private EntityHealthBarOverlay _overlay = default!;
 
@@ -21,7 +19,7 @@ public sealed partial class ShowHealthBarsSystem : EquipmentHudSystem<ShowHealth
 
         SubscribeLocalEvent<ShowHealthBarsComponent, AfterAutoHandleStateEvent>(OnHandleState);
 
-        _overlay = new(EntityManager, _prototype);
+        _overlay = new(EntityManager, ProtoMan);
     }
 
     private void OnHandleState(Entity<ShowHealthBarsComponent> ent, ref AfterAutoHandleStateEvent args)

--- a/Content.Client/Overlays/ShowHealthIconsSystem.cs
+++ b/Content.Client/Overlays/ShowHealthIconsSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Overlays;
 using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
-using Robust.Shared.Prototypes;
 using Content.Shared.Damage.Components;
 
 namespace Content.Client.Overlays;
@@ -14,8 +13,6 @@ namespace Content.Client.Overlays;
 /// </summary>
 public sealed partial class ShowHealthIconsSystem : EquipmentHudSystem<ShowHealthIconsComponent>
 {
-    [Dependency] private IPrototypeManager _prototypeMan = default!;
-
     [ViewVariables]
     public HashSet<string> DamageContainers = new();
 
@@ -81,9 +78,9 @@ public sealed partial class ShowHealthIconsSystem : EquipmentHudSystem<ShowHealt
             if (TryComp<MobStateComponent>(entity, out var state))
             {
                 // Since there is no MobState for a rotting mob, we have to deal with this case first.
-                if (HasComp<RottingComponent>(entity) && _prototypeMan.Resolve(injurableComp.RottingIcon, out var rottingIcon))
+                if (HasComp<RottingComponent>(entity) && ProtoMan.Resolve(injurableComp.RottingIcon, out var rottingIcon))
                     result.Add(rottingIcon);
-                else if (injurableComp.HealthIcons.TryGetValue(state.CurrentState, out var value) && _prototypeMan.Resolve(value, out var icon))
+                else if (injurableComp.HealthIcons.TryGetValue(state.CurrentState, out var value) && ProtoMan.Resolve(value, out var icon))
                     result.Add(icon);
             }
         }

--- a/Content.Client/Overlays/ShowMindShieldIconsSystem.cs
+++ b/Content.Client/Overlays/ShowMindShieldIconsSystem.cs
@@ -1,15 +1,11 @@
 using Content.Shared.Mindshield.Components;
 using Content.Shared.Overlays;
-using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Overlays;
 
 public sealed partial class ShowMindShieldIconsSystem : EquipmentHudSystem<ShowMindShieldIconsComponent>
 {
-    [Dependency] private IPrototypeManager _prototype = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -21,9 +17,9 @@ public sealed partial class ShowMindShieldIconsSystem : EquipmentHudSystem<ShowM
     //  ...imagine cheating in a game about silly paper dolls
     private void OnGetStatusIconsEventFake(EntityUid uid, FakeMindShieldComponent component, ref GetStatusIconsEvent ev)
     {
-        if(!IsActive)
+        if (!IsActive)
             return;
-        if (component.IsEnabled && _prototype.Resolve(component.MindShieldStatusIcon, out var fakeStatusIconPrototype))
+        if (component.IsEnabled && ProtoMan.Resolve(component.MindShieldStatusIcon, out var fakeStatusIconPrototype))
             ev.StatusIcons.Add(fakeStatusIconPrototype);
     }
 
@@ -32,7 +28,7 @@ public sealed partial class ShowMindShieldIconsSystem : EquipmentHudSystem<ShowM
         if (!IsActive)
             return;
 
-        if (_prototype.Resolve(component.MindShieldStatusIcon, out var iconPrototype))
+        if (ProtoMan.Resolve(component.MindShieldStatusIcon, out var iconPrototype))
             ev.StatusIcons.Add(iconPrototype);
     }
 }

--- a/Content.Client/Overlays/ShowSyndicateIconsSystem.cs
+++ b/Content.Client/Overlays/ShowSyndicateIconsSystem.cs
@@ -2,14 +2,11 @@ using Content.Shared.Overlays;
 using Content.Shared.NukeOps;
 using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Overlays;
 
 public sealed partial class ShowSyndicateIconsSystem : EquipmentHudSystem<ShowSyndicateIconsComponent>
 {
-    [Dependency] private IPrototypeManager _prototype = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -22,7 +19,7 @@ public sealed partial class ShowSyndicateIconsSystem : EquipmentHudSystem<ShowSy
         if (!IsActive)
             return;
 
-        if (_prototype.TryIndex<FactionIconPrototype>(component.SyndStatusIcon, out var iconPrototype))
+        if (ProtoMan.TryIndex<FactionIconPrototype>(component.SyndStatusIcon, out var iconPrototype))
             ev.StatusIcons.Add(iconPrototype);
     }
 }

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Content.Shared.Containers;
 using Content.Shared.Examine;
 using Content.Shared.GameTicking;
 using Content.Shared.Popups;
@@ -12,7 +11,6 @@ using Robust.Shared.Collections;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Replays;
 using Robust.Shared.Timing;
 
@@ -24,7 +22,6 @@ namespace Content.Client.Popups
         [Dependency] private IInputManager _inputManager = default!;
         [Dependency] private IOverlayManager _overlay = default!;
         [Dependency] private IPlayerManager _playerManager = default!;
-        [Dependency] private IPrototypeManager _prototype = default!;
         [Dependency] private IGameTiming _timing = default!;
         [Dependency] private IUserInterfaceManager _uiManager = default!;
         [Dependency] private IReplayRecordingManager _replayRecording = default!;
@@ -52,7 +49,7 @@ namespace Content.Client.Popups
                     _configManager,
                     EntityManager,
                     _playerManager,
-                    _prototype,
+                    ProtoMan,
                     _uiManager,
                     _uiManager.GetUIController<PopupUIController>(),
                     _examine,

--- a/Content.Client/RCD/RCDConstructionGhostSystem.cs
+++ b/Content.Client/RCD/RCDConstructionGhostSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.RCD.Components;
 using Robust.Client.Placement;
 using Robust.Client.Player;
 using Robust.Shared.Enums;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.RCD;
 
@@ -18,7 +17,6 @@ public sealed partial class RCDConstructionGhostSystem : EntitySystem
 
     [Dependency] private IPlayerManager _playerManager = default!;
     [Dependency] private IPlacementManager _placementManager = default!;
-    [Dependency] private IPrototypeManager _protoManager = default!;
     [Dependency] private HandsSystem _hands = default!;
 
     private Direction _placementDirection = default;
@@ -55,7 +53,7 @@ public sealed partial class RCDConstructionGhostSystem : EntitySystem
 
             return;
         }
-        var prototype = _protoManager.Index(rcd.ProtoId);
+        var prototype = ProtoMan.Index(rcd.ProtoId);
 
         // Update the direction the RCD prototype based on the placer direction
         if (_placementDirection != _placementManager.Direction)

--- a/Content.Client/Revolutionary/RevolutionarySystem.cs
+++ b/Content.Client/Revolutionary/RevolutionarySystem.cs
@@ -1,7 +1,6 @@
 using Content.Shared.Revolutionary.Components;
 using Content.Shared.Revolutionary;
 using Content.Shared.StatusIcon.Components;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Revolutionary;
 
@@ -10,8 +9,6 @@ namespace Content.Client.Revolutionary;
 /// </summary>
 public sealed partial class RevolutionarySystem : SharedRevolutionarySystem
 {
-    [Dependency] private IPrototypeManager _prototype = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -25,13 +22,13 @@ public sealed partial class RevolutionarySystem : SharedRevolutionarySystem
         if (HasComp<HeadRevolutionaryComponent>(ent))
             return;
 
-        if (_prototype.Resolve(ent.Comp.StatusIcon, out var iconPrototype))
+        if (ProtoMan.Resolve(ent.Comp.StatusIcon, out var iconPrototype))
             args.StatusIcons.Add(iconPrototype);
     }
 
     private void GetHeadRevIcon(Entity<HeadRevolutionaryComponent> ent, ref GetStatusIconsEvent args)
     {
-        if (_prototype.Resolve(ent.Comp.StatusIcon, out var iconPrototype))
+        if (ProtoMan.Resolve(ent.Comp.StatusIcon, out var iconPrototype))
             args.StatusIcons.Add(iconPrototype);
     }
 }

--- a/Content.Client/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Client/SSDIndicator/SSDIndicatorSystem.cs
@@ -3,10 +3,8 @@ using Content.Shared.Mind.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.NPC;
 using Content.Shared.SSDIndicator;
-using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
 using Robust.Shared.Configuration;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.SSDIndicator;
 
@@ -15,7 +13,6 @@ namespace Content.Client.SSDIndicator;
 /// </summary>
 public sealed partial class SSDIndicatorSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private MobStateSystem _mobState = default!;
 
@@ -34,7 +31,7 @@ public sealed partial class SSDIndicatorSystem : EntitySystem
             !HasComp<ActiveNPCComponent>(uid) &&
             HasComp<MindExaminableComponent>(uid))
         {
-            args.StatusIcons.Add(_prototype.Index(component.Icon));
+            args.StatusIcons.Add(ProtoMan.Index(component.Icon));
         }
     }
 }

--- a/Content.Client/Stealth/StealthSystem.cs
+++ b/Content.Client/Stealth/StealthSystem.cs
@@ -1,5 +1,4 @@
 using Content.Client.Interactable.Components;
-using Content.Client.StatusIcon;
 using Content.Shared.Stealth;
 using Content.Shared.Stealth.Components;
 using Robust.Client.GameObjects;
@@ -12,7 +11,6 @@ public sealed partial class StealthSystem : SharedStealthSystem
 {
     private static readonly ProtoId<ShaderPrototype> Shader = "Stealth";
 
-    [Dependency] private IPrototypeManager _protoMan = default!;
     [Dependency] private SharedTransformSystem _transformSystem = default!;
     [Dependency] private SpriteSystem _sprite = default!;
 
@@ -22,7 +20,7 @@ public sealed partial class StealthSystem : SharedStealthSystem
     {
         base.Initialize();
 
-        _shader = _protoMan.Index(Shader).InstanceUnique();
+        _shader = ProtoMan.Index(Shader).InstanceUnique();
 
         SubscribeLocalEvent<StealthComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<StealthComponent, ComponentStartup>(OnStartup);

--- a/Content.Client/Storage/Visualizers/EntityStorageVisualizerSystem.cs
+++ b/Content.Client/Storage/Visualizers/EntityStorageVisualizerSystem.cs
@@ -1,13 +1,11 @@
 using Content.Shared.SprayPainter.Prototypes;
 using Content.Shared.Storage;
 using Robust.Client.GameObjects;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Storage.Visualizers;
 
 public sealed partial class EntityStorageVisualizerSystem : VisualizerSystem<EntityStorageVisualsComponent>
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IComponentFactory _componentFactory = default!;
 
     public override void Initialize()
@@ -42,13 +40,13 @@ public sealed partial class EntityStorageVisualizerSystem : VisualizerSystem<Ent
         var forceRedrawBase = false;
         if (AppearanceSystem.TryGetData<string>(uid, PaintableVisuals.Prototype, out var prototype, args.Component))
         {
-            if (_prototypeManager.Resolve(prototype, out var proto))
+            if (ProtoMan.Resolve(prototype, out var proto))
             {
-                if (proto.TryGetComponent(out SpriteComponent? sprite, _componentFactory))
+                if (proto.TryComp(out SpriteComponent? sprite, _componentFactory))
                 {
                     SpriteSystem.SetBaseRsi((uid, args.Sprite), sprite.BaseRSI);
                 }
-                if (proto.TryGetComponent(out EntityStorageVisualsComponent? visuals, _componentFactory))
+                if (proto.TryComp(out EntityStorageVisualsComponent? visuals, _componentFactory))
                 {
                     comp.StateBaseOpen = visuals.StateBaseOpen;
                     comp.StateBaseClosed = visuals.StateBaseClosed;

--- a/Content.Client/Storage/Visualizers/EntityStorageVisualizerSystem.cs
+++ b/Content.Client/Storage/Visualizers/EntityStorageVisualizerSystem.cs
@@ -6,8 +6,6 @@ namespace Content.Client.Storage.Visualizers;
 
 public sealed partial class EntityStorageVisualizerSystem : VisualizerSystem<EntityStorageVisualsComponent>
 {
-    [Dependency] private IComponentFactory _componentFactory = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -42,11 +40,11 @@ public sealed partial class EntityStorageVisualizerSystem : VisualizerSystem<Ent
         {
             if (ProtoMan.Resolve(prototype, out var proto))
             {
-                if (proto.TryComp(out SpriteComponent? sprite, _componentFactory))
+                if (proto.TryComp(out SpriteComponent? sprite, Factory))
                 {
                     SpriteSystem.SetBaseRsi((uid, args.Sprite), sprite.BaseRSI);
                 }
-                if (proto.TryComp(out EntityStorageVisualsComponent? visuals, _componentFactory))
+                if (proto.TryComp(out EntityStorageVisualsComponent? visuals, Factory))
                 {
                     comp.StateBaseOpen = visuals.StateBaseOpen;
                     comp.StateBaseClosed = visuals.StateBaseClosed;

--- a/Content.Client/Zombies/ZombieSystem.cs
+++ b/Content.Client/Zombies/ZombieSystem.cs
@@ -1,17 +1,13 @@
 using System.Linq;
 using Content.Shared.Body;
-using Content.Shared.Ghost;
-using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
 using Content.Shared.Zombies;
 using Robust.Client.GameObjects;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Zombies;
 
 public sealed partial class ZombieSystem : SharedZombieSystem
 {
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private SpriteSystem _sprite = default!;
 
     public override void Initialize()
@@ -25,7 +21,7 @@ public sealed partial class ZombieSystem : SharedZombieSystem
 
     private void GetZombieIcon(Entity<ZombieComponent> ent, ref GetStatusIconsEvent args)
     {
-        var iconPrototype = _prototype.Index(ent.Comp.StatusIcon);
+        var iconPrototype = ProtoMan.Index(ent.Comp.StatusIcon);
         args.StatusIcons.Add(iconPrototype);
     }
 
@@ -34,7 +30,7 @@ public sealed partial class ZombieSystem : SharedZombieSystem
         if (HasComp<ZombieComponent>(ent))
             return;
 
-        var iconPrototype = _prototype.Index(ent.Comp.StatusIcon);
+        var iconPrototype = ProtoMan.Index(ent.Comp.StatusIcon);
         args.StatusIcons.Add(iconPrototype);
     }
 

--- a/Content.IntegrationTests/Tests/Actions/RetractableItemActionTest.cs
+++ b/Content.IntegrationTests/Tests/Actions/RetractableItemActionTest.cs
@@ -32,7 +32,7 @@ public sealed class RetractableItemActionTest : InteractionTest
             var armBladeActionProto = ProtoMan.Index(ArmBladeActionProtoId);
 
             // Find the component
-            Assert.That(armBladeActionProto.TryGetComponent<RetractableItemActionComponent>(out var actionComp, SEntMan.ComponentFactory));
+            Assert.That(armBladeActionProto.TryComp<RetractableItemActionComponent>(out var actionComp, SEntMan.ComponentFactory));
             // Get the item protoId from the component
             var spawnedProtoId = actionComp!.SpawnedPrototype;
 

--- a/Content.IntegrationTests/Tests/Atmos/GasArrayTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/GasArrayTest.cs
@@ -54,7 +54,7 @@ public sealed class GasArrayTest : GameTest
             var gasTank = prototypeManager.Index(GasTankTestDummyId);
             Assert.Multiple(() =>
             {
-                Assert.That(gasTank.TryGetComponent<GasTankComponent>(out var gasTankComponent, compFactory));
+                Assert.That(gasTank.TryComp<GasTankComponent>(out var gasTankComponent, compFactory));
 
                 Assert.That(gasTankComponent!.Air.GetMoles(Gas.Oxygen), Is.EqualTo(10));
                 Assert.That(gasTankComponent!.Air.GetMoles(Gas.Frezon), Is.EqualTo(20));
@@ -67,7 +67,7 @@ public sealed class GasArrayTest : GameTest
             var legacyGasTank = prototypeManager.Index(GasTankLegacyTestDummyId);
             Assert.Multiple(() =>
             {
-                Assert.That(legacyGasTank.TryGetComponent<GasTankComponent>(out var gasTankComponent, compFactory));
+                Assert.That(legacyGasTank.TryComp<GasTankComponent>(out var gasTankComponent, compFactory));
 
                 Assert.That(gasTankComponent!.Air.GetMoles(3), Is.EqualTo(10));
 

--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -108,7 +108,7 @@ public sealed class CargoTest : GameTest
                 foreach (var (proto, staticPriceComp) in protoIds)
                 {
                     if (
-                        proto.TryGetComponent<StackPriceComponent>(out var stackPriceComp, _sCompFact)
+                        proto.TryComp<StackPriceComponent>(out var stackPriceComp, _sCompFact)
                         && stackPriceComp.Price > 0
                     )
                     {
@@ -243,7 +243,7 @@ public sealed class CargoTest : GameTest
                 foreach (var (proto, comp) in Pair.GetPrototypesWithComponent<MobPriceComponent>())
                 {
                     Assert.That(
-                        proto.TryGetComponent<MobStateComponent>(out _, _sCompFact),
+                        proto.TryComp<MobStateComponent>(out _, _sCompFact),
                         $"Found {nameof(MobPriceComponent)} on {proto.ID}, but no {nameof(MobStateComponent)}!"
                     );
                 }

--- a/Content.IntegrationTests/Tests/ContrabandTest.cs
+++ b/Content.IntegrationTests/Tests/ContrabandTest.cs
@@ -25,7 +25,7 @@ public sealed class ContrabandTest : GameTest
                     if (proto.Abstract || pair.IsTestPrototype(proto))
                         continue;
 
-                    if (!proto.TryGetComponent<ContrabandComponent>(out var contraband, componentFactory))
+                    if (!proto.TryComp<ContrabandComponent>(out var contraband, componentFactory))
                         continue;
 
                     if (!protoMan.TryIndex(contraband.Severity, out var severity))

--- a/Content.IntegrationTests/Tests/DeviceLinking/DeviceLinkingTest.cs
+++ b/Content.IntegrationTests/Tests/DeviceLinking/DeviceLinkingTest.cs
@@ -43,7 +43,7 @@ public sealed class DeviceLinkingTest : GameTest
             using (Assert.EnterMultipleScope())
             {
                 var proto = protoMan.Index(protoKey);
-                Assert.That(proto.TryGetComponent<DeviceLinkSinkComponent>(out var protoSinkComp, compFact));
+                Assert.That(proto.TryComp<DeviceLinkSinkComponent>(out var protoSinkComp, compFact));
 
                 foreach (var port in protoSinkComp!.Ports)
                 {

--- a/Content.IntegrationTests/Tests/FillLevelSpriteTest.cs
+++ b/Content.IntegrationTests/Tests/FillLevelSpriteTest.cs
@@ -33,7 +33,7 @@ public sealed class FillLevelSpriteTest : GameTest
             var protos = protoMan.EnumeratePrototypes<EntityPrototype>()
                 .Where(p => !p.Abstract)
                 .Where(p => !pair.IsTestPrototype(p))
-                .Where(p => p.TryGetComponent<SolutionContainerVisualsComponent>(out _, componentFactory))
+                .Where(p => p.TryComp<SolutionContainerVisualsComponent>(out _, componentFactory))
                 .OrderBy(p => p.ID)
                 .ToList();
 
@@ -41,8 +41,8 @@ public sealed class FillLevelSpriteTest : GameTest
             {
                 foreach (var proto in protos)
                 {
-                    Assert.That(proto.TryGetComponent<SolutionContainerVisualsComponent>(out var visuals, componentFactory));
-                    Assert.That(proto.TryGetComponent<SpriteComponent>(out var sprite, componentFactory));
+                    Assert.That(proto.TryComp<SolutionContainerVisualsComponent>(out var visuals, componentFactory));
+                    Assert.That(proto.TryComp<SpriteComponent>(out var sprite, componentFactory));
                     if (!proto.HasComponent<AppearanceComponent>(componentFactory))
                     {
                         Assert.Fail(@$"{proto.ID} has SolutionContainerVisualsComponent but no AppearanceComponent.");

--- a/Content.IntegrationTests/Tests/GameRules/AllGamePresetsStartTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/AllGamePresetsStartTest.cs
@@ -70,7 +70,7 @@ public sealed class AllGamePresetsStartTest : AntagTest
                     continue; // Bruh moment
 
                 // Ignore non-antag game-rules.
-                if (!rule.TryGetComponent<AntagSelectionComponent>(out var antag, SEntMan.ComponentFactory))
+                if (!rule.TryComp<AntagSelectionComponent>(out var antag, SEntMan.ComponentFactory))
                     continue;
 
                 var runningCount = 0;

--- a/Content.IntegrationTests/Tests/GameRules/AntagGhostRoleTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/AntagGhostRoleTest.cs
@@ -40,7 +40,7 @@ public sealed partial class AntagGhostRoleTest : AntagTest
     public void TestAntagGhostRoles(string ruleId)
     {
         var rule = SProtoMan.Index<EntityPrototype>(ruleId);
-        Assert.That(rule.TryGetComponent<AntagSelectionComponent>(out var antag, SEntMan.ComponentFactory), Is.True);
+        Assert.That(rule.TryComp<AntagSelectionComponent>(out var antag, SEntMan.ComponentFactory), Is.True);
 
         STicker.StartGameRule(ruleId, out var gameRule);
 
@@ -88,7 +88,7 @@ public sealed partial class AntagGhostRoleTest : AntagTest
         foreach (var ruleId in AntagGameRules)
         {
             var rule = SProtoMan.Index<EntityPrototype>(ruleId);
-            Assert.That(rule.TryGetComponent<AntagSelectionComponent>(out var antag, SEntMan.ComponentFactory), Is.True);
+            Assert.That(rule.TryComp<AntagSelectionComponent>(out var antag, SEntMan.ComponentFactory), Is.True);
             STicker.StartGameRule(ruleId);
         }
 

--- a/Content.IntegrationTests/Tests/GameRules/TraitorRuleTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/TraitorRuleTest.cs
@@ -56,10 +56,10 @@ public sealed class TraitorRuleTest : GameTest
             Assert.That(protoMan.TryIndex<EntityPrototype>(TraitorGameRuleProtoId, out var gameRuleEnt),
             $"Failed to lookup traitor game rule entity prototype with ID \"{TraitorGameRuleProtoId}\"!");
 
-            Assert.That(gameRuleEnt.TryGetComponent<GameRuleComponent>(out var gameRule, compFact),
+            Assert.That(gameRuleEnt.TryComp<GameRuleComponent>(out var gameRule, compFact),
             $"Game rule entity {TraitorGameRuleProtoId} does not have a GameRuleComponent!");
 
-            Assert.That(gameRuleEnt.TryGetComponent<AntagRandomObjectivesComponent>(out var randomObjectives, compFact),
+            Assert.That(gameRuleEnt.TryComp<AntagRandomObjectivesComponent>(out var randomObjectives, compFact),
             $"Game rule entity {TraitorGameRuleProtoId} does not have an AntagRandomObjectivesComponent!");
 
             minPlayers = gameRule.MinPlayers;
@@ -87,7 +87,7 @@ public sealed class TraitorRuleTest : GameTest
         await server.WaitPost(() =>
         {
             var gameRuleEnt = ticker.AddGameRule(TraitorGameRuleProtoId);
-            Assert.That(entMan.TryGetComponent<TraitorRuleComponent>(gameRuleEnt, out traitorRule));
+            Assert.That(entMan.TryGetComponent(gameRuleEnt, out traitorRule));
 
             // Ready up
             ticker.ToggleReadyAll(true);

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.EntitySpecifier.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.EntitySpecifier.cs
@@ -80,7 +80,7 @@ public abstract partial class InteractionTest
             StackComponent? stack = null;
             await server.WaitPost(() =>
             {
-                entProto.TryGetComponent(factory.GetComponentName<StackComponent>(), out stack);
+                entProto.TryComp(out stack, factory);
             });
 
             if (stack != null)
@@ -110,7 +110,7 @@ public abstract partial class InteractionTest
         StackComponent? stack = null;
         await Server.WaitPost(() =>
         {
-            entProto.TryGetComponent(Factory.GetComponentName<StackComponent>(), out stack);
+            entProto.TryComp(out stack, Factory);
         });
 
         if (stack != null)

--- a/Content.IntegrationTests/Tests/Interaction/InteractionTest.EntitySpecifierCollection.cs
+++ b/Content.IntegrationTests/Tests/Interaction/InteractionTest.EntitySpecifierCollection.cs
@@ -134,7 +134,7 @@ public abstract partial class InteractionTest
                 StackComponent? stack = null;
                 await server.WaitPost(() =>
                 {
-                    entProto.TryGetComponent(factory.GetComponentName<StackComponent>(), out stack);
+                    entProto.TryComp(out stack, factory);
                 });
 
                 if (stack == null)

--- a/Content.IntegrationTests/Tests/Lathe/LatheTest.cs
+++ b/Content.IntegrationTests/Tests/Lathe/LatheTest.cs
@@ -55,10 +55,10 @@ public sealed class LatheTest : GameTest
                 // Check each lathe individually
                 foreach (var latheProto in latheProtos)
                 {
-                    if (!latheProto.TryGetComponent<LatheComponent>(out var latheComp, compFactory))
+                    if (!latheProto.TryComp<LatheComponent>(out var latheComp, compFactory))
                         continue;
 
-                    if (!latheProto.TryGetComponent<MaterialStorageComponent>(out var storageComp, compFactory))
+                    if (!latheProto.TryComp<MaterialStorageComponent>(out var storageComp, compFactory))
                         continue;
 
                     // Test which material-containing entities are accepted by this lathe
@@ -80,7 +80,7 @@ public sealed class LatheTest : GameTest
                     var recipes = new HashSet<ProtoId<LatheRecipePrototype>>();
                     latheSystem.AddRecipesFromPacks(recipes, latheComp.StaticPacks);
                     latheSystem.AddRecipesFromPacks(recipes, latheComp.DynamicPacks);
-                    if (latheProto.TryGetComponent<EmagLatheRecipesComponent>(out var emagRecipesComp, compFactory))
+                    if (latheProto.TryComp<EmagLatheRecipesComponent>(out var emagRecipesComp, compFactory))
                     {
                         latheSystem.AddRecipesFromPacks(recipes, emagRecipesComp.EmagStaticPacks);
                         latheSystem.AddRecipesFromPacks(recipes, emagRecipesComp.EmagDynamicPacks);

--- a/Content.IntegrationTests/Tests/MachineBoardTest.cs
+++ b/Content.IntegrationTests/Tests/MachineBoardTest.cs
@@ -46,7 +46,7 @@ public sealed class MachineBoardTest : GameTest
                          .Where(p => !pair.IsTestPrototype(p))
                          .Where(p => !_ignoredPrototypes.Contains(p.ID)))
             {
-                if (!p.TryGetComponent<MachineBoardComponent>(out var mbc, compFact))
+                if (!p.TryComp<MachineBoardComponent>(out var mbc, compFact))
                     continue;
                 var mId = mbc.Prototype;
 
@@ -54,7 +54,7 @@ public sealed class MachineBoardTest : GameTest
                 {
                     Assert.That(protoMan.TryIndex<EntityPrototype>(mId, out var mProto),
                         $"Machine board {p.ID}'s corresponding machine has an invalid prototype.");
-                    Assert.That(mProto.TryGetComponent<MachineComponent>(out var mComp, compFact),
+                    Assert.That(mProto.TryComp<MachineComponent>(out var mComp, compFact),
                         $"Machine board {p.ID}'s corresponding machine {mId} does not have MachineComponent");
                     Assert.That(mComp.Board, Is.EqualTo(p.ID),
                         $"Machine {mId}'s BoardPrototype is not equal to it's corresponding machine board, {p.ID}");
@@ -83,7 +83,7 @@ public sealed class MachineBoardTest : GameTest
                          .Where(p => !pair.IsTestPrototype(p))
                          .Where(p => !_ignoredPrototypes.Contains(p.ID)))
             {
-                if (!p.TryGetComponent<ComputerBoardComponent>(out var cbc, compFact))
+                if (!p.TryComp<ComputerBoardComponent>(out var cbc, compFact))
                     continue;
                 var cId = cbc.Prototype;
 
@@ -92,7 +92,7 @@ public sealed class MachineBoardTest : GameTest
                     Assert.That(cId, Is.Not.Null, $"Computer board \"{p.ID}\" does not have a corresponding computer.");
                     Assert.That(protoMan.TryIndex<EntityPrototype>(cId, out var cProto),
                         $"Computer board \"{p.ID}\"'s corresponding computer has an invalid prototype.");
-                    Assert.That(cProto.TryGetComponent<ComputerComponent>(out var cComp, compFact),
+                    Assert.That(cProto.TryComp<ComputerComponent>(out var cComp, compFact),
                         $"Computer board {p.ID}'s corresponding computer \"{cId}\" does not have ComputerComponent");
                     Assert.That(cComp.BoardPrototype, Is.EqualTo(p.ID),
                         $"Computer \"{cId}\"'s BoardPrototype is not equal to it's corresponding computer board, \"{p.ID}\"");
@@ -121,7 +121,7 @@ public sealed class MachineBoardTest : GameTest
                          .Where(p => !pair.IsTestPrototype(p))
                          .Where(p => !_ignoredPrototypes.Contains(p.ID)))
             {
-                if (!p.TryGetComponent<MachineBoardComponent>(out var board, entMan.ComponentFactory))
+                if (!p.TryComp<MachineBoardComponent>(out var board, entMan.ComponentFactory))
                     continue;
 
                 Assert.Multiple(() =>

--- a/Content.IntegrationTests/Tests/Power/PowerStatePrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Power/PowerStatePrototypeTest.cs
@@ -33,12 +33,12 @@ public sealed class PowerStatePrototypeTest : GameTest
                              .Where(p => !p.Abstract)
                              .Where(p => !pair.IsTestPrototype(p)))
                 {
-                    if (!prototype.TryGetComponent<PowerStateComponent>(out var powerStateComp, entMan.ComponentFactory))
+                    if (!prototype.TryComp<PowerStateComponent>(out var powerStateComp, entMan.ComponentFactory))
                         continue;
 
                     // LESSON LEARNED:
                     // ENSURE THAT THE COMPONENT YOU ARE TRYING TO GET IS THE SERVER-SIDE VARIANT
-                    if (!prototype.TryGetComponent<ApcPowerReceiverComponent>(out var powerReceiverComp, entMan.ComponentFactory))
+                    if (!prototype.TryComp<ApcPowerReceiverComponent>(out var powerReceiverComp, entMan.ComponentFactory))
                     {
                         Assert.Fail(
                             $"Entity prototype '{prototype.ID}' has a PowerStateComponent but is missing the required ApcPowerReceiverComponent.");

--- a/Content.IntegrationTests/Tests/PrototypeTests/PrototypeUploadTest.cs
+++ b/Content.IntegrationTests/Tests/PrototypeTests/PrototypeUploadTest.cs
@@ -69,16 +69,16 @@ public sealed class PrototypeUploadTest : GameTest
 
         await pair.Server.WaitPost(() =>
         {
-            Assert.That(sProtoA!.TryGetComponent<TagComponent>(out _, sCompFact), Is.True);
-            Assert.That(sProtoB!.TryGetComponent<TagComponent>(out _, sCompFact), Is.False);
-            Assert.That(sProtoD!.TryGetComponent<TagComponent>(out _, sCompFact), Is.True);
+            Assert.That(sProtoA!.TryComp<TagComponent>(out _, sCompFact), Is.True);
+            Assert.That(sProtoB!.TryComp<TagComponent>(out _, sCompFact), Is.False);
+            Assert.That(sProtoD!.TryComp<TagComponent>(out _, sCompFact), Is.True);
         });
 
         await pair.Client.WaitPost(() =>
         {
-            Assert.That(cProtoA!.TryGetComponent<TagComponent>(out _, cCompFact), Is.True);
-            Assert.That(cProtoB!.TryGetComponent<TagComponent>(out _, cCompFact), Is.False);
-            Assert.That(cProtoD!.TryGetComponent<TagComponent>(out _, cCompFact), Is.True);
+            Assert.That(cProtoA!.TryComp<TagComponent>(out _, cCompFact), Is.True);
+            Assert.That(cProtoB!.TryComp<TagComponent>(out _, cCompFact), Is.False);
+            Assert.That(cProtoD!.TryComp<TagComponent>(out _, cCompFact), Is.True);
         });
     }
 }

--- a/Content.IntegrationTests/Tests/Puller/PullerTest.cs
+++ b/Content.IntegrationTests/Tests/Puller/PullerTest.cs
@@ -30,7 +30,7 @@ public sealed class PullerTest : GameTest
             {
                 foreach (var proto in protoManager.EnumeratePrototypes<EntityPrototype>())
                 {
-                    if (!proto.TryGetComponent(out PullerComponent? puller, compFactory))
+                    if (!proto.TryComp(out PullerComponent? puller, compFactory))
                         continue;
 
                     if (!puller.NeedsHands)

--- a/Content.IntegrationTests/Tests/ResearchTest.cs
+++ b/Content.IntegrationTests/Tests/ResearchTest.cs
@@ -69,12 +69,12 @@ public sealed class ResearchTest : GameTest
                 if (pair.IsTestPrototype(proto))
                     continue;
 
-                if (!proto.TryGetComponent<LatheComponent>(out var lathe, compFact))
+                if (!proto.TryComp<LatheComponent>(out var lathe, compFact))
                     continue;
 
                 latheSys.AddRecipesFromPacks(latheTechs, lathe.DynamicPacks);
 
-                if (proto.TryGetComponent<EmagLatheRecipesComponent>(out var emag, compFact))
+                if (proto.TryComp<EmagLatheRecipesComponent>(out var emag, compFact))
                     latheSys.AddRecipesFromPacks(latheTechs, emag.EmagDynamicPacks);
             }
 

--- a/Content.IntegrationTests/Tests/Storage/StorageTest.cs
+++ b/Content.IntegrationTests/Tests/Storage/StorageTest.cs
@@ -27,6 +27,7 @@ public sealed class StorageTest : GameTest
 
         var protoManager = server.ResolveDependency<IPrototypeManager>();
         var entMan = server.ResolveDependency<IEntityManager>();
+        var compFact = server.ResolveDependency<IComponentFactory>();
 
         var itemSys = entMan.System<SharedItemSystem>();
 
@@ -34,10 +35,10 @@ public sealed class StorageTest : GameTest
         {
             foreach (var proto in protoManager.EnumeratePrototypes<EntityPrototype>())
             {
-                if (!proto.TryGetComponent<StorageComponent>("Storage", out var storage) ||
+                if (!proto.TryComp<StorageComponent>(out var storage, compFact) ||
                     storage.Whitelist != null ||
                     storage.MaxItemSize == null ||
-                    !proto.TryGetComponent<ItemComponent>("Item", out var item))
+                    !proto.TryComp<ItemComponent>(out var item, compFact))
                     continue;
 
                 Assert.That(itemSys.GetSizePrototype(storage.MaxItemSize.Value).Weight,
@@ -54,6 +55,7 @@ public sealed class StorageTest : GameTest
         var server = pair.Server;
 
         var protoManager = server.ResolveDependency<IPrototypeManager>();
+        var compFact = server.ResolveDependency<IComponentFactory>();
 
         await server.WaitAssertion(() =>
         {
@@ -61,7 +63,7 @@ public sealed class StorageTest : GameTest
             {
                 foreach (var proto in protoManager.EnumeratePrototypes<EntityPrototype>())
                 {
-                    if (!proto.TryGetComponent<StorageFillComponent>("StorageFill", out var storage))
+                    if (!proto.TryComp<StorageFillComponent>(out var storage, compFact))
                         continue;
 
                     foreach (var entry in storage.Contents)
@@ -102,14 +104,14 @@ public sealed class StorageTest : GameTest
                 var size = 0;
                 await server.WaitAssertion(() =>
                 {
-                    if (!proto.TryGetComponent("Storage", out storage))
+                    if (!proto.TryComp(out storage, compFact))
                     {
                         Assert.Fail($"Entity {proto.ID} has storage-fill without a storage component!");
                         return;
                     }
 
-                    proto.TryGetComponent("Item", out item);
-                    size = GetFillSize(fill, false, protoMan, itemSys);
+                    proto.TryComp(out item, compFact);
+                    size = GetFillSize(fill, false, protoMan, compFact, itemSys);
                 });
 
                 if (storage == null)
@@ -146,7 +148,7 @@ public sealed class StorageTest : GameTest
                     ItemComponent? entryItem = null;
                     await server.WaitPost(() =>
                     {
-                        fillItem.TryGetComponent("Item", out entryItem);
+                        fillItem.TryComp(out entryItem, compFact);
                     });
 
                     if (entryItem == null)
@@ -180,20 +182,20 @@ public sealed class StorageTest : GameTest
 
             await server.WaitAssertion(() =>
             {
-                if (!proto.TryGetComponent("EntityStorage", out EntityStorageComponent? entStorage))
+                if (!proto.TryComp(out EntityStorageComponent? entStorage, compFact))
                     Assert.Fail($"Entity {proto.ID} has storage-fill without a storage component!");
 
                 if (entStorage == null)
                     return;
 
-                var size = GetFillSize(fill, true, protoMan, itemSys);
+                var size = GetFillSize(fill, true, protoMan, compFact, itemSys);
                 Assert.That(size, Is.LessThanOrEqualTo(entStorage.Capacity),
                     $"{proto.ID} storage fill is too large.");
             });
         }
     }
 
-    private int GetEntrySize(EntitySpawnEntry entry, bool getCount, IPrototypeManager protoMan, SharedItemSystem itemSystem)
+    private int GetEntrySize(EntitySpawnEntry entry, bool getCount, IPrototypeManager protoMan, IComponentFactory compFact, SharedItemSystem itemSystem)
     {
         if (entry.PrototypeId == null)
             return 0;
@@ -208,20 +210,20 @@ public sealed class StorageTest : GameTest
             return entry.Amount;
 
 
-        if (proto.TryGetComponent<ItemComponent>("Item", out var item))
+        if (proto.TryComp<ItemComponent>(out var item, compFact))
             return itemSystem.GetItemShape(item).GetArea() * entry.Amount;
 
         Assert.Fail($"Prototype is missing item comp: {entry.PrototypeId}");
         return 0;
     }
 
-    private int GetFillSize(StorageFillComponent fill, bool getCount, IPrototypeManager protoMan, SharedItemSystem itemSystem)
+    private int GetFillSize(StorageFillComponent fill, bool getCount, IPrototypeManager protoMan, IComponentFactory compFact, SharedItemSystem itemSystem)
     {
         var totalSize = 0;
         var groups = new Dictionary<string, int>();
         foreach (var entry in fill.Contents)
         {
-            var size = GetEntrySize(entry, getCount, protoMan, itemSystem);
+            var size = GetEntrySize(entry, getCount, protoMan, compFact, itemSystem);
 
             if (entry.GroupId == null)
                 totalSize += size;
@@ -245,13 +247,13 @@ public sealed class StorageTest : GameTest
         {
             foreach (var (proto, fill) in pair.GetPrototypesWithComponent<EntityTableContainerFillComponent>())
             {
-                Assert.That(!proto.HasComponent<StorageFillComponent>(compFact), $"Prototype {proto.ID} has both {nameof(EntityTableContainerFillComponent)} and {nameof(StorageFillComponent)}.");
-                Assert.That(!proto.HasComponent<ContainerFillComponent>(compFact), $"Prototype {proto.ID} has both {nameof(EntityTableContainerFillComponent)} and {nameof(ContainerFillComponent)}.");
+                Assert.That(!proto.HasComp<StorageFillComponent>(compFact), $"Prototype {proto.ID} has both {nameof(EntityTableContainerFillComponent)} and {nameof(StorageFillComponent)}.");
+                Assert.That(!proto.HasComp<ContainerFillComponent>(compFact), $"Prototype {proto.ID} has both {nameof(EntityTableContainerFillComponent)} and {nameof(ContainerFillComponent)}.");
             }
 
             foreach (var (proto, fill) in pair.GetPrototypesWithComponent<ContainerFillComponent>())
             {
-                Assert.That(!proto.HasComponent<StorageFillComponent>(compFact), $"Prototype {proto.ID} has both {nameof(ContainerFillComponent)} and {nameof(StorageFillComponent)}.");
+                Assert.That(!proto.HasComp<StorageFillComponent>(compFact), $"Prototype {proto.ID} has both {nameof(ContainerFillComponent)} and {nameof(StorageFillComponent)}.");
             }
         });
     }

--- a/Content.IntegrationTests/Tests/VendingMachineRestockTest.cs
+++ b/Content.IntegrationTests/Tests/VendingMachineRestockTest.cs
@@ -141,7 +141,7 @@ namespace Content.IntegrationTests.Tests
                     List<EntProtoId<VendingMachineRestockComponent>>> entitiesWhichSpawnRestocks = new();
                 foreach (var proto in prototypeManager.EnumeratePrototypes<EntityPrototype>())
                 {
-                    if (!proto.TryGetComponent<EntityTableContainerFillComponent>(out var fill, compFact))
+                    if (!proto.TryComp<EntityTableContainerFillComponent>(out var fill, compFact))
                         continue;
 
                     var containers = fill.Containers;
@@ -320,7 +320,7 @@ namespace Content.IntegrationTests.Tests
 #pragma warning disable NUnit2045
                 Assert.That(!damageResult.Empty, "Received empty damageResult when attempting to damage restock box.");
 
-                Assert.That((int) damageResult.GetTotal(), Is.GreaterThan(0), "Box damage result was not greater than 0.");
+                Assert.That((int)damageResult.GetTotal(), Is.GreaterThan(0), "Box damage result was not greater than 0.");
 #pragma warning restore NUnit2045
             });
             await server.WaitRunTicks(15);

--- a/Content.Server/Access/Systems/AgentIDCardSystem.cs
+++ b/Content.Server/Access/Systems/AgentIDCardSystem.cs
@@ -16,7 +16,6 @@ using Content.Shared.StatusIcon;
 using Content.Shared.UserInterface;
 using Content.Shared.VoiceMask;
 using Robust.Server.GameObjects;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Access.Systems
 {
@@ -25,7 +24,6 @@ namespace Content.Server.Access.Systems
         [Dependency] private PopupSystem _popupSystem = default!;
         [Dependency] private IdCardSystem _cardSystem = default!;
         [Dependency] private UserInterfaceSystem _uiSystem = default!;
-        [Dependency] private IPrototypeManager _prototypeManager = default!;
         [Dependency] private ChameleonClothingSystem _chameleon = default!;
         [Dependency] private ChameleonControllerSystem _chamController = default!;
         [Dependency] private LockSystem _lock = default!;
@@ -49,13 +47,13 @@ namespace Content.Server.Access.Systems
             if (!TryComp<IdCardComponent>(ent, out var idCardComp))
                 return;
 
-            _prototypeManager.Resolve(args.Args.ChameleonOutfit.Job, out var jobProto);
+            ProtoMan.Resolve(args.Args.ChameleonOutfit.Job, out var jobProto);
 
             var jobIcon = args.Args.ChameleonOutfit.Icon ?? jobProto?.Icon;
             var jobName = args.Args.ChameleonOutfit.Name ?? jobProto?.Name ?? "";
 
             if (jobIcon != null)
-                _cardSystem.TryChangeJobIcon(ent, _prototypeManager.Index(jobIcon.Value), idCardComp);
+                _cardSystem.TryChangeJobIcon(ent, ProtoMan.Index(jobIcon.Value), idCardComp);
 
             if (jobName != "")
                 _cardSystem.TryChangeJobTitle(ent, Loc.GetString(jobName), idCardComp);
@@ -76,8 +74,8 @@ namespace Content.Server.Access.Systems
             if (idSlotGear == null)
                 return;
 
-            var proto = _prototypeManager.Index(idSlotGear);
-            if (!proto.TryGetComponent<PdaComponent>(out var comp, EntityManager.ComponentFactory))
+            var proto = ProtoMan.Index(idSlotGear);
+            if (!proto.TryComp<PdaComponent>(out var comp, EntityManager.ComponentFactory))
                 return;
 
             if (TryComp<ChameleonClothingComponent>(ent, out var chameleonComp) && chameleonComp.CanBeSetByController)
@@ -146,7 +144,7 @@ namespace Content.Server.Access.Systems
             if (!TryComp<IdCardComponent>(uid, out var idCard))
                 return;
 
-            if (!_prototypeManager.Resolve(args.JobIconId, out var jobIcon))
+            if (!ProtoMan.Resolve(args.JobIconId, out var jobIcon))
                 return;
 
             _cardSystem.TryChangeJobIcon(uid, jobIcon, idCard);
@@ -159,7 +157,7 @@ namespace Content.Server.Access.Systems
 
         private bool TryFindJobProtoFromIcon(JobIconPrototype jobIcon, [NotNullWhen(true)] out JobPrototype? job)
         {
-            foreach (var jobPrototype in _prototypeManager.EnumeratePrototypes<JobPrototype>())
+            foreach (var jobPrototype in ProtoMan.EnumeratePrototypes<JobPrototype>())
             {
                 if (jobPrototype.Icon == jobIcon.ID)
                 {

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -30,7 +30,6 @@ namespace Content.Server.Access.Systems;
 public sealed partial class IdCardConsoleSystem : SharedIdCardConsoleSystem
 {
     [Dependency] private IConfigurationManager _cfgManager = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private StationRecordsSystem _record = default!;
     [Dependency] private UserInterfaceSystem _userInterface = default!;
     [Dependency] private AccessReaderSystem _accessReader = default!;
@@ -158,8 +157,8 @@ public sealed partial class IdCardConsoleSystem : SharedIdCardConsoleSystem
         _idCard.TryChangeFullName(targetId, newFullName, player: player);
         _idCard.TryChangeJobTitle(targetId, newJobTitle, player: player);
 
-        if (_prototype.TryIndex(newJobProto, out var job)
-            && _prototype.Resolve(job.Icon, out var jobIcon))
+        if (ProtoMan.TryIndex(newJobProto, out var job)
+            && ProtoMan.Resolve(job.Icon, out var jobIcon))
         {
             _idCard.TryChangeJobIcon(targetId, jobIcon, player: player);
             _idCard.TryChangeJobDepartment(targetId, job);

--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -10,7 +10,6 @@ using Content.Shared.Chat;
 using Content.Shared.Database;
 using Content.Shared.Kitchen;
 using Content.Shared.Popups;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Server.Kitchen.EntitySystems;
 
@@ -20,7 +19,6 @@ public sealed partial class IdCardSystem : SharedIdCardSystem
 {
     [Dependency] private PopupSystem _popupSystem = default!;
     [Dependency] private IRobustRandom _random = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
     [Dependency] private ChatSystem _chat = default!;
     [Dependency] private MicrowaveSystem _microwave = default!;
@@ -82,7 +80,7 @@ public sealed partial class IdCardSystem : SharedIdCardSystem
             }
 
             // Give them a wonderful new access to compensate for everything
-            var ids = _prototypeManager.EnumeratePrototypes<AccessLevelPrototype>().Where(x => x.CanAddToIdCard).ToArray();
+            var ids = ProtoMan.EnumeratePrototypes<AccessLevelPrototype>().Where(x => x.CanAddToIdCard).ToArray();
 
             if (ids.Length == 0)
                 return;

--- a/Content.Server/Access/Systems/PresetIdCardSystem.cs
+++ b/Content.Server/Access/Systems/PresetIdCardSystem.cs
@@ -4,14 +4,11 @@ using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Shared.Access.Systems;
 using Content.Shared.Roles;
-using Content.Shared.StatusIcon;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Access.Systems;
 
 public sealed partial class PresetIdCardSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IdCardSystem _cardSystem = default!;
     [Dependency] private SharedAccessSystem _accessSystem = default!;
     [Dependency] private StationSystem _stationSystem = default!;
@@ -71,7 +68,7 @@ public sealed partial class PresetIdCardSystem : EntitySystem
         if (id.JobName == null)
             return;
 
-        if (!_prototypeManager.TryIndex(id.JobName, out JobPrototype? job))
+        if (!ProtoMan.TryIndex(id.JobName, out JobPrototype? job))
         {
             Log.Error($"Invalid job id ({id.JobName}) for preset card");
             return;
@@ -82,7 +79,7 @@ public sealed partial class PresetIdCardSystem : EntitySystem
         _cardSystem.TryChangeJobTitle(uid, job.LocalizedName);
         _cardSystem.TryChangeJobDepartment(uid, job);
 
-        if (_prototypeManager.Resolve(job.Icon, out var jobIcon))
+        if (ProtoMan.Resolve(job.Icon, out var jobIcon))
             _cardSystem.TryChangeJobIcon(uid, jobIcon);
     }
 }

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -20,7 +20,6 @@ using Content.Shared.PDA;
 using Content.Shared.Players.PlayTimeTracking;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
-using Content.Shared.Roles.Components;
 using Content.Shared.Roles.Jobs;
 using Content.Shared.StationRecords;
 using Content.Shared.Throwing;
@@ -32,7 +31,6 @@ using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Administration.Systems;
 
@@ -49,7 +47,6 @@ public sealed partial class AdminSystem : EntitySystem
     [Dependency] private PopupSystem _popup = default!;
     [Dependency] private PhysicsSystem _physics = default!;
     [Dependency] private PlayTimeTrackingManager _playTime = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private SharedRoleSystem _role = default!;
     [Dependency] private GameTicker _gameTicker = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
@@ -238,7 +235,7 @@ public sealed partial class AdminSystem : EntitySystem
         {
             sortWeight = _role.GetRoleCompByTime(mindComp)?.Comp.SortWeight ?? 0;
 
-            if (_proto.TryIndex(mindComp.RoleType, out var role))
+            if (ProtoMan.TryIndex(mindComp.RoleType, out var role))
             {
                 roleType = role;
                 subtype = mindComp.Subtype;

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -12,7 +12,6 @@ using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Administration;
 using Content.Shared.Administration.Components;
-using Content.Shared.Administration.Systems;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Construction.Components;
@@ -832,7 +831,7 @@ public sealed partial class AdminVerbSystem
 
     private void GiveAllAccess(EntityUid entity)
     {
-        var allAccess = _prototypeManager
+        var allAccess = ProtoMan
             .EnumeratePrototypes<AccessLevelPrototype>()
             .Select(p => new ProtoId<AccessLevelPrototype>(p.ID)).ToArray();
 

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -31,7 +31,6 @@ using Robust.Shared.Console;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Utility;
@@ -51,7 +50,6 @@ namespace Content.Server.Administration.Systems
         [Dependency] private IAdminManager _adminManager = default!;
         [Dependency] private IGameTiming _gameTiming = default!;
         [Dependency] private SharedMapSystem _map = default!;
-        [Dependency] private IPrototypeManager _prototypeManager = default!;
         [Dependency] private AdminSystem _adminSystem = default!;
         [Dependency] private DisposalTubeSystem _disposalTubes = default!;
         [Dependency] private EuiManager _euiManager = default!;

--- a/Content.Server/Advertise/EntitySystems/SpeakOnUIClosedSystem.cs
+++ b/Content.Server/Advertise/EntitySystems/SpeakOnUIClosedSystem.cs
@@ -3,7 +3,6 @@ using Content.Shared.Advertise.Components;
 using Content.Shared.Advertise.Systems;
 using Content.Shared.Chat;
 using Content.Shared.UserInterface;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Advertise.EntitySystems;
@@ -11,7 +10,6 @@ namespace Content.Server.Advertise.EntitySystems;
 public sealed partial class SpeakOnUIClosedSystem : SharedSpeakOnUIClosedSystem
 {
     [Dependency] private IRobustRandom _random = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private ChatSystem _chat = default!;
 
     public override void Initialize()
@@ -39,7 +37,7 @@ public sealed partial class SpeakOnUIClosedSystem : SharedSpeakOnUIClosedSystem
         if (!entity.Comp.Enabled)
             return false;
 
-        if (!_prototypeManager.Resolve(entity.Comp.Pack, out var messagePack))
+        if (!ProtoMan.Resolve(entity.Comp.Pack, out var messagePack))
             return false;
 
         var message = Loc.GetString(_random.Pick(messagePack.Values), ("name", Name(entity)));

--- a/Content.Server/AlertLevel/AlertLevelSystem.cs
+++ b/Content.Server/AlertLevel/AlertLevelSystem.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using Content.Server.Chat.Systems;
 using Content.Server.Station.Systems;
 using Content.Shared.CCVar;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
@@ -12,7 +11,6 @@ namespace Content.Server.AlertLevel;
 public sealed partial class AlertLevelSystem : EntitySystem
 {
     [Dependency] private IConfigurationManager _cfg = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private ChatSystem _chatSystem = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private StationSystem _stationSystem = default!;
@@ -51,7 +49,7 @@ public sealed partial class AlertLevelSystem : EntitySystem
         if (!TryComp<AlertLevelComponent>(args.Station, out var alertLevelComponent))
             return;
 
-        if (!_prototypeManager.TryIndex(alertLevelComponent.AlertLevelPrototype, out AlertLevelPrototype? alerts))
+        if (!ProtoMan.TryIndex(alertLevelComponent.AlertLevelPrototype, out AlertLevelPrototype? alerts))
         {
             return;
         }

--- a/Content.Server/Anomaly/AnomalySystem.Generator.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Generator.cs
@@ -176,7 +176,7 @@ public sealed partial class AnomalySystem
         Audio.PlayPvs(component.GeneratingFinishedSound, uid);
 
         var message = Loc.GetString("anomaly-generator-announcement");
-        _radio.SendRadioMessage(uid, message, _prototype.Index<RadioChannelPrototype>(component.ScienceChannel), uid);
+        _radio.SendRadioMessage(uid, message, ProtoMan.Index<RadioChannelPrototype>(component.ScienceChannel), uid);
     }
 
     private void UpdateGenerator()

--- a/Content.Server/Anomaly/AnomalySystem.cs
+++ b/Content.Server/Anomaly/AnomalySystem.cs
@@ -27,7 +27,6 @@ namespace Content.Server.Anomaly;
 public sealed partial class AnomalySystem : SharedAnomalySystem
 {
     [Dependency] private IConfigurationManager _configuration = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private AmbientSoundSystem _ambient = default!;
     [Dependency] private AtmosphereSystem _atmosphere = default!;
     [Dependency] private ExplosionSystem _explosion = default!;
@@ -101,7 +100,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
         var behaviorMod = 1f;
         if (anomaly.Comp.CurrentBehavior != null)
         {
-            var b = _prototype.Index(anomaly.Comp.CurrentBehavior.Value);
+            var b = ProtoMan.Index(anomaly.Comp.CurrentBehavior.Value);
             behaviorMod = b.ParticleSensivity;
         }
         // small function to randomize because it's easier to read like this
@@ -152,7 +151,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
         //Apply behavior modifier
         if (component.CurrentBehavior != null)
         {
-            var behavior = _prototype.Index(component.CurrentBehavior.Value);
+            var behavior = ProtoMan.Index(component.CurrentBehavior.Value);
             multiplier *= behavior.EarnPointModifier;
         }
 
@@ -189,7 +188,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
     #region Behavior
     private string GetRandomBehavior()
     {
-        var weightList = _prototype.Index(WeightListProto);
+        var weightList = ProtoMan.Index(WeightListProto);
         return weightList.Pick(_random);
     }
 
@@ -202,7 +201,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
             RemoveBehavior(anomaly, anomaly.Comp.CurrentBehavior.Value);
 
         anomaly.Comp.CurrentBehavior = behaviorProto;
-        var behavior = _prototype.Index(behaviorProto);
+        var behavior = ProtoMan.Index(behaviorProto);
         EntityManager.AddComponents(anomaly, behavior.Components);
 
         var ev = new AnomalyBehaviorChangedEvent(anomaly, anomaly.Comp.CurrentBehavior, behaviorProto);
@@ -214,7 +213,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
         if (anomaly.Comp.CurrentBehavior == null)
             return;
 
-        var behavior = _prototype.Index(behaviorProto);
+        var behavior = ProtoMan.Index(behaviorProto);
 
         EntityManager.RemoveComponents(anomaly, behavior.Components);
     }
@@ -347,7 +346,7 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
         {
             if (anomalyComp.CurrentBehavior != null)
             {
-                var behavior = _prototype.Index(anomalyComp.CurrentBehavior.Value);
+                var behavior = ProtoMan.Index(anomalyComp.CurrentBehavior.Value);
 
                 msg.AddMarkupOrThrow("- " + Loc.GetString(behavior.Description));
                 msg.PushNewline();

--- a/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.cs
@@ -1,5 +1,4 @@
 using Content.Server.Administration.Logs;
-using Content.Server.Body.Systems;
 using Content.Server.Chat.Managers;
 using Content.Server.Jittering;
 using Content.Server.Mind;
@@ -7,7 +6,6 @@ using Content.Server.Stunnable;
 using Content.Shared.Anomaly;
 using Content.Shared.Anomaly.Components;
 using Content.Shared.Anomaly.Effects;
-using Content.Shared.Body.Components;
 using Content.Shared.Chat;
 using Content.Shared.Database;
 using Content.Shared.Gibbing;
@@ -17,7 +15,6 @@ using Content.Shared.Whitelist;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Anomaly.Effects;
 
@@ -33,7 +30,6 @@ public sealed partial class InnerBodyAnomalySystem : SharedInnerBodyAnomalySyste
     [Dependency] private JitteringSystem _jitter = default!;
     [Dependency] private MindSystem _mind = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private StunSystem _stun = default!;
 
     private readonly Color _messageColor = Color.FromSrgb(new Color(201, 22, 94));
@@ -87,7 +83,7 @@ public sealed partial class InnerBodyAnomalySystem : SharedInnerBodyAnomalySyste
 
     private void AddAnomalyToBody(Entity<InnerBodyAnomalyComponent> ent)
     {
-        if (!_proto.Resolve(ent.Comp.InjectionProto, out var injectedAnom))
+        if (!ProtoMan.Resolve(ent.Comp.InjectionProto, out var injectedAnom))
             return;
 
         if (ent.Comp.Injected)
@@ -208,7 +204,7 @@ public sealed partial class InnerBodyAnomalySystem : SharedInnerBodyAnomalySyste
         if (!ent.Comp.Injected)
             return;
 
-        if (_proto.Resolve(ent.Comp.InjectionProto, out var injectedAnom))
+        if (ProtoMan.Resolve(ent.Comp.InjectionProto, out var injectedAnom))
             EntityManager.RemoveComponents(ent, injectedAnom.Components);
 
         _stun.TryUpdateParalyzeDuration(ent, TimeSpan.FromSeconds(ent.Comp.StunDuration));

--- a/Content.Server/Anomaly/Effects/ReagentProducerAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/ReagentProducerAnomalySystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.Sprite;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Anomaly.Effects;
@@ -31,7 +30,6 @@ public sealed partial class ReagentProducerAnomalySystem : EntitySystem
     [Dependency] private SharedSolutionContainerSystem _solutionContainer = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private PointLightSystem _light = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
 
     public const string FallbackReagent = "Water";
@@ -87,7 +85,7 @@ public sealed partial class ReagentProducerAnomalySystem : EntitySystem
             // and nothing worked out for me. So for now it will be like this.
             if (component.NeedRecolor)
             {
-                var color = producerSolution.GetColor(_prototypeManager);
+                var color = producerSolution.GetColor(ProtoMan);
                 _light.SetColor(uid, color);
                 if (TryComp<RandomSpriteComponent>(uid, out var randomSprite))
                 {

--- a/Content.Server/Antag/AntagSelectionSystem.API.Assignment.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.Assignment.cs
@@ -33,7 +33,7 @@ public sealed partial class AntagSelectionSystem
         bool checkPref = true)
     {
         // Can't be this antag if it doesn't exist :)
-        if (!Proto.Resolve(proto, out var antag))
+        if (!ProtoMan.Resolve(proto, out var antag))
             return false;
 
         return CanBeAntag(player, gameRule, antag, checkPref);
@@ -71,7 +71,7 @@ public sealed partial class AntagSelectionSystem
         Entity<AntagSelectionComponent> gameRule,
         ProtoId<AntagSpecifierPrototype> def)
     {
-        if (!Proto.Resolve(def, out var antag))
+        if (!ProtoMan.Resolve(def, out var antag))
             return false;
 
         return IsSessionValid(player, gameRule, antag);
@@ -159,7 +159,7 @@ public sealed partial class AntagSelectionSystem
     /// <inhereitdoc cref="IsEntityValid(EntityUid?,AntagSpecifierPrototype)"/>
     public bool IsEntityValid([NotNullWhen(true)] EntityUid? uid, ProtoId<AntagSpecifierPrototype> def)
     {
-        if (!Proto.Resolve(def, out var antag))
+        if (!ProtoMan.Resolve(def, out var antag))
             return false;
 
         return IsEntityValid(uid, antag);
@@ -221,7 +221,7 @@ public sealed partial class AntagSelectionSystem
         ICommonSession session,
         bool checkPref = true)
     {
-        if (!Proto.Resolve(proto, out var def))
+        if (!ProtoMan.Resolve(proto, out var def))
             return false;
 
         return TryMakeAntag(gameRule, def, session, checkPref);
@@ -265,7 +265,7 @@ public sealed partial class AntagSelectionSystem
     {
         foreach (var selector in gameRule.Comp.Antags)
         {
-            if (!Proto.Resolve(selector.Proto, out var antag))
+            if (!ProtoMan.Resolve(selector.Proto, out var antag))
                 continue;
 
             // Because this value can theoretically fluctuate as players leave and join, we don't want to cache it.
@@ -361,7 +361,7 @@ public sealed partial class AntagSelectionSystem
         int count,
         bool assert = false)
     {
-        if (!Proto.Resolve(protoId, out var antag))
+        if (!ProtoMan.Resolve(protoId, out var antag))
             return;
 
         SpawnGhostRoles(gameRule, antag, count, assert);
@@ -432,7 +432,7 @@ public sealed partial class AntagSelectionSystem
         if (TryAssignNextAvailableAntag(rule, player))
             return;
 
-        if (rule.Comp.Antags.LastOrDefault() is not { } antag || !Proto.Resolve(antag.Proto, out var proto))
+        if (rule.Comp.Antags.LastOrDefault() is not { } antag || !ProtoMan.Resolve(antag.Proto, out var proto))
             return;
 
         PreSelectSession(rule, proto, player);
@@ -442,7 +442,7 @@ public sealed partial class AntagSelectionSystem
     /// <inhereitdoc cref="ForceMakeAntag{T}(ICommonSession,EntProtoId,AntagSpecifierPrototype)"/>
     public void ForceMakeAntag<T>(ICommonSession player, EntProtoId ruleProto, ProtoId<AntagSpecifierPrototype> antagProto) where T : Component
     {
-        if (!Proto.Resolve(antagProto, out var antag))
+        if (!ProtoMan.Resolve(antagProto, out var antag))
             return;
 
         ForceMakeAntag<T>(player, ruleProto, antag);

--- a/Content.Server/Antag/AntagSelectionSystem.API.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.cs
@@ -91,7 +91,7 @@ public sealed partial class AntagSelectionSystem
         // This is how the system worked when I got here, and I decided not to change it to avoid fucking with team antag balance
         foreach (var antag in gameRule.Comp.Antags)
         {
-            if (!Proto.Resolve(antag.Proto, out _))
+            if (!ProtoMan.Resolve(antag.Proto, out _))
                 continue;
 
             count += GetTargetAntagCount(antag, playerCount, ref runningCount);
@@ -110,7 +110,7 @@ public sealed partial class AntagSelectionSystem
     [PublicAPI]
     public int GetTargetAntagCount(Entity<AntagSelectionComponent> gameRule, int playerCount, ProtoId<AntagSpecifierPrototype> proto)
     {
-        if (!Proto.Resolve(proto, out var antag))
+        if (!ProtoMan.Resolve(proto, out var antag))
             return 0;
 
         return GetTargetAntagCount(gameRule, playerCount, antag);
@@ -127,7 +127,7 @@ public sealed partial class AntagSelectionSystem
         // This is how the system worked when I got here, and I decided not to change it to avoid fucking with team antag balance
         foreach (var antag in gameRule.Comp.Antags)
         {
-            if (!Proto.Resolve(antag.Proto, out _))
+            if (!ProtoMan.Resolve(antag.Proto, out _))
                 continue;
 
             // We need to update our running count which is why we get the count for definitions we may not be assigning.
@@ -404,7 +404,7 @@ public sealed partial class AntagSelectionSystem
                 if (except.Contains(antag))
                     continue;
 
-                if (!comp.PreSelectedSessions.TryGetValue(antag, out var set) || !Proto.Resolve(antag.Proto, out var proto))
+                if (!comp.PreSelectedSessions.TryGetValue(antag, out var set) || !ProtoMan.Resolve(antag.Proto, out var proto))
                     continue;
 
                 // Check this here so we don't make a dictionary entry for a bunch of players, with empty blacklists and whitelists.
@@ -468,7 +468,7 @@ public sealed partial class AntagSelectionSystem
                 if (!comp.PreSelectedSessions.TryGetValue(antag, out var set) || !set.Contains(player))
                     continue;
 
-                if (!Proto.Resolve(antag.Proto, out var proto))
+                if (!ProtoMan.Resolve(antag.Proto, out var proto))
                     continue;
 
                 if (proto.JobWhitelist != null)
@@ -654,7 +654,7 @@ public sealed partial class AntagSelectionSystem
 
             foreach (var (proto, sessions) in comp.PreSelectedSessions)
             {
-                if (!Proto.Resolve(proto, out var def))
+                if (!ProtoMan.Resolve(proto, out var def))
                     continue; // How did you even get here?
 
                 if (!sessions.Contains(player))

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -148,7 +148,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         if (ent.Comp.Rule is not { } rule || ent.Comp.Definition is not { } proto)
             return;
 
-        if (!Proto.Resolve(proto, out var def))
+        if (!ProtoMan.Resolve(proto, out var def))
             return;
 
         if (!Exists(rule) || !RuleQuery.TryComp(rule, out var select))
@@ -304,7 +304,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 
         foreach (var antag in gameRule.Comp.Antags)
         {
-            if (!Proto.Resolve(antag.Proto, out var proto))
+            if (!ProtoMan.Resolve(antag.Proto, out var proto))
                 continue;
 
             // We do it this way in case our resolve fails.
@@ -323,7 +323,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         // This is how the system worked when I got here, and I decided not to change it to avoid fucking with team antag balance
         foreach (var antag in gameRule.Comp.Antags)
         {
-            if (!Proto.Resolve(antag.Proto, out var definition))
+            if (!ProtoMan.Resolve(antag.Proto, out var definition))
                 continue;
 
             // We do it this way in case our resolve fails.
@@ -723,7 +723,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         foreach (var (proto, set) in gameRule.Comp.PreSelectedSessions)
         {
             // How did we even get here?
-            if (!Proto.Resolve(proto, out var def))
+            if (!ProtoMan.Resolve(proto, out var def))
                 continue;
 
             foreach (var session in set)

--- a/Content.Server/Arcade/SpaceVillainGame/SpaceVillainArcadeSystem.cs
+++ b/Content.Server/Arcade/SpaceVillainGame/SpaceVillainArcadeSystem.cs
@@ -8,14 +8,12 @@ using Content.Shared.Random.Helpers;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Arcade.SpaceVillain;
 
 public sealed partial class SpaceVillainArcadeSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SharedAudioSystem _audioSystem = default!;
     [Dependency] private UserInterfaceSystem _uiSystem = default!;
@@ -55,7 +53,7 @@ public sealed partial class SpaceVillainArcadeSystem : EntitySystem
     /// <returns>A fight-verb.</returns>
     public string GenerateFightVerb(SpaceVillainArcadeComponent arcade)
     {
-        return _random.Pick(_prototypeManager.Index(arcade.PossibleFightVerbs));
+        return _random.Pick(ProtoMan.Index(arcade.PossibleFightVerbs));
     }
 
     /// <summary>
@@ -64,8 +62,8 @@ public sealed partial class SpaceVillainArcadeSystem : EntitySystem
     /// <returns>An enemy-name.</returns>
     public string GenerateEnemyName(SpaceVillainArcadeComponent arcade)
     {
-        var possibleFirstEnemyNames = _prototypeManager.Index(arcade.PossibleFirstEnemyNames);
-        var possibleLastEnemyNames = _prototypeManager.Index(arcade.PossibleLastEnemyNames);
+        var possibleFirstEnemyNames = ProtoMan.Index(arcade.PossibleFirstEnemyNames);
+        var possibleLastEnemyNames = ProtoMan.Index(arcade.PossibleLastEnemyNames);
 
         return $"{_random.Pick(possibleFirstEnemyNames)} {_random.Pick(possibleLastEnemyNames)}";
     }

--- a/Content.Server/Armor/ArmorSystem.cs
+++ b/Content.Server/Armor/ArmorSystem.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Armor;
 using Content.Shared.Cargo;
-using Robust.Shared.Prototypes;
 using Content.Shared.Damage.Prototypes;
 
 namespace Content.Server.Armor;
@@ -8,8 +7,6 @@ namespace Content.Server.Armor;
 /// <inheritdoc/>
 public sealed partial class ArmorSystem : SharedArmorSystem
 {
-    [Dependency] private IPrototypeManager _protoManager = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -21,13 +18,13 @@ public sealed partial class ArmorSystem : SharedArmorSystem
     {
         foreach (var modifier in component.Modifiers.Coefficients)
         {
-            var damageType = _protoManager.Index<DamageTypePrototype>(modifier.Key);
+            var damageType = ProtoMan.Index<DamageTypePrototype>(modifier.Key);
             args.Price += component.PriceMultiplier * damageType.ArmorPriceCoefficient * 100 * (1 - modifier.Value);
         }
 
         foreach (var modifier in component.Modifiers.FlatReduction)
         {
-            var damageType = _protoManager.Index<DamageTypePrototype>(modifier.Key);
+            var damageType = ProtoMan.Index<DamageTypePrototype>(modifier.Key);
             args.Price += component.PriceMultiplier * damageType.ArmorPriceFlat * modifier.Value;
         }
     }

--- a/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
@@ -16,7 +16,6 @@ using Content.Shared.DeviceNetwork;
 using Content.Shared.DeviceNetwork.Events;
 using Content.Shared.Power;
 using Content.Shared.Tag;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Atmos.Monitor.Systems;
 
@@ -30,7 +29,6 @@ public sealed partial class AtmosMonitorSystem : EntitySystem
     [Dependency] private AtmosphereSystem _atmosphereSystem = default!;
     [Dependency] private AtmosDeviceSystem _atmosDeviceSystem = default!;
     [Dependency] private DeviceNetworkSystem _deviceNetSystem = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private NodeContainerSystem _nodeContainerSystem = default!;
 
     // Commands
@@ -84,13 +82,13 @@ public sealed partial class AtmosMonitorSystem : EntitySystem
     {
         if (component.TemperatureThresholdId != null)
         {
-            var proto = _prototypeManager.Index<AtmosAlarmThresholdPrototype>(component.TemperatureThresholdId);
+            var proto = ProtoMan.Index<AtmosAlarmThresholdPrototype>(component.TemperatureThresholdId);
             component.TemperatureThreshold ??= new(proto);
         }
 
         if (component.PressureThresholdId != null)
         {
-            var proto = _prototypeManager.Index<AtmosAlarmThresholdPrototype>(component.PressureThresholdId);
+            var proto = ProtoMan.Index<AtmosAlarmThresholdPrototype>(component.PressureThresholdId);
             component.PressureThreshold ??= new(proto);
         }
 
@@ -100,7 +98,7 @@ public sealed partial class AtmosMonitorSystem : EntitySystem
         component.GasThresholds ??= new();
         foreach (var (gas, id) in component.GasThresholdPrototypes)
         {
-            var proto = _prototypeManager.Index<AtmosAlarmThresholdPrototype>(id);
+            var proto = ProtoMan.Index<AtmosAlarmThresholdPrototype>(id);
             component.GasThresholds.TryAdd(gas, new(proto));
         }
     }

--- a/Content.Server/Audio/ContentAudioSystem.cs
+++ b/Content.Server/Audio/ContentAudioSystem.cs
@@ -18,7 +18,6 @@ public sealed partial class ContentAudioSystem : SharedContentAudioSystem
 {
     [Dependency] private AudioSystem _serverAudio = default!;
     [Dependency] private IRobustRandom _robustRandom = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
 
     private SoundCollectionPrototype? _lobbyMusicCollection = default!;
@@ -36,7 +35,7 @@ public sealed partial class ContentAudioSystem : SharedContentAudioSystem
             {
                 //Checks to see if the sound collection exists. If it does change it if not defaults to null
                 // as the new _lobbyMusicCollection meaning it wont play anything in the lobby.
-                if(_prototypeManager.TryIndex<SoundCollectionPrototype>(x, out var outputSoundCollection))
+                if(ProtoMan.TryIndex<SoundCollectionPrototype>(x, out var outputSoundCollection))
                 {
                     _lobbyMusicCollection = outputSoundCollection;
                 }

--- a/Content.Server/Audio/Jukebox/JukeboxSystem.cs
+++ b/Content.Server/Audio/Jukebox/JukeboxSystem.cs
@@ -12,7 +12,6 @@ namespace Content.Server.Audio.Jukebox;
 
 public sealed partial class JukeboxSystem : SharedJukeboxSystem
 {
-    [Dependency] private IPrototypeManager _protoManager = default!;
     [Dependency] private AppearanceSystem _appearanceSystem = default!;
 
     public override void Initialize()
@@ -156,7 +155,7 @@ public sealed partial class JukeboxSystem : SharedJukeboxSystem
         else
         {
             if (string.IsNullOrEmpty(ent.Comp.SelectedSongId) ||
-                !_protoManager.Resolve(ent.Comp.SelectedSongId, out var jukeboxProto))
+                !ProtoMan.Resolve(ent.Comp.SelectedSongId, out var jukeboxProto))
             {
                 return false;
             }

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -32,7 +32,6 @@ public sealed partial class RespiratorSystem : EntitySystem
 {
     [Dependency] private IAdminLogManager _adminLogger = default!;
     [Dependency] private IGameTiming _gameTiming = default!;
-    [Dependency] private IPrototypeManager _protoMan = default!;
     [Dependency] private AlertsSystem _alertsSystem = default!;
     [Dependency] private AtmosphereSystem _atmosSys = default!;
     [Dependency] private BodySystem _body = default!;
@@ -283,7 +282,7 @@ public sealed partial class RespiratorSystem : EntitySystem
         float saturation = 0;
         foreach (var (id, quantity) in solution.Contents)
         {
-            var reagent = _protoMan.Index<ReagentPrototype>(id.Prototype);
+            var reagent = ProtoMan.Index<ReagentPrototype>(id.Prototype);
             if (reagent.Metabolisms == null)
                 continue;
 

--- a/Content.Server/Botany/Systems/BotanySystem.Seed.cs
+++ b/Content.Server/Botany/Systems/BotanySystem.Seed.cs
@@ -22,7 +22,6 @@ namespace Content.Server.Botany.Systems;
 
 public sealed partial class BotanySystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _robustRandom = default!;
     [Dependency] private AppearanceSystem _appearance = default!;
     [Dependency] private PopupSystem _popupSystem = default!;
@@ -52,7 +51,7 @@ public sealed partial class BotanySystem : EntitySystem
         }
 
         if (comp.SeedId != null
-            && _prototypeManager.TryIndex(comp.SeedId, out SeedPrototype? protoSeed))
+            && ProtoMan.TryIndex(comp.SeedId, out SeedPrototype? protoSeed))
         {
             seed = protoSeed;
             return true;
@@ -71,7 +70,7 @@ public sealed partial class BotanySystem : EntitySystem
         }
 
         if (comp.SeedId != null
-            && _prototypeManager.TryIndex(comp.SeedId, out SeedPrototype? protoSeed))
+            && ProtoMan.TryIndex(comp.SeedId, out SeedPrototype? protoSeed))
         {
             seed = protoSeed;
             return true;

--- a/Content.Server/Botany/Systems/MutationSystem.cs
+++ b/Content.Server/Botany/Systems/MutationSystem.cs
@@ -9,16 +9,15 @@ namespace Content.Server.Botany;
 
 public sealed partial class MutationSystem : EntitySystem
 {
-    private static ProtoId<RandomPlantMutationListPrototype> RandomPlantMutations = "RandomPlantMutations";
+    private static ProtoId<RandomPlantMutationListPrototype> _randomPlantMutations = "RandomPlantMutations";
 
     [Dependency] private IRobustRandom _robustRandom = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private SharedEntityEffectsSystem _entityEffects = default!;
     private RandomPlantMutationListPrototype _randomMutations = default!;
 
     public override void Initialize()
     {
-        _randomMutations = _prototypeManager.Index(RandomPlantMutations);
+        _randomMutations = ProtoMan.Index(_randomPlantMutations);
     }
 
     /// <summary>

--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -34,7 +34,6 @@ public sealed partial class PlantHolderSystem : EntitySystem
 {
     [Dependency] private AtmosphereSystem _atmosphere = default!;
     [Dependency] private BotanySystem _botany = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private MutationSystem _mutation = default!;
     [Dependency] private AppearanceSystem _appearance = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
@@ -895,7 +894,7 @@ public sealed partial class PlantHolderSystem : EntitySystem
                 if (entry.Quantity < PlantMetabolismRate)
                     continue;
 
-                var reagentProto = _prototype.Index<ReagentPrototype>(entry.Reagent.Prototype);
+                var reagentProto = ProtoMan.Index<ReagentPrototype>(entry.Reagent.Prototype);
                 _entityEffects.ApplyEffects(uid, reagentProto.PlantMetabolisms.ToArray(), entry.Quantity);
             }
 

--- a/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
@@ -107,7 +107,7 @@ public sealed partial class CargoSystem
 
     public void SetupBountyLabel(EntityUid uid, EntityUid stationId, CargoBountyData bounty, PaperComponent? paper = null, CargoBountyLabelComponent? label = null)
     {
-        if (!Resolve(uid, ref paper, ref label) || !_protoMan.Resolve<CargoBountyPrototype>(bounty.Bounty, out var prototype))
+        if (!Resolve(uid, ref paper, ref label) || !ProtoMan.Resolve<CargoBountyPrototype>(bounty.Bounty, out var prototype))
             return;
 
         label.Id = bounty.Id;
@@ -150,7 +150,7 @@ public sealed partial class CargoSystem
         if (!TryGetBountyFromId(station, component.Id, out var bounty, database))
             return;
 
-        if (!_protoMan.Resolve(bounty.Value.Bounty, out var bountyPrototype) ||
+        if (!ProtoMan.Resolve(bounty.Value.Bounty, out var bountyPrototype) ||
             !IsBountyComplete(container.Owner, bountyPrototype))
             return;
 
@@ -269,7 +269,7 @@ public sealed partial class CargoSystem
 
     public bool IsBountyComplete(EntityUid container, CargoBountyData data, out HashSet<EntityUid> bountyEntities)
     {
-        if (!_protoMan.Resolve(data.Bounty, out var proto))
+        if (!ProtoMan.Resolve(data.Bounty, out var proto))
         {
             bountyEntities = new();
             return false;
@@ -280,7 +280,7 @@ public sealed partial class CargoSystem
 
     public bool IsBountyComplete(EntityUid container, string id)
     {
-        if (!_protoMan.TryIndex<CargoBountyPrototype>(id, out var proto))
+        if (!ProtoMan.TryIndex<CargoBountyPrototype>(id, out var proto))
             return false;
 
         return IsBountyComplete(container, proto.Entries);
@@ -288,7 +288,7 @@ public sealed partial class CargoSystem
 
     public bool IsBountyComplete(EntityUid container, ProtoId<CargoBountyPrototype> prototypeId)
     {
-        var prototype = _protoMan.Index(prototypeId);
+        var prototype = ProtoMan.Index(prototypeId);
 
         return IsBountyComplete(container, prototype.Entries);
     }
@@ -393,7 +393,7 @@ public sealed partial class CargoSystem
             return false;
 
         // todo: consider making the cargo bounties weighted.
-        var allBounties = _protoMan.EnumeratePrototypes<CargoBountyPrototype>()
+        var allBounties = ProtoMan.EnumeratePrototypes<CargoBountyPrototype>()
             .Where(p => p.Group == component.Group)
             .ToList();
         var filteredBounties = new List<CargoBountyPrototype>();
@@ -412,7 +412,7 @@ public sealed partial class CargoSystem
     [PublicAPI]
     public bool TryAddBounty(EntityUid uid, string bountyId, StationCargoBountyDatabaseComponent? component = null)
     {
-        if (!_protoMan.TryIndex<CargoBountyPrototype>(bountyId, out var bounty))
+        if (!ProtoMan.TryIndex<CargoBountyPrototype>(bountyId, out var bounty))
         {
             return false;
         }

--- a/Content.Server/Cargo/Systems/CargoSystem.Funds.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Funds.cs
@@ -48,12 +48,12 @@ public sealed partial class CargoSystem
         UpdateBankAccount((station, bank), -args.Amount, ent.Comp.Account, dirty: false);
         _audio.PlayPvs(ApproveSound, ent);
 
-        var ourAccount = _protoMan.Index(ent.Comp.Account);
+        var ourAccount = ProtoMan.Index(ent.Comp.Account);
         var name = _identity.GetIdentityShortInfo(args.Actor, ent)
                    ?? Loc.GetString("cargo-console-fund-transfer-user-unknown");
         if (args.Account == null)
         {
-            var stackPrototype = _protoMan.Index(ent.Comp.CashType);
+            var stackPrototype = ProtoMan.Index(ent.Comp.CashType);
             _stack.SpawnAtPosition(args.Amount, stackPrototype, Transform(ent).Coordinates);
 
             if (!_emag.CheckFlag(ent, EmagType.Interaction))
@@ -68,7 +68,7 @@ public sealed partial class CargoSystem
         }
         else
         {
-            var otherAccount = _protoMan.Index(args.Account.Value);
+            var otherAccount = ProtoMan.Index(args.Account.Value);
             UpdateBankAccount((station, bank), args.Amount, args.Account.Value);
 
             if (!_emag.CheckFlag(ent, EmagType.Interaction))

--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -65,7 +65,7 @@ namespace Content.Server.Cargo.Systems
             if (!TryGetOrderDatabase(stationUid, out var orderDatabase))
                 return;
 
-            if (!_protoMan.TryIndex(slip.Product, out var product))
+            if (!ProtoMan.TryIndex(slip.Product, out var product))
             {
                 Log.Error($"Tried to add invalid cargo product {slip.Product} as order!");
                 return;
@@ -166,13 +166,13 @@ namespace Content.Server.Cargo.Systems
 
             // Find our order again. It might have been dispatched or approved already
             var order = orderDatabase.Orders[component.Account].Find(order => args.OrderId == order.OrderId && !order.Approved);
-            if (order == null || !_protoMan.Resolve(order.Account, out var account))
+            if (order == null || !ProtoMan.Resolve(order.Account, out var account))
             {
                 return;
             }
 
             // Invalid order
-            if (!_protoMan.Resolve(order.Product, out var product))
+            if (!ProtoMan.Resolve(order.Product, out var product))
             {
                 ConsolePopup(args.Actor, Loc.GetString("cargo-console-invalid-product"));
                 PlayDenySound(uid, component);
@@ -330,7 +330,7 @@ namespace Content.Server.Cargo.Systems
 
         private void OnAddOrderMessageSlipPrinter(EntityUid uid, CargoOrderConsoleComponent component, CargoConsoleAddOrderMessage args, CargoProductPrototype product)
         {
-            if (!_protoMan.Resolve(component.Account, out var account))
+            if (!ProtoMan.Resolve(component.Account, out var account))
                 return;
 
             if (Timing.CurTime < component.NextPrintTime)
@@ -377,7 +377,7 @@ namespace Content.Server.Cargo.Systems
             if (!TryComp<StationBankAccountComponent>(stationUid, out var bank))
                 return;
 
-            if (!_protoMan.TryIndex<CargoProductPrototype>(args.CargoProductId, out var product))
+            if (!ProtoMan.TryIndex<CargoProductPrototype>(args.CargoProductId, out var product))
             {
                 Log.Error($"Tried to add invalid cargo product {args.CargoProductId} as order!");
                 return;
@@ -623,7 +623,7 @@ namespace Content.Server.Cargo.Systems
         /// </summary>
         private bool FulfillOrder(CargoOrderData order, ProtoId<CargoAccountPrototype> account, EntityCoordinates spawn, string? paperProto)
         {
-            if (!_protoMan.Resolve(order.Product, out var product))
+            if (!ProtoMan.Resolve(order.Product, out var product))
                 return false;
 
             // Create the item itself
@@ -660,7 +660,7 @@ namespace Content.Server.Cargo.Systems
                 var val = Loc.GetString("cargo-console-paper-print-name", ("orderNumber", order.OrderId));
                 _metaSystem.SetEntityName(printed, val);
 
-                var accountProto = _protoMan.Index(account);
+                var accountProto = ProtoMan.Index(account);
                 _paperSystem.SetContent((printed, paper),
                     Loc.GetString(
                         "cargo-console-paper-print-text",
@@ -696,7 +696,7 @@ namespace Content.Server.Cargo.Systems
 
             // Note that a market must be both on the station and on the console to be available.
             var markets = ent.Comp.AllowedGroups.Intersect(db.Markets).ToList();
-            foreach (var product in _protoMan.EnumeratePrototypes<CargoProductPrototype>())
+            foreach (var product in ProtoMan.EnumeratePrototypes<CargoProductPrototype>())
             {
                 if (!markets.Contains(product.Group))
                     continue;

--- a/Content.Server/Cargo/Systems/CargoSystem.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.cs
@@ -15,7 +15,6 @@ using Content.Shared.Paper;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Cargo.Systems;
@@ -23,7 +22,6 @@ namespace Content.Server.Cargo.Systems;
 public sealed partial class CargoSystem : SharedCargoSystem
 {
     [Dependency] private IConfigurationManager _cfg = default!;
-    [Dependency] private IPrototypeManager _protoMan = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private AccessReaderSystem _accessReaderSystem = default!;

--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -25,7 +25,6 @@ public sealed partial class PricingSystem : EntitySystem
 {
     [Dependency] private IConsoleHost _consoleHost = default!;
     [Dependency] private IRobustRandom _random = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private MobStateSystem _mobStateSystem = default!;
     [Dependency] private SharedSolutionContainerSystem _solutionContainerSystem = default!;
 
@@ -134,7 +133,7 @@ public sealed partial class PricingSystem : EntitySystem
         double price = 0;
         foreach (var (id, quantity) in component.MaterialComposition)
         {
-            price += _prototypeManager.Index<MaterialPrototype>(id).Price * quantity;
+            price += ProtoMan.Index<MaterialPrototype>(id).Price * quantity;
         }
         return price;
     }
@@ -145,14 +144,14 @@ public sealed partial class PricingSystem : EntitySystem
 
         if (recipe.Result is { } result)
         {
-            price += GetEstimatedPrice(_prototypeManager.Index(result));
+            price += GetEstimatedPrice(ProtoMan.Index(result));
         }
 
         if (recipe.ResultReagents is { } resultReagents)
         {
             foreach (var (reagent, amount) in resultReagents)
             {
-                price += (_prototypeManager.Index(reagent).PricePerUnit * amount).Double();
+                price += (ProtoMan.Index(reagent).PricePerUnit * amount).Double();
             }
         }
 
@@ -285,7 +284,7 @@ public sealed partial class PricingSystem : EntitySystem
             var solution = soln.Comp.Solution;
             foreach (var (reagent, quantity) in solution.Contents)
             {
-                if (!_prototypeManager.TryIndex<ReagentPrototype>(reagent.Prototype, out var reagentProto))
+                if (!ProtoMan.TryIndex<ReagentPrototype>(reagent.Prototype, out var reagentProto))
                     continue;
 
                 // TODO check ReagentData for price information?
@@ -307,7 +306,7 @@ public sealed partial class PricingSystem : EntitySystem
         {
             foreach (var (reagent, quantity) in solution.Contents)
             {
-                if (!_prototypeManager.TryIndex<ReagentPrototype>(reagent.Prototype, out var reagentProto))
+                if (!ProtoMan.TryIndex<ReagentPrototype>(reagent.Prototype, out var reagentProto))
                     continue;
 
                 // TODO check ReagentData for price information?

--- a/Content.Server/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Server/CharacterInfo/CharacterInfoSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.CharacterInfo;
 using Content.Shared.Objectives;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Objectives.Systems;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.CharacterInfo;
 
@@ -15,7 +14,6 @@ public sealed partial class CharacterInfoSystem : EntitySystem
     [Dependency] private MindSystem _minds = default!;
     [Dependency] private RoleSystem _roles = default!;
     [Dependency] private SharedObjectivesSystem _objectives = default!;
-    [Dependency] private IPrototypeManager _protoMan = default!;
 
     public override void Initialize()
     {
@@ -44,7 +42,7 @@ public sealed partial class CharacterInfoSystem : EntitySystem
                 if (info == null)
                     continue;
 
-                if (!_protoMan.TryIndex(Comp<ObjectiveComponent>(objective).Issuer, out var issuerProto))
+                if (!ProtoMan.TryIndex(Comp<ObjectiveComponent>(objective).Issuer, out var issuerProto))
                 {
                     Log.Error($"Found incorrect objective issuer {issuerProto} when generating character info for objective {MetaData(objective).EntityPrototype}.");
                     continue;

--- a/Content.Server/Chat/Systems/AutoEmoteSystem.cs
+++ b/Content.Server/Chat/Systems/AutoEmoteSystem.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using Content.Shared.Chat;
 using Content.Shared.Chat.Prototypes;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -11,7 +10,6 @@ namespace Content.Server.Chat.Systems;
 public sealed partial class AutoEmoteSystem : EntitySystem
 {
     [Dependency] private IGameTiming _gameTiming = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private ChatSystem _chatSystem = default!;
 
@@ -39,7 +37,7 @@ public sealed partial class AutoEmoteSystem : EntitySystem
                 if (time > curTime)
                     continue;
 
-                var autoEmotePrototype = _prototypeManager.Index<AutoEmotePrototype>(key);
+                var autoEmotePrototype = ProtoMan.Index<AutoEmotePrototype>(key);
                 ResetTimer(uid, key, autoEmote, autoEmotePrototype);
 
                 if (!_random.Prob(autoEmotePrototype.Chance))
@@ -106,7 +104,7 @@ public sealed partial class AutoEmoteSystem : EntitySystem
         if (!Resolve(uid, ref autoEmote, logMissing: false))
             return false;
 
-        DebugTools.Assert(_prototypeManager.HasIndex<AutoEmotePrototype>(autoEmotePrototypeId), "Prototype not found. Did you make a typo?");
+        DebugTools.Assert(ProtoMan.HasIndex<AutoEmotePrototype>(autoEmotePrototypeId), "Prototype not found. Did you make a typo?");
 
         if (!autoEmote.EmoteTimers.Remove(autoEmotePrototypeId))
             return false;
@@ -132,7 +130,7 @@ public sealed partial class AutoEmoteSystem : EntitySystem
         if (!autoEmote.Emotes.Contains(autoEmotePrototypeId))
             return false;
 
-        autoEmotePrototype ??= _prototypeManager.Index<AutoEmotePrototype>(autoEmotePrototypeId);
+        autoEmotePrototype ??= ProtoMan.Index<AutoEmotePrototype>(autoEmotePrototypeId);
 
         var curTime = _gameTiming.CurTime;
         var time = curTime + autoEmotePrototype.Interval;

--- a/Content.Server/Chat/Systems/ChatNotificationSystem.cs
+++ b/Content.Server/Chat/Systems/ChatNotificationSystem.cs
@@ -14,7 +14,6 @@ namespace Content.Server.Chat.Systems;
 /// </summary>
 public sealed partial class ChatNotificationSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IChatManager _chats = default!;
     [Dependency] private SharedMindSystem _mind = default!;
     [Dependency] private SharedRoleSystem _roles = default!;
@@ -49,7 +48,7 @@ public sealed partial class ChatNotificationSystem : EntitySystem
     /// <param name="args">The chat notification event</param>
     public void OnChatNotification(Entity<ActorComponent> ent, ref ChatNotificationEvent args)
     {
-        if (!_proto.TryIndex(args.ChatNotification, out var chatNotification))
+        if (!ProtoMan.TryIndex(args.ChatNotification, out var chatNotification))
         {
             _sawmill.Warning("Attempted to index ChatNotificationPrototype " + args.ChatNotification + " but the prototype does not exist.");
             return;

--- a/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
@@ -43,7 +43,7 @@ public sealed partial class ChatSystem
             RaiseLocalEvent(source, nameEv);
             name = nameEv.VoiceName;
             // Check for a speech verb override
-            if (nameEv.SpeechVerb != null && _prototypeManager.Resolve(nameEv.SpeechVerb, out var proto))
+            if (nameEv.SpeechVerb != null && ProtoMan.Resolve(nameEv.SpeechVerb, out var proto))
                 speech = proto;
         }
 

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -18,7 +18,6 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Replays;
 
@@ -37,7 +36,6 @@ public sealed partial class ChatSystem : SharedChatSystem
     [Dependency] private IChatSanitizationManager _sanitizer = default!;
     [Dependency] private IAdminManager _adminManager = default!;
     [Dependency] private IPlayerManager _playerManager = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
     [Dependency] private ActionBlockerSystem _actionBlocker = default!;

--- a/Content.Server/Chat/Systems/EmoteOnDamageSystem.cs
+++ b/Content.Server/Chat/Systems/EmoteOnDamageSystem.cs
@@ -1,19 +1,15 @@
 using Content.Shared.Damage.Systems;
-
-namespace Content.Server.Chat.Systems;
-
 using Content.Shared.Chat;
 using Content.Shared.Chat.Prototypes;
-using Content.Shared.Damage;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
+namespace Content.Server.Chat.Systems;
+
 public sealed partial class EmoteOnDamageSystem : EntitySystem
 {
     [Dependency] private IGameTiming _gameTiming = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private ChatSystem _chatSystem = default!;
 
@@ -60,7 +56,7 @@ public sealed partial class EmoteOnDamageSystem : EntitySystem
             return false;
 
         DebugTools.Assert(emoteOnDamage.LifeStage <= ComponentLifeStage.Running);
-        DebugTools.Assert(_prototypeManager.HasIndex<EmotePrototype>(emotePrototypeId), "Prototype not found. Did you make a typo?");
+        DebugTools.Assert(ProtoMan.HasIndex<EmotePrototype>(emotePrototypeId), "Prototype not found. Did you make a typo?");
 
         return emoteOnDamage.Emotes.Add(emotePrototypeId);
     }
@@ -73,7 +69,7 @@ public sealed partial class EmoteOnDamageSystem : EntitySystem
         if (!Resolve(uid, ref emoteOnDamage, logMissing: false))
             return false;
 
-        DebugTools.Assert(_prototypeManager.HasIndex<EmotePrototype>(emotePrototypeId), "Prototype not found. Did you make a typo?");
+        DebugTools.Assert(ProtoMan.HasIndex<EmotePrototype>(emotePrototypeId), "Prototype not found. Did you make a typo?");
 
         if (!emoteOnDamage.Emotes.Remove(emotePrototypeId))
             return false;

--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -11,7 +11,6 @@ using Robust.Server.Audio;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
-using Robust.Shared.Prototypes;
 using Content.Shared.Labels.Components;
 using Content.Shared.Storage;
 using Content.Server.Hands.Systems;
@@ -30,7 +29,6 @@ namespace Content.Server.Chemistry.EntitySystems
         [Dependency] private SolutionTransferSystem _solutionTransferSystem = default!;
         [Dependency] private ItemSlotsSystem _itemSlotsSystem = default!;
         [Dependency] private UserInterfaceSystem _userInterfaceSystem = default!;
-        [Dependency] private IPrototypeManager _prototypeManager = default!;
         [Dependency] private OpenableSystem _openable = default!;
         [Dependency] private HandsSystem _handsSystem = default!;
 
@@ -107,7 +105,7 @@ namespace Content.Server.Chemistry.EntitySystems
                 if (_solutionContainerSystem.TryGetDrainableSolution(storedContainer, out _, out var sol))
                 {
                     quantity = sol.Volume;
-                    reagentColor = sol.GetColor(_prototypeManager);
+                    reagentColor = sol.GetColor(ProtoMan);
                 }
 
                 inventory.Add(new ReagentInventoryItem(storageLocation, reagentLabel, quantity, reagentColor));

--- a/Content.Server/Chemistry/EntitySystems/SolutionRandomFillSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionRandomFillSystem.cs
@@ -3,8 +3,6 @@ using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
-using Content.Shared.Storage.Components;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Chemistry.EntitySystems;
@@ -12,7 +10,6 @@ namespace Content.Server.Chemistry.EntitySystems;
 public sealed partial class SolutionRandomFillSystem : EntitySystem
 {
     [Dependency] private SharedSolutionContainerSystem _solutionsSystem = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IRobustRandom _random = default!;
 
     public override void Initialize()
@@ -27,12 +24,12 @@ public sealed partial class SolutionRandomFillSystem : EntitySystem
         if (entity.Comp.WeightedRandomId == null)
             return;
 
-        var pick = _proto.Index<WeightedRandomFillSolutionPrototype>(entity.Comp.WeightedRandomId).Pick(_random);
+        var pick = ProtoMan.Index<WeightedRandomFillSolutionPrototype>(entity.Comp.WeightedRandomId).Pick(_random);
 
         var reagent = pick.reagent;
         var quantity = pick.quantity;
 
-        if (!_proto.HasIndex<ReagentPrototype>(reagent))
+        if (!ProtoMan.HasIndex<ReagentPrototype>(reagent))
         {
             Log.Error($"Tried to add invalid reagent Id {reagent} using SolutionRandomFill.");
             return;

--- a/Content.Server/Chemistry/EntitySystems/TransformableContainerSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/TransformableContainerSystem.cs
@@ -2,13 +2,11 @@ using Content.Server.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.NameModifier.EntitySystems;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Chemistry.EntitySystems;
 
 public sealed partial class TransformableContainerSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private SharedSolutionContainerSystem _solutionsSystem = default!;
     [Dependency] private MetaDataSystem _metadataSystem = default!;
     [Dependency] private NameModifierSystem _nameMod = default!;
@@ -53,7 +51,7 @@ public sealed partial class TransformableContainerSystem : EntitySystem
 
         //Only reagents with spritePath property can change appearance of transformable containers!
         if (!string.IsNullOrWhiteSpace(reagentId?.Prototype)
-            && _prototypeManager.TryIndex(reagentId.Value.Prototype, out ReagentPrototype? proto))
+            && ProtoMan.TryIndex(reagentId.Value.Prototype, out ReagentPrototype? proto))
         {
             var metadata = MetaData(entity.Owner);
             _metadataSystem.SetEntityDescription(entity.Owner, proto.LocalizedDescription, metadata);
@@ -66,7 +64,7 @@ public sealed partial class TransformableContainerSystem : EntitySystem
 
     private void OnRefreshNameModifiers(Entity<TransformableContainerComponent> entity, ref RefreshNameModifiersEvent args)
     {
-        if (_prototypeManager.Resolve(entity.Comp.CurrentReagent, out var currentReagent))
+        if (ProtoMan.Resolve(entity.Comp.CurrentReagent, out var currentReagent))
         {
             args.AddModifier("transformable-container-component-glass", priority: -1, ("reagent", currentReagent.LocalizedName));
         }

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -11,8 +11,6 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
-using Robust.Shared.Physics.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Spawners;
 using System.Numerics;
 using Content.Shared.Vapor;
@@ -22,12 +20,10 @@ namespace Content.Server.Chemistry.EntitySystems
     [UsedImplicitly]
     internal sealed partial class VaporSystem : EntitySystem
     {
-        [Dependency] private IPrototypeManager _protoManager = default!;
         [Dependency] private ReactiveSystem _reactive = default!;
         [Dependency] private ThrowingSystem _throwing = default!;
         [Dependency] private SharedAppearanceSystem _appearance = default!;
         [Dependency] private SharedMapSystem _map = default!;
-        [Dependency] private SharedPhysicsSystem _physics = default!;
         [Dependency] private SharedSolutionContainerSystem _solutionContainer = default!;
         [Dependency] private SharedTransformSystem _transformSystem = default!;
 
@@ -85,7 +81,7 @@ namespace Content.Server.Chemistry.EntitySystems
 
             if (TryComp<AppearanceComponent>(vapor, out var appearance))
             {
-                _appearance.SetData(vapor, VaporVisuals.Color, newSolution.GetColor(_protoManager).WithAlpha(1f), appearance);
+                _appearance.SetData(vapor, VaporVisuals.Color, newSolution.GetColor(ProtoMan).WithAlpha(1f), appearance);
                 _appearance.SetData(vapor, VaporVisuals.State, true, appearance);
             }
 
@@ -126,7 +122,7 @@ namespace Content.Server.Chemistry.EntitySystems
                         if (reagentQuantity.Quantity == FixedPoint2.Zero)
                             continue;
 
-                        var reagent = _protoManager.Index<ReagentPrototype>(reagentQuantity.Reagent.Prototype);
+                        var reagent = ProtoMan.Index<ReagentPrototype>(reagentQuantity.Reagent.Prototype);
 
                         // Limit the reaction amount to a minimum value to ensure no floating point funnies.
                         // Ex: A solution with a low percentage transfer amount will slowly approach 0.01... and never get deleted

--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -29,7 +29,6 @@ public sealed partial class CloningSystem : SharedCloningSystem
 {
     [Dependency] private InventorySystem _inventory = default!;
     [Dependency] private MetaDataSystem _metaData = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private SharedContainerSystem _container = default!;
@@ -46,13 +45,13 @@ public sealed partial class CloningSystem : SharedCloningSystem
         [NotNullWhen(true)] out EntityUid? clone)
     {
         clone = null;
-        if (!_prototype.Resolve(settingsId, out var settings))
+        if (!ProtoMan.Resolve(settingsId, out var settings))
             return false; // invalid settings
 
         if (!TryComp<HumanoidProfileComponent>(original, out var humanoid))
             return false; // whatever body was to be cloned, was not a humanoid
 
-        if (!_prototype.Resolve(humanoid.Species, out var speciesPrototype))
+        if (!ProtoMan.Resolve(humanoid.Species, out var speciesPrototype))
             return false; // invalid species
 
         if (!settings.ForceCloning)
@@ -100,7 +99,7 @@ public sealed partial class CloningSystem : SharedCloningSystem
         EntityUid clone,
         ProtoId<CloningSettingsPrototype> settings)
     {
-        if (!_prototype.Resolve(settings, out var proto))
+        if (!ProtoMan.Resolve(settings, out var proto))
             return;
 
         CloneComponents(original, clone, proto);

--- a/Content.Server/Cloning/RandomCloneSpawnerSystem.cs
+++ b/Content.Server/Cloning/RandomCloneSpawnerSystem.cs
@@ -1,8 +1,5 @@
 using Content.Server.Cloning.Components;
-using Content.Shared.Mind;
-using Content.Shared.Mobs.Systems;
 using Content.Shared.Objectives.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Cloning;
@@ -13,7 +10,6 @@ namespace Content.Server.Cloning;
 public sealed partial class RandomCloneSpawnerSystem : EntitySystem
 {
     [Dependency] private CloningSystem _cloning = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SharedTransformSystem _transformSystem = default!;
     [Dependency] private TargetSystem _target = default!;
@@ -29,7 +25,7 @@ public sealed partial class RandomCloneSpawnerSystem : EntitySystem
     {
         QueueDel(ent.Owner);
 
-        if (!_prototypeManager.TryIndex(ent.Comp.Settings, out var settings))
+        if (!ProtoMan.TryIndex(ent.Comp.Settings, out var settings))
         {
             Log.Error($"Used invalid cloning settings {ent.Comp.Settings} for RandomCloneSpawner");
             return;

--- a/Content.Server/Clothing/Systems/ChameleonClothingSystem.cs
+++ b/Content.Server/Clothing/Systems/ChameleonClothingSystem.cs
@@ -3,14 +3,12 @@ using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Emp;
 using Content.Shared.IdentityManagement;
 using Content.Shared.IdentityManagement.Components;
-using Content.Shared.Prototypes;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.Clothing.Systems;
 
 public sealed partial class ChameleonClothingSystem : SharedChameleonClothingSystem
 {
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IdentitySystem _identity = default!;
 
     public override void Initialize()
@@ -51,7 +49,7 @@ public sealed partial class ChameleonClothingSystem : SharedChameleonClothingSys
             return;
 
         // make sure that it is valid change
-        if (string.IsNullOrEmpty(protoId) || !_proto.TryIndex(protoId, out EntityPrototype? proto))
+        if (string.IsNullOrEmpty(protoId) || !ProtoMan.TryIndex(protoId, out EntityPrototype? proto))
             return;
 
         if (validate && !IsValidTarget(proto, component.Slot, component.RequireTag))
@@ -88,7 +86,7 @@ public sealed partial class ChameleonClothingSystem : SharedChameleonClothingSys
 
     private void UpdateIdentityBlocker(EntityUid uid, ChameleonClothingComponent component, EntityPrototype proto)
     {
-        if (proto.HasComponent<IdentityBlockerComponent>(Factory))
+        if (proto.HasComp<IdentityBlockerComponent>(Factory))
             EnsureComp<IdentityBlockerComponent>(uid);
         else
             RemComp<IdentityBlockerComponent>(uid);

--- a/Content.Server/Clothing/Systems/OutfitSystem.cs
+++ b/Content.Server/Clothing/Systems/OutfitSystem.cs
@@ -15,14 +15,12 @@ using Content.Shared.Station;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Storage;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Clothing.Systems;
 
 public sealed partial class OutfitSystem : EntitySystem
 {
     [Dependency] private IServerPreferencesManager _preferenceManager = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private HandsSystem _handSystem = default!;
     [Dependency] private InventorySystem _invSystem = default!;
     [Dependency] private SharedStationSpawningSystem _spawningSystem = default!;
@@ -34,7 +32,7 @@ public sealed partial class OutfitSystem : EntitySystem
         if (!TryComp(target, out InventoryComponent? inventoryComponent))
             return false;
 
-        if (!_prototypeManager.TryIndex<StartingGearPrototype>(gear, out var startingGear))
+        if (!ProtoMan.TryIndex<StartingGearPrototype>(gear, out var startingGear))
             return false;
 
         HumanoidCharacterProfile? profile = null;
@@ -110,14 +108,14 @@ public sealed partial class OutfitSystem : EntitySystem
         }
 
         // See if this starting gear is associated with a job
-        var jobs = _prototypeManager.EnumeratePrototypes<JobPrototype>();
+        var jobs = ProtoMan.EnumeratePrototypes<JobPrototype>();
         foreach (var job in jobs)
         {
             if (job.StartingGear != gear)
                 continue;
 
             var jobProtoId = LoadoutSystem.GetJobPrototype(job.ID);
-            if (!_prototypeManager.TryIndex<RoleLoadoutPrototype>(jobProtoId, out var jobProto))
+            if (!ProtoMan.TryIndex<RoleLoadoutPrototype>(jobProtoId, out var jobProto))
                 break;
 
             // Don't require a player, so this works on Urists
@@ -131,7 +129,7 @@ public sealed partial class OutfitSystem : EntitySystem
             {
                 // If they don't have a loadout for the role, make a default one
                 roleLoadout = new RoleLoadout(jobProtoId);
-                roleLoadout.SetDefault(profile, session, _prototypeManager);
+                roleLoadout.SetDefault(profile, session, ProtoMan);
             }
 
             // Equip the target with the job loadout

--- a/Content.Server/Cluwne/CluwneSystem.cs
+++ b/Content.Server/Cluwne/CluwneSystem.cs
@@ -15,7 +15,6 @@ using Content.Shared.Popups;
 using Content.Shared.Stunnable;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Random;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Cluwne;
 
@@ -27,7 +26,6 @@ public sealed partial class CluwneSystem : EntitySystem
     [Dependency] private IRobustRandom _robustRandom = default!;
     [Dependency] private SharedStunSystem _stunSystem = default!;
     [Dependency] private DamageableSystem _damageableSystem = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private ChatSystem _chat = default!;
     [Dependency] private AutoEmoteSystem _autoEmote = default!;
     [Dependency] private NameModifierSystem _nameMod = default!;
@@ -68,7 +66,7 @@ public sealed partial class CluwneSystem : EntitySystem
         if (ent.Comp.EmoteSoundsId == null)
             return;
 
-        _prototypeManager.TryIndex(ent.Comp.EmoteSoundsId, out EmoteSounds);
+        ProtoMan.TryIndex(ent.Comp.EmoteSoundsId, out EmoteSounds);
 
 
         if (ent.Comp.RandomEmote && ent.Comp.AutoEmoteId != null)

--- a/Content.Server/Codewords/CodewordSystem.cs
+++ b/Content.Server/Codewords/CodewordSystem.cs
@@ -13,7 +13,6 @@ namespace Content.Server.Codewords;
 /// </summary>
 public sealed partial class CodewordSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
     [Dependency] private IRobustRandom _random = default!;
 
@@ -53,7 +52,7 @@ public sealed partial class CodewordSystem : EntitySystem
 
     private string[] GenerateForFaction(ProtoId<CodewordFactionPrototype> faction, ref CodewordManagerComponent manager)
     {
-        var factionProto = _prototypeManager.Index<CodewordFactionPrototype>(faction.Id);
+        var factionProto = ProtoMan.Index<CodewordFactionPrototype>(faction.Id);
 
         var codewords = GenerateCodewords(factionProto.Generator);
         var codewordsContainer = Spawn(prototype: null, MapCoordinates.Nullspace);
@@ -70,11 +69,11 @@ public sealed partial class CodewordSystem : EntitySystem
     /// </summary>
     public string[] GenerateCodewords(ProtoId<CodewordGeneratorPrototype> generatorId)
     {
-        var generator = _prototypeManager.Index(generatorId);
+        var generator = ProtoMan.Index(generatorId);
 
         var codewordPool = new List<string>();
         foreach (var dataset in generator.Words
-                     .Select(datasetPrototype => _prototypeManager.Index(datasetPrototype)))
+                     .Select(datasetPrototype => ProtoMan.Index(datasetPrototype)))
         {
             codewordPool.AddRange(dataset.Values);
         }

--- a/Content.Server/Communications/CommsHackerSystem.cs
+++ b/Content.Server/Communications/CommsHackerSystem.cs
@@ -6,9 +6,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
-using Robust.Shared.Serialization;
 
 namespace Content.Server.Communications;
 
@@ -16,7 +14,6 @@ public sealed partial class CommsHackerSystem : SharedCommsHackerSystem
 {
     [Dependency] private ChatSystem _chat = default!;
     [Dependency] private GameTicker _gameTicker = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IRobustRandom _random = default!;
     // TODO: remove when generic check event is used
     [Dependency] private NinjaGlovesSystem _gloves = default!;
@@ -62,9 +59,9 @@ public sealed partial class CommsHackerSystem : SharedCommsHackerSystem
         if (args.Cancelled || args.Handled || args.Target == null)
             return;
 
-        var threats = _proto.Index<WeightedRandomPrototype>(comp.Threats);
+        var threats = ProtoMan.Index<WeightedRandomPrototype>(comp.Threats);
         var threat = threats.Pick(_random);
-        CallInThreat(_proto.Index<NinjaHackingThreatPrototype>(threat));
+        CallInThreat(ProtoMan.Index<NinjaHackingThreatPrototype>(threat));
 
         // prevent calling in multiple threats
         RemComp<CommsHackerComponent>(uid);

--- a/Content.Server/Crayon/CrayonSystem.cs
+++ b/Content.Server/Crayon/CrayonSystem.cs
@@ -13,14 +13,12 @@ using Content.Shared.Nutrition.EntitySystems;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Crayon;
 
 public sealed partial class CrayonSystem : SharedCrayonSystem
 {
     [Dependency] private IAdminLogManager _adminLogger = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private DecalSystem _decals = default!;
     [Dependency] private PopupSystem _popup = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
@@ -42,7 +40,7 @@ public sealed partial class CrayonSystem : SharedCrayonSystem
     private void OnMapInit(Entity<CrayonComponent> ent, ref MapInitEvent args)
     {
         // Get the first one from the catalog and set it as default
-        var decal = _prototypeManager.EnumeratePrototypes<DecalPrototype>().FirstOrDefault(x => x.Tags.Contains("crayon"));
+        var decal = ProtoMan.EnumeratePrototypes<DecalPrototype>().FirstOrDefault(x => x.Tags.Contains("crayon"));
         ent.Comp.SelectedState = decal?.ID ?? string.Empty;
         Dirty(ent);
     }
@@ -106,7 +104,7 @@ public sealed partial class CrayonSystem : SharedCrayonSystem
     private void OnCrayonBoundUI(EntityUid uid, CrayonComponent component, CrayonSelectMessage args)
     {
         // Check if the selected state is valid
-        if (!_prototypeManager.TryIndex<DecalPrototype>(args.State, out var prototype) || !prototype.Tags.Contains("crayon"))
+        if (!ProtoMan.TryIndex<DecalPrototype>(args.State, out var prototype) || !prototype.Tags.Contains("crayon"))
             return;
 
         component.SelectedState = args.State;

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using Content.Server.Administration;
 using Content.Server.EUI;
 using Content.Server.Station.Systems;
-using Content.Server.StationRecords;
 using Content.Server.StationRecords.Systems;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
@@ -14,7 +13,6 @@ using Content.Shared.StationRecords;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.CrewManifest;
 
@@ -24,7 +22,6 @@ public sealed partial class CrewManifestSystem : EntitySystem
     [Dependency] private StationRecordsSystem _recordsSystem = default!;
     [Dependency] private EuiManager _euiManager = default!;
     [Dependency] private IConfigurationManager _configManager = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
 
     /// <summary>
     ///     Cached crew manifest entries. The alternative is to outright
@@ -231,7 +228,7 @@ public sealed partial class CrewManifestSystem : EntitySystem
             var record = recordObject.Item2;
             var entry = new CrewManifestEntry(record.Name, record.JobTitle, record.JobIcon, record.JobPrototype);
 
-            _prototypeManager.TryIndex(record.JobPrototype, out JobPrototype? job);
+            ProtoMan.TryIndex(record.JobPrototype, out JobPrototype? job);
             entriesSort.Add((job, entry));
         }
 

--- a/Content.Server/CriminalRecords/Systems/CriminalRecordsHackerSystem.cs
+++ b/Content.Server/CriminalRecords/Systems/CriminalRecordsHackerSystem.cs
@@ -7,7 +7,6 @@ using Content.Shared.CriminalRecords.Systems;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Security;
 using Content.Shared.StationRecords;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.CriminalRecords.Systems;
@@ -16,7 +15,6 @@ public sealed partial class CriminalRecordsHackerSystem : SharedCriminalRecordsH
 {
     [Dependency] private ChatSystem _chat = default!;
     [Dependency] private CriminalRecordsSystem _criminalRecords = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private StationSystem _station = default!;
     [Dependency] private StationRecordsSystem _records = default!;
@@ -36,7 +34,7 @@ public sealed partial class CriminalRecordsHackerSystem : SharedCriminalRecordsH
         if (_station.GetOwningStation(ent) is not {} station)
             return;
 
-        var reasons = _proto.Index(ent.Comp.Reasons);
+        var reasons = ProtoMan.Index(ent.Comp.Reasons);
         foreach (var (key, record) in _records.GetRecordsOfType<CriminalRecord>(station))
         {
             var reason = _random.Pick(reasons);

--- a/Content.Server/Damage/ForceSay/DamageForceSaySystem.cs
+++ b/Content.Server/Damage/ForceSay/DamageForceSaySystem.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Bed.Sleep;
-using Content.Shared.Damage;
 using Content.Shared.Damage.Events;
 using Content.Shared.Damage.ForceSay;
 using Content.Shared.Damage.Systems;
@@ -9,7 +8,6 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Stunnable;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -19,7 +17,6 @@ namespace Content.Server.Damage.ForceSay;
 public sealed partial class DamageForceSaySystem : EntitySystem
 {
     [Dependency] private IGameTiming _timing = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IRobustRandom _random = default!;
 
     public override void Initialize()
@@ -63,7 +60,7 @@ public sealed partial class DamageForceSaySystem : EntitySystem
         var ev = new BeforeForceSayEvent(component.ForceSayStringDataset);
         RaiseLocalEvent(uid, ev);
 
-        if (!_prototype.Resolve(ev.Prefix, out var prefixList))
+        if (!ProtoMan.Resolve(ev.Prefix, out var prefixList))
             return;
 
         var suffix = Loc.GetString(_random.Pick(prefixList.Values));
@@ -109,7 +106,7 @@ public sealed partial class DamageForceSaySystem : EntitySystem
         if (component.ValidDamageGroups != null)
         {
             var totalApplicableDamage = FixedPoint2.Zero;
-            foreach (var (group, value) in args.DamageDelta.GetDamagePerGroup(_prototype))
+            foreach (var (group, value) in args.DamageDelta.GetDamagePerGroup(ProtoMan))
             {
                 if (!component.ValidDamageGroups.Contains(group))
                     continue;

--- a/Content.Server/Damage/Systems/ExaminableDamageSystem.cs
+++ b/Content.Server/Damage/Systems/ExaminableDamageSystem.cs
@@ -4,14 +4,12 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Examine;
 using Content.Shared.Rounding;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Damage.Systems;
 
 public sealed partial class ExaminableDamageSystem : EntitySystem
 {
     [Dependency] private DestructibleSystem _destructible = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private DamageableSystem _damageable = default!;
 
     public override void Initialize()
@@ -22,7 +20,7 @@ public sealed partial class ExaminableDamageSystem : EntitySystem
 
     private void OnExamine(Entity<ExaminableDamageComponent> ent, ref ExaminedEvent args)
     {
-        if (!_prototype.Resolve(ent.Comp.Messages, out var proto) || proto.Values.Count == 0)
+        if (!ProtoMan.Resolve(ent.Comp.Messages, out var proto) || proto.Values.Count == 0)
             return;
 
         var percent = GetDamagePercent(ent);

--- a/Content.Server/Delivery/DeliverySystem.cs
+++ b/Content.Server/Delivery/DeliverySystem.cs
@@ -30,7 +30,6 @@ public sealed partial class DeliverySystem : SharedDeliverySystem
     [Dependency] private LabelSystem _label = default!;
     [Dependency] private SharedContainerSystem _container = default!;
     [Dependency] private ChatSystem _chat = default!;
-    [Dependency] private IPrototypeManager _protoMan = default!;
 
     /// <summary>
     /// Default reason to use if the penalization is triggered
@@ -103,7 +102,7 @@ public sealed partial class DeliverySystem : SharedDeliverySystem
         if (ent.Comp.WasPenalized)
             return;
 
-        if (!_protoMan.Resolve(ent.Comp.PenaltyBankAccount, out var accountInfo))
+        if (!ProtoMan.Resolve(ent.Comp.PenaltyBankAccount, out var accountInfo))
             return;
 
         var multiplier = GetDeliveryMultiplier(ent);

--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -30,7 +30,7 @@ public sealed partial class DestructibleSystem : SharedDestructibleSystem
     [Dependency] public IAdminLogManager AdminLogger = default!;
     [Dependency] public IRobustRandom Random = default!;
     public new IEntityManager EntityManager => base.EntityManager;
-    public IPrototypeManager PrototypeManager => base.ProtoMan;
+    public IPrototypeManager PrototypeManager => ProtoMan;
 
     [Dependency] public AtmosphereSystem AtmosphereSystem = default!;
     [Dependency] public ConstructionSystem ConstructionSystem = default!;

--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -28,9 +28,9 @@ namespace Content.Server.Destructible;
 public sealed partial class DestructibleSystem : SharedDestructibleSystem
 {
     [Dependency] public IAdminLogManager AdminLogger = default!;
-    [Dependency] public IPrototypeManager PrototypeManager = default!;
     [Dependency] public IRobustRandom Random = default!;
     public new IEntityManager EntityManager => base.EntityManager;
+    public IPrototypeManager PrototypeManager => base.ProtoMan;
 
     [Dependency] public AtmosphereSystem AtmosphereSystem = default!;
     [Dependency] public ConstructionSystem ConstructionSystem = default!;

--- a/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
@@ -1,11 +1,10 @@
-﻿using System.Numerics;
+using System.Numerics;
 using Content.Server.Spawners.Components;
 using Content.Server.Spawners.EntitySystems;
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
 using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Spawners;
 using Robust.Shared.Random;
 

--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -1,13 +1,12 @@
-using Content.Shared.DeviceNetwork;
-using JetBrains.Annotations;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared.DeviceNetwork;
 using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.DeviceNetwork.Events;
 using Content.Shared.DeviceNetwork.Systems;
 using Content.Shared.Examine;
+using JetBrains.Annotations;
+using Robust.Shared.Random;
 
 namespace Content.Server.DeviceNetwork.Systems
 {
@@ -19,7 +18,6 @@ namespace Content.Server.DeviceNetwork.Systems
     public sealed partial class DeviceNetworkSystem : SharedDeviceNetworkSystem
     {
         [Dependency] private IRobustRandom _random = default!;
-        [Dependency] private IPrototypeManager _protoMan = default!;
         [Dependency] private SharedTransformSystem _transformSystem = default!;
         [Dependency] private DeviceListSystem _deviceLists = default!;
         [Dependency] private NetworkConfiguratorSystem _configurator = default!;
@@ -107,14 +105,14 @@ namespace Content.Server.DeviceNetwork.Systems
         {
             if (device.ReceiveFrequency == null
                 && device.ReceiveFrequencyId != null
-                && _protoMan.TryIndex<DeviceFrequencyPrototype>(device.ReceiveFrequencyId, out var receive))
+                && ProtoMan.TryIndex<DeviceFrequencyPrototype>(device.ReceiveFrequencyId, out var receive))
             {
                 device.ReceiveFrequency = receive.Frequency;
             }
 
             if (device.TransmitFrequency == null
                 && device.TransmitFrequencyId != null
-                && _protoMan.TryIndex<DeviceFrequencyPrototype>(device.TransmitFrequencyId, out var xmit))
+                && ProtoMan.TryIndex<DeviceFrequencyPrototype>(device.TransmitFrequencyId, out var xmit))
             {
                 device.TransmitFrequency = xmit.Frequency;
             }

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -37,7 +37,6 @@ namespace Content.Server.Electrocution;
 public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
 {
     [Dependency] private IAdminLogManager _adminLogger = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private EntityLookupSystem _entityLookup = default!;
@@ -405,7 +404,7 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
 
         if (shockDamage is { } dmg)
         {
-            if (_damageable.TryChangeDamage(uid, new DamageSpecifier(_prototypeManager.Index(DamageType), dmg), out var damage, origin: sourceUid))
+            if (_damageable.TryChangeDamage(uid, new DamageSpecifier(ProtoMan.Index(DamageType), dmg), out var damage, origin: sourceUid))
             {
                 _adminLogger.Add(LogType.Electrocution,
                     $"{ToPrettyString(uid):entity} received {damage:damage} powered electrocution damage{(sourceUid != null ? " from " + ToPrettyString(sourceUid.Value) : ""):source}");

--- a/Content.Server/Emoting/Systems/BodyEmotesSystem.cs
+++ b/Content.Server/Emoting/Systems/BodyEmotesSystem.cs
@@ -9,7 +9,6 @@ namespace Content.Server.Emoting.Systems;
 
 public sealed partial class BodyEmotesSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private ChatSystem _chat = default!;
 
     public override void Initialize()
@@ -37,7 +36,7 @@ public sealed partial class BodyEmotesSystem : EntitySystem
         if (!TryComp(uid, out HandsComponent? hands) || hands.Count <= 0)
             return false;
 
-        if (!_proto.Resolve(component.SoundsId, out var sounds))
+        if (!ProtoMan.Resolve(component.SoundsId, out var sounds))
             return false;
 
         return _chat.TryPlayEmoteSound(uid, sounds, emote);

--- a/Content.Server/EntityEffects/Effects/Botany/PlantMutateChemicalsEntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/Effects/Botany/PlantMutateChemicalsEntityEffectSystem.cs
@@ -4,14 +4,12 @@ using Content.Shared.EntityEffects;
 using Content.Shared.EntityEffects.Effects.Botany;
 using Content.Shared.FixedPoint;
 using Content.Shared.Random.Helpers;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.EntityEffects.Effects.Botany;
 
 public sealed partial class PlantMutateChemicalsEntityEffectSystem : EntityEffectSystem<PlantHolderComponent, PlantMutateChemicals>
 {
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IRobustRandom _random = default!;
 
     protected override void Effect(Entity<PlantHolderComponent> entity, ref EntityEffectEvent<PlantMutateChemicals> args)
@@ -20,7 +18,7 @@ public sealed partial class PlantMutateChemicalsEntityEffectSystem : EntityEffec
             return;
 
         var chemicals = entity.Comp.Seed.Chemicals;
-        var randomChems = _proto.Index(args.Effect.RandomPickBotanyReagent);
+        var randomChems = ProtoMan.Index(args.Effect.RandomPickBotanyReagent);
 
         // Add a random amount of a random chemical to this set of chemicals
         var (chemicalId, quantity) = randomChems.Pick(_random);

--- a/Content.Server/EntityEffects/Effects/Botany/PlantMutateSpeciesChangeEntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/Effects/Botany/PlantMutateSpeciesChangeEntityEffectSystem.cs
@@ -2,14 +2,12 @@ using Content.Server.Botany;
 using Content.Server.Botany.Components;
 using Content.Shared.EntityEffects;
 using Content.Shared.EntityEffects.Effects.Botany;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.EntityEffects.Effects.Botany;
 
 public sealed partial class PlantMutateSpeciesChangeEntityEffectSystem : EntityEffectSystem<PlantHolderComponent, PlantMutateSpeciesChange>
 {
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IRobustRandom _random = default!;
 
     protected override void Effect(Entity<PlantHolderComponent> entity, ref EntityEffectEvent<PlantMutateSpeciesChange> args)
@@ -18,7 +16,7 @@ public sealed partial class PlantMutateSpeciesChangeEntityEffectSystem : EntityE
             return;
 
         var targetProto = _random.Pick(entity.Comp.Seed.MutationPrototypes);
-        _proto.TryIndex(targetProto, out SeedPrototype? protoSeed);
+        ProtoMan.TryIndex(targetProto, out SeedPrototype? protoSeed);
 
         if (protoSeed == null)
         {

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Airtight.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Airtight.cs
@@ -38,7 +38,7 @@ public sealed partial class ExplosionSystem
         _explosionTypes.Clear();
 
         int index = 0;
-        foreach (var prototype in _prototypeManager.EnumeratePrototypes<ExplosionPrototype>())
+        foreach (var prototype in ProtoMan.EnumeratePrototypes<ExplosionPrototype>())
         {
             _explosionTypes.Add(prototype.ID, index);
             index++;
@@ -241,7 +241,7 @@ public sealed partial class ExplosionSystem
         {
             // TODO EXPLOSION SYSTEM
             // cache explosion type damage.
-            if (!_prototypeManager.Resolve(id, out var explosionType))
+            if (!ProtoMan.Resolve(id, out var explosionType))
                 continue;
 
             // evaluate the damage that this damage type would do to this entity

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -19,7 +19,6 @@ using Content.Shared.Explosion.EntitySystems;
 using Content.Shared.GameTicking;
 using Content.Shared.Inventory;
 using Content.Shared.Maps;
-using Content.Shared.Projectiles;
 using Content.Shared.Throwing;
 using Robust.Server.GameStates;
 using Robust.Server.Player;
@@ -28,7 +27,6 @@ using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -40,7 +38,6 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
     [Dependency] private IMapManager _mapManager = default!;
     [Dependency] private IRobustRandom _robustRandom = default!;
     [Dependency] private ITileDefinitionManager _tileDefinitionManager = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private IPlayerManager _playerManager = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
@@ -81,7 +78,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
     {
         base.Initialize();
 
-        DebugTools.Assert(_prototypeManager.HasIndex(DefaultExplosionPrototypeId));
+        DebugTools.Assert(ProtoMan.HasIndex(DefaultExplosionPrototypeId));
 
         // handled in ExplosionSystem.GridMap.cs
         SubscribeLocalEvent<GridRemovalEvent>(OnGridRemoved);
@@ -104,7 +101,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
         InitAirtightMap();
         InitVisuals();
 
-        _prototypeManager.PrototypesReloaded += ReloadExplosionPrototypes;
+        ProtoMan.PrototypesReloaded += ReloadExplosionPrototypes;
     }
 
     private void OnReset(RoundRestartCleanupEvent ev)
@@ -123,7 +120,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
         base.Shutdown();
         _nodeGroupSystem.PauseUpdating = false;
         _pathfindingSystem.PauseUpdating = false;
-        _prototypeManager.PrototypesReloaded -= ReloadExplosionPrototypes;
+        ProtoMan.PrototypesReloaded -= ReloadExplosionPrototypes;
     }
 
     private void RelayedResistance(EntityUid uid, ExplosionResistanceComponent component,
@@ -284,7 +281,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
         if (totalIntensity <= 0 || slope <= 0)
             return;
 
-        if (!_prototypeManager.TryIndex<ExplosionPrototype>(typeId, out var type))
+        if (!ProtoMan.TryIndex<ExplosionPrototype>(typeId, out var type))
         {
             Log.Error($"Attempted to spawn unknown explosion prototype: {type}");
             return;

--- a/Content.Server/FeedbackSystem/FeedbackSystem.cs
+++ b/Content.Server/FeedbackSystem/FeedbackSystem.cs
@@ -9,7 +9,6 @@ public sealed partial class FeedbackSystem : EntitySystem
 {
     [Dependency] private ServerFeedbackManager _feedbackManager = null!;
     [Dependency] private GameTicker _gameTicker = null!;
-    [Dependency] private IPrototypeManager _prototypeManager = null!;
 
     public override void Initialize()
     {
@@ -24,7 +23,7 @@ public sealed partial class FeedbackSystem : EntitySystem
 
         foreach (var feedback in _feedbackManager.GetOriginFeedbackPrototypes(true, true))
         {
-            if (_gameTicker.IsGameRuleAdded(_prototypeManager.Index(feedback).RuleWhitelist))
+            if (_gameTicker.IsGameRuleAdded(ProtoMan.Index(feedback).RuleWhitelist))
                 validPopups.Add(feedback);
             else
                 notValidPopups.Add(feedback);

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -2,7 +2,6 @@ using Content.Server.Fluids.Components;
 using Content.Server.Spreader;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
-using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reaction;
 using Content.Shared.Database;
@@ -18,7 +17,6 @@ using Robust.Shared.Collections;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Fluids.EntitySystems;
@@ -29,7 +27,6 @@ namespace Content.Server.Fluids.EntitySystems;
 public sealed partial class PuddleSystem : SharedPuddleSystem
 {
     [Dependency] private SharedMapSystem _map = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private SharedColorFlashEffectSystem _color = default!;
@@ -436,7 +433,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
                 PopupType.SmallCaution);
         }
 
-        _color.RaiseEffect(spilled.GetColor(_prototypeManager), targets,
+        _color.RaiseEffect(spilled.GetColor(ProtoMan), targets,
             Filter.Pvs(entity, entityManager: EntityManager));
 
         return TrySpillAt(coordinates, spilled, out puddleUid, sound);

--- a/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
@@ -16,7 +16,6 @@ using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using System.Linq;
@@ -34,7 +33,6 @@ public sealed partial class SmokeSystem : EntitySystem
     [Dependency] private IAdminLogManager _logger = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SharedMapSystem _map = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private AppearanceSystem _appearance = default!;
     [Dependency] private BloodstreamSystem _blood = default!;
@@ -306,7 +304,7 @@ public sealed partial class SmokeSystem : EntitySystem
             if (reagentQuantity.Quantity == FixedPoint2.Zero)
                 continue;
 
-            var reagent = _prototype.Index<ReagentPrototype>(reagentQuantity.Reagent.Prototype);
+            var reagent = ProtoMan.Index<ReagentPrototype>(reagentQuantity.Reagent.Prototype);
             reagent.ReactionTile(tile, reagentQuantity.Quantity, EntityManager, reagentQuantity.Reagent.Data);
         }
     }
@@ -337,7 +335,7 @@ public sealed partial class SmokeSystem : EntitySystem
             !_solutionContainerSystem.ResolveSolution(smoke.Owner, SmokeComponent.SolutionName, ref smoke.Comp1.Solution, out var solution))
             return;
 
-        var color = solution.GetColor(_prototype);
+        var color = solution.GetColor(ProtoMan);
         _appearance.SetData(smoke.Owner, SmokeVisuals.Color, color, smoke.Comp2);
     }
 }

--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -147,10 +147,10 @@ public sealed partial class GameTicker
 
     public GamePresetPrototype? FindGamePreset(string preset)
     {
-        if (_prototypeManager.TryIndex(preset, out GamePresetPrototype? presetProto))
+        if (ProtoMan.TryIndex(preset, out GamePresetPrototype? presetProto))
             return presetProto;
 
-        foreach (var proto in _prototypeManager.EnumeratePrototypes<GamePresetPrototype>())
+        foreach (var proto in ProtoMan.EnumeratePrototypes<GamePresetPrototype>())
         {
             foreach (var alias in proto.Alias)
             {
@@ -174,7 +174,7 @@ public sealed partial class GameTicker
         if (Preset == null)
             return true;
 
-        if (Preset.MapPool == null || !_prototypeManager.TryIndex<GameMapPoolPrototype>(Preset.MapPool, out var pool))
+        if (Preset.MapPool == null || !ProtoMan.TryIndex<GameMapPoolPrototype>(Preset.MapPool, out var pool))
             return true;
 
         return pool.Maps.Contains(map.ID);
@@ -186,7 +186,7 @@ public sealed partial class GameTicker
             return;
 
         if (Preset.MapPool == null ||
-            !_prototypeManager.TryIndex<GameMapPoolPrototype>(Preset.MapPool, out var pool))
+            !ProtoMan.TryIndex<GameMapPoolPrototype>(Preset.MapPool, out var pool))
             return;
 
         if (pool.Maps.Contains(map.ID))
@@ -232,7 +232,7 @@ public sealed partial class GameTicker
     [PublicAPI]
     public int GetMinimumPlayerCount(ProtoId<GamePresetPrototype> proto)
     {
-        if (!_prototypeManager.Resolve(proto, out var preset))
+        if (!ProtoMan.Resolve(proto, out var preset))
             return 0;
 
         return GetMinimumPlayerCount(preset);
@@ -250,10 +250,10 @@ public sealed partial class GameTicker
         var min = proto.MinPlayers ?? 0;
         foreach (var entProto in proto.Rules)
         {
-            if (!_prototypeManager.Resolve(entProto, out var ent))
+            if (!ProtoMan.Resolve(entProto, out var ent))
                 continue;
 
-            if (!ent.TryGetComponent<GameRuleComponent>(out var rule, Factory))
+            if (!ent.TryComp<GameRuleComponent>(out var rule, Factory))
                 continue;
 
             min = Math.Max(min, rule.MinPlayers);

--- a/Content.Server/GameTicking/GameTicker.GameRule.cs
+++ b/Content.Server/GameTicking/GameTicker.GameRule.cs
@@ -402,7 +402,7 @@ public sealed partial class GameTicker
     /// </summary>
     public IEnumerable<EntityPrototype> GetAllGameRulePrototypes()
     {
-        foreach (var proto in _prototypeManager.EnumeratePrototypes<EntityPrototype>())
+        foreach (var proto in ProtoMan.EnumeratePrototypes<EntityPrototype>())
         {
             if (proto.Abstract)
                 continue;
@@ -465,7 +465,7 @@ public sealed partial class GameTicker
 
         foreach (var rule in args)
         {
-            if (!_prototypeManager.HasIndex(rule))
+            if (!ProtoMan.HasIndex(rule))
             {
                 shell.WriteError($"Invalid game rule {rule} was skipped.");
 

--- a/Content.Server/GameTicking/GameTicker.LobbyBackground.cs
+++ b/Content.Server/GameTicking/GameTicker.LobbyBackground.cs
@@ -1,7 +1,6 @@
 using Content.Shared.GameTicking.Prototypes;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
-using Robust.Shared.Utility;
 using System.Linq;
 
 namespace Content.Server.GameTicking;
@@ -18,7 +17,7 @@ public sealed partial class GameTicker
 
     private void InitializeLobbyBackground()
     {
-        var allprotos = _prototypeManager.EnumeratePrototypes<LobbyBackgroundPrototype>().ToList();
+        var allprotos = ProtoMan.EnumeratePrototypes<LobbyBackgroundPrototype>().ToList();
         _lobbyBackgrounds ??= new List<ProtoId<LobbyBackgroundPrototype>>();
 
         //create protoids from them

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -119,7 +119,7 @@ namespace Content.Server.GameTicking
             }
 
             if (CurrentPreset?.MapPool != null &&
-                _prototypeManager.TryIndex<GameMapPoolPrototype>(CurrentPreset.MapPool, out var pool) &&
+                ProtoMan.TryIndex<GameMapPoolPrototype>(CurrentPreset.MapPool, out var pool) &&
                 !pool.Maps.Contains(mainStationMap.ID))
             {
                 var msg = Loc.GetString("game-ticker-start-round-invalid-map",
@@ -791,7 +791,7 @@ namespace Content.Server.GameTicking
         {
             if (CurrentPreset == null) return;
 
-            var options = _prototypeManager.EnumeratePrototypes<RoundAnnouncementPrototype>().ToList();
+            var options = ProtoMan.EnumeratePrototypes<RoundAnnouncementPrototype>().ToList();
 
             if (options.Count == 0)
                 return;

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -192,7 +192,7 @@ namespace Content.Server.GameTicking
                 {
                     var roundStart = new List<ProtoId<SpeciesPrototype>>();
 
-                    var speciesPrototypes = _prototypeManager.EnumeratePrototypes<SpeciesPrototype>();
+                    var speciesPrototypes = ProtoMan.EnumeratePrototypes<SpeciesPrototype>();
                     foreach (var proto in speciesPrototypes)
                     {
                         if (proto.RoundStart)
@@ -205,7 +205,7 @@ namespace Content.Server.GameTicking
                 }
                 else
                 {
-                    var weights = _prototypeManager.Index<WeightedRandomSpeciesPrototype>(weightId);
+                    var weights = ProtoMan.Index<WeightedRandomSpeciesPrototype>(weightId);
                     speciesId = weights.Pick(_robustRandom);
                 }
 
@@ -345,7 +345,7 @@ namespace Content.Server.GameTicking
 
             DebugTools.AssertNotNull(data);
 
-            jobPrototype = _prototypeManager.Index<JobPrototype>(jobId);
+            jobPrototype = ProtoMan.Index<JobPrototype>(jobId);
 
             var mobMaybe = _stationSpawning.SpawnPlayerCharacterOnStation(station, jobId, character);
             DebugTools.AssertNotNull(mobMaybe);

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -15,13 +15,11 @@ using Content.Shared.GameTicking;
 using Content.Shared.Mind;
 using Content.Shared.Roles;
 using Robust.Server;
-using Robust.Server.GameObjects;
 using Robust.Server.GameStates;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Console;
 using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.Map;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -42,7 +40,6 @@ namespace Content.Server.GameTicking
         [Dependency] private IGameTiming _gameTiming = default!;
         [Dependency] private ILogManager _logManager = default!;
         [Dependency] private IMapManager _mapManager = default!;
-        [Dependency] private IPrototypeManager _prototypeManager = default!;
         [Dependency] private IRobustRandom _robustRandom = default!;
 #if EXCEPTION_TOLERANCE
         [Dependency] private IRuntimeLog _runtimeLog = default!;
@@ -93,7 +90,7 @@ namespace Content.Server.GameTicking
             InitializePlayer();
             InitializeLobbyBackground();
             InitializeGamePreset();
-            DebugTools.Assert(_prototypeManager.Index(FallbackOverflowJob).Name == FallbackOverflowJobName,
+            DebugTools.Assert(ProtoMan.Index(FallbackOverflowJob).Name == FallbackOverflowJobName,
                 "Overflow role does not have the correct name!");
             InitializeGameRules();
             InitializeReplays();

--- a/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
@@ -1,6 +1,5 @@
 using Content.Server.Antag;
 using Content.Server.GameTicking.Rules.Components;
-using Content.Server.Humanoid;
 using Content.Server.Preferences.Managers;
 using Content.Shared.Body;
 using Content.Shared.Humanoid;
@@ -33,15 +32,15 @@ public sealed partial class AntagLoadProfileRuleSystem : GameRuleSystem<AntagLoa
             : HumanoidCharacterProfile.RandomWithSpecies();
 
 
-        if (profile?.Species is not { } speciesId || !Proto.Resolve(speciesId, out var species))
+        if (profile?.Species is not { } speciesId || !ProtoMan.Resolve(speciesId, out var species))
         {
-            species = Proto.Index(HumanoidCharacterProfile.DefaultSpecies);
+            species = ProtoMan.Index(HumanoidCharacterProfile.DefaultSpecies);
         }
 
         if (ent.Comp.SpeciesOverride != null
             && (ent.Comp.SpeciesOverrideBlacklist?.Contains(new ProtoId<SpeciesPrototype>(species.ID)) ?? false))
         {
-            species = Proto.Index(ent.Comp.SpeciesOverride.Value);
+            species = ProtoMan.Index(ent.Comp.SpeciesOverride.Value);
         }
 
         args.Entity = Spawn(species.Prototype, args.Coords);

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -1,8 +1,6 @@
 using Content.Server.Atmos.EntitySystems;
-using Content.Server.Chat.Managers;
 using Content.Shared.GameTicking.Components;
 using Robust.Server.GameObjects;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -11,7 +9,6 @@ namespace Content.Server.GameTicking.Rules;
 public abstract partial class GameRuleSystem<T> : EntitySystem where T : IComponent
 {
     [Dependency] protected IGameTiming Timing = default!;
-    [Dependency] protected IPrototypeManager Proto = default!;
     [Dependency] protected IRobustRandom RobustRandom = default!;
     [Dependency] protected GameTicker GameTicker = default!;
 

--- a/Content.Server/GameTicking/Rules/LoadMapRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/LoadMapRuleSystem.cs
@@ -7,14 +7,12 @@ using Robust.Server.GameObjects;
 using Robust.Shared.EntitySerialization;
 using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.Map;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Content.Server.GameTicking.Rules;
 
 public sealed partial class LoadMapRuleSystem : StationEventSystem<LoadMapRuleComponent>
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private MapSystem _map = default!;
     [Dependency] private MapLoaderSystem _mapLoader = default!;
     [Dependency] private TransformSystem _transform = default!;
@@ -39,7 +37,7 @@ public sealed partial class LoadMapRuleSystem : StationEventSystem<LoadMapRuleCo
             DebugTools.AssertNull(comp.GridPath);
             DebugTools.AssertNull(comp.PreloadedGrid);
 
-            var gameMap = _prototypeManager.Index(comp.GameMap.Value);
+            var gameMap = ProtoMan.Index(comp.GameMap.Value);
             grids = GameTicker.LoadGameMap(gameMap, out mapId, null);
             Log.Info($"Created map {mapId} for {ToPrettyString(uid):rule}");
         }

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Server.Administration.Logs;
-using Content.Server.Chat.Managers;
 using Content.Server.GameTicking.Presets;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Shared.GameTicking.Components;
@@ -17,7 +16,6 @@ namespace Content.Server.GameTicking.Rules;
 
 public sealed partial class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IConfigurationManager _configurationManager = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
@@ -76,7 +74,7 @@ public sealed partial class SecretRuleSystem : GameRuleSystem<SecretRuleComponen
 
     private bool TryPickPreset(ProtoId<WeightedRandomPrototype> weights, [NotNullWhen(true)] out GamePresetPrototype? preset)
     {
-        var options = _prototypeManager.Index(weights).Weights.ShallowClone();
+        var options = ProtoMan.Index(weights).Weights.ShallowClone();
         var players = GameTicker.ReadyPlayerCount();
 
         GamePresetPrototype? selectedPreset = null;
@@ -91,7 +89,7 @@ public sealed partial class SecretRuleSystem : GameRuleSystem<SecretRuleComponen
                 if (accumulated < rand)
                     continue;
 
-                if (!_prototypeManager.TryIndex(key, out selectedPreset))
+                if (!ProtoMan.TryIndex(key, out selectedPreset))
                     Log.Error($"Invalid preset {selectedPreset} in secret rule weights: {weights}");
 
                 options.Remove(key);
@@ -124,7 +122,7 @@ public sealed partial class SecretRuleSystem : GameRuleSystem<SecretRuleComponen
     /// </summary>
     public bool CanPickAny(ProtoId<WeightedRandomPrototype> weightedPresets)
     {
-        var ids = _prototypeManager.Index(weightedPresets).Weights.Keys
+        var ids = ProtoMan.Index(weightedPresets).Weights.Keys
             .Select(x => new ProtoId<GamePresetPrototype>(x));
 
         return CanPickAny(ids);
@@ -138,7 +136,7 @@ public sealed partial class SecretRuleSystem : GameRuleSystem<SecretRuleComponen
         var players = GameTicker.ReadyPlayerCount();
         foreach (var id in protos)
         {
-            if (!_prototypeManager.TryIndex(id, out var selectedPreset))
+            if (!ProtoMan.TryIndex(id, out var selectedPreset))
                 Log.Error($"Invalid preset {selectedPreset} in secret rule weights: {id}");
 
             if (CanPick(selectedPreset, players))

--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -2,7 +2,6 @@ using Content.Server.Antag;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Mind;
 using Content.Server.Objectives;
-using Content.Server.PDA.Ringer;
 using Content.Server.Traitor.Uplink;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mind;
@@ -13,12 +12,10 @@ using Content.Shared.Roles;
 using Content.Shared.Roles.Components;
 using Content.Shared.Roles.Jobs;
 using Content.Shared.Roles.RoleCodeword;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Linq;
 using System.Text;
 using Content.Server.Codewords;
-using Robust.Shared.Map;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -30,7 +27,6 @@ public sealed partial class TraitorRuleSystem : GameRuleSystem<TraitorRuleCompon
     [Dependency] private SharedJobSystem _jobs = default!;
     [Dependency] private MindSystem _mindSystem = default!;
     [Dependency] private NpcFactionSystem _npcFaction = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SharedRoleCodewordSystem _roleCodewordSystem = default!;
     [Dependency] private SharedRoleSystem _roleSystem = default!;
@@ -73,7 +69,7 @@ public sealed partial class TraitorRuleSystem : GameRuleSystem<TraitorRuleCompon
             briefing = Loc.GetString("traitor-role-codewords-short", ("codewords", string.Join(", ", factionCodewords)));
         }
 
-        var issuer = _random.Pick(_prototypeManager.Index(component.ObjectiveIssuers));
+        var issuer = _random.Pick(ProtoMan.Index(component.ObjectiveIssuers));
 
         // Uplink code will go here if applicable, but we still need the variable if there aren't any
         Note[]? code = null;

--- a/Content.Server/GameTicking/Rules/VariationPass/PuddleMessVariationPassSystem.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/PuddleMessVariationPassSystem.cs
@@ -2,7 +2,6 @@
 using Content.Server.GameTicking.Rules.VariationPass.Components;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Random.Helpers;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.GameTicking.Rules.VariationPass;
@@ -11,13 +10,12 @@ namespace Content.Server.GameTicking.Rules.VariationPass;
 public sealed partial class PuddleMessVariationPassSystem : VariationPassSystem<PuddleMessVariationPassComponent>
 {
     [Dependency] private PuddleSystem _puddle = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
 
     protected override void ApplyVariation(Entity<PuddleMessVariationPassComponent> ent, ref StationVariationPassEvent args)
     {
         var totalTiles = Stations.GetTileCount(args.Station.AsNullable());
 
-        if (!_proto.Resolve(ent.Comp.RandomPuddleSolutionFill, out var proto))
+        if (!ProtoMan.Resolve(ent.Comp.RandomPuddleSolutionFill, out var proto))
             return;
 
         var puddleMod = Random.NextGaussian(ent.Comp.TilesPerSpillAverage, ent.Comp.TilesPerSpillStdDev);

--- a/Content.Server/Gateway/Systems/GatewayGeneratorSystem.cs
+++ b/Content.Server/Gateway/Systems/GatewayGeneratorSystem.cs
@@ -25,7 +25,6 @@ public sealed partial class GatewayGeneratorSystem : EntitySystem
 {
     [Dependency] private IConfigurationManager _cfgManager = default!;
     [Dependency] private IGameTiming _timing = default!;
-    [Dependency] private IPrototypeManager _protoManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private ITileDefinitionManager _tileDefManager = default!;
     [Dependency] private BiomeSystem _biome = default!;
@@ -103,7 +102,7 @@ public sealed partial class GatewayGeneratorSystem : EntitySystem
         random.SetSeed(seed);
         var mapUid = _maps.CreateMap();
 
-        var gatewayName = _salvage.GetFTLName(_protoManager.Index(PlanetNames), seed);
+        var gatewayName = _salvage.GetFTLName(ProtoMan.Index(PlanetNames), seed);
         _metadata.SetEntityName(mapUid, gatewayName);
 
         var origin = new Vector2i(random.Next(-MaxOffset, MaxOffset), random.Next(-MaxOffset, MaxOffset));
@@ -113,7 +112,7 @@ public sealed partial class GatewayGeneratorSystem : EntitySystem
         };
         AddComp(mapUid, restricted);
 
-        _biome.EnsurePlanet(mapUid, _protoManager.Index(BiomeTemplate), seed);
+        _biome.EnsurePlanet(mapUid, ProtoMan.Index(BiomeTemplate), seed);
 
         var grid = Comp<MapGridComponent>(mapUid);
 
@@ -185,7 +184,7 @@ public sealed partial class GatewayGeneratorSystem : EntitySystem
         var dungeonRotation = _dungeon.GetDungeonRotation(seed);
         var dungeonPosition = (origin + dungeonRotation.RotateVec(new Vector2i(0, dungeonDistance))).Floored();
 
-        _dungeon.GenerateDungeon(_protoManager.Index(DungeonConfig), args.MapUid, grid, dungeonPosition, seed);
+        _dungeon.GenerateDungeon(ProtoMan.Index(DungeonConfig), args.MapUid, grid, dungeonPosition, seed);
 
         // TODO: Dungeon mobs + loot.
 

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -56,7 +56,6 @@ namespace Content.Server.Ghost
         [Dependency] private VisibilitySystem _visibilitySystem = default!;
         [Dependency] private MetaDataSystem _metaData = default!;
         [Dependency] private MobThresholdSystem _mobThresholdSystem = default!;
-        [Dependency] private IPrototypeManager _prototypeManager = default!;
         [Dependency] private IConfigurationManager _configurationManager = default!;
         [Dependency] private IChatManager _chatManager = default!;
         [Dependency] private SharedMindSystem _mind = default!;
@@ -593,7 +592,7 @@ namespace Content.Server.Ghost
                                       _damageable.GetTotalDamage((playerEntity.Value, damageable));
                     }
 
-                    DamageSpecifier damage = new(_prototypeManager.Index(AsphyxiationDamageType), dealtDamage);
+                    DamageSpecifier damage = new(ProtoMan.Index(AsphyxiationDamageType), dealtDamage);
 
                     _damageable.ChangeDamage(playerEntity.Value, damage, true);
                 }

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -54,7 +54,6 @@ public sealed partial class GhostRoleSystem : EntitySystem
     [Dependency] private SharedRoleSystem _roleSystem = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private PopupSystem _popupSystem = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
 
     private uint _nextRoleIdentifier;
     private bool _needsUpdateGhostRoleCount = true;
@@ -246,7 +245,7 @@ public sealed partial class GhostRoleSystem : EntitySystem
             }
 
             var foundWinner = false;
-            var deciderPrototype = _prototype.Index(ghostRole.RaffleConfig.Decider);
+            var deciderPrototype = ProtoMan.Index(ghostRole.RaffleConfig.Decider);
 
             // use the ghost role's chosen winner picker to find a winner
             deciderPrototype.Decider.PickWinner(
@@ -355,7 +354,7 @@ public sealed partial class GhostRoleSystem : EntitySystem
             return; // should, realistically, never be reached but you never know
 
         var settings = config.SettingsOverride
-                       ?? _prototype.Index<GhostRoleRaffleSettingsPrototype>(config.Settings).Settings;
+                       ?? ProtoMan.Index<GhostRoleRaffleSettingsPrototype>(config.Settings).Settings;
 
         if (settings.MaxDuration < settings.InitialDuration)
         {
@@ -532,8 +531,8 @@ public sealed partial class GhostRoleSystem : EntitySystem
         // If there is no mind, check the mindRole prototypes
         foreach (var proto in roleEnt.Comp.MindRoles)
         {
-            if (!_prototype.TryIndex(proto, out var indexed)
-                || !indexed.TryGetComponent<MindRoleComponent>(out var comp, _ent.ComponentFactory))
+            if (!ProtoMan.TryIndex(proto, out var indexed)
+                || !indexed.TryComp<MindRoleComponent>(out var comp, _ent.ComponentFactory))
                 continue;
             var roleComp = (MindRoleComponent)comp;
 
@@ -856,7 +855,7 @@ public sealed partial class GhostRoleSystem : EntitySystem
 
         foreach (var prototypeID in prototypes)
         {
-            if (_prototype.TryIndex<GhostRolePrototype>(prototypeID, out var prototype))
+            if (ProtoMan.TryIndex<GhostRolePrototype>(prototypeID, out var prototype))
             {
                 var verb = CreateVerb(uid, component, args.User, prototype);
                 verbs.Add(verb);
@@ -902,7 +901,7 @@ public sealed partial class GhostRoleSystem : EntitySystem
 
     public void OnGhostRoleRadioMessage(Entity<GhostRoleMobSpawnerComponent> entity, ref GhostRoleRadioMessage args)
     {
-        if (!_prototype.Resolve(args.ProtoId, out var ghostRoleProto))
+        if (!ProtoMan.Resolve(args.ProtoId, out var ghostRoleProto))
             return;
 
         // if the prototype chosen isn't actually part of the selectable options, ignore it

--- a/Content.Server/Ghost/SpookySpeakerSystem.cs
+++ b/Content.Server/Ghost/SpookySpeakerSystem.cs
@@ -2,7 +2,6 @@ using Content.Server.Chat.Systems;
 using Content.Server.Ghost.Components;
 using Content.Shared.Chat;
 using Content.Shared.Random.Helpers;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -10,7 +9,6 @@ namespace Content.Server.Ghost;
 
 public sealed partial class SpookySpeakerSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private ChatSystem _chat = default!;
@@ -33,7 +31,7 @@ public sealed partial class SpookySpeakerSystem : EntitySystem
         if (curTime < entity.Comp.NextSpeakTime)
             return;
 
-        if (!_proto.Resolve(entity.Comp.MessageSet, out var messages))
+        if (!ProtoMan.Resolve(entity.Comp.MessageSet, out var messages))
             return;
 
         // Grab a random localized message from the set

--- a/Content.Server/GridPreloader/GridPreloaderSystem.cs
+++ b/Content.Server/GridPreloader/GridPreloaderSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.GridPreloader.Systems;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
-using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Prototypes;
 using System.Numerics;
@@ -15,13 +14,13 @@ using JetBrains.Annotations;
 using Robust.Shared.EntitySerialization.Systems;
 
 namespace Content.Server.GridPreloader;
+
 public sealed partial class GridPreloaderSystem : SharedGridPreloaderSystem
 {
     [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private MapSystem _map = default!;
     [Dependency] private MapLoaderSystem _mapLoader = default!;
     [Dependency] private MetaDataSystem _meta = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
 
     /// <summary>
@@ -68,7 +67,7 @@ public sealed partial class GridPreloaderSystem : SharedGridPreloaderSystem
         _map.SetPaused(mapId, true);
 
         var globalXOffset = 0f;
-        foreach (var proto in _prototype.EnumeratePrototypes<PreloadedGridPrototype>())
+        foreach (var proto in ProtoMan.EnumeratePrototypes<PreloadedGridPrototype>())
         {
             for (var i = 0; i < proto.Copies; i++)
             {

--- a/Content.Server/Guidebook/GuidebookDataSystem.cs
+++ b/Content.Server/Guidebook/GuidebookDataSystem.cs
@@ -11,8 +11,6 @@ namespace Content.Server.Guidebook;
 /// </summary>
 public sealed partial class GuidebookDataSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _protoMan = default!;
-
     private readonly Dictionary<string, List<MemberInfo>> _tagged = [];
     private GuidebookData _cachedData = new();
 
@@ -72,7 +70,7 @@ public sealed partial class GuidebookDataSystem : EntitySystem
         }
 
         // Scan entity prototypes for the component-member pairs we noted
-        var entityPrototypes = _protoMan.EnumeratePrototypes<EntityPrototype>();
+        var entityPrototypes = ProtoMan.EnumeratePrototypes<EntityPrototype>();
         foreach (var prototype in entityPrototypes)
         {
             foreach (var (component, entry) in prototype.Components)

--- a/Content.Server/Holiday/Christmas/RandomGiftSystem.cs
+++ b/Content.Server/Holiday/Christmas/RandomGiftSystem.cs
@@ -20,7 +20,6 @@ public sealed partial class RandomGiftSystem : EntitySystem
 {
     [Dependency] private AudioSystem _audio = default!;
     [Dependency] private HandsSystem _hands = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
     [Dependency] private EntityWhitelistSystem _whitelistSystem = default!;
@@ -44,7 +43,7 @@ public sealed partial class RandomGiftSystem : EntitySystem
         if (_whitelistSystem.IsWhitelistFail(component.ContentsViewers, args.Examiner) || component.SelectedEntity is null)
             return;
 
-        var name = _prototype.Index<EntityPrototype>(component.SelectedEntity).Name;
+        var name = ProtoMan.Index<EntityPrototype>(component.SelectedEntity).Name;
         args.PushText(Loc.GetString("gift-packin-contains", ("name", name)));
     }
 
@@ -96,7 +95,7 @@ public sealed partial class RandomGiftSystem : EntitySystem
         var mapGridCompName = Factory.GetComponentName<MapGridComponent>();
         var physicsCompName = Factory.GetComponentName<PhysicsComponent>();
 
-        foreach (var proto in _prototype.EnumeratePrototypes<EntityPrototype>())
+        foreach (var proto in ProtoMan.EnumeratePrototypes<EntityPrototype>())
         {
             if (proto.Abstract || proto.HideSpawnMenu || proto.Components.ContainsKey(mapGridCompName) || !proto.Components.ContainsKey(physicsCompName))
                 continue;

--- a/Content.Server/Holiday/HolidaySystem.cs
+++ b/Content.Server/Holiday/HolidaySystem.cs
@@ -4,14 +4,12 @@ using Content.Server.GameTicking;
 using Content.Shared.CCVar;
 using Content.Shared.Holiday;
 using Robust.Shared.Configuration;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Holiday
 {
     public sealed partial class HolidaySystem : EntitySystem
     {
         [Dependency] private IConfigurationManager _configManager = default!;
-        [Dependency] private IPrototypeManager _prototypeManager = default!;
         [Dependency] private IChatManager _chatManager = default!;
         [Dependency] private SharedAppearanceSystem _appearance = default!;
 
@@ -40,7 +38,7 @@ namespace Content.Server.Holiday
 
             var now = DateTime.Now;
 
-            foreach (var holiday in _prototypeManager.EnumeratePrototypes<HolidayPrototype>())
+            foreach (var holiday in ProtoMan.EnumeratePrototypes<HolidayPrototype>())
             {
                 if (holiday.ShouldCelebrate(now))
                 {
@@ -74,7 +72,7 @@ namespace Content.Server.Holiday
 
         public bool IsCurrentlyHoliday(string holiday)
         {
-            if (!_prototypeManager.TryIndex(holiday, out HolidayPrototype? prototype))
+            if (!ProtoMan.TryIndex(holiday, out HolidayPrototype? prototype))
                 return false;
 
             return _currentHolidays.Contains(prototype);

--- a/Content.Server/Humanoid/Systems/RandomHumanoidSystem.cs
+++ b/Content.Server/Humanoid/Systems/RandomHumanoidSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Humanoid;
 using Content.Shared.Preferences;
 using Robust.Shared.Map;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.Manager;
 
 namespace Content.Server.Humanoid.Systems;
@@ -16,7 +15,6 @@ namespace Content.Server.Humanoid.Systems;
 public sealed partial class RandomHumanoidSystem : EntitySystem
 {
     [Dependency] private HumanoidProfileSystem _humanoidProfile = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private ISerializationManager _serialization = default!;
     [Dependency] private MetaDataSystem _metaData = default!;
     [Dependency] private SharedVisualBodySystem _visualBody = default!;
@@ -37,11 +35,11 @@ public sealed partial class RandomHumanoidSystem : EntitySystem
 
     public EntityUid SpawnRandomHumanoid(string prototypeId, EntityCoordinates coordinates, string name)
     {
-        if (!_prototypeManager.TryIndex<RandomHumanoidSettingsPrototype>(prototypeId, out var prototype))
+        if (!ProtoMan.TryIndex<RandomHumanoidSettingsPrototype>(prototypeId, out var prototype))
             throw new ArgumentException("Could not get random humanoid settings");
 
         var profile = HumanoidCharacterProfile.Random(prototype.SpeciesBlacklist);
-        var speciesProto = _prototypeManager.Index<SpeciesPrototype>(profile.Species);
+        var speciesProto = ProtoMan.Index<SpeciesPrototype>(profile.Species);
         var humanoid = EntityManager.CreateEntityUninitialized(speciesProto.Prototype, coordinates);
 
         _metaData.SetEntityName(humanoid, prototype.RandomizeName ? profile.Name : name);

--- a/Content.Server/Implants/ChameleonControllerSystem.cs
+++ b/Content.Server/Implants/ChameleonControllerSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.Clothing;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Implants;
 using Content.Shared.Implants.Components;
-using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Preferences;
 using Content.Shared.Preferences.Loadouts;
@@ -18,7 +17,6 @@ namespace Content.Server.Implants;
 
 public sealed partial class ChameleonControllerSystem : SharedChameleonControllerSystem
 {
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private InventorySystem _inventory = default!;
     [Dependency] private SharedStationSpawningSystem _stationSpawningSystem = default!;
     [Dependency] private ChameleonClothingSystem _chameleonClothingSystem = default!;
@@ -47,10 +45,10 @@ public sealed partial class ChameleonControllerSystem : SharedChameleonControlle
     /// </summary>
     private void ChangeChameleonClothingToOutfit(EntityUid user, ProtoId<ChameleonOutfitPrototype> outfit)
     {
-        var outfitPrototype = _proto.Index(outfit);
+        var outfitPrototype = ProtoMan.Index(outfit);
 
-        _proto.Resolve(outfitPrototype.Job, out var jobPrototype);
-        _proto.Resolve(outfitPrototype.StartingGear, out var startingGearPrototype);
+        ProtoMan.Resolve(outfitPrototype.Job, out var jobPrototype);
+        ProtoMan.Resolve(outfitPrototype.StartingGear, out var startingGearPrototype);
 
         GetJobEquipmentInformation(jobPrototype, user, out var customRoleLoadout, out var defaultRoleLoadout, out var jobStartingGearPrototype);
 
@@ -81,7 +79,7 @@ public sealed partial class ChameleonControllerSystem : SharedChameleonControlle
         if (jobPrototype == null)
             return;
 
-        _proto.Resolve(jobPrototype.StartingGear, out jobStartingGearPrototype);
+        ProtoMan.Resolve(jobPrototype.StartingGear, out jobStartingGearPrototype);
 
         if (!TryComp<ActorComponent>(user, out var actorComponent))
             return;
@@ -96,11 +94,11 @@ public sealed partial class ChameleonControllerSystem : SharedChameleonControlle
 
         profile.Loadouts.TryGetValue(jobProtoId, out customRoleLoadout);
 
-        if (!_proto.HasIndex<RoleLoadoutPrototype>(jobProtoId))
+        if (!ProtoMan.HasIndex<RoleLoadoutPrototype>(jobProtoId))
             return;
 
         defaultRoleLoadout = new RoleLoadout(jobProtoId);
-        defaultRoleLoadout.SetDefault(profile, null, _proto); // only sets the default if the player has no loadout
+        defaultRoleLoadout.SetDefault(profile, null, ProtoMan); // only sets the default if the player has no loadout
     }
 
     private void ChameleonControllerOutfitItemSelected(Entity<ChameleonClothingComponent> ent, ref InventoryRelayedEvent<ChameleonControllerOutfitSelectedEvent> args)

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -62,7 +62,6 @@ namespace Content.Server.Kitchen.EntitySystems
         [Dependency] private HandsSystem _handsSystem = default!;
         [Dependency] private SharedItemSystem _item = default!;
         [Dependency] private SharedStackSystem _stack = default!;
-        [Dependency] private IPrototypeManager _prototype = default!;
         [Dependency] private IAdminLogManager _adminLogger = default!;
         [Dependency] private SharedSuicideSystem _suicide = default!;
         [Dependency] private SharedPowerStateSystem _powerState = default!;
@@ -238,7 +237,7 @@ namespace Content.Server.Kitchen.EntitySystems
                         // If an entity has a stack component, use the stacktype instead of prototype id
                         if (TryComp<StackComponent>(item, out var stackComp))
                         {
-                            itemID = _prototype.Index(stackComp.StackTypeId).Spawn;
+                            itemID = ProtoMan.Index(stackComp.StackTypeId).Spawn;
                         }
                         else
                         {
@@ -558,7 +557,7 @@ namespace Content.Server.Kitchen.EntitySystems
                 // If a microwave recipe uses a stacked item, use the default stack prototype id instead of prototype id
                 if (TryComp<StackComponent>(item, out var stackComp))
                 {
-                    solidID = _prototype.Index<StackPrototype>(stackComp.StackTypeId).Spawn;
+                    solidID = ProtoMan.Index<StackPrototype>(stackComp.StackTypeId).Spawn;
                     amountToAdd = stackComp.Count;
                 }
                 else
@@ -705,7 +704,7 @@ namespace Content.Server.Kitchen.EntitySystems
         {
             foreach (ProtoId<FoodRecipePrototype> recipeId in ent.Comp.ProvidedRecipes)
             {
-                if (_prototype.Resolve(recipeId, out var recipeProto))
+                if (ProtoMan.Resolve(recipeId, out var recipeProto))
                 {
                     args.Recipes.Add(recipeProto);
                 }

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -6,7 +6,6 @@ using Content.Server.Fluids.EntitySystems;
 using Content.Server.Lathe.Components;
 using Content.Server.Materials;
 using Content.Server.Popups;
-using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Radio.EntitySystems;
 using Content.Server.Stack;
@@ -16,9 +15,7 @@ using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.UserInterface;
 using Content.Shared.Database;
-using Content.Shared.Emag.Components;
 using Content.Shared.Emag.Systems;
-using Content.Shared.Examine;
 using Content.Shared.Lathe;
 using Content.Shared.Lathe.Prototypes;
 using Content.Shared.Localizations;
@@ -40,7 +37,6 @@ namespace Content.Server.Lathe
     public sealed partial class LatheSystem : SharedLatheSystem
     {
         [Dependency] private IGameTiming _timing = default!;
-        [Dependency] private IPrototypeManager _proto = default!;
         [Dependency] private IAdminLogManager _adminLogger = default!;
         [Dependency] private AtmosphereSystem _atmosphere = default!;
         [Dependency] private SharedAppearanceSystem _appearance = default!;
@@ -137,7 +133,7 @@ namespace Content.Server.Lathe
             var recipes = GetAvailableRecipes(uid, component, true);
             foreach (var id in recipes)
             {
-                if (!_proto.Resolve(id, out var proto))
+                if (!ProtoMan.Resolve(id, out var proto))
                     continue;
                 foreach (var (mat, _) in proto.Materials)
                 {
@@ -204,7 +200,7 @@ namespace Content.Server.Lathe
             batch.ItemsPrinted++;
             if (batch.ItemsPrinted >= batch.ItemsRequested || batch.ItemsPrinted < 0) // Rollover sanity check
                 component.Queue.RemoveFirst();
-            var recipe = _proto.Index(batch.Recipe);
+            var recipe = ProtoMan.Index(batch.Recipe);
 
             var time = _reagentSpeed.ApplySpeed(uid, recipe.CompleteTime) * component.TimeMultiplier;
 
@@ -234,7 +230,7 @@ namespace Content.Server.Lathe
 
             if (comp.CurrentRecipe != null)
             {
-                var currentRecipe = _proto.Index(comp.CurrentRecipe.Value);
+                var currentRecipe = ProtoMan.Index(comp.CurrentRecipe.Value);
                 if (currentRecipe.Result is { } resultProto)
                 {
                     var result = Spawn(resultProto, Transform(uid).Coordinates);
@@ -293,7 +289,7 @@ namespace Content.Server.Lathe
         {
             foreach (var id in packs)
             {
-                var pack = _proto.Index(id);
+                var pack = ProtoMan.Index(id);
                 foreach (var recipe in pack.Recipes)
                 {
                     if (args.GetUnavailable || database.UnlockedRecipes.Contains(recipe))
@@ -384,7 +380,7 @@ namespace Content.Server.Lathe
                 if (!potentialRecipes.Contains(new(recipeId)))
                     continue;
 
-                if (!_proto.TryIndex(recipeId, out LatheRecipePrototype? recipe))
+                if (!ProtoMan.TryIndex(recipeId, out LatheRecipePrototype? recipe))
                     continue;
 
                 var itemName = GetRecipeName(recipe!);
@@ -444,7 +440,7 @@ namespace Content.Server.Lathe
         /// </summary>
         private void RefundCurrentRecipe(EntityUid uid, LatheComponent lathe)
         {
-            _proto.Resolve(lathe.CurrentRecipe, out var recipe);
+            ProtoMan.Resolve(lathe.CurrentRecipe, out var recipe);
 
             foreach (var (mat, amount) in GetAdjustedAmount(lathe, recipe!))
                 _materialStorage.TryChangeMaterialAmount(uid, mat, amount);
@@ -458,7 +454,7 @@ namespace Content.Server.Lathe
         {
             var delta = batch.ItemsRequested - batch.ItemsPrinted;
 
-            _proto.Resolve(batch.Recipe, out var recipe);
+            ProtoMan.Resolve(batch.Recipe, out var recipe);
 
             foreach (var (mat, amount) in GetAdjustedAmount(lathe, recipe!))
                 _materialStorage.TryChangeMaterialAmount(uid, mat, amount * delta);
@@ -498,7 +494,7 @@ namespace Content.Server.Lathe
 
         private void OnLatheQueueRecipeMessage(EntityUid uid, LatheComponent component, LatheQueueRecipeMessage args)
         {
-            if (_proto.TryIndex(args.ID, out LatheRecipePrototype? recipe))
+            if (ProtoMan.TryIndex(args.ID, out LatheRecipePrototype? recipe))
             {
                 if (TryAddToQueue(uid, recipe, args.Quantity, component))
                 {

--- a/Content.Server/Machines/EntitySystems/MultipartMachineSystem.cs
+++ b/Content.Server/Machines/EntitySystems/MultipartMachineSystem.cs
@@ -15,7 +15,6 @@ namespace Content.Server.Machines.EntitySystems;
 /// </summary>
 public sealed partial class MultipartMachineSystem : SharedMultipartMachineSystem
 {
-    [Dependency] private IComponentFactory _factory = default!;
     [Dependency] private MapSystem _mapSystem = default!;
     [Dependency] private EntityLookupSystem _lookupSystem = default!;
 
@@ -99,7 +98,7 @@ public sealed partial class MultipartMachineSystem : SharedMultipartMachineSyste
             var originalPart = part.Entity;
             part.Entity = null;
 
-            if (!_factory.TryGetRegistration(part.Component, out var registration))
+            if (!Factory.TryGetRegistration(part.Component, out var registration))
                 break;
 
             var query = EntityManager.GetEntityQuery(registration.Type);

--- a/Content.Server/Maps/MapMigrationSystem.cs
+++ b/Content.Server/Maps/MapMigrationSystem.cs
@@ -17,9 +17,6 @@ namespace Content.Server.Maps;
 /// </summary>
 public sealed partial class MapMigrationSystem : EntitySystem
 {
-#if DEBUG
-    [Dependency] private IPrototypeManager _protoMan = default!;
-#endif
     [Dependency] private IResourceManager _resMan = default!;
 
     private const string MigrationFile = "/migration.yml";
@@ -38,7 +35,7 @@ public sealed partial class MapMigrationSystem : EntitySystem
         {
             var newId = ((ValueDataNode) node).Value;
             if (!string.IsNullOrEmpty(newId) && newId != "null")
-                DebugTools.Assert(_protoMan.HasIndex<EntityPrototype>(newId), $"{newId} is not an entity prototype.");
+                DebugTools.Assert(ProtoMan.HasIndex<EntityPrototype>(newId), $"{newId} is not an entity prototype.");
         }
 #endif
     }

--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -19,7 +19,6 @@ using Content.Shared.Repairable;
 using Content.Shared.Stacks;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Materials;
@@ -27,7 +26,6 @@ namespace Content.Server.Materials;
 /// <inheritdoc/>
 public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSystem
 {
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private AppearanceSystem _appearance = default!;
     [Dependency] private GhostSystem _ghostSystem = default!;
     [Dependency] private MaterialStorageSystem _materialStorage = default!;
@@ -242,7 +240,7 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
             // Are we a recycler? Only use drainable solution.
             if (_solutionContainer.TryGetDrainableSolution(item, out _, out var drainableSolution))
             {
-                totalChemicals.AddSolution(drainableSolution, _prototype);
+                totalChemicals.AddSolution(drainableSolution, ProtoMan);
             }
         }
         else
@@ -250,7 +248,7 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
             // Are we an industrial reagent grinder? Use extractable solution.
             if (_solutionContainer.TryGetExtractableSolution(item, out _, out var extractableSolution))
             {
-                totalChemicals.AddSolution(extractableSolution, _prototype);
+                totalChemicals.AddSolution(extractableSolution, ProtoMan);
             }
         }
 

--- a/Content.Server/Materials/MaterialStorageSystem.cs
+++ b/Content.Server/Materials/MaterialStorageSystem.cs
@@ -21,7 +21,6 @@ namespace Content.Server.Materials;
 public sealed partial class MaterialStorageSystem : SharedMaterialStorageSystem
 {
     [Dependency] private IAdminLogManager _adminLogger = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
@@ -62,14 +61,14 @@ public sealed partial class MaterialStorageSystem : SharedMaterialStorageSystem
         if (!_actionBlocker.CanInteract(player, uid))
             return;
 
-        if (!component.CanEjectStoredMaterials || !_prototypeManager.TryIndex<MaterialPrototype>(msg.Material, out var material))
+        if (!component.CanEjectStoredMaterials || !ProtoMan.TryIndex<MaterialPrototype>(msg.Material, out var material))
             return;
 
         var volume = 0;
 
         if (material.StackEntity != null)
         {
-            if (!_prototypeManager.Index<EntityPrototype>(material.StackEntity).TryGetComponent<PhysicalCompositionComponent>(out var composition, EntityManager.ComponentFactory))
+            if (!ProtoMan.Index(material.StackEntity.Value).TryComp(out PhysicalCompositionComponent? composition, EntityManager.ComponentFactory))
                 return;
 
             var volumePerSheet = composition.MaterialComposition.FirstOrDefault(kvp => kvp.Key == msg.Material).Value;
@@ -138,7 +137,7 @@ public sealed partial class MaterialStorageSystem : SharedMaterialStorageSystem
     public List<EntityUid> SpawnMultipleFromMaterial(int amount, string material, EntityCoordinates coordinates, out int overflowMaterial)
     {
         overflowMaterial = 0;
-        if (!_prototypeManager.TryIndex<MaterialPrototype>(material, out var stackType))
+        if (!ProtoMan.TryIndex<MaterialPrototype>(material, out var stackType))
         {
             Log.Error("Failed to index material prototype " + material);
             return new List<EntityUid>();
@@ -172,8 +171,8 @@ public sealed partial class MaterialStorageSystem : SharedMaterialStorageSystem
         if (amount <= 0 || materialProto.StackEntity == null)
             return new List<EntityUid>();
 
-        var entProto = _prototypeManager.Index<EntityPrototype>(materialProto.StackEntity);
-        if (!entProto.TryGetComponent<PhysicalCompositionComponent>(out var composition, EntityManager.ComponentFactory))
+        var entProto = ProtoMan.Index<EntityPrototype>(materialProto.StackEntity);
+        if (!entProto.TryComp<PhysicalCompositionComponent>(out var composition, EntityManager.ComponentFactory))
             return new List<EntityUid>();
 
         var materialPerStack = composition.MaterialComposition[materialProto.ID];

--- a/Content.Server/Mining/MiningSystem.cs
+++ b/Content.Server/Mining/MiningSystem.cs
@@ -13,7 +13,6 @@ namespace Content.Server.Mining;
 /// </summary>
 public sealed partial class MiningSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IRobustRandom _random = default!;
 
     /// <inheritdoc/>
@@ -29,7 +28,7 @@ public sealed partial class MiningSystem : EntitySystem
         if (component.CurrentOre == null)
             return;
 
-        var proto = _proto.Index<OrePrototype>(component.CurrentOre);
+        var proto = ProtoMan.Index<OrePrototype>(component.CurrentOre);
 
         if (proto.OreEntity == null)
             return;
@@ -47,6 +46,6 @@ public sealed partial class MiningSystem : EntitySystem
         if (component.CurrentOre != null || component.OreRarityPrototypeId == null || !_random.Prob(component.OreChance))
             return;
 
-        component.CurrentOre = _proto.Index<WeightedRandomOrePrototype>(component.OreRarityPrototypeId).Pick(_random);
+        component.CurrentOre = ProtoMan.Index<WeightedRandomOrePrototype>(component.OreRarityPrototypeId).Pick(_random);
     }
 }

--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -19,7 +19,6 @@ namespace Content.Server.NPC.HTN;
 public sealed partial class HTNSystem : EntitySystem
 {
     [Dependency] private IAdminManager _admin = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private NPCSystem _npc = default!;
     [Dependency] private NPCUtilitySystem _utility = default!;
 
@@ -78,7 +77,7 @@ public sealed partial class HTNSystem : EntitySystem
 
         // Add dependencies for all operators.
         // We put code on operators as I couldn't think of a clean way to put it on systems.
-        foreach (var compound in _prototypeManager.EnumeratePrototypes<HTNCompoundPrototype>())
+        foreach (var compound in ProtoMan.EnumeratePrototypes<HTNCompoundPrototype>())
         {
             UpdateCompound(compound);
         }
@@ -314,7 +313,7 @@ public sealed partial class HTNSystem : EntitySystem
 
         if (task is HTNCompoundTask compTask)
         {
-            var compound = _prototypeManager.Index<HTNCompoundPrototype>(compTask.Task);
+            var compound = ProtoMan.Index<HTNCompoundPrototype>(compTask.Task);
             level++;
             text.AppendLine(compound.ID);
             var branches = compound.Branches;
@@ -487,7 +486,7 @@ public sealed partial class HTNSystem : EntitySystem
 
         var job = new HTNPlanJob(
             0.02,
-            _prototypeManager,
+            ProtoMan,
             component.RootTask,
             component.Blackboard.ShallowClone(), branchTraversal, cancelToken.Token);
 
@@ -517,7 +516,7 @@ public sealed partial class HTNSystem : EntitySystem
         }
         else if (task is HTNCompoundTask compTask)
         {
-            var compound = _prototypeManager.Index<HTNCompoundPrototype>(compTask.Task);
+            var compound = ProtoMan.Index<HTNCompoundPrototype>(compTask.Task);
             builder.AppendLine(buffer + $"Compound: {task}");
 
             for (var i = 0; i < compound.Branches.Count; i++)

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -42,7 +42,6 @@ namespace Content.Server.NPC.Systems;
 /// </summary>
 public sealed partial class NPCUtilitySystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private ContainerSystem _container = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private HandsSystem _hands = default!;
@@ -81,7 +80,7 @@ public sealed partial class NPCUtilitySystem : EntitySystem
     {
         // TODO: PickHostilesop or whatever needs to juse be UtilityQueryOperator
 
-        var weh = _proto.Index<UtilityQueryPrototype>(proto);
+        var weh = ProtoMan.Index<UtilityQueryPrototype>(proto);
         var ents = _entPool.Get();
 
         foreach (var query in weh.Query)
@@ -152,7 +151,7 @@ public sealed partial class NPCUtilitySystem : EntitySystem
             case InverseBoolCurve:
                 return conScore.Equals(0f) ? 1f : 0f;
             case PresetCurve presetCurve:
-                return GetScore(_proto.Index<UtilityCurvePresetPrototype>(presetCurve.Preset).Curve, conScore);
+                return GetScore(ProtoMan.Index<UtilityCurvePresetPrototype>(presetCurve.Preset).Curve, conScore);
             case QuadraticCurve quadraticCurve:
                 return Math.Clamp(quadraticCurve.Slope * MathF.Pow(conScore - quadraticCurve.XOffset, quadraticCurve.Exponent) + quadraticCurve.YOffset, 0f, 1f);
             default:

--- a/Content.Server/NameIdentifier/NameIdentifierSystem.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierSystem.cs
@@ -9,7 +9,6 @@ namespace Content.Server.NameIdentifier;
 
 public sealed partial class NameIdentifierSystem : SharedNameIdentifierSystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _robustRandom = default!;
     [Dependency] private NameModifierSystem _nameModifier = default!;
 
@@ -55,7 +54,7 @@ public sealed partial class NameIdentifierSystem : SharedNameIdentifierSystem
     /// </summary>
     public string GenerateUniqueName(EntityUid uid, ProtoId<NameIdentifierGroupPrototype> proto, out int randomVal)
     {
-        return GenerateUniqueName(uid, _prototypeManager.Index(proto), out randomVal);
+        return GenerateUniqueName(uid, ProtoMan.Index(proto), out randomVal);
     }
 
     /// <summary>
@@ -88,7 +87,7 @@ public sealed partial class NameIdentifierSystem : SharedNameIdentifierSystem
         if (ent.Comp.Group is null)
             return;
 
-        if (!_prototypeManager.Resolve(ent.Comp.Group, out var group))
+        if (!ProtoMan.Resolve(ent.Comp.Group, out var group))
             return;
 
         int id;
@@ -147,7 +146,7 @@ public sealed partial class NameIdentifierSystem : SharedNameIdentifierSystem
 
     private void EnsureIds()
     {
-        foreach (var proto in _prototypeManager.EnumeratePrototypes<NameIdentifierGroupPrototype>())
+        foreach (var proto in ProtoMan.EnumeratePrototypes<NameIdentifierGroupPrototype>())
         {
             var ids = GetOrCreateIdList(proto);
 
@@ -164,7 +163,7 @@ public sealed partial class NameIdentifierSystem : SharedNameIdentifierSystem
 
         foreach (var proto in CurrentIds.Keys)
         {
-            if (!_prototypeManager.HasIndex<NameIdentifierGroupPrototype>(proto))
+            if (!ProtoMan.HasIndex<NameIdentifierGroupPrototype>(proto))
             {
                 toRemove.Add(proto);
             }

--- a/Content.Server/Objectives/ObjectivesSystem.cs
+++ b/Content.Server/Objectives/ObjectivesSystem.cs
@@ -25,7 +25,6 @@ public sealed partial class ObjectivesSystem : SharedObjectivesSystem
 {
     [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private IPlayerManager _player = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private EmergencyShuttleSystem _emergencyShuttle = default!;
     [Dependency] private SharedJobSystem _job = default!;
@@ -42,14 +41,14 @@ public sealed partial class ObjectivesSystem : SharedObjectivesSystem
 
         Subs.CVar(_cfg, CCVars.GameShowGreentext, value => _showGreentext = value, true);
 
-        _prototypeManager.PrototypesReloaded += CreateCompletions;
+        ProtoMan.PrototypesReloaded += CreateCompletions;
     }
 
     public override void Shutdown()
     {
         base.Shutdown();
 
-        _prototypeManager.PrototypesReloaded -= CreateCompletions;
+        ProtoMan.PrototypesReloaded -= CreateCompletions;
     }
 
     /// <summary>
@@ -152,7 +151,7 @@ public sealed partial class ObjectivesSystem : SharedObjectivesSystem
                 //TO DO:
                 //check for the right group here. Getting the target issuer is easy: objectiveGroup.Key
                 //It should be compared to the type of the group's issuer.
-                if (!_prototypeManager.TryIndex(objectiveGroup.Key, out var issuer))
+                if (!ProtoMan.TryIndex(objectiveGroup.Key, out var issuer))
                 {
                     Log.Error($"Found incorrect objective issuer {issuer} when generating round end text.");
                     continue;
@@ -226,7 +225,7 @@ public sealed partial class ObjectivesSystem : SharedObjectivesSystem
 
     public EntityUid? GetRandomObjective(EntityUid mindId, MindComponent mind, ProtoId<WeightedRandomPrototype> objectiveGroupProto, float maxDifficulty)
     {
-        if (!_prototypeManager.TryIndex(objectiveGroupProto, out var groupsProto))
+        if (!ProtoMan.TryIndex(objectiveGroupProto, out var groupsProto))
         {
             Log.Error($"Tried to get a random objective, but can't index WeightedRandomPrototype {objectiveGroupProto}");
             return null;
@@ -237,7 +236,7 @@ public sealed partial class ObjectivesSystem : SharedObjectivesSystem
 
         while (_random.TryPickAndTake(groups, out var groupName))
         {
-            if (!_prototypeManager.TryIndex<WeightedRandomPrototype>(groupName, out var group))
+            if (!ProtoMan.TryIndex<WeightedRandomPrototype>(groupName, out var group))
             {
                 Log.Error($"Couldn't index objective group prototype {groupName}");
                 return null;
@@ -246,7 +245,7 @@ public sealed partial class ObjectivesSystem : SharedObjectivesSystem
             var objectives = group.Weights.ShallowClone();
             while (_random.TryPickAndTake(objectives, out var objectiveProto))
             {
-                if (!_prototypeManager.Index(objectiveProto).TryGetComponent<ObjectiveComponent>(out var objectiveComp, EntityManager.ComponentFactory))
+                if (!ProtoMan.Index(objectiveProto).TryComp<ObjectiveComponent>(out var objectiveComp, EntityManager.ComponentFactory))
                     continue;
 
                 if (objectiveComp.Difficulty <= maxDifficulty && TryCreateObjective((mindId, mind), objectiveProto, out var objective))
@@ -320,7 +319,7 @@ public sealed partial class ObjectivesSystem : SharedObjectivesSystem
 
     private void CreateCompletions()
     {
-        _objectives = _prototypeManager.EnumeratePrototypes<EntityPrototype>()
+        _objectives = ProtoMan.EnumeratePrototypes<EntityPrototype>()
             .Where(p => p.HasComponent<ObjectiveComponent>())
             .Select(p => p.ID)
             .Order();

--- a/Content.Server/Objectives/Systems/StealConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/StealConditionSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Mind;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Objectives.Systems;
 using Robust.Shared.Containers;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Shared.Mind.Components;
 using Content.Shared.Mobs.Systems;
@@ -18,7 +17,6 @@ namespace Content.Server.Objectives.Systems;
 public sealed partial class StealConditionSystem : EntitySystem
 {
     [Dependency] private IRobustRandom _random = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private MetaDataSystem _metaData = default!;
     [Dependency] private MobStateSystem _mobState = default!;
     [Dependency] private SharedInteractionSystem _interaction = default!;
@@ -73,7 +71,7 @@ public sealed partial class StealConditionSystem : EntitySystem
     //Set the visual, name, icon for the objective.
     private void OnAfterAssign(Entity<StealConditionComponent> condition, ref ObjectiveAfterAssignEvent args)
     {
-        var group = _proto.Index(condition.Comp.StealGroup);
+        var group = ProtoMan.Index(condition.Comp.StealGroup);
         string localizedName = Loc.GetString(group.Name);
 
         var title = condition.Comp.OwnerText == null

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -36,9 +36,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
 {
     [Dependency] private IConfigurationManager _configManager = default!;
     [Dependency] private IConsoleHost _console = default!;
-    [Dependency] private IMapManager _mapManager = default!;
     [Dependency] private IParallelManager _parallel = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IPlayerManager _playerManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private AtmosphereSystem _atmos = default!;
@@ -119,7 +117,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
             SetSeed(uid, component, _random.Next());
         }
 
-        if (_proto.Resolve(component.Template, out var biome))
+        if (ProtoMan.Resolve(component.Template, out var biome))
             SetTemplate(uid, component, biome);
 
         var xform = Transform(uid);
@@ -129,7 +127,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         {
             var setTiles = new List<(Vector2i Index, Tile tile)>();
 
-            foreach (var grid in _mapManager.GetAllGrids(mapId))
+            foreach (var grid in _mapSystem.GetAllGrids(mapId))
             {
                 if (!_fixturesQuery.TryGetComponent(grid.Owner, out var fixtures))
                     continue;

--- a/Content.Server/Players/JobWhitelist/JobWhitelistSystem.cs
+++ b/Content.Server/Players/JobWhitelist/JobWhitelistSystem.cs
@@ -15,7 +15,6 @@ public sealed partial class JobWhitelistSystem : EntitySystem
     [Dependency] private IConfigurationManager _config = default!;
     [Dependency] private JobWhitelistManager _manager = default!;
     [Dependency] private IPlayerManager _player = default!;
-    [Dependency] private IPrototypeManager _prototypes = default!;
 
     private ImmutableArray<ProtoId<JobPrototype>> _whitelistedJobs = [];
 
@@ -79,7 +78,7 @@ public sealed partial class JobWhitelistSystem : EntitySystem
     private void CacheJobs()
     {
         var builder = ImmutableArray.CreateBuilder<ProtoId<JobPrototype>>();
-        foreach (var job in _prototypes.EnumeratePrototypes<JobPrototype>())
+        foreach (var job in ProtoMan.EnumeratePrototypes<JobPrototype>())
         {
             if (job.Whitelisted)
                 builder.Add(job.ID);

--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
@@ -34,7 +34,6 @@ public sealed partial class PlayTimeTrackingSystem : EntitySystem
     [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private IPlayerManager _playerManager = default!;
     [Dependency] private IServerPreferencesManager _preferencesManager = default!;
-    [Dependency] private IPrototypeManager _prototypes = default!;
     [Dependency] private SharedRoleSystem _roles = default!;
     [Dependency] private PlayTimeTrackingManager _tracking = default!;
 
@@ -110,7 +109,7 @@ public sealed partial class PlayTimeTrackingSystem : EntitySystem
             if (string.IsNullOrWhiteSpace(role.PlayTimeTrackerId))
                 continue;
 
-            yield return _prototypes.Index<PlayTimeTrackerPrototype>(role.PlayTimeTrackerId).ID;
+            yield return ProtoMan.Index<PlayTimeTrackerPrototype>(role.PlayTimeTrackerId).ID;
         }
     }
 
@@ -255,7 +254,7 @@ public sealed partial class PlayTimeTrackingSystem : EntitySystem
             playTimes,
             out _,
             EntityManager,
-            _prototypes,
+            ProtoMan,
             (HumanoidCharacterProfile?)
             _preferencesManager.GetPreferences(player.UserId).SelectedCharacter);
     }
@@ -283,7 +282,7 @@ public sealed partial class PlayTimeTrackingSystem : EntitySystem
             playTimes,
             out _,
             EntityManager,
-            _prototypes,
+            ProtoMan,
             (HumanoidCharacterProfile?)
             _preferencesManager.GetPreferences(player.UserId).SelectedCharacter);
     }
@@ -300,9 +299,9 @@ public sealed partial class PlayTimeTrackingSystem : EntitySystem
             playTimes = new Dictionary<string, TimeSpan>();
         }
 
-        foreach (var job in _prototypes.EnumeratePrototypes<JobPrototype>())
+        foreach (var job in ProtoMan.EnumeratePrototypes<JobPrototype>())
         {
-            if (JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(player.UserId).SelectedCharacter))
+            if (JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, ProtoMan, (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(player.UserId).SelectedCharacter))
                 roles.Add(job.ID);
         }
 
@@ -324,8 +323,8 @@ public sealed partial class PlayTimeTrackingSystem : EntitySystem
 
         for (var i = 0; i < jobs.Count; i++)
         {
-            if (_prototypes.Resolve(jobs[i], out var job)
-                && JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, _prototypes, (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(userId).SelectedCharacter))
+            if (ProtoMan.Resolve(jobs[i], out var job)
+                && JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, ProtoMan, (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(userId).SelectedCharacter))
             {
                 continue;
             }

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -27,7 +27,6 @@ namespace Content.Server.Polymorph.Systems;
 public sealed partial class PolymorphSystem : EntitySystem
 {
     [Dependency] private SharedMapSystem _map = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IGameTiming _gameTiming = default!;
     [Dependency] private ActionsSystem _actions = default!;
     [Dependency] private AudioSystem _audio = default!;
@@ -113,7 +112,7 @@ public sealed partial class PolymorphSystem : EntitySystem
 
     private void OnPolymorphActionEvent(Entity<PolymorphableComponent> ent, ref PolymorphActionEvent args)
     {
-        if (!_proto.Resolve(args.ProtoId, out var prototype) || args.Handled)
+        if (!ProtoMan.Resolve(args.ProtoId, out var prototype) || args.Handled)
             return;
 
         PolymorphEntity(ent, prototype.Configuration);
@@ -168,7 +167,7 @@ public sealed partial class PolymorphSystem : EntitySystem
     /// <param name="protoId">The id of the polymorph prototype</param>
     public EntityUid? PolymorphEntity(EntityUid uid, ProtoId<PolymorphPrototype> protoId)
     {
-        var config = _proto.Index(protoId).Configuration;
+        var config = ProtoMan.Index(protoId).Configuration;
         return PolymorphEntity(uid, config);
     }
 
@@ -390,10 +389,10 @@ public sealed partial class PolymorphSystem : EntitySystem
         if (target.Comp.PolymorphActions.ContainsKey(id))
             return;
 
-        if (!_proto.Resolve(id, out var polyProto))
+        if (!ProtoMan.Resolve(id, out var polyProto))
             return;
 
-        var entProto = _proto.Index(polyProto.Configuration.Entity);
+        var entProto = ProtoMan.Index(polyProto.Configuration.Entity);
 
         EntityUid? actionId = default!;
         if (!_actions.AddAction(target, ref actionId, RevertPolymorphId, target))

--- a/Content.Server/Procedural/DungeonSystem.Commands.cs
+++ b/Content.Server/Procedural/DungeonSystem.Commands.cs
@@ -29,7 +29,7 @@ public sealed partial class DungeonSystem
 
         var mapId = new MapId(mapInt);
 
-        if (!_prototype.TryIndex<DungeonConfigPrototype>(args[1], out var dungeon))
+        if (!ProtoMan.TryIndex<DungeonConfigPrototype>(args[1], out var dungeon))
         {
             shell.WriteError(Loc.GetString("cmd-dungen-config"));
             return;
@@ -81,7 +81,7 @@ public sealed partial class DungeonSystem
 
         if (args.Length == 2)
         {
-            return CompletionResult.FromHintOptions(CompletionHelper.PrototypeIDs<DungeonConfigPrototype>(proto: _prototype), Loc.GetString("cmd-dungen-hint-config"));
+            return CompletionResult.FromHintOptions(CompletionHelper.PrototypeIDs<DungeonConfigPrototype>(proto: ProtoMan), Loc.GetString("cmd-dungen-hint-config"));
         }
 
         if (args.Length == 3)
@@ -118,7 +118,7 @@ public sealed partial class DungeonSystem
         var mapId = new MapId(mapInt);
         var mapUid = _maps.GetMapOrInvalid(mapId);
 
-        if (!_prototype.TryIndex<DungeonRoomPackPrototype>(args[1], out var pack))
+        if (!ProtoMan.TryIndex<DungeonRoomPackPrototype>(args[1], out var pack))
         {
             return;
         }
@@ -174,7 +174,7 @@ public sealed partial class DungeonSystem
         var mapId = new MapId(mapInt);
         var mapUid =_maps.GetMapOrInvalid(mapId);
 
-        if (!_prototype.TryIndex<DungeonPresetPrototype>(args[1], out var preset))
+        if (!ProtoMan.TryIndex<DungeonPresetPrototype>(args[1], out var preset))
         {
             return;
         }
@@ -208,7 +208,7 @@ public sealed partial class DungeonSystem
 
         if (args.Length == 2)
         {
-            return CompletionResult.FromOptions(CompletionHelper.PrototypeIDs<DungeonPresetPrototype>(proto: _prototype));
+            return CompletionResult.FromOptions(CompletionHelper.PrototypeIDs<DungeonPresetPrototype>(proto: ProtoMan));
         }
 
         return CompletionResult.Empty;
@@ -223,7 +223,7 @@ public sealed partial class DungeonSystem
 
         if (args.Length == 2)
         {
-            return CompletionResult.FromOptions(CompletionHelper.PrototypeIDs<DungeonRoomPackPrototype>(proto: _prototype));
+            return CompletionResult.FromOptions(CompletionHelper.PrototypeIDs<DungeonRoomPackPrototype>(proto: ProtoMan));
         }
 
         return CompletionResult.Empty;

--- a/Content.Server/Procedural/DungeonSystem.Rooms.cs
+++ b/Content.Server/Procedural/DungeonSystem.Rooms.cs
@@ -40,7 +40,7 @@ public sealed partial class DungeonSystem
 
         _availableRooms.Clear();
 
-        foreach (var proto in _prototype.EnumeratePrototypes<DungeonRoomPrototype>())
+        foreach (var proto in ProtoMan.EnumeratePrototypes<DungeonRoomPrototype>())
         {
             if (minSize is not null && (proto.Size.X < minSize.Value.X || proto.Size.Y < minSize.Value.Y))
                 continue;

--- a/Content.Server/Procedural/DungeonSystem.cs
+++ b/Content.Server/Procedural/DungeonSystem.cs
@@ -25,7 +25,6 @@ public sealed partial class DungeonSystem : SharedDungeonSystem
 {
     [Dependency] private IConfigurationManager _configManager = default!;
     [Dependency] private IConsoleHost _console = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private ITileDefinitionManager _tileDefManager = default!;
     [Dependency] private AnchorableSystem _anchorable = default!;
@@ -95,7 +94,7 @@ public sealed partial class DungeonSystem : SharedDungeonSystem
             return;
 
         // Force all templates to be setup.
-        foreach (var room in _prototype.EnumeratePrototypes<DungeonRoomPrototype>())
+        foreach (var room in ProtoMan.EnumeratePrototypes<DungeonRoomPrototype>())
         {
             GetOrCreateTemplate(room);
         }
@@ -201,7 +200,7 @@ public sealed partial class DungeonSystem : SharedDungeonSystem
             Log,
             DungeonJobTime,
             EntityManager,
-            _prototype,
+            ProtoMan,
             _tileDefManager,
             _anchorable,
             _decals,
@@ -234,7 +233,7 @@ public sealed partial class DungeonSystem : SharedDungeonSystem
             Log,
             DungeonJobTime,
             EntityManager,
-            _prototype,
+            ProtoMan,
             _tileDefManager,
             _anchorable,
             _decals,

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -21,7 +21,6 @@ namespace Content.Server.Radio.EntitySystems;
 /// </summary>
 public sealed partial class RadioDeviceSystem : SharedRadioDeviceSystem
 {
-    [Dependency] private IPrototypeManager _protoMan = default!;
     [Dependency] private PopupSystem _popup = default!;
     [Dependency] private ChatSystem _chat = default!;
     [Dependency] private RadioSystem _radio = default!;
@@ -139,7 +138,7 @@ public sealed partial class RadioDeviceSystem : SharedRadioDeviceSystem
         if (!args.IsInDetailsRange)
             return;
 
-        var proto = _protoMan.Index<RadioChannelPrototype>(component.BroadcastChannel);
+        var proto = ProtoMan.Index<RadioChannelPrototype>(component.BroadcastChannel);
 
         using (args.PushGroup(nameof(RadioMicrophoneComponent)))
         {
@@ -154,7 +153,7 @@ public sealed partial class RadioDeviceSystem : SharedRadioDeviceSystem
         if (HasComp<RadioSpeakerComponent>(args.Source))
             return; // no feedback loops please.
 
-        var channel = _protoMan.Index<RadioChannelPrototype>(component.BroadcastChannel)!;
+        var channel = ProtoMan.Index<RadioChannelPrototype>(component.BroadcastChannel)!;
         if (_recentlySent.Add((args.Message, args.Source, channel)))
             _radio.SendRadioMessage(args.Source, args.Message, channel, uid);
     }
@@ -220,7 +219,7 @@ public sealed partial class RadioDeviceSystem : SharedRadioDeviceSystem
         if (ent.Comp.RequiresPower && !this.IsPowered(ent, EntityManager))
             return;
 
-        if (!_protoMan.HasIndex<RadioChannelPrototype>(args.Channel) || !ent.Comp.SupportedChannels.Contains(args.Channel))
+        if (!ProtoMan.HasIndex<RadioChannelPrototype>(args.Channel) || !ent.Comp.SupportedChannels.Contains(args.Channel))
             return;
 
         SetIntercomChannel(ent, args.Channel);

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -26,7 +26,6 @@ public sealed partial class RadioSystem : EntitySystem
     [Dependency] private INetManager _netMan = default!;
     [Dependency] private IReplayRecordingManager _replay = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private ChatSystem _chat = default!;
     [Dependency] private IChatManager _chatManager = default!;
@@ -80,7 +79,7 @@ public sealed partial class RadioSystem : EntitySystem
     /// </summary>
     public void SendRadioMessage(EntityUid messageSource, string message, ProtoId<RadioChannelPrototype> channel, EntityUid radioSource, bool escapeMarkup = true)
     {
-        SendRadioMessage(messageSource, message, _prototype.Index(channel), radioSource, escapeMarkup: escapeMarkup);
+        SendRadioMessage(messageSource, message, ProtoMan.Index(channel), radioSource, escapeMarkup: escapeMarkup);
     }
 
     /// <summary>
@@ -101,7 +100,7 @@ public sealed partial class RadioSystem : EntitySystem
         name = FormattedMessage.EscapeText(name);
 
         SpeechVerbPrototype speech;
-        if (evt.SpeechVerb != null && _prototype.Resolve(evt.SpeechVerb, out var evntProto))
+        if (evt.SpeechVerb != null && ProtoMan.Resolve(evt.SpeechVerb, out var evntProto))
             speech = evntProto;
         else
             speech = _chat.GetSpeechVerb(messageSource, message);

--- a/Content.Server/RandomMetadata/RandomMetadataSystem.cs
+++ b/Content.Server/RandomMetadata/RandomMetadataSystem.cs
@@ -8,7 +8,6 @@ namespace Content.Server.RandomMetadata;
 
 public sealed partial class RandomMetadataSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private MetaDataSystem _metaData = default!;
 
@@ -50,7 +49,7 @@ public sealed partial class RandomMetadataSystem : EntitySystem
         _outputSegments.Clear();
         for (var i = 0; i < segments.Count; ++i)
         {
-            var localizedProto = _prototype.Index(segments[i]);
+            var localizedProto = ProtoMan.Index(segments[i]);
             _outputSegments.Add(($"part{i}", _random.Pick(localizedProto)));
         }
 

--- a/Content.Server/Research/Disk/ResearchDiskSystem.cs
+++ b/Content.Server/Research/Disk/ResearchDiskSystem.cs
@@ -4,13 +4,11 @@ using Content.Server.Popups;
 using Content.Shared.Research.Prototypes;
 using Content.Server.Research.Systems;
 using Content.Shared.Research.Components;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Research.Disk
 {
     public sealed partial class ResearchDiskSystem : EntitySystem
     {
-        [Dependency] private IPrototypeManager _prototype = default!;
         [Dependency] private PopupSystem _popupSystem = default!;
         [Dependency] private ResearchSystem _research = default!;
         public override void Initialize()
@@ -39,7 +37,7 @@ namespace Content.Server.Research.Disk
             if (!component.UnlockAllTech)
                 return;
 
-            component.Points = _prototype.EnumeratePrototypes<TechnologyPrototype>()
+            component.Points = ProtoMan.EnumeratePrototypes<TechnologyPrototype>()
                 .Sum(tech => tech.Cost);
         }
     }

--- a/Content.Server/Respawn/SpecialRespawnSystem.cs
+++ b/Content.Server/Respawn/SpecialRespawnSystem.cs
@@ -9,7 +9,6 @@ using Content.Shared.Respawn;
 using Content.Shared.Station.Components;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Respawn;
@@ -23,7 +22,6 @@ public sealed partial class SpecialRespawnSystem : SharedSpecialRespawnSystem
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private TurfSystem _turf = default!;
     [Dependency] private IChatManager _chat = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
 
     public override void Initialize()
     {
@@ -89,7 +87,7 @@ public sealed partial class SpecialRespawnSystem : SharedSpecialRespawnSystem
             return;
 
         //Invalid prototype
-        if (!_proto.HasIndex(component.Prototype))
+        if (!ProtoMan.HasIndex(component.Prototype))
             return;
 
         if (TryFindRandomTile(entityGridUid.Value, entityMapUid.Value, 10, out var coords))

--- a/Content.Server/Roles/RoleSystem.cs
+++ b/Content.Server/Roles/RoleSystem.cs
@@ -2,14 +2,12 @@ using Content.Server.Chat.Managers;
 using Content.Shared.Chat;
 using Content.Shared.Mind;
 using Content.Shared.Roles;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Roles;
 
 public sealed partial class RoleSystem : SharedRoleSystem
 {
     [Dependency] private IChatManager _chat = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
 
     public string? MindGetBriefing(EntityUid? mindId)
     {
@@ -49,7 +47,7 @@ public sealed partial class RoleSystem : SharedRoleSystem
         if (!Player.TryGetSessionById(mind.UserId, out var session))
             return;
 
-        if (!_proto.Resolve(mind.RoleType, out var proto))
+        if (!ProtoMan.Resolve(mind.RoleType, out var proto))
             return;
 
         var roleText = Loc.GetString(proto.Name);

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -16,7 +16,6 @@ using Content.Shared.GameTicking;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.Station.Components;
@@ -34,7 +33,6 @@ namespace Content.Server.RoundEnd
         [Dependency] private IConfigurationManager _cfg = default!;
         [Dependency] private IChatManager _chatManager = default!;
         [Dependency] private IGameTiming _gameTiming = default!;
-        [Dependency] private IPrototypeManager _protoManager = default!;
         [Dependency] private ChatSystem _chatSystem = default!;
         [Dependency] private GameTicker _gameTicker = default!;
         [Dependency] private DeviceNetworkSystem _deviceNetworkSystem = default!;
@@ -149,7 +147,7 @@ namespace Content.Server.RoundEnd
                 var stationUid = _stationSystem.GetOwningStation(requester.Value);
                 if (TryComp<AlertLevelComponent>(stationUid, out var alertLevel))
                 {
-                    duration = _protoManager
+                    duration = ProtoMan
                         .Index<AlertLevelPrototype>(AlertLevelSystem.DefaultAlertLevelSet)
                         .Levels[alertLevel.CurrentLevel].ShuttleTime;
                 }

--- a/Content.Server/Salvage/JobBoard/SalvageJobBoardSystem.cs
+++ b/Content.Server/Salvage/JobBoard/SalvageJobBoardSystem.cs
@@ -21,7 +21,6 @@ namespace Content.Server.Salvage.JobBoard;
 public sealed partial class SalvageJobBoardSystem : EntitySystem
 {
     [Dependency] private IGameTiming _timing = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private AudioSystem _audio = default!;
     [Dependency] private CargoSystem _cargo = default!;
     [Dependency] private LabelSystem _label = default!;
@@ -78,7 +77,7 @@ public sealed partial class SalvageJobBoardSystem : EntitySystem
             availableGroups.Add(rank.BountyGroup.Value);
         }
 
-        foreach (var bounty in _prototypeManager.EnumeratePrototypes<CargoBountyPrototype>())
+        foreach (var bounty in ProtoMan.EnumeratePrototypes<CargoBountyPrototype>())
         {
             if (ent.Comp.CompletedJobs.Contains(bounty))
                 continue;
@@ -110,7 +109,7 @@ public sealed partial class SalvageJobBoardSystem : EntitySystem
             // don't worry abooouuuuut it (it'll be O K !)
             var high = i != ent.Comp.RankThresholds.Count - 1
                 ? ent.Comp.RankThresholds.Keys.ElementAt(i + 1)
-                :  _prototypeManager.EnumeratePrototypes<CargoBountyPrototype>()
+                :  ProtoMan.EnumeratePrototypes<CargoBountyPrototype>()
                 .Count(p => ent.Comp.RankThresholds.Values
                     .Select(r => r.BountyGroup)
                     .Contains(p.Group));
@@ -160,7 +159,7 @@ public sealed partial class SalvageJobBoardSystem : EntitySystem
         if (!GetAvailableJobs(ent).Contains(job))
             return false;
 
-        var jobProto = _prototypeManager.Index(job);
+        var jobProto = ProtoMan.Index(job);
 
         var oldRank = GetRank(ent);
 
@@ -260,7 +259,7 @@ public sealed partial class SalvageJobBoardSystem : EntitySystem
             !TryComp<SalvageJobsDataComponent>(station, out var jobsData))
             return;
 
-        if (!_prototypeManager.TryIndex<CargoBountyPrototype>(args.JobId, out var job))
+        if (!ProtoMan.TryIndex<CargoBountyPrototype>(args.JobId, out var job))
             return;
 
         if (!GetAvailableJobs((station, jobsData)).Contains(args.JobId))

--- a/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
+++ b/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Shuttles.Components;
 using Content.Shared.Procedural;
 using Content.Shared.Salvage.Expeditions;
 using Content.Shared.Dataset;
@@ -25,10 +24,10 @@ public sealed partial class SalvageSystem
         SpawnMission(missionparams, station.Value, cdUid);
 
         data.ActiveMission = args.Index;
-        var mission = GetMission(_prototypeManager.Index<SalvageDifficultyPrototype>(missionparams.Difficulty), missionparams.Seed);
+        var mission = GetMission(ProtoMan.Index<SalvageDifficultyPrototype>(missionparams.Difficulty), missionparams.Seed);
         data.NextOffer = _timing.CurTime + mission.Duration + TimeSpan.FromSeconds(1);
 
-        _labelSystem.Label(cdUid, GetFTLName(_prototypeManager.Index(PlanetNames), missionparams.Seed));
+        _labelSystem.Label(cdUid, GetFTLName(ProtoMan.Index(PlanetNames), missionparams.Seed));
         _audio.PlayPvs(component.PrintSound, uid);
 
         UpdateConsoles((station.Value, data));

--- a/Content.Server/Salvage/SalvageSystem.Expeditions.cs
+++ b/Content.Server/Salvage/SalvageSystem.Expeditions.cs
@@ -169,7 +169,7 @@ public sealed partial class SalvageSystem
             EntityManager,
             _timing,
             _logManager,
-            _prototypeManager,
+            ProtoMan,
             _anchorable,
             _biome,
             _dungeon,

--- a/Content.Server/Salvage/SalvageSystem.Magnet.cs
+++ b/Content.Server/Salvage/SalvageSystem.Magnet.cs
@@ -296,7 +296,7 @@ public sealed partial class SalvageSystem
                 await _dungeon.GenerateDungeonAsync(asteroid.DungeonConfig, grid.Owner, grid.Comp, Vector2i.Zero, seed);
                 break;
             case DebrisOffering debris:
-                var debrisProto = _prototypeManager.Index<DungeonConfigPrototype>(debris.Id);
+                var debrisProto = ProtoMan.Index<DungeonConfigPrototype>(debris.Id);
                 var debrisGrid = _mapManager.CreateGridEntity(salvMap);
                 await _dungeon.GenerateDungeonAsync(debrisProto, debrisGrid.Owner, debrisGrid.Comp, Vector2i.Zero, seed);
                 break;

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.Salvage;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Server.Chat.Managers;
 using Content.Server.Gravity;
@@ -28,7 +27,6 @@ namespace Content.Server.Salvage
         [Dependency] private IGameTiming _timing = default!;
         [Dependency] private ILogManager _logManager = default!;
         [Dependency] private IMapManager _mapManager = default!;
-        [Dependency] private IPrototypeManager _prototypeManager = default!;
         [Dependency] private IRobustRandom _random = default!;
         [Dependency] private AnchorableSystem _anchorable = default!;
         [Dependency] private BiomeSystem _biome = default!;
@@ -59,7 +57,7 @@ namespace Content.Server.Salvage
         private void Report(EntityUid source, string channelName, string messageKey, params (string, object)[] args)
         {
             var message = args.Length == 0 ? Loc.GetString(messageKey) : Loc.GetString(messageKey, args);
-            var channel = _prototypeManager.Index<RadioChannelPrototype>(channelName);
+            var channel = ProtoMan.Index<RadioChannelPrototype>(channelName);
             _radioSystem.SendRadioMessage(source, message, channel, source);
         }
 

--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -49,7 +49,6 @@ public sealed partial class ArrivalsSystem : EntitySystem
     [Dependency] private IConfigurationManager _cfgManager = default!;
     [Dependency] private IConsoleHost _console = default!;
     [Dependency] private IGameTiming _timing = default!;
-    [Dependency] private IPrototypeManager _protoManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private ActorSystem _actor = default!;
     [Dependency] private BiomeSystem _biomes = default!;
@@ -550,7 +549,7 @@ public sealed partial class ArrivalsSystem : EntitySystem
         if (_cfgManager.GetCVar(CCVars.ArrivalsPlanet))
         {
             var template = _random.Pick(_arrivalsBiomeOptions);
-            _biomes.EnsurePlanet(mapUid, _protoManager.Index(template));
+            _biomes.EnsurePlanet(mapUid, ProtoMan.Index(template));
             var restricted = new RestrictedRangeComponent
             {
                 Range = 32f

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -91,7 +91,7 @@ public sealed partial class ShuttleSystem
 
         var dungeonProtoId = _random.Pick(group.Protos);
 
-        if (!_protoManager.Resolve(dungeonProtoId, out var dungeonProto))
+        if (!ProtoMan.Resolve(dungeonProtoId, out var dungeonProto))
         {
             return false;
         }
@@ -194,7 +194,7 @@ public sealed partial class ShuttleSystem
                         throw new NotImplementedException();
                 }
 
-                if (_protoManager.Resolve(group.NameDataset, out var dataset))
+                if (ProtoMan.Resolve(group.NameDataset, out var dataset))
                 {
                     _metadata.SetEntityName(spawned, _salvage.GetFTLName(dataset, _random.Next()));
                 }

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -77,7 +77,7 @@ public sealed partial class ShuttleSystem
         Subs.CVar(_cfg, CCVars.ImpactMassBias, value => _massBias = value, true);
         Subs.CVar(_cfg, CCVars.ImpactInertiaScaling, value => _inertiaScaling = value, true);
 
-        _platingMass = _protoManager.Index(_platingId).Mass;
+        _platingMass = ProtoMan.Index(_platingId).Mass;
     }
 
     /// <summary>

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -39,7 +39,6 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
     [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private IGameTiming _gameTiming = default!;
     [Dependency] private IMapManager _mapManager = default!;
-    [Dependency] private IPrototypeManager _protoManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private BiomeSystem _biomes = default!;
     [Dependency] private GibbingSystem _gibbing = default!;

--- a/Content.Server/Silicons/Laws/IonLawSystem.cs
+++ b/Content.Server/Silicons/Laws/IonLawSystem.cs
@@ -14,7 +14,6 @@ namespace Content.Server.Silicons.Laws;
 /// </summary>
 public sealed partial class IonLawSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SharedStationSystem _stationSystem = default!;
     [Dependency] private StationRecordsSystem _stationRecordsSystem = default!;
@@ -134,7 +133,7 @@ public sealed partial class IonLawSystem : EntitySystem
     /// <returns>A formatted string representing the new ion law.</returns>
     public string GetIonLaw()
     {
-        var laws = _prototypeManager.EnumeratePrototypes<IonLawPrototype>().ToList();
+        var laws = ProtoMan.EnumeratePrototypes<IonLawPrototype>().ToList();
         if (laws.Count == 0)
         {
             _sawmill.Error("No Ion Laws found");
@@ -255,7 +254,7 @@ public sealed partial class IonLawSystem : EntitySystem
         switch (selector)
         {
             case DatasetFill datasetFill:
-                if (_prototypeManager.TryIndex(datasetFill.Dataset, out var dataset) && dataset.Values.Any())
+                if (ProtoMan.TryIndex(datasetFill.Dataset, out var dataset) && dataset.Values.Any())
                 {
                     return _random.Pick(dataset.Values);
                 }
@@ -275,7 +274,7 @@ public sealed partial class IonLawSystem : EntitySystem
                 }
 
                 // Fallback to dataset if no manifest record found or stations are empty
-                if (_prototypeManager.TryIndex(randomManifestFill.FallbackDataset, out var fallbackDataset) && fallbackDataset.Values.Any())
+                if (ProtoMan.TryIndex(randomManifestFill.FallbackDataset, out var fallbackDataset) && fallbackDataset.Values.Any())
                 {
                     return _random.Pick(fallbackDataset.Values);
                 }

--- a/Content.Server/Silicons/Laws/IonStormSystem.cs
+++ b/Content.Server/Silicons/Laws/IonStormSystem.cs
@@ -7,13 +7,11 @@ using Robust.Shared.Random;
 using System.Linq;
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Silicons.Laws;
 
 public sealed partial class IonStormSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private SiliconLawSystem _siliconLaw = default!;
     [Dependency] private IRobustRandom _robustRandom = default!;
@@ -36,7 +34,7 @@ public sealed partial class IonStormSystem : EntitySystem
         // try to swap it out with a random lawset
         if (_robustRandom.Prob(target.RandomLawsetChance))
         {
-            var lawsets = _proto.Index<WeightedRandomPrototype>(target.RandomLawsets);
+            var lawsets = ProtoMan.Index<WeightedRandomPrototype>(target.RandomLawsets);
             var lawset = lawsets.Pick(_robustRandom);
             laws = _siliconLaw.GetLawset(lawset);
         }

--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -28,7 +28,6 @@ public sealed partial class SiliconLawSystem : SharedSiliconLawSystem
 {
     [Dependency] private IChatManager _chatManager = default!;
     [Dependency] private SharedMindSystem _mind = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private SharedRoleSystem _roles = default!;
     [Dependency] private StationSystem _station = default!;
     [Dependency] private UserInterfaceSystem _userInterface = default!;
@@ -265,14 +264,14 @@ public sealed partial class SiliconLawSystem : SharedSiliconLawSystem
     /// </summary>
     public SiliconLawset GetLawset(ProtoId<SiliconLawsetPrototype> lawset)
     {
-        var proto = _prototype.Index(lawset);
+        var proto = ProtoMan.Index(lawset);
         var laws = new SiliconLawset()
         {
             Laws = new List<SiliconLaw>(proto.Laws.Count)
         };
         foreach (var law in proto.Laws)
         {
-            laws.Laws.Add(_prototype.Index<SiliconLawPrototype>(law).ShallowClone());
+            laws.Laws.Add(ProtoMan.Index<SiliconLawPrototype>(law).ShallowClone());
         }
         laws.ObeysTo = proto.ObeysTo;
 

--- a/Content.Server/Silicons/StationAi/StationAiSystem.cs
+++ b/Content.Server/Silicons/StationAi/StationAiSystem.cs
@@ -57,7 +57,6 @@ public sealed partial class StationAiSystem : SharedStationAiSystem
     [Dependency] private SharedPopupSystem _popups = default!;
     [Dependency] private StationSystem _station = default!;
     [Dependency] private StationJobsSystem _stationJobs = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private MobStateSystem _mobState = default!;
     [Dependency] private SharedAppearanceSystem _appearance = default!;
 
@@ -269,7 +268,7 @@ public sealed partial class StationAiSystem : SharedStationAiSystem
         if (!TryGetHeld((ent.Owner, ent.Comp), out var held))
             return;
 
-        if (!_proto.TryIndex(_batteryAlert, out var proto))
+        if (!ProtoMan.TryIndex(_batteryAlert, out var proto))
             return;
 
         var chargePercent = _battery.GetChargeLevel((ent.Owner, battery));
@@ -297,7 +296,7 @@ public sealed partial class StationAiSystem : SharedStationAiSystem
         if (!TryGetHeld((ent.Owner, ent.Comp), out var held))
             return;
 
-        if (!_proto.TryIndex(_damageAlert, out var proto))
+        if (!ProtoMan.TryIndex(_damageAlert, out var proto))
             return;
 
         var damagePercent = _damageable.GetTotalDamage((ent, damageable)) / _destructible.DestroyedAt(ent, destructible);

--- a/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
@@ -4,7 +4,6 @@ using Content.Server.Station.Systems;
 using Content.Shared.Preferences;
 using Robust.Server.Containers;
 using Robust.Shared.Containers;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Spawners.EntitySystems;
@@ -13,7 +12,6 @@ public sealed partial class ContainerSpawnPointSystem : EntitySystem
 {
     [Dependency] private ContainerSystem _container = default!;
     [Dependency] private GameTicker _gameTicker = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private StationSystem _station = default!;
     [Dependency] private StationSpawningSystem _stationSpawning = default!;
@@ -31,7 +29,7 @@ public sealed partial class ContainerSpawnPointSystem : EntitySystem
 
         // If it's just a spawn pref check if it's for cryo (silly).
         if (args.HumanoidCharacterProfile?.SpawnPriority != SpawnPriorityPreference.Cryosleep &&
-            (!_proto.Resolve(args.Job, out var jobProto) || jobProto.JobEntity == null))
+            (!ProtoMan.Resolve(args.Job, out var jobProto) || jobProto.JobEntity == null))
         {
             return;
         }

--- a/Content.Server/Spawners/EntitySystems/RandomDecalSpawnerSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/RandomDecalSpawnerSystem.cs
@@ -3,7 +3,6 @@ using Content.Server.Decals;
 using Content.Server.Spawners.Components;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Spawners.EntitySystems;
@@ -12,7 +11,6 @@ public sealed partial class RandomDecalSpawnerSystem : EntitySystem
 {
     [Dependency] private DecalSystem _decal = default!;
     [Dependency] private SharedMapSystem _map = default!;
-    [Dependency] private IPrototypeManager _prototypes = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private ITileDefinitionManager _tileDefs = default!;
 
@@ -89,7 +87,7 @@ public sealed partial class RandomDecalSpawnerSystem : EntitySystem
             }
 
             var decalProtoId = _random.Pick(comp.Decals);
-            var decalProto = _prototypes.Index(decalProtoId);
+            var decalProto = ProtoMan.Index(decalProtoId);
             var snapPosition = comp.SnapPosition ?? decalProto.DefaultSnap;
             if (snapPosition)
             {

--- a/Content.Server/Species/Systems/NymphSystem.cs
+++ b/Content.Server/Species/Systems/NymphSystem.cs
@@ -9,7 +9,6 @@ namespace Content.Server.Species.Systems;
 
 public sealed partial class NymphSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _protoManager = default!;
     [Dependency] private MindSystem _mindSystem = default!;
     [Dependency] private ZombieSystem _zombie = default!;
 
@@ -25,7 +24,7 @@ public sealed partial class NymphSystem : EntitySystem
         if (TerminatingOrDeleted(uid) || TerminatingOrDeleted(args.Target))
             return;
 
-        if (!_protoManager.TryIndex<EntityPrototype>(comp.EntityPrototype, out var entityProto))
+        if (!ProtoMan.TryIndex<EntityPrototype>(comp.EntityPrototype, out var entityProto))
             return;
 
         // Get the organs' position & spawn a nymph there

--- a/Content.Server/Speech/EmotesMenuSystem.cs
+++ b/Content.Server/Speech/EmotesMenuSystem.cs
@@ -1,12 +1,10 @@
 ﻿using Content.Shared.Chat;
 using Content.Server.Chat.Systems;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Speech;
 
 public sealed partial class EmotesMenuSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private ChatSystem _chat = default!;
 
     public override void Initialize()
@@ -22,7 +20,7 @@ public sealed partial class EmotesMenuSystem : EntitySystem
         if (!player.HasValue)
             return;
 
-        if (!_prototypeManager.Resolve(msg.ProtoId, out var proto) || proto.ChatTriggers.Count == 0)
+        if (!ProtoMan.Resolve(msg.ProtoId, out var proto) || proto.ChatTriggers.Count == 0)
             return;
 
         _chat.TryEmoteWithChat(player.Value, msg.ProtoId);

--- a/Content.Server/Speech/EntitySystems/MumbleAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/MumbleAccentSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.Chat;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Speech;
 using Content.Shared.Speech.Components;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Speech.EntitySystems;
 
@@ -12,7 +11,6 @@ public sealed partial class MumbleAccentSystem : EntitySystem
 {
     [Dependency] private ChatSystem _chat = default!;
     [Dependency] private ReplacementAccentSystem _replacement = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
 
     public override void Initialize()
     {
@@ -32,7 +30,7 @@ public sealed partial class MumbleAccentSystem : EntitySystem
             // play a muffled version of the vocal emote
             args.Handled = _chat.TryPlayEmoteSound(
                 ent.Owner,
-                _prototype.Index(sounds),
+                ProtoMan.Index(sounds),
                 args.Emote,
                 ent.Comp.EmoteAudioParams);
         }

--- a/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
@@ -15,7 +15,6 @@ namespace Content.Server.Speech.EntitySystems
     /// </summary>
     public sealed partial class ReplacementAccentSystem : EntitySystem
     {
-        [Dependency] private IPrototypeManager _proto = default!;
         [Dependency] private IRobustRandom _random = default!;
         [Dependency] private ILocalizationManager _loc = default!;
 
@@ -26,14 +25,14 @@ namespace Content.Server.Speech.EntitySystems
         {
             SubscribeLocalEvent<ReplacementAccentComponent, AccentGetEvent>(OnAccent);
 
-            _proto.PrototypesReloaded += OnPrototypesReloaded;
+            ProtoMan.PrototypesReloaded += OnPrototypesReloaded;
         }
 
         public override void Shutdown()
         {
             base.Shutdown();
 
-            _proto.PrototypesReloaded -= OnPrototypesReloaded;
+            ProtoMan.PrototypesReloaded -= OnPrototypesReloaded;
         }
 
         private void OnAccent(EntityUid uid, ReplacementAccentComponent component, AccentGetEvent args)
@@ -47,7 +46,7 @@ namespace Content.Server.Speech.EntitySystems
         [PublicAPI]
         public string ApplyReplacements(string message, string accent)
         {
-            if (!_proto.TryIndex<ReplacementAccentPrototype>(accent, out var prototype))
+            if (!ProtoMan.TryIndex<ReplacementAccentPrototype>(accent, out var prototype))
                 return message;
 
             if (!_random.Prob(prototype.ReplacementChance))

--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -6,7 +6,6 @@ using Content.Shared.Humanoid;
 using Content.Shared.Speech;
 using Content.Shared.Speech.Components;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Speech.EntitySystems;
@@ -14,7 +13,6 @@ namespace Content.Server.Speech.EntitySystems;
 public sealed partial class VocalSystem : EntitySystem
 {
     [Dependency] private IRobustRandom _random = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private ChatSystem _chat = default!;
     [Dependency] private ActionsSystem _actions = default!;
@@ -86,7 +84,7 @@ public sealed partial class VocalSystem : EntitySystem
             return;
 
         // just play regular sound based on emote proto
-        args.Handled = _chat.TryPlayEmoteSound(uid, _proto.Index(sounds), args.Emote);
+        args.Handled = _chat.TryPlayEmoteSound(uid, ProtoMan.Index(sounds), args.Emote);
     }
 
     private void OnEmoteAction(EntityUid uid, VocalComponent component, EmoteActionEvent args)
@@ -109,7 +107,7 @@ public sealed partial class VocalSystem : EntitySystem
         if (component.EmoteSounds is not { } sounds)
             return false;
 
-        return _chat.TryPlayEmoteSound(uid, _proto.Index(sounds), component.ScreamId);
+        return _chat.TryPlayEmoteSound(uid, ProtoMan.Index(sounds), component.ScreamId);
     }
 
     private void LoadSounds(EntityUid uid, VocalComponent component, Sex? sex = null)
@@ -122,7 +120,7 @@ public sealed partial class VocalSystem : EntitySystem
         if (!component.Sounds.TryGetValue(sex.Value, out var protoId))
             return;
 
-        if (!_proto.HasIndex(protoId))
+        if (!ProtoMan.HasIndex(protoId))
             return;
 
         component.EmoteSounds = protoId;

--- a/Content.Server/Speech/Muting/MutingSystem.cs
+++ b/Content.Server/Speech/Muting/MutingSystem.cs
@@ -13,7 +13,6 @@ namespace Content.Server.Speech.Muting
     public sealed partial class MutingSystem : EntitySystem
     {
         [Dependency] private PopupSystem _popupSystem = default!;
-        [Dependency] private IPrototypeManager _prototypeManager = default!;
 
         public override void Initialize()
         {
@@ -38,7 +37,7 @@ namespace Content.Server.Speech.Muting
             if (args.Handled)
                 return;
 
-            if (!_prototypeManager.Resolve(args.Emote, out var emote))
+            if (!ProtoMan.Resolve(args.Emote, out var emote))
                 return;
 
             if (!emote.Category.HasFlag(EmoteCategory.Vocal))

--- a/Content.Server/Speech/SpeechNoiseSystem.cs
+++ b/Content.Server/Speech/SpeechNoiseSystem.cs
@@ -2,7 +2,6 @@ using Content.Shared.Chat;
 using Content.Shared.Speech;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -11,7 +10,6 @@ namespace Content.Server.Speech
     public sealed partial class SpeechSoundSystem : EntitySystem
     {
         [Dependency] private IGameTiming _gameTiming = default!;
-        [Dependency] private IPrototypeManager _protoManager = default!;
         [Dependency] private IRobustRandom _random = default!;
         [Dependency] private SharedAudioSystem _audio = default!;
 
@@ -29,7 +27,7 @@ namespace Content.Server.Speech
 
             // Play speech sound
             SoundSpecifier? contextSound;
-            var prototype = _protoManager.Index<SpeechSoundsPrototype>(ent.Comp.SpeechSounds);
+            var prototype = ProtoMan.Index<SpeechSoundsPrototype>(ent.Comp.SpeechSounds);
 
             // Different sounds for ask/exclaim based on last character
             contextSound = message[^1] switch

--- a/Content.Server/Spreader/SpreaderSystem.cs
+++ b/Content.Server/Spreader/SpreaderSystem.cs
@@ -19,7 +19,6 @@ namespace Content.Server.Spreader;
 /// </summary>
 public sealed partial class SpreaderSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IRobustRandom _robustRandom = default!;
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private TagSystem _tag = default!;
@@ -64,7 +63,7 @@ public sealed partial class SpreaderSystem : EntitySystem
     private void SetupPrototypes()
     {
         _prototypeUpdates = [];
-        foreach (var proto in _prototype.EnumeratePrototypes<EdgeSpreaderPrototype>())
+        foreach (var proto in ProtoMan.EnumeratePrototypes<EdgeSpreaderPrototype>())
         {
             _prototypeUpdates.Add(proto.ID, proto.UpdatesPerSecond);
         }
@@ -178,7 +177,7 @@ public sealed partial class SpreaderSystem : EntitySystem
         occupiedTiles = [];
         neighbors = [];
         // TODO remove occupiedTiles -- its currently unused and just slows this method down.
-        if (!_prototype.Resolve(prototype, out var spreaderPrototype))
+        if (!ProtoMan.Resolve(prototype, out var spreaderPrototype))
             return;
 
         if (!TryComp<MapGridComponent>(comp.GridUid, out var grid))
@@ -348,9 +347,9 @@ public sealed partial class SpreaderSystem : EntitySystem
 
     public bool RequiresFloorToSpread(EntProtoId<EdgeSpreaderComponent> spreader)
     {
-        if (!_prototype.Index(spreader).TryGetComponent<EdgeSpreaderComponent>(out var spreaderComp, EntityManager.ComponentFactory))
+        if (!ProtoMan.Index(spreader).TryComp<EdgeSpreaderComponent>(out var spreaderComp, EntityManager.ComponentFactory))
             return false;
 
-        return _prototype.Index(spreaderComp.Id).PreventSpreadOnSpaced;
+        return ProtoMan.Index(spreaderComp.Id).PreventSpreadOnSpaced;
     }
 }

--- a/Content.Server/Sprite/RandomSpriteSystem.cs
+++ b/Content.Server/Sprite/RandomSpriteSystem.cs
@@ -2,14 +2,12 @@ using Content.Shared.Decals;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Sprite;
 using Robust.Shared.GameStates;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Sprite;
 
-public sealed partial class RandomSpriteSystem: SharedRandomSpriteSystem
+public sealed partial class RandomSpriteSystem : SharedRandomSpriteSystem
 {
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IRobustRandom _random = default!;
 
     public override void Initialize()
@@ -54,7 +52,7 @@ public sealed partial class RandomSpriteSystem: SharedRandomSpriteSystem
                         color = previousColor;
                     else
                     {
-                        color = _random.Pick(_prototype.Index<ColorPalettePrototype>(selectedState.Value).Colors.Values);
+                        color = _random.Pick(ProtoMan.Index<ColorPalettePrototype>(selectedState.Value).Colors.Values);
                         previousColor = color;
                     }
                 }

--- a/Content.Server/Stack/StackSystem.cs
+++ b/Content.Server/Stack/StackSystem.cs
@@ -13,8 +13,6 @@ namespace Content.Server.Stack
     [UsedImplicitly]
     public sealed partial class StackSystem : SharedStackSystem
     {
-        [Dependency] private IPrototypeManager _prototypeManager = default!;
-
         #region Spawning
 
         /// <summary>
@@ -35,7 +33,7 @@ namespace Content.Server.Stack
             if (!TryUse(ent, amount))
                 return null;
 
-            if (!_prototypeManager.Resolve(ent.Comp.StackTypeId, out var stackType))
+            if (!ProtoMan.Resolve(ent.Comp.StackTypeId, out var stackType))
                 return null;
 
             // Set the output parameter in the event instance to the newly split stack.
@@ -73,7 +71,7 @@ namespace Content.Server.Stack
         [PublicAPI]
         public EntityUid SpawnAtPosition(int count, ProtoId<StackPrototype> id, EntityCoordinates spawnPosition)
         {
-            var proto = _prototypeManager.Index(id);
+            var proto = ProtoMan.Index(id);
             return SpawnAtPosition(count, proto, spawnPosition);
         }
 
@@ -145,7 +143,7 @@ namespace Content.Server.Stack
                                                        int amount,
                                                        EntityCoordinates spawnPosition)
         {
-            var stackProto = _prototypeManager.Index(stackId);
+            var stackProto = ProtoMan.Index(stackId);
             return SpawnMultipleAtPosition(stackProto.Spawn,
                                             CalculateSpawns(stackProto, amount),
                                             spawnPosition);
@@ -167,7 +165,7 @@ namespace Content.Server.Stack
         [PublicAPI]
         public EntityUid SpawnNextToOrDrop(int amount, ProtoId<StackPrototype> id, EntityUid source)
         {
-            var proto = _prototypeManager.Index(id);
+            var proto = ProtoMan.Index(id);
             return SpawnNextToOrDrop(amount, proto, source);
         }
 
@@ -234,7 +232,7 @@ namespace Content.Server.Stack
                                                          int amount,
                                                          EntityUid target)
         {
-            var stackProto = _prototypeManager.Index(stackId);
+            var stackProto = ProtoMan.Index(stackId);
             return SpawnMultipleNextToOrDrop(stackProto.Spawn,
                                              CalculateSpawns(stackProto, amount),
                                              target);

--- a/Content.Server/Station/Systems/StationBiomeSystem.cs
+++ b/Content.Server/Station/Systems/StationBiomeSystem.cs
@@ -1,14 +1,12 @@
 using Content.Server.Parallax;
 using Content.Server.Station.Components;
 using Content.Server.Station.Events;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Station.Systems;
 
 public sealed partial class StationBiomeSystem : EntitySystem
 {
     [Dependency] private BiomeSystem _biome = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private StationSystem _station = default!;
     [Dependency] private SharedMapSystem _map = default!;
 
@@ -27,6 +25,6 @@ public sealed partial class StationBiomeSystem : EntitySystem
         var mapId = Transform(station.Value).MapID;
         var mapUid = _map.GetMapOrInvalid(mapId);
 
-        _biome.EnsurePlanet(mapUid, _proto.Index(map.Comp.Biome), map.Comp.Seed, mapLight: map.Comp.MapLightColor);
+        _biome.EnsurePlanet(mapUid, ProtoMan.Index(map.Comp.Biome), map.Comp.Seed, mapLight: map.Comp.MapLightColor);
     }
 }

--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -1,12 +1,10 @@
 using System.Linq;
 using Content.Server.Administration.Managers;
 using Content.Server.Antag;
-using Content.Server.Players.PlayTimeTracking;
 using Content.Server.Station.Components;
 using Content.Server.Station.Events;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
-using Robust.Server.Player;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -17,7 +15,6 @@ namespace Content.Server.Station.Systems;
 // Contains code for round-start spawning.
 public sealed partial class StationJobsSystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IBanManager _banManager = default!;
     [Dependency] private AntagSelectionSystem _antag = default!;
 
@@ -30,7 +27,7 @@ public sealed partial class StationJobsSystem
     private void InitializeRoundStart()
     {
         _jobsByWeight = new Dictionary<int, HashSet<string>>();
-        foreach (var job in _prototypeManager.EnumeratePrototypes<JobPrototype>())
+        foreach (var job in ProtoMan.EnumeratePrototypes<JobPrototype>())
         {
             if (!_jobsByWeight.ContainsKey(job.Weight))
                 _jobsByWeight.Add(job.Weight, new HashSet<string>());
@@ -369,7 +366,7 @@ public sealed partial class StationJobsSystem
                 if (!(priority == selectedPriority || selectedPriority is null))
                     continue;
 
-                if (!_prototypeManager.Resolve(jobId, out var job))
+                if (!ProtoMan.Resolve(jobId, out var job))
                     continue;
 
                 if (whitelist != null && !whitelist.Contains(jobId))

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -42,7 +42,6 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
     [Dependency] private IdentitySystem _identity = default!;
     [Dependency] private MetaDataSystem _metaSystem = default!;
     [Dependency] private PdaSystem _pdaSystem = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private MindSystem _mindSystem = default!;
 
     /// <summary>
@@ -90,13 +89,13 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
         EntityUid? station,
         EntityUid? entity = null)
     {
-        _prototypeManager.Resolve(job, out var prototype);
+        ProtoMan.Resolve(job, out var prototype);
         RoleLoadout? loadout = null;
 
         // Need to get the loadout up-front to handle names if we use an entity spawn override.
         var jobLoadout = LoadoutSystem.GetJobPrototype(prototype?.ID);
 
-        if (_prototypeManager.TryIndex(jobLoadout, out RoleLoadoutPrototype? roleProto))
+        if (ProtoMan.TryIndex(jobLoadout, out RoleLoadoutPrototype? roleProto))
         {
             profile?.Loadouts.TryGetValue(jobLoadout, out loadout);
 
@@ -104,7 +103,7 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
             if (loadout == null)
             {
                 loadout = new RoleLoadout(jobLoadout);
-                loadout.SetDefault(profile, _actors.GetSession(entity), _prototypeManager);
+                loadout.SetDefault(profile, _actors.GetSession(entity), ProtoMan);
             }
         }
 
@@ -128,7 +127,7 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
 
         string speciesId = profile != null ? profile.Species : HumanoidCharacterProfile.DefaultSpecies;
 
-        if (!_prototypeManager.TryIndex<SpeciesPrototype>(speciesId, out var species))
+        if (!ProtoMan.TryIndex<SpeciesPrototype>(speciesId, out var species))
             throw new ArgumentException($"Invalid species prototype was used: {speciesId}");
 
         entity ??= Spawn(species.Prototype, coordinates);
@@ -152,7 +151,7 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
 
         if (prototype?.StartingGear != null)
         {
-            var startingGear = _prototypeManager.Index<StartingGearPrototype>(prototype.StartingGear);
+            var startingGear = ProtoMan.Index<StartingGearPrototype>(prototype.StartingGear);
             EquipStartingGear(entity.Value, startingGear, raiseEvent: false);
         }
 
@@ -171,7 +170,7 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
 
     private void DoJobSpecials(ProtoId<JobPrototype>? job, EntityUid entity)
     {
-        if (!_prototypeManager.Resolve(job, out JobPrototype? prototype))
+        if (!ProtoMan.Resolve(job, out JobPrototype? prototype))
             return;
 
         foreach (var jobSpecial in prototype.Special)
@@ -202,7 +201,7 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
         _cardSystem.TryChangeFullName(cardId, characterName, card);
         _cardSystem.TryChangeJobTitle(cardId, jobPrototype.LocalizedName, card);
 
-        if (_prototypeManager.Resolve(jobPrototype.Icon, out var jobIcon))
+        if (ProtoMan.Resolve(jobPrototype.Icon, out var jobIcon))
             _cardSystem.TryChangeJobIcon(cardId, jobIcon, card);
 
         var extendedAccess = false;

--- a/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
@@ -10,8 +10,6 @@ using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Toolshed;
-using Robust.Shared.Toolshed.TypeParsers;
-using Robust.Shared.Utility;
 
 namespace Content.Server.StationEvents
 {
@@ -113,7 +111,7 @@ namespace Content.Server.StationEvents
 
             var eventScheduler = _protoMan.Index(eventSchedulerProto);
 
-            if (!eventScheduler.TryGetComponent<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
+            if (!eventScheduler.TryComp<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
             {
                 return occurrences.Select(p => (p.Key, (float)p.Value)).OrderByDescending(p => p.Item2);
             }
@@ -159,7 +157,7 @@ namespace Content.Server.StationEvents
 
             var eventScheduler = _protoMan.Index(eventSchedulerProto);
 
-            if (!eventScheduler.TryGetComponent<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
+            if (!eventScheduler.TryComp<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
                 yield break;
 
             var sortedEvents
@@ -181,7 +179,7 @@ namespace Content.Server.StationEvents
 
             var eventScheduler = _protoMan.Index(eventSchedulerProto);
 
-            if (!eventScheduler.TryGetComponent<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
+            if (!eventScheduler.TryComp<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
                 yield break;
 
             var timemins = time * 60;
@@ -208,7 +206,7 @@ namespace Content.Server.StationEvents
 
             var eventScheduler = _protoMan.Index(eventSchedulerProto);
 
-            if (!eventScheduler.TryGetComponent<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
+            if (!eventScheduler.TryComp<BasicStationEventSchedulerComponent>(out var basicScheduler, _compFac))
                 return 0f;
 
             foreach (var (proto, prob) in _stationEvent.ListLimitedEvents(basicScheduler.ScheduledGameRules))

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -17,7 +17,6 @@ public sealed partial class EventManagerSystem : EntitySystem
     [Dependency] private IConfigurationManager _configurationManager = default!;
     [Dependency] private IPlayerManager _playerManager = default!;
     [Dependency] private IRobustRandom _random = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private EntityTableSystem _entityTable = default!;
     [Dependency] public GameTicker GameTicker = default!;
     [Dependency] private RoundEndSystem _roundEnd = default!;
@@ -62,7 +61,7 @@ public sealed partial class EventManagerSystem : EntitySystem
             return;
         }
 
-        if (!_prototype.Resolve(randomLimitedEvent, out _))
+        if (!ProtoMan.Resolve(randomLimitedEvent, out _))
         {
             Log.Warning("A requested event is not available!");
             return;
@@ -112,13 +111,13 @@ public sealed partial class EventManagerSystem : EntitySystem
 
         foreach (var (eventId, prob) in selectedEvents)
         {
-            if (!_prototype.Resolve(eventId, out var eventproto))
+            if (!ProtoMan.Resolve(eventId, out var eventproto))
                 continue;
 
             if (eventproto.Abstract)
                 continue;
 
-            if (!eventproto.TryGetComponent<StationEventComponent>(out var stationEvent, EntityManager.ComponentFactory))
+            if (!eventproto.TryComp<StationEventComponent>(out var stationEvent, EntityManager.ComponentFactory))
                 continue;
 
             if (!CanRun(eventproto, stationEvent, playerCount.Value, currentTime.Value))
@@ -166,7 +165,7 @@ public sealed partial class EventManagerSystem : EntitySystem
             if (GameTicker.IsIgnored(eventid))
                 continue;
 
-            if (!_prototype.Resolve(eventid, out var eventproto))
+            if (!ProtoMan.Resolve(eventid, out var eventproto))
             {
                 Log.Warning("An event ID has no prototype index!");
                 continue;
@@ -178,7 +177,7 @@ public sealed partial class EventManagerSystem : EntitySystem
             if (eventproto.Abstract)
                 continue;
 
-            if (!eventproto.TryGetComponent<StationEventComponent>(out var stationEvent, EntityManager.ComponentFactory))
+            if (!eventproto.TryComp<StationEventComponent>(out var stationEvent, EntityManager.ComponentFactory))
                 continue;
 
             if (!CanRun(eventproto, stationEvent, playerCount.Value, currentTime.Value))
@@ -281,12 +280,12 @@ public sealed partial class EventManagerSystem : EntitySystem
     private Dictionary<EntityPrototype, StationEventComponent> GetAllEvents()
     {
         var allEvents = new Dictionary<EntityPrototype, StationEventComponent>();
-        foreach (var prototype in _prototype.EnumeratePrototypes<EntityPrototype>())
+        foreach (var prototype in ProtoMan.EnumeratePrototypes<EntityPrototype>())
         {
             if (prototype.Abstract)
                 continue;
 
-            if (!prototype.TryGetComponent<StationEventComponent>(out var stationEvent, EntityManager.ComponentFactory))
+            if (!prototype.TryComp<StationEventComponent>(out var stationEvent, EntityManager.ComponentFactory))
                 continue;
 
             allEvents.Add(prototype, stationEvent);

--- a/Content.Server/StationEvents/Events/ImmovableRodRule.cs
+++ b/Content.Server/StationEvents/Events/ImmovableRodRule.cs
@@ -1,12 +1,10 @@
 using System.Numerics;
-using Content.Server.GameTicking.Rules.Components;
 using Content.Server.ImmovableRod;
 using Content.Server.StationEvents.Components;
 using Content.Server.Weapons.Ranged.Systems;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Storage;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
 using TimedDespawnComponent = Robust.Shared.Spawners.TimedDespawnComponent;
 using System.Linq;
 
@@ -26,8 +24,8 @@ public sealed partial class ImmovableRodRule : StationEventSystem<ImmovableRodRu
 
         var proto = _prototypeManager.Index<EntityPrototype>(protoName);
 
-        if (proto.TryGetComponent<ImmovableRodComponent>(out var rod, EntityManager.ComponentFactory) &&
-            proto.TryGetComponent<TimedDespawnComponent>(out var despawn, EntityManager.ComponentFactory))
+        if (proto.TryComp<ImmovableRodComponent>(out var rod, EntityManager.ComponentFactory) &&
+            proto.TryComp<TimedDespawnComponent>(out var despawn, EntityManager.ComponentFactory))
         {
             if (!TryFindRandomTile(out _, out _, out _, out var targetCoords))
                 return;

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -8,8 +8,6 @@ using Content.Shared.Database;
 using Content.Shared.GameTicking.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
 
@@ -19,7 +17,6 @@ namespace Content.Server.StationEvents.Events;
 public abstract partial class StationEventSystem<T> : GameRuleSystem<T> where T : IComponent
 {
     [Dependency] protected IAdminLogManager AdminLogManager = default!;
-    [Dependency] protected IPrototypeManager PrototypeManager = default!;
     [Dependency] protected ChatSystem ChatSystem = default!;
     [Dependency] protected SharedAudioSystem Audio = default!;
     [Dependency] protected StationSystem StationSystem = default!;

--- a/Content.Server/StationEvents/Events/VentClogRule.cs
+++ b/Content.Server/StationEvents/Events/VentClogRule.cs
@@ -26,7 +26,7 @@ public sealed partial class VentClogRule : StationEventSystem<VentClogRuleCompon
             return;
 
         // TODO: "safe random" for chems. Right now this includes admin chemicals.
-        var allReagents = PrototypeManager.EnumeratePrototypes<ReagentPrototype>()
+        var allReagents = ProtoMan.EnumeratePrototypes<ReagentPrototype>()
             .Where(x => !x.Abstract)
             .Select(x => new ProtoId<ReagentPrototype>(x.ID)).ToList();
 

--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -9,7 +9,6 @@ using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Content.Shared.StationRecords;
 using Robust.Shared.Enums;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.StationRecords.Systems;
@@ -37,7 +36,6 @@ public sealed partial class StationRecordsSystem : SharedStationRecordsSystem
 {
     [Dependency] private InventorySystem _inventory = default!;
     [Dependency] private StationRecordKeyStorageSystem _keyStorage = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IdCardSystem _idCard = default!;
     [Dependency] private IRobustRandom _random = default!;
 
@@ -87,7 +85,7 @@ public sealed partial class StationRecordsSystem : SharedStationRecordsSystem
     {
         // TODO make PlayerSpawnCompleteEvent.JobId a ProtoId
         if (string.IsNullOrEmpty(jobId)
-            || !_prototypeManager.HasIndex<JobPrototype>(jobId))
+            || !ProtoMan.HasIndex<JobPrototype>(jobId))
             return;
 
         if (!_inventory.TryGetSlotEntity(player, "id", out var idUid))
@@ -140,7 +138,7 @@ public sealed partial class StationRecordsSystem : SharedStationRecordsSystem
         HumanoidCharacterProfile profile,
         StationRecordsComponent records)
     {
-        if (!_prototypeManager.TryIndex<JobPrototype>(jobId, out var jobPrototype))
+        if (!ProtoMan.TryIndex<JobPrototype>(jobId, out var jobPrototype))
             throw new ArgumentException($"Invalid job prototype ID: {jobId}");
 
         // when adding a record that already exists use the old one

--- a/Content.Server/Storage/EntitySystems/StorageSystem.Fill.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.Fill.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Content.Server.Spawners.Components;
-using Content.Server.Storage.Components;
 using Content.Shared.Item;
 using Content.Shared.Prototypes;
 using Content.Shared.Storage;
@@ -48,7 +47,7 @@ public sealed partial class StorageSystem
             var ent = Spawn(spawnPrototype, coordinates);
 
             // No, you are not allowed to fill a container with entity spawners.
-            DebugTools.Assert(!_prototype.Index<EntityPrototype>(spawnPrototype)
+            DebugTools.Assert(!ProtoMan.Index<EntityPrototype>(spawnPrototype)
                 .HasComponent(typeof(RandomSpawnerComponent)));
 
             if (!TryComp<ItemComponent>(ent, out var itemComp))
@@ -99,7 +98,7 @@ public sealed partial class StorageSystem
         foreach (var item in spawnItems)
         {
             // No, you are not allowed to fill a container with entity spawners.
-            DebugTools.Assert(!_prototype.Index<EntityPrototype>(item)
+            DebugTools.Assert(!ProtoMan.Index<EntityPrototype>(item)
                 .HasComponent(typeof(RandomSpawnerComponent)));
             var ent = Spawn(item, coordinates);
 

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -5,13 +5,10 @@ using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 namespace Content.Server.Storage.EntitySystems;
 
 public sealed partial class StorageSystem : SharedStorageSystem
 {
-    [Dependency] private IPrototypeManager _prototype = default!;
-
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -13,7 +13,6 @@ using Content.Shared.Store;
 using Content.Shared.Store.Components;
 using Content.Shared.UserInterface;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Store.Systems;
 
@@ -27,7 +26,6 @@ public sealed partial class StoreSystem
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedHandsSystem _hands = default!;
     [Dependency] private StackSystem _stack = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
 
     private void InitializeUi()
     {
@@ -126,7 +124,7 @@ public sealed partial class StoreSystem
         //apply components
         if (listing.ProductComponents != null)
         {
-            if (_proto.Resolve(listing.ProductComponents, out var productComponentsEntity))
+            if (ProtoMan.Resolve(listing.ProductComponents, out var productComponentsEntity))
                 EntityManager.AddComponents(buyer, productComponentsEntity.Components);
         }
 

--- a/Content.Server/StoreDiscount/Systems/StoreDiscountSystem.cs
+++ b/Content.Server/StoreDiscount/Systems/StoreDiscountSystem.cs
@@ -17,7 +17,6 @@ public sealed partial class StoreDiscountSystem : EntitySystem
     private static readonly ProtoId<StoreCategoryPrototype> DiscountedStoreCategoryPrototypeKey = "DiscountedItems";
 
     [Dependency] private IRobustRandom _random = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
 
     /// <inheritdoc />
     public override void Initialize()
@@ -80,7 +79,7 @@ public sealed partial class StoreDiscountSystem : EntitySystem
         // each category, and after that - roll exact items in categories
         // and their cost
 
-        var prototypes = _prototypeManager.EnumeratePrototypes<DiscountCategoryPrototype>();
+        var prototypes = ProtoMan.EnumeratePrototypes<DiscountCategoryPrototype>();
         var categoriesWithCumulativeWeight = new CategoriesWithCumulativeWeightMap(prototypes);
         var uniqueListingItemCountByCategory = PickCategoriesToRoll(totalAvailableDiscounts, categoriesWithCumulativeWeight);
 

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraRouterSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraRouterSystem.cs
@@ -6,7 +6,6 @@ using Content.Shared.Power;
 using Content.Shared.SurveillanceCamera;
 using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
-using Robust.Shared.Prototypes;
 using Content.Shared.DeviceNetwork.Components;
 
 namespace Content.Server.SurveillanceCamera;
@@ -15,7 +14,6 @@ public sealed partial class SurveillanceCameraRouterSystem : EntitySystem
 {
     [Dependency] private DeviceNetworkSystem _deviceNetworkSystem = default!;
     [Dependency] private ActionBlockerSystem _actionBlocker = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private UserInterfaceSystem _userInterface = default!;
     public override void Initialize()
     {
@@ -29,7 +27,7 @@ public sealed partial class SurveillanceCameraRouterSystem : EntitySystem
     private void OnInitialize(EntityUid uid, SurveillanceCameraRouterComponent router, ComponentInit args)
     {
         if (router.SubnetFrequencyId == null ||
-            !_prototypeManager.TryIndex(router.SubnetFrequencyId, out DeviceFrequencyPrototype? subnetFrequency))
+            !ProtoMan.TryIndex(router.SubnetFrequencyId, out DeviceFrequencyPrototype? subnetFrequency))
         {
             return;
         }
@@ -121,7 +119,7 @@ public sealed partial class SurveillanceCameraRouterSystem : EntitySystem
             return;
         }
 
-        if (!_prototypeManager.Resolve<DeviceFrequencyPrototype>(component.AvailableNetworks[args.Network],
+        if (!ProtoMan.Resolve<DeviceFrequencyPrototype>(component.AvailableNetworks[args.Network],
                 out var frequency))
         {
             return;

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraSystem.cs
@@ -8,14 +8,12 @@ using Content.Shared.SurveillanceCamera;
 using Content.Shared.SurveillanceCamera.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 using Content.Shared.DeviceNetwork.Components;
 
 namespace Content.Server.SurveillanceCamera;
 
 public sealed partial class SurveillanceCameraSystem : SharedSurveillanceCameraSystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private ViewSubscriberSystem _viewSubscriberSystem = default!;
     [Dependency] private DeviceNetworkSystem _deviceNetworkSystem = default!;
     [Dependency] private UserInterfaceSystem _userInterface = default!;
@@ -168,7 +166,7 @@ public sealed partial class SurveillanceCameraSystem : SharedSurveillanceCameraS
             return;
         }
 
-        if (!_prototypeManager.Resolve<DeviceFrequencyPrototype>(component.AvailableNetworks[args.Network],
+        if (!ProtoMan.Resolve<DeviceFrequencyPrototype>(component.AvailableNetworks[args.Network],
                 out var frequency))
         {
             return;

--- a/Content.Server/Telephone/TelephoneSystem.cs
+++ b/Content.Server/Telephone/TelephoneSystem.cs
@@ -17,7 +17,6 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Replays;
 using System.Linq;
@@ -31,7 +30,6 @@ public sealed partial class TelephoneSystem : SharedTelephoneSystem
     [Dependency] private IdCardSystem _idCardSystem = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private ChatSystem _chat = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
@@ -365,7 +363,7 @@ public sealed partial class TelephoneSystem : SharedTelephoneSystem
         name = FormattedMessage.EscapeText(name);
 
         SpeechVerbPrototype speech;
-        if (ev.SpeechVerb != null && _prototype.Resolve(ev.SpeechVerb, out var evntProto))
+        if (ev.SpeechVerb != null && ProtoMan.Resolve(ev.SpeechVerb, out var evntProto))
             speech = evntProto;
         else
             speech = _chat.GetSpeechVerb(messageSource, message);

--- a/Content.Server/Thief/Systems/ThiefUndeterminedBackpackSystem.cs
+++ b/Content.Server/Thief/Systems/ThiefUndeterminedBackpackSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Thief;
 using Robust.Server.GameObjects;
 using Robust.Server.Audio;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Thief.Systems;
 
@@ -16,7 +15,6 @@ namespace Content.Server.Thief.Systems;
 public sealed partial class ThiefUndeterminedBackpackSystem : EntitySystem
 {
     [Dependency] private AudioSystem _audio = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private UserInterfaceSystem _ui = default!;
     [Dependency] private SharedStorageSystem _storage = default!;
@@ -47,7 +45,7 @@ public sealed partial class ThiefUndeterminedBackpackSystem : EntitySystem
 
         foreach (var i in backpack.Comp.SelectedSets)
         {
-            var set = _proto.Index(backpack.Comp.PossibleSets[i]);
+            var set = ProtoMan.Index(backpack.Comp.PossibleSets[i]);
             foreach (var item in set.Content)
             {
                 var ent = Spawn(item, _transform.GetMapCoordinates(backpack.Owner));
@@ -86,7 +84,7 @@ public sealed partial class ThiefUndeterminedBackpackSystem : EntitySystem
 
         for (int i = 0; i < component.PossibleSets.Count; i++)
         {
-            var set = _proto.Index(component.PossibleSets[i]);
+            var set = ProtoMan.Index(component.PossibleSets[i]);
             var selected = component.SelectedSets.Contains(i);
             var info = new ThiefBackpackSetInfo(
                 set.Name,

--- a/Content.Server/Tips/TipsSystem.cs
+++ b/Content.Server/Tips/TipsSystem.cs
@@ -15,7 +15,6 @@ namespace Content.Server.Tips;
 public sealed partial class TipsSystem : SharedTipsSystem
 {
     [Dependency] private IChatManager _chat = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IRobustRandom _random = default!;
@@ -113,7 +112,7 @@ public sealed partial class TipsSystem : SharedTipsSystem
 
     public override void AnnounceRandomTip()
     {
-        if (!_prototype.TryIndex<LocalizedDatasetPrototype>(_tipsDataset, out var tips))
+        if (!ProtoMan.TryIndex<LocalizedDatasetPrototype>(_tipsDataset, out var tips))
             return;
 
         var tip = _random.Pick(tips.Values);

--- a/Content.Server/Traitor/Uplink/UplinkSystem.cs
+++ b/Content.Server/Traitor/Uplink/UplinkSystem.cs
@@ -19,7 +19,6 @@ public sealed partial class UplinkSystem : EntitySystem
 {
     [Dependency] private InventorySystem _inventorySystem = default!;
     [Dependency] private SharedHandsSystem _handsSystem = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private StoreSystem _store = default!;
     [Dependency] private SharedSubdermalImplantSystem _subdermalImplant = default!;
     [Dependency] private SharedMindSystem _mind = default!;
@@ -162,7 +161,7 @@ public sealed partial class UplinkSystem : EntitySystem
     /// </summary>
     public bool TryImplantUplink(EntityUid user, EntityUid storeEntity, FixedPoint2 balance, bool giveDiscounts)
     {
-        if (!_proto.Resolve(FallbackUplinkCatalog, out var catalog))
+        if (!ProtoMan.Resolve(FallbackUplinkCatalog, out var catalog))
             return false;
 
         if (!catalog.Cost.TryGetValue(TelecrystalCurrencyPrototype, out var cost))

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -10,7 +10,6 @@ namespace Content.Server.Traits;
 
 public sealed partial class TraitSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private SharedHandsSystem _sharedHandsSystem = default!;
     [Dependency] private EntityWhitelistSystem _whitelistSystem = default!;
 
@@ -26,7 +25,7 @@ public sealed partial class TraitSystem : EntitySystem
     {
         // Check if player's job allows to apply traits
         if (args.JobId == null ||
-            !_prototypeManager.Resolve<JobPrototype>(args.JobId, out var protoJob) ||
+            !ProtoMan.Resolve<JobPrototype>(args.JobId, out var protoJob) ||
             !protoJob.ApplyTraits)
         {
             return;
@@ -34,7 +33,7 @@ public sealed partial class TraitSystem : EntitySystem
 
         foreach (var traitId in args.Profile.TraitPreferences)
         {
-            if (!_prototypeManager.TryIndex<TraitPrototype>(traitId, out var traitPrototype))
+            if (!ProtoMan.TryIndex<TraitPrototype>(traitId, out var traitPrototype))
             {
                 Log.Error($"No trait found with ID {traitId}!");
                 return;

--- a/Content.Server/Trigger/Systems/RattleOnTriggerSystem.cs
+++ b/Content.Server/Trigger/Systems/RattleOnTriggerSystem.cs
@@ -10,7 +10,6 @@ namespace Content.Server.Trigger.Systems;
 
 public sealed partial class RattleOnTriggerSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private RadioSystem _radio = default!;
     [Dependency] private NavMapSystem _navMap = default!;
 
@@ -44,6 +43,6 @@ public sealed partial class RattleOnTriggerSystem : EntitySystem
 
         var message = Loc.GetString(messageId, ("user", target.Value), ("position", posText));
         // Sends a message to the radio channel specified by the implant
-        _radio.SendRadioMessage(ent.Owner, message, _prototypeManager.Index(ent.Comp.RadioChannel), ent.Owner);
+        _radio.SendRadioMessage(ent.Owner, message, ProtoMan.Index(ent.Comp.RadioChannel), ent.Owner);
     }
 }

--- a/Content.Server/Trigger/Systems/SpeakOnTriggerSystem.cs
+++ b/Content.Server/Trigger/Systems/SpeakOnTriggerSystem.cs
@@ -2,7 +2,6 @@ using Content.Server.Chat.Systems;
 using Content.Shared.Chat;
 using Content.Shared.Trigger;
 using Content.Shared.Trigger.Components.Effects;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.Trigger.Systems;
@@ -10,7 +9,6 @@ namespace Content.Server.Trigger.Systems;
 public sealed partial class SpeakOnTriggerSystem : EntitySystem
 {
     [Dependency] private IRobustRandom _random = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private ChatSystem _chat = default!;
 
     public override void Initialize()
@@ -35,7 +33,7 @@ public sealed partial class SpeakOnTriggerSystem : EntitySystem
             message = Loc.GetString(ent.Comp.Text);
         else
         {
-            if (!_prototypeManager.Resolve(ent.Comp.Pack, out var messagePack))
+            if (!ProtoMan.Resolve(ent.Comp.Pack, out var messagePack))
                 return;
             message = Loc.GetString(_random.Pick(messagePack.Values));
         }

--- a/Content.Server/Vocalization/Systems/DatasetVocalizationSystem.cs
+++ b/Content.Server/Vocalization/Systems/DatasetVocalizationSystem.cs
@@ -8,7 +8,6 @@ namespace Content.Server.Vocalization.Systems;
 /// <inheritdoc cref="DatasetVocalizerComponent"/>
 public sealed partial class DatasetVocalizationSystem : EntitySystem
 {
-    [Dependency] private IPrototypeManager _protoMan = default!;
     [Dependency] private IRobustRandom _random = default!;
 
     public override void Initialize()
@@ -23,7 +22,7 @@ public sealed partial class DatasetVocalizationSystem : EntitySystem
         if (args.Handled)
             return;
 
-        var dataset = _protoMan.Index(ent.Comp.Dataset);
+        var dataset = ProtoMan.Index(ent.Comp.Dataset);
 
         args.Message = _random.Pick(dataset);
         args.Handled = true;

--- a/Content.Server/Vocalization/Systems/RadioVocalizationSystem.cs
+++ b/Content.Server/Vocalization/Systems/RadioVocalizationSystem.cs
@@ -15,7 +15,6 @@ namespace Content.Server.Vocalization.Systems;
 public sealed partial class RadioVocalizationSystem : EntitySystem
 {
     [Dependency] private ChatSystem _chat = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private InventorySystem _inventory = default!;
 
@@ -83,7 +82,7 @@ public sealed partial class RadioVocalizationSystem : EntitySystem
         if (!TryPickRandomRadioChannel(entity, out var channel))
             return false;
 
-        var channelPrefix = _proto.Index<RadioChannelPrototype>(channel).KeyCode;
+        var channelPrefix = ProtoMan.Index<RadioChannelPrototype>(channel).KeyCode;
 
         // send a whisper using the radio channel prefix and whatever relevant radio channel character
         // along with the message. This is analogous to how radio messages are sent by players

--- a/Content.Server/VoiceMask/VoiceMaskSystem.cs
+++ b/Content.Server/VoiceMask/VoiceMaskSystem.cs
@@ -15,7 +15,6 @@ using Content.Shared.Speech;
 using Content.Shared.VoiceMask;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.VoiceMask;
 
@@ -25,7 +24,6 @@ public sealed partial class VoiceMaskSystem : EntitySystem
     [Dependency] private SharedPopupSystem _popupSystem = default!;
     [Dependency] private IConfigurationManager _cfgManager = default!;
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
-    [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private SharedActionsSystem _actions = default!;
     [Dependency] private LockSystem _lock = default!;
     [Dependency] private SharedContainerSystem _container = default!;
@@ -190,7 +188,7 @@ public sealed partial class VoiceMaskSystem : EntitySystem
     #region User inputs from UI
     private void OnChangeVerb(Entity<VoiceMaskComponent> entity, ref VoiceMaskChangeVerbMessage msg)
     {
-        if (msg.Verb is { } id && !_proto.HasIndex<SpeechVerbPrototype>(id))
+        if (msg.Verb is { } id && !ProtoMan.HasIndex<SpeechVerbPrototype>(id))
             return;
 
         entity.Comp.VoiceMaskSpeechVerb = msg.Verb;

--- a/Content.Server/Wagging/WaggingSystem.cs
+++ b/Content.Server/Wagging/WaggingSystem.cs
@@ -17,7 +17,6 @@ public sealed partial class WaggingSystem : EntitySystem
 {
     [Dependency] private ActionsSystem _actions = default!;
     [Dependency] private SharedVisualBodySystem _visualBody = default!;
-    [Dependency] private IPrototypeManager _prototype = default!;
 
     public override void Initialize()
     {
@@ -115,7 +114,7 @@ public sealed partial class WaggingSystem : EntitySystem
                     }
                 }
 
-                if (!_prototype.HasIndex<MarkingPrototype>(newMarkingId))
+                if (!ProtoMan.HasIndex<MarkingPrototype>(newMarkingId))
                 {
                     Log.Warning($"{ToPrettyString(ent):ent} tried toggling wagging but {newMarkingId} marking doesn't exist");
                     continue;

--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -24,7 +24,6 @@ namespace Content.Server.Wires;
 
 public sealed partial class WiresSystem : SharedWiresSystem
 {
-    [Dependency] private IPrototypeManager _protoMan = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
     [Dependency] private HandsSystem _hands = default!;
     [Dependency] private SharedPopupSystem _popupSystem = default!;
@@ -74,7 +73,7 @@ public sealed partial class WiresSystem : SharedWiresSystem
         List<IWireAction> wireActions = new();
         var dummyWires = 0;
 
-        if (!_protoMan.Resolve(wires.LayoutId, out WireLayoutPrototype? layoutPrototype))
+        if (!ProtoMan.Resolve(wires.LayoutId, out WireLayoutPrototype? layoutPrototype))
         {
             return;
         }
@@ -88,7 +87,7 @@ public sealed partial class WiresSystem : SharedWiresSystem
 
         // does the prototype have a parent (and are the wires empty?) if so, we just create
         // a new layout based on that
-        foreach (var parentLayout in _protoMan.EnumerateParents<WireLayoutPrototype>(wires.LayoutId))
+        foreach (var parentLayout in ProtoMan.EnumerateParents<WireLayoutPrototype>(wires.LayoutId))
         {
             if (parentLayout.Wires != null)
             {

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAECreatePuddleSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAECreatePuddleSystem.cs
@@ -11,12 +11,11 @@ namespace Content.Server.Xenoarchaeology.Artifact.XAE;
 /// <summary>
 /// System for xeno artifact effect that creates puddle of chemical reagents under artifact.
 /// </summary>
-public sealed partial class XAECreatePuddleSystem: BaseXAESystem<XAECreatePuddleComponent>
+public sealed partial class XAECreatePuddleSystem : BaseXAESystem<XAECreatePuddleComponent>
 {
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private PuddleSystem _puddle = default!;
-    [Dependency] private MetaDataSystem _metaData= default!;
-    [Dependency] private IPrototypeManager _prototypeManager= default!;
+    [Dependency] private MetaDataSystem _metaData = default!;
 
     /// <inheritdoc />
     public override void Initialize()
@@ -49,7 +48,7 @@ public sealed partial class XAECreatePuddleSystem: BaseXAESystem<XAECreatePuddle
             var reagentNames = new HashSet<string>();
             foreach (var chemProtoId in component.SelectedChemicals)
             {
-                var reagent = _prototypeManager.Index(chemProtoId);
+                var reagent = ProtoMan.Index(chemProtoId);
                 reagentNames.Add(reagent.LocalizedName);
             }
 

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAEFoamSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAEFoamSystem.cs
@@ -17,7 +17,6 @@ public sealed partial class XAEFoamSystem : BaseXAESystem<XAEFoamComponent>
 {
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SmokeSystem _smoke = default!;
-    [Dependency] private IPrototypeManager _prototypeManager= default!;
     [Dependency] private MetaDataSystem _metaData = default!;
 
     /// <inheritdoc />
@@ -40,7 +39,7 @@ public sealed partial class XAEFoamSystem : BaseXAESystem<XAEFoamComponent>
 
         if (component.ReplaceDescription)
         {
-            var reagent = _prototypeManager.Index<ReagentPrototype>(component.SelectedReagent);
+            var reagent = ProtoMan.Index<ReagentPrototype>(component.SelectedReagent);
             var newEntityDescription = Loc.GetString("xenoarch-effect-foam", ("reagent", reagent.LocalizedName));
             _metaData.SetEntityDescription(uid, newEntityDescription);
         }

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -11,7 +11,6 @@ using Content.Shared.Bed.Sleep;
 using Content.Shared.Cloning.Events;
 using Content.Shared.Chat;
 using Content.Shared.Damage.Systems;
-using Content.Shared.Humanoid;
 using Content.Shared.Inventory;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
@@ -33,7 +32,6 @@ namespace Content.Server.Zombies
     public sealed partial class ZombieSystem : SharedZombieSystem
     {
         [Dependency] private IGameTiming _timing = default!;
-        [Dependency] private IPrototypeManager _protoManager = default!;
         [Dependency] private IRobustRandom _random = default!;
         [Dependency] private BloodstreamSystem _bloodstream = default!;
         [Dependency] private DamageableSystem _damageable = default!;
@@ -185,7 +183,7 @@ namespace Content.Server.Zombies
             if (args.Handled)
                 return;
 
-            _protoManager.Resolve(component.EmoteSoundsId, out var sounds);
+            ProtoMan.Resolve(component.EmoteSoundsId, out var sounds);
 
             args.Handled = _chat.TryPlayEmoteSound(uid, sounds, args.Emote);
         }

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -15,7 +15,6 @@ public abstract partial class SharedItemSystem : EntitySystem
 {
     [Dependency] private SharedHandsSystem _handsSystem = default!;
     [Dependency] protected SharedContainerSystem Container = default!;
-    [Dependency] private IComponentFactory _compFactory = default!;
 
     public override void Initialize()
     {
@@ -282,8 +281,8 @@ public abstract partial class SharedItemSystem : EntitySystem
     {
         var protoA = ProtoMan.Index(a);
         var protoB = ProtoMan.Index(b);
-        if (!protoA.TryComp<ItemComponent>(out var compA, _compFactory) ||
-            !protoB.TryComp<ItemComponent>(out var compB, _compFactory))
+        if (!protoA.TryComp<ItemComponent>(out var compA, Factory) ||
+            !protoB.TryComp<ItemComponent>(out var compB, Factory))
         {
             return 0;
         }

--- a/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
@@ -14,7 +14,6 @@ namespace Content.Shared.StatusEffectNew;
 /// </summary>
 public sealed partial class StatusEffectsSystem : EntitySystem
 {
-    [Dependency] private IComponentFactory _factory = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SharedContainerSystem _container = default!;
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
@@ -78,7 +77,7 @@ public sealed partial class StatusEffectsSystem : EntitySystem
 
         foreach (var ent in ProtoMan.EnumeratePrototypes<EntityPrototype>())
         {
-            if (ent.HasComp<StatusEffectComponent>(_factory))
+            if (ent.HasComp<StatusEffectComponent>(Factory))
                 StatusEffectPrototypes.Add(ent.ID);
         }
     }

--- a/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
@@ -78,7 +78,7 @@ public sealed partial class StatusEffectsSystem : EntitySystem
 
         foreach (var ent in ProtoMan.EnumeratePrototypes<EntityPrototype>())
         {
-            if (ent.TryGetComponent<StatusEffectComponent>(out _, _factory))
+            if (ent.HasComp<StatusEffectComponent>(_factory))
                 StatusEffectPrototypes.Add(ent.ID);
         }
     }
@@ -167,7 +167,7 @@ public sealed partial class StatusEffectsSystem : EntitySystem
         if (!ProtoMan.Resolve(effectProto, out var effectProtoData))
             return false;
 
-        if (!effectProtoData.TryGetComponent<StatusEffectComponent>(out var effectProtoComp, Factory))
+        if (!effectProtoData.TryComp<StatusEffectComponent>(out var effectProtoComp, Factory))
             return false;
 
         if (!_whitelist.CheckBoth(uid, effectProtoComp.Blacklist, effectProtoComp.Whitelist))

--- a/Content.Shared/Whitelist/EntityWhitelistSystem.cs
+++ b/Content.Shared/Whitelist/EntityWhitelistSystem.cs
@@ -6,7 +6,6 @@ namespace Content.Shared.Whitelist;
 
 public sealed partial class EntityWhitelistSystem : EntitySystem
 {
-    [Dependency] private IComponentFactory _factory = default!;
     [Dependency] private TagSystem _tag = default!;
     [Dependency] private EntityQuery<ItemComponent> _itemQuery;
 
@@ -18,8 +17,8 @@ public sealed partial class EntityWhitelistSystem : EntitySystem
         base.Initialize();
 
         // caching for minor performance improvement
-        _itemComponentName = CompName.Get<ItemComponent>(_factory);
-        _tagComponentName = CompName.Get<TagComponent>(_factory);
+        _itemComponentName = CompName.Get<ItemComponent>(Factory);
+        _tagComponentName = CompName.Get<TagComponent>(Factory);
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR

Continuing from #44386.

Removes all* redundant IPrototypeManager instances within Client and Server EntitySystems.  All instances of TryGetComponent warnings removed from Content projects.

*DestructibleSystem's instance is some load-bearing jank since the destructible behaviours need it, considering it as out of scope for this - could maybe make a property that points to the backing base field?  [Did that :+1:]

May have missed an instance or two in oddly named systems, I am unfortunately human (looking at you, GameTicker).  Search within \*System\*.cs looks good, though.

Also did the same for IComponentFactory instances - didn't know that existed.

Apologies for the size of this one.

## Why / Balance

IPrototypeManager: these members are redundant, less boilerplate code is probably good.

TryGetComponent: With the TryComp changes, the entire solution goes from building with 1106 warnings down to 1030.  I'll take that 7%.

Another wink and a nod to https://github.com/space-wizards/space-station-14/issues/33279 re: TryGetComponent proxy replacement.

## Technical details

Most of it should be straightforward.  A few of the older integration tests (StorageTest in particular?) swapped from using component names to the generic method - added a few component factory dependencies in a few places.

Not leaving new breaking changes given the message in #44386.

## Test plan

Build game.
Run tests.
Read PR.

## Media

<details>
<summary>Supplementary material</summary>
<img width="924" height="924" alt="image" src="https://github.com/user-attachments/assets/71563737-c082-4f95-818e-eb8116469c45" />
</details>

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
kleen