### PR TITLE
Stop disposal units pressurizing while unpowered

### DIFF
--- a/Content.Client/Disposal/Mailing/MailingUnitBoundUserInterface.cs
+++ b/Content.Client/Disposal/Mailing/MailingUnitBoundUserInterface.cs
@@ -1,4 +1,5 @@
 using Content.Client.Disposal.Unit;
+using Content.Client.Power.Components;
 using Content.Client.Power.EntitySystems;
 using Content.Shared.Disposal.Components;
 using Robust.Client.UserInterface;
@@ -88,7 +89,7 @@ public sealed class MailingUnitBoundUserInterface : BoundUserInterface
         _mailingUnitWindow.PressurePerSecond = pressurePerSecond;
         _mailingUnitWindow.PowerOff = disposals.PowerOff;
         _mailingUnitWindow.PressureBar.UpdatePressure(fullPressure, pressurePerSecond, disposals.PowerOff);
-        _mailingUnitWindow.Power.Pressed = EntMan.System<PowerReceiverSystem>().IsPowered(Owner);
+        _mailingUnitWindow.Power.Pressed = !EntMan.TryGetComponent(entity.Owner, out ApcPowerReceiverComponent? apc) || !apc.PowerDisabled;
         _mailingUnitWindow.Engage.Pressed = disposals.Engaged;
     }
 }

--- a/Content.Client/Disposal/Mailing/MailingUnitBoundUserInterface.cs
+++ b/Content.Client/Disposal/Mailing/MailingUnitBoundUserInterface.cs
@@ -86,7 +86,8 @@ public sealed class MailingUnitBoundUserInterface : BoundUserInterface
         _mailingUnitWindow.UnitState.Text = Loc.GetString($"disposal-unit-state-{disposalState}");
         _mailingUnitWindow.FullPressure = fullPressure;
         _mailingUnitWindow.PressurePerSecond = pressurePerSecond;
-        _mailingUnitWindow.PressureBar.UpdatePressure(fullPressure, pressurePerSecond);
+        _mailingUnitWindow.PowerOff = disposals.PowerOff;
+        _mailingUnitWindow.PressureBar.UpdatePressure(fullPressure, pressurePerSecond, disposals.PowerOff);
         _mailingUnitWindow.Power.Pressed = EntMan.System<PowerReceiverSystem>().IsPowered(Owner);
         _mailingUnitWindow.Engage.Pressed = disposals.Engaged;
     }

--- a/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml.cs
+++ b/Content.Client/Disposal/Mailing/MailingUnitWindow.xaml.cs
@@ -13,6 +13,7 @@ namespace Content.Client.Disposal.Mailing
     {
         public TimeSpan FullPressure;
         public float PressurePerSecond;
+        public TimeSpan? PowerOff;
 
         public MailingUnitWindow()
         {
@@ -22,7 +23,7 @@ namespace Content.Client.Disposal.Mailing
         protected override void FrameUpdate(FrameEventArgs args)
         {
             base.FrameUpdate(args);
-            PressureBar.UpdatePressure(FullPressure, PressurePerSecond);
+            PressureBar.UpdatePressure(FullPressure, PressurePerSecond, PowerOff);
         }
     }
 }

--- a/Content.Client/Disposal/PressureBar.cs
+++ b/Content.Client/Disposal/PressureBar.cs
@@ -7,9 +7,9 @@ namespace Content.Client.Disposal;
 
 public sealed class PressureBar : ProgressBar
 {
-    public bool UpdatePressure(TimeSpan fullPressureTime, float pressurePreSecond)
+    public bool UpdatePressure(TimeSpan fullPressureTime, float pressurePreSecond, TimeSpan? frozenTime = null)
     {
-        var currentTime = IoCManager.Resolve<IGameTiming>().CurTime;
+        var currentTime = frozenTime ?? IoCManager.Resolve<IGameTiming>().CurTime;
         var pressure = (float)Math.Min(1.0f, 1.0f - (fullPressureTime.TotalSeconds - currentTime.TotalSeconds) * pressurePreSecond);
         UpdatePressureBar(pressure);
         return pressure >= 1.0f;

--- a/Content.Client/Disposal/Unit/DisposalUnitBoundUserInterface.cs
+++ b/Content.Client/Disposal/Unit/DisposalUnitBoundUserInterface.cs
@@ -1,3 +1,4 @@
+using Content.Client.Power.Components;
 using Content.Client.Power.EntitySystems;
 using Content.Shared.Disposal.Components;
 using JetBrains.Annotations;
@@ -65,10 +66,10 @@ namespace Content.Client.Disposal.Unit
 
             _disposalUnitWindow.UnitState.Text = Loc.GetString($"disposal-unit-state-{disposalState}");
             _disposalUnitWindow.FullPressure = disposalUnit.EstimatedFullPressure(entity);
-            _disposalUnitWindow.PressurePerSecond = entity.Comp.PressurePerSecond;
+            _disposalUnitWindow.PressurePerSecond = pressurePerSecond;
             _disposalUnitWindow.PowerOff = entity.Comp.PowerOff;
             _disposalUnitWindow.PressureBar.UpdatePressure(fullPressure, pressurePerSecond, disposals.PowerOff);
-            _disposalUnitWindow.Power.Pressed = EntMan.System<PowerReceiverSystem>().IsPowered(Owner);
+            _disposalUnitWindow.Power.Pressed = !EntMan.TryGetComponent(entity.Owner, out ApcPowerReceiverComponent? apc) || !apc.PowerDisabled;
             _disposalUnitWindow.Engage.Pressed = entity.Comp.Engaged;
         }
     }

--- a/Content.Client/Disposal/Unit/DisposalUnitBoundUserInterface.cs
+++ b/Content.Client/Disposal/Unit/DisposalUnitBoundUserInterface.cs
@@ -66,7 +66,8 @@ namespace Content.Client.Disposal.Unit
             _disposalUnitWindow.UnitState.Text = Loc.GetString($"disposal-unit-state-{disposalState}");
             _disposalUnitWindow.FullPressure = disposalUnit.EstimatedFullPressure(entity);
             _disposalUnitWindow.PressurePerSecond = entity.Comp.PressurePerSecond;
-            _disposalUnitWindow.PressureBar.UpdatePressure(fullPressure, pressurePerSecond);
+            _disposalUnitWindow.PowerOff = entity.Comp.PowerOff;
+            _disposalUnitWindow.PressureBar.UpdatePressure(fullPressure, pressurePerSecond, disposals.PowerOff);
             _disposalUnitWindow.Power.Pressed = EntMan.System<PowerReceiverSystem>().IsPowered(Owner);
             _disposalUnitWindow.Engage.Pressed = entity.Comp.Engaged;
         }

--- a/Content.Client/Disposal/Unit/DisposalUnitBoundUserInterface.cs
+++ b/Content.Client/Disposal/Unit/DisposalUnitBoundUserInterface.cs
@@ -53,23 +53,20 @@ namespace Content.Client.Disposal.Unit
             if (_disposalUnitWindow == null)
                 return;
 
-            var name = EntMan.GetComponent<MetaDataComponent>(entity.Owner).EntityName;
+            var name = EntMan.GetComponent<MetaDataComponent>(entity).EntityName;
             _disposalUnitWindow.Title = Loc.GetString("ui-disposal-unit-title", ("name", name));
-
-            if (!EntMan.TryGetComponent(entity.Owner, out DisposalUnitComponent? disposals))
-                return;
 
             var disposalUnit = EntMan.System<DisposalUnitSystem>();
             var disposalState = disposalUnit.GetState(entity);
-            var fullPressure = disposalUnit.EstimatedFullPressure((Owner, disposals));
-            var pressurePerSecond = disposals.PressurePerSecond;
+            var fullPressure = disposalUnit.EstimatedFullPressure(entity);
+            var pressurePerSecond = entity.Comp.PressurePerSecond;
 
             _disposalUnitWindow.UnitState.Text = Loc.GetString($"disposal-unit-state-{disposalState}");
             _disposalUnitWindow.FullPressure = disposalUnit.EstimatedFullPressure(entity);
             _disposalUnitWindow.PressurePerSecond = pressurePerSecond;
             _disposalUnitWindow.PowerOff = entity.Comp.PowerOff;
-            _disposalUnitWindow.PressureBar.UpdatePressure(fullPressure, pressurePerSecond, disposals.PowerOff);
-            _disposalUnitWindow.Power.Pressed = !EntMan.TryGetComponent(entity.Owner, out ApcPowerReceiverComponent? apc) || !apc.PowerDisabled;
+            _disposalUnitWindow.PressureBar.UpdatePressure(fullPressure, pressurePerSecond, entity.Comp.PowerOff);
+            _disposalUnitWindow.Power.Pressed = !EntMan.TryGetComponent(entity, out ApcPowerReceiverComponent? apc) || !apc.PowerDisabled;
             _disposalUnitWindow.Engage.Pressed = entity.Comp.Engaged;
         }
     }

--- a/Content.Client/Disposal/Unit/DisposalUnitSystem.cs
+++ b/Content.Client/Disposal/Unit/DisposalUnitSystem.cs
@@ -60,37 +60,18 @@ public sealed partial class DisposalUnitSystem : SharedDisposalUnitSystem
         UpdateUI((uid, component));
     }
 
+    /// <summary>
+    /// AppearanceChangeEvent handler: updates the disposal unit's animation if it's flushing.
+    /// </summary>
     private void OnAppearanceChange(Entity<DisposalUnitComponent> ent, ref AppearanceChangeEvent args)
     {
-        if (args.Sprite == null)
-            return;
-
-        UpdateState(ent, args.Sprite, args.Component);
-    }
-
-    /// <summary>
-    /// Updates the animation of a disposal unit.
-    /// </summary>
-    /// <param name="ent">The disposal unit.</param>
-    /// <param name="sprite">The disposal unit's sprite.</param>
-    /// <param name="appearance">The disposal unit's appearance.</param>
-    private void UpdateState(Entity<DisposalUnitComponent> ent, SpriteComponent sprite, AppearanceComponent appearance)
-    {
-        if (!_appearanceSystem.TryGetData<bool>(ent, DisposalUnitVisuals.IsFlushing, out var isFlushing, appearance))
-            return;
-
         // This is a transient state so not too worried about replaying in range.
-        if (isFlushing)
+        if (_appearanceSystem.TryGetData<bool>(ent, DisposalUnitVisuals.IsFlushing, out var isFlushing, args.Component)
+            && isFlushing
+            && !_animationSystem.HasRunningAnimation(ent, AnimationKey))
         {
-            if (!_animationSystem.HasRunningAnimation(ent, AnimationKey))
-            {
-                _animationSystem.Play(ent, (Animation)ent.Comp.FlushingAnimation, AnimationKey);
-            }
-
-            return;
+            _animationSystem.Play(ent, (Animation)ent.Comp.FlushingAnimation, AnimationKey);
         }
-
-        _animationSystem.Stop(ent.Owner, AnimationKey);
     }
 }
 

--- a/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml.cs
+++ b/Content.Client/Disposal/Unit/DisposalUnitWindow.xaml.cs
@@ -13,6 +13,7 @@ namespace Content.Client.Disposal.Unit
     {
         public TimeSpan FullPressure;
         public float PressurePerSecond;
+        public TimeSpan? PowerOff;
 
         public DisposalUnitWindow()
         {
@@ -22,7 +23,7 @@ namespace Content.Client.Disposal.Unit
         protected override void FrameUpdate(FrameEventArgs args)
         {
             base.FrameUpdate(args);
-            PressureBar.UpdatePressure(FullPressure, PressurePerSecond);
+            PressureBar.UpdatePressure(FullPressure, PressurePerSecond, PowerOff);
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
+++ b/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
@@ -9,6 +9,7 @@ using Content.Shared.Disposal.Tube;
 using Content.Shared.Disposal.Unit;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Reflection;
+using Robust.Shared.Timing;
 
 namespace Content.IntegrationTests.Tests.Disposal
 {
@@ -232,6 +233,68 @@ namespace Content.IntegrationTests.Tests.Disposal
             {
                 // Re-pressurizing
                 Flush(disposalUnit, unitComponent, false, disposalSystem);
+            });
+        }
+
+        [Test]
+        public async Task UnpoweredUnitDoesNotRepressurize()
+        {
+            var pair = Pair;
+            var server = pair.Server;
+
+            var testMap = await pair.CreateTestMap();
+
+            var entityManager = server.ResolveDependency<IEntityManager>();
+            var timing = server.ResolveDependency<IGameTiming>();
+            var disposalSystem = entityManager.System<SharedDisposalUnitSystem>();
+            var power = entityManager.System<PowerReceiverSystem>();
+
+            EntityUid unit = default;
+            DisposalUnitComponent comp = default!;
+            var unpoweredRemaining = TimeSpan.Zero;
+
+            await server.WaitAssertion(() =>
+            {
+                unit = entityManager.SpawnEntity("DisposalUnitDummy", testMap.GridCoords);
+                comp = entityManager.GetComponent<DisposalUnitComponent>(unit);
+                Assert.That(power.IsPowered(unit), Is.False);
+
+                comp.NextPressurized = timing.CurTime + TimeSpan.FromSeconds(10);
+                Assert.That(disposalSystem.GetState((unit, comp)), Is.EqualTo(DisposalsPressureState.Pressurizing));
+
+                unpoweredRemaining = comp.NextPressurized - timing.CurTime;
+            });
+
+            await pair.RunTicksSync(60);
+
+            var poweredRemaining = TimeSpan.Zero;
+
+            await server.WaitAssertion(() =>
+            {
+                // Unpowered: the timer is frozen, so the unit never reaches Ready.
+                var remaining = comp.NextPressurized - timing.CurTime;
+                Assert.Multiple(() =>
+                {
+                    Assert.That(disposalSystem.GetState((unit, comp)), Is.EqualTo(DisposalsPressureState.Pressurizing));
+                    Assert.That((remaining - unpoweredRemaining).TotalSeconds, Is.GreaterThan(-0.1));
+                });
+
+                power.SetNeedsPower(unit, false);
+                entityManager.GetComponent<ApcPowerReceiverComponent>(unit).Powered = true;
+                poweredRemaining = comp.NextPressurized - timing.CurTime;
+            });
+
+            await pair.RunTicksSync(60);
+
+            await server.WaitAssertion(() =>
+            {
+                // Powered: the timer advances again.
+                var remaining = comp.NextPressurized - timing.CurTime;
+                Assert.Multiple(() =>
+                {
+                    Assert.That(power.IsPowered(unit), Is.True);
+                    Assert.That(remaining, Is.LessThan(poweredRemaining - TimeSpan.FromSeconds(0.1)));
+                });
             });
         }
     }

--- a/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
+++ b/Content.IntegrationTests/Tests/Disposal/DisposalUnitTest.cs
@@ -251,50 +251,44 @@ namespace Content.IntegrationTests.Tests.Disposal
 
             EntityUid unit = default;
             DisposalUnitComponent comp = default!;
-            var unpoweredRemaining = TimeSpan.Zero;
 
             await server.WaitAssertion(() =>
             {
                 unit = entityManager.SpawnEntity("DisposalUnitDummy", testMap.GridCoords);
                 comp = entityManager.GetComponent<DisposalUnitComponent>(unit);
-                Assert.That(power.IsPowered(unit), Is.False);
+                power.SetNeedsPower(unit, false);
+            });
 
-                comp.NextPressurized = timing.CurTime + TimeSpan.FromSeconds(10);
+            await pair.RunTicksSync(1);
+
+            await server.WaitAssertion(() =>
+            {
+                Assert.That(power.IsPowered(unit), Is.True);
+
+                comp.NextPressurized = timing.CurTime + TimeSpan.FromSeconds(0.5);
                 Assert.That(disposalSystem.GetState((unit, comp)), Is.EqualTo(DisposalsPressureState.Pressurizing));
 
-                unpoweredRemaining = comp.NextPressurized - timing.CurTime;
+                power.SetNeedsPower(unit, true);
             });
 
             await pair.RunTicksSync(60);
 
-            var poweredRemaining = TimeSpan.Zero;
-
             await server.WaitAssertion(() =>
             {
-                // Unpowered: the timer is frozen, so the unit never reaches Ready.
-                var remaining = comp.NextPressurized - timing.CurTime;
-                Assert.Multiple(() =>
-                {
-                    Assert.That(disposalSystem.GetState((unit, comp)), Is.EqualTo(DisposalsPressureState.Pressurizing));
-                    Assert.That((remaining - unpoweredRemaining).TotalSeconds, Is.GreaterThan(-0.1));
-                });
+                // Frozen while unpowered: never reaches Ready despite plenty of time passing.
+                Assert.That(power.IsPowered(unit), Is.False);
+                Assert.That(disposalSystem.GetState((unit, comp)), Is.EqualTo(DisposalsPressureState.Pressurizing));
 
                 power.SetNeedsPower(unit, false);
-                entityManager.GetComponent<ApcPowerReceiverComponent>(unit).Powered = true;
-                poweredRemaining = comp.NextPressurized - timing.CurTime;
             });
 
             await pair.RunTicksSync(60);
 
             await server.WaitAssertion(() =>
             {
-                // Powered: the timer advances again.
-                var remaining = comp.NextPressurized - timing.CurTime;
-                Assert.Multiple(() =>
-                {
-                    Assert.That(power.IsPowered(unit), Is.True);
-                    Assert.That(remaining, Is.LessThan(poweredRemaining - TimeSpan.FromSeconds(0.1)));
-                });
+                // With power back it finishes pressurizing.
+                Assert.That(power.IsPowered(unit), Is.True);
+                Assert.That(disposalSystem.GetState((unit, comp)), Is.EqualTo(DisposalsPressureState.Ready));
             });
         }
     }

--- a/Content.Shared/Disposal/Unit/DisposalUnitComponent.cs
+++ b/Content.Shared/Disposal/Unit/DisposalUnitComponent.cs
@@ -83,6 +83,12 @@ public sealed partial class DisposalUnitComponent : Component
     public TimeSpan NextPressurized = TimeSpan.Zero;
 
     /// <summary>
+    /// When the unit lost power, if it's currently unpowered. Freezes pressurization.
+    /// </summary>
+    [DataField, AutoNetworkedField, AutoPausedField]
+    public TimeSpan? PowerOff;
+
+    /// <summary>
     /// The percentage of pressure gained per second by the unit.
     /// </summary>
     [DataField]

--- a/Content.Shared/Disposal/Unit/DisposalUnitComponent.cs
+++ b/Content.Shared/Disposal/Unit/DisposalUnitComponent.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Disposal.Components;
 
@@ -78,15 +79,28 @@ public sealed partial class DisposalUnitComponent : Component
 
     /// <summary>
     /// Next time the disposal unit will be pressurized.
+    /// If PowerOff is not null, this is unreliable.
     /// </summary>
-    [DataField, AutoNetworkedField, AutoPausedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoNetworkedField, AutoPausedField]
     public TimeSpan NextPressurized = TimeSpan.Zero;
 
     /// <summary>
-    /// When the unit lost power, if it's currently unpowered. Freezes pressurization.
+    /// If not null, the time the entity lost power while repressurizing.
     /// </summary>
-    [DataField, AutoNetworkedField, AutoPausedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoNetworkedField, AutoPausedField]
     public TimeSpan? PowerOff;
+
+    /// <summary>
+    /// The last time the disposal unit was flushed.
+    /// </summary>
+    /// <remarks>
+    /// Needed as NextPressurized is unreliable for judging time since last flush.
+    /// </remarks
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoNetworkedField, AutoPausedField]
+    public TimeSpan? LastFlushTime;
 
     /// <summary>
     /// The percentage of pressure gained per second by the unit.
@@ -193,12 +207,6 @@ public record DisposalSystemTransitionEvent;
 /// </summary>
 [Serializable, NetSerializable]
 public sealed partial class DisposalDoAfterEvent : SimpleDoAfterEvent;
-
-/// <summary>
-/// Message sent from the server to the client to update the UI of disposal units.
-/// </summary>
-[Serializable, NetSerializable]
-public sealed class DisposalUnitBoundUserInterfaceState : BoundUserInterfaceState;
 
 /// <summary>
 /// Disposal unit pressure states.

--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.VisualsAndUi.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.VisualsAndUi.cs
@@ -44,12 +44,9 @@ public abstract partial class SharedDisposalUnitSystem
 
     protected void UpdateUI(Entity<DisposalUnitComponent> entity)
     {
-        if (_timing.ApplyingState)
-            return;
-
         if (_ui.TryGetOpenUi(entity.Owner, DisposalUnitUiKey.Key, out var bui))
         {
-            bui.Update<DisposalUnitBoundUserInterfaceState>();
+            bui.Update();
         }
     }
 

--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.VisualsAndUi.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.VisualsAndUi.cs
@@ -36,7 +36,7 @@ public abstract partial class SharedDisposalUnitSystem
     /// <returns>The estimated time.</returns>
     public TimeSpan EstimatedFullPressure(Entity<DisposalUnitComponent> ent)
     {
-        if (ent.Comp.NextPressurized < _timing.CurTime)
+        if (ent.Comp.NextPressurized < (ent.Comp.PowerOff ?? _timing.CurTime))
             return TimeSpan.Zero;
 
         return ent.Comp.NextPressurized;

--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
@@ -100,9 +100,9 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
 
     private void OnPowerChange(Entity<DisposalUnitComponent> ent, ref PowerChangedEvent args)
     {
-        if (!args.Powered && ent.Comp.PowerOff == null && ent.Comp.NextPressurized > _timing.CurTime)
+        if (!args.Powered && ent.Comp.NextPressurized > _timing.CurTime)
         {
-            ent.Comp.PowerOff = _timing.CurTime;
+            ent.Comp.PowerOff ??= _timing.CurTime;
         }
         else if (args.Powered && ent.Comp.PowerOff != null)
         {
@@ -179,15 +179,10 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
     /// <returns>The disposal unit's pressure state.</returns>
     public DisposalsPressureState GetState(Entity<DisposalUnitComponent> ent)
     {
-        // While unpowered the timer is held at the moment power was lost.
-        var nextPressure = ent.Comp.NextPressurized - (ent.Comp.PowerOff ?? _timing.CurTime);
-        var pressurizeTime = 1f / ent.Comp.PressurePerSecond;
-        var pressurizeDuration = pressurizeTime - ent.Comp.FlushDelay.TotalSeconds;
-
-        if (nextPressure.TotalSeconds > pressurizeDuration)
+        if (ent.Comp.LastFlushTime != null && _timing.CurTime <= ent.Comp.LastFlushTime.Value + ent.Comp.FlushDelay)
             return DisposalsPressureState.Flushed;
 
-        if (nextPressure > TimeSpan.Zero)
+        if (ent.Comp.PowerOff != null || _timing.CurTime < ent.Comp.NextPressurized)
             return DisposalsPressureState.Pressurizing;
 
         return DisposalsPressureState.Ready;
@@ -244,27 +239,16 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
 
     private void UpdateDisposalUnit(Entity<DisposalUnitComponent> ent, MetaDataComponent metadata)
     {
-        // Pressurization is frozen while unpowered.
-        if (ent.Comp.PowerOff != null)
-            return;
-
-        var state = GetState(ent);
-
-        // Check if we need a state update
-        if (ent.Comp.NextPressurized > _timing.CurTime)
-        {
-            UpdateState(ent, state);
-            return;
-        }
-
-        // Check if we need to flush
-        if (ent.Comp.NextFlush != null &&
-            ent.Comp.NextFlush.Value < _timing.CurTime)
+        // Check if we need to flush (not recharging)
+        if (ent.Comp.PowerOff == null
+            && ent.Comp.NextPressurized <= _timing.CurTime
+            && ent.Comp.NextFlush != null
+            && ent.Comp.NextFlush.Value <= _timing.CurTime)
         {
             TryFlush(ent);
         }
 
-        UpdateState(ent, state);
+        UpdateState(ent, GetState(ent));
     }
 
     private void UpdateState(Entity<DisposalUnitComponent> ent, DisposalsPressureState state)
@@ -329,6 +313,7 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
         // Try to transfer entities from the unit into disposals.
         TryTransfer(ent, tube.Value, beforeFlushArgs.Tags);
 
+        ent.Comp.LastFlushTime = _timing.CurTime;
         ent.Comp.NextPressurized = _timing.CurTime;
 
         if (!ent.Comp.DisablePressure)
@@ -443,7 +428,15 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
 
             if (GetState(ent) != DisposalsPressureState.Ready)
             {
-                newFlush += ent.Comp.NextPressurized;
+                // Power currently off while recharging? nextPressurized is unreliable.
+                if (ent.Comp.PowerOff != null)
+                {
+                    newFlush = TimeSpan.MaxValue;
+                }
+                else
+                {
+                    newFlush += ent.Comp.NextPressurized;
+                }
             }
 
             nextFlush = (ent.Comp.NextFlush ?? TimeSpan.MaxValue);

--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
@@ -100,6 +100,16 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
 
     private void OnPowerChange(Entity<DisposalUnitComponent> ent, ref PowerChangedEvent args)
     {
+        if (!args.Powered && ent.Comp.PowerOff == null && ent.Comp.NextPressurized > _timing.CurTime)
+        {
+            ent.Comp.PowerOff = _timing.CurTime;
+        }
+        else if (args.Powered && ent.Comp.PowerOff != null)
+        {
+            ent.Comp.NextPressurized += _timing.CurTime - ent.Comp.PowerOff.Value;
+            ent.Comp.PowerOff = null;
+        }
+
         RecalculateFlushTime(ent, true);
         UpdateVisualState(ent);
     }
@@ -169,7 +179,8 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
     /// <returns>The disposal unit's pressure state.</returns>
     public DisposalsPressureState GetState(Entity<DisposalUnitComponent> ent)
     {
-        var nextPressure = ent.Comp.NextPressurized - _timing.CurTime;
+        // While unpowered the timer is held at the moment power was lost.
+        var nextPressure = ent.Comp.NextPressurized - (ent.Comp.PowerOff ?? _timing.CurTime);
         var pressurizeTime = 1f / ent.Comp.PressurePerSecond;
         var pressurizeDuration = pressurizeTime - ent.Comp.FlushDelay.TotalSeconds;
 
@@ -227,18 +238,15 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
         var query = EntityQueryEnumerator<DisposalUnitComponent, MetaDataComponent>();
         while (query.MoveNext(out var uid, out var unit, out var metadata))
         {
-            UpdateDisposalUnit((uid, unit), metadata, frameTime);
+            UpdateDisposalUnit((uid, unit), metadata);
         }
     }
 
-    private void UpdateDisposalUnit(Entity<DisposalUnitComponent> ent, MetaDataComponent metadata, float frameTime)
+    private void UpdateDisposalUnit(Entity<DisposalUnitComponent> ent, MetaDataComponent metadata)
     {
-        // Don't build up pressure while unpowered.
-        if (ent.Comp.NextPressurized > _timing.CurTime && !_power.IsPowered(ent.Owner))
-        {
-            ent.Comp.NextPressurized += TimeSpan.FromSeconds(frameTime);
-            Dirty(ent);
-        }
+        // Pressurization is frozen while unpowered.
+        if (ent.Comp.PowerOff != null)
+            return;
 
         var state = GetState(ent);
 

--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
@@ -227,12 +227,19 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
         var query = EntityQueryEnumerator<DisposalUnitComponent, MetaDataComponent>();
         while (query.MoveNext(out var uid, out var unit, out var metadata))
         {
-            UpdateDisposalUnit((uid, unit), metadata);
+            UpdateDisposalUnit((uid, unit), metadata, frameTime);
         }
     }
 
-    private void UpdateDisposalUnit(Entity<DisposalUnitComponent> ent, MetaDataComponent metadata)
+    private void UpdateDisposalUnit(Entity<DisposalUnitComponent> ent, MetaDataComponent metadata, float frameTime)
     {
+        // Don't build up pressure while unpowered.
+        if (ent.Comp.NextPressurized > _timing.CurTime && !_power.IsPowered(ent.Owner))
+        {
+            ent.Comp.NextPressurized += TimeSpan.FromSeconds(frameTime);
+            Dirty(ent);
+        }
+
         var state = GetState(ent);
 
         // Check if we need a state update


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Cut the power on a disposal unit and it'd just keep building up pressure anyway. Now it doesn't.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
unplugged machine should not do machine things. Closes #44112.

## Technical details
<!-- Summary of code changes for easier review. -->
While the unit is unpowered the pressurize timer gets held in place instead of ticking back up to Ready.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Disposal units no longer build up pressure while unpowered.