### PR TITLE
Fix ID card names can use markup in PDAs

### DIFF
--- a/Content.Client/PDA/PdaMenu.xaml.cs
+++ b/Content.Client/PDA/PdaMenu.xaml.cs
@@ -140,7 +140,7 @@ namespace Content.Client.PDA
             {
                 _pdaOwner = state.PdaOwnerInfo.ActualOwnerName;
                 PdaOwnerLabel.SetMarkup(Loc.GetString("comp-pda-ui-owner",
-                    ("actualOwnerName", _pdaOwner)));
+                    ("actualOwnerName", FormattedMessage.RemoveMarkupPermissive(_pdaOwner))));
                 PdaOwnerLabel.Visible = true;
             }
             else
@@ -153,9 +153,10 @@ namespace Content.Client.PDA
             {
                 _owner = state.PdaOwnerInfo.IdOwner ?? Loc.GetString("comp-pda-ui-unknown");
                 _jobTitle = state.PdaOwnerInfo.JobTitle ?? Loc.GetString("comp-pda-ui-unassigned");
+
                 IdInfoLabel.SetMarkup(Loc.GetString("comp-pda-ui",
-                    ("owner", _owner),
-                    ("jobTitle", _jobTitle)));
+                    ("owner", FormattedMessage.RemoveMarkupPermissive(_owner)),
+                    ("jobTitle", FormattedMessage.RemoveMarkupPermissive(_jobTitle))));
             }
             else
             {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes #44052

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
sanitize input, hop only assigns jobs not colors

## Technical details
<!-- Summary of code changes for easier review. -->
Made the strings go through `RemoveMarkupPermissive` before going through `Loc.GetStrings` so they don't override the LOC set color tags

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Name an ID something like `[color=red]john smith[/color]`
2. Put ID card into PDA
3. Ensure the markup does not persist

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

You can't see it, but this guys name is actually `[color=red]john smith[/color]`
<img width="591" height="463" alt="image" src="https://github.com/user-attachments/assets/a7d8a12e-80cc-4d8f-88f1-40f8f23c9376" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
