### PR TITLE
Restore general ruminant digestion

### DIFF
--- a/Resources/Prototypes/Body/Animals/ruminant.yml
+++ b/Resources/Prototypes/Body/Animals/ruminant.yml
@@ -9,6 +9,7 @@
       - Ruminant
       - Wheat
       - BananaPeel
+    isSpecialDigestibleExclusive: false
   - type: SolutionManager
     solutions:
     - SolutionStomachRuminant


### PR DESCRIPTION
## About the PR

Restores general digestion to ruminants (cows, pigs, goats).

## Why / Balance

Seems like a regression from #39031 that's persisted until now.

I believe the intent was to allow ruminants to eat wheat, but they lost the ability to eat anything else.  Let's restore that.

Why shouldn't a cow be able to eat an apple?  Why shouldn't the cow make a mad dash for the delicious pie you just baked?

## Technical details

YAML ops.

## Test plan

Spawn a cow.
Feed the cow an apple.
Smile knowing that the cow will not go hungry.

## Media

Feeding a cow an apple.  The cow can digest the apple.  Plus bonus AttemptToolRefineEvent popup bug.

https://github.com/user-attachments/assets/4b7d3989-a508-4a3e-a66b-ae4978d10b3e

<details>
<summary>Supplementary material</summary>
<img width="361" height="242" alt="image" src="https://github.com/user-attachments/assets/4e234103-354e-4a9a-a5e0-8c54b25f7366" />
</details>

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
Very minor fix, please remove the changelog if it's excessive.
:cl:
- fix: Cows, pigs and goats can eat just about anything again.