### PR TITLE
Set time limit on test runner

### DIFF
--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -16,6 +16,7 @@ jobs:
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     steps:
     - name: Checkout Master


### PR DESCRIPTION
For some reason these have been timing out for months and the default 6 hour limit is overkill.