### PR TITLE
Add EntitySpawnVariationPass as an EntityEffect 

### DIFF
--- a/Content.Shared/EntityEffects/Effects/VariationPass/EntitySpawnVariationPassEntityEffect.cs
+++ b/Content.Shared/EntityEffects/Effects/VariationPass/EntitySpawnVariationPassEntityEffect.cs
@@ -95,10 +95,10 @@ public sealed partial class EntitySpawnVariationPass : EntityEffectBase<EntitySp
     ///     Number of tiles before we spawn one entity on average.
     /// </summary>
     [DataField]
-    public float TilesPerEntityAverage = 120f;
+    public float TilesPerEntityAverage = 50f;
 
     [DataField]
-    public float TilesPerEntityStdDev = 5f;
+    public float TilesPerEntityStdDev = 7f;
 
     /// <summary>
     ///     Spawn entries for each chosen location.

--- a/Content.Shared/EntityEffects/Effects/VariationPass/EntitySpawnVariationPassEntityEffect.cs
+++ b/Content.Shared/EntityEffects/Effects/VariationPass/EntitySpawnVariationPassEntityEffect.cs
@@ -1,7 +1,9 @@
 ﻿using System.Linq;
+using Content.Shared.Physics;
 using Content.Shared.Storage;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Physics;
 using Robust.Shared.Random;
 
 namespace Content.Shared.EntityEffects.Effects.VariationPass;
@@ -14,40 +16,75 @@ public sealed partial class EntitySpawnVariationPassEntityEffectSystem : EntityE
 {
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private EntityLookupSystem _lookup = default!;
 
     protected override void Effect(Entity<MapGridComponent> entity, ref EntityEffectEvent<EntitySpawnVariationPass> args)
     {
-        var totalTiles = _map.GetAllTiles(entity, entity).Count();
+        var tiles = _map.GetAllTiles(entity, entity).ToList();
+        var totalTiles = tiles.Count();
 
         var dirtyMod = _random.NextGaussian(args.Effect.TilesPerEntityAverage, args.Effect.TilesPerEntityStdDev);
         var trashTiles = Math.Max((int) (totalTiles * (1 / dirtyMod)), 0);
 
         for (var i = 0; i < trashTiles; i++)
         {
-            FindRandomTileOnStation(entity, out var coords);
-
-            var ents = EntitySpawnCollection.GetSpawns(args.Effect.Entities, _random);
-            foreach (var spawn in ents)
+            if (TryFindRandomTile(entity, tiles, out var coords))
             {
-                SpawnAtPosition(spawn, coords);
+                var ents = EntitySpawnCollection.GetSpawns(args.Effect.Entities, _random);
+                foreach (var spawn in ents)
+                {
+                    SpawnAtPosition(spawn, coords);
+                }
             }
         }
     }
 
-    private void FindRandomTileOnStation(Entity<MapGridComponent> grid,
+    /// Attempts to find an empty tile 10 times, returns true if successful.
+    private bool TryFindRandomTile(Entity<MapGridComponent> grid,
+        List<TileRef> tiles,
         out EntityCoordinates targetCoords)
     {
         targetCoords = EntityCoordinates.Invalid;
-        var aabb = grid.Comp.LocalAABB;
 
-        // TODO: Check for atmospherics, which isn't available in Shared. Until that is done, this method isn't the same as the old one
+        var found = false;
 
-        var randomX = _random.Next((int) aabb.Left, (int) aabb.Right);
-        var randomY = _random.Next((int) aabb.Bottom, (int) aabb.Top);
+        for (var i = 0; i < 10; i++)
+        {
+            var tile = _random.Pick(tiles);
+            var tileCoords = tile.GridIndices;
 
-        var tile = new Vector2i(randomX, randomY);
+            var intersectingEntities = new HashSet<EntityUid>();
+            _lookup.GetLocalEntitiesIntersecting(grid, tileCoords, intersectingEntities, -0.05f, LookupFlags.Uncontained);
 
-        targetCoords = _map.GridTileToLocal(grid, grid.Comp, tile);
+            var blocker = false;
+            foreach (var ent in intersectingEntities)
+            {
+                if (TryComp<FixturesComponent>(ent, out var fixtures))
+                {
+                    foreach (var fixture in fixtures.Fixtures.Values)
+                    {
+                        // Continue if no collision is possible
+                        if (!fixture.Hard || fixture.CollisionLayer <= 0 || (fixture.CollisionLayer & (int) CollisionGroup.Impassable) == 0)
+                            continue;
+
+                        blocker = true;
+                        break;
+                    }
+                }
+
+                if (blocker)
+                    break;
+            }
+
+            if (!blocker)
+            {
+                found = true;
+                targetCoords = _map.GridTileToLocal(grid, grid.Comp, tileCoords);
+                return found;
+            }
+        }
+
+        return found;
     }
 }
 

--- a/Content.Shared/EntityEffects/Effects/VariationPass/EntitySpawnVariationPassEntityEffect.cs
+++ b/Content.Shared/EntityEffects/Effects/VariationPass/EntitySpawnVariationPassEntityEffect.cs
@@ -1,0 +1,71 @@
+﻿using System.Linq;
+using Content.Shared.Storage;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Random;
+
+namespace Content.Shared.EntityEffects.Effects.VariationPass;
+
+/// <summary>
+/// Used for spawning entities randomly dotted around the grid.
+/// </summary>
+/// <inheritdoc cref="EntityEffectSystem{T,TEffect}"/>
+public sealed partial class EntitySpawnVariationPassEntityEffectSystem : EntityEffectSystem<MapGridComponent, EntitySpawnVariationPass>
+{
+    [Dependency] private SharedMapSystem _map = default!;
+    [Dependency] private IRobustRandom _random = default!;
+
+    protected override void Effect(Entity<MapGridComponent> entity, ref EntityEffectEvent<EntitySpawnVariationPass> args)
+    {
+        var totalTiles = _map.GetAllTiles(entity, entity).Count();
+
+        var dirtyMod = _random.NextGaussian(args.Effect.TilesPerEntityAverage, args.Effect.TilesPerEntityStdDev);
+        var trashTiles = Math.Max((int) (totalTiles * (1 / dirtyMod)), 0);
+
+        for (var i = 0; i < trashTiles; i++)
+        {
+            FindRandomTileOnStation(entity, out var coords);
+
+            var ents = EntitySpawnCollection.GetSpawns(args.Effect.Entities, _random);
+            foreach (var spawn in ents)
+            {
+                SpawnAtPosition(spawn, coords);
+            }
+        }
+    }
+
+    private void FindRandomTileOnStation(Entity<MapGridComponent> grid,
+        out EntityCoordinates targetCoords)
+    {
+        targetCoords = EntityCoordinates.Invalid;
+        var aabb = grid.Comp.LocalAABB;
+
+        // TODO: Check for atmospherics, which isn't available in Shared. Until that is done, this method isn't the same as the old one
+
+        var randomX = _random.Next((int) aabb.Left, (int) aabb.Right);
+        var randomY = _random.Next((int) aabb.Bottom, (int) aabb.Top);
+
+        var tile = new Vector2i(randomX, randomY);
+
+        targetCoords = _map.GridTileToLocal(grid, grid.Comp, tile);
+    }
+}
+
+/// <inheritdoc cref="EntityEffect"/>
+public sealed partial class EntitySpawnVariationPass : EntityEffectBase<EntitySpawnVariationPass>
+{
+    /// <summary>
+    ///     Number of tiles before we spawn one entity on average.
+    /// </summary>
+    [DataField]
+    public float TilesPerEntityAverage = 120f;
+
+    [DataField]
+    public float TilesPerEntityStdDev = 5f;
+
+    /// <summary>
+    ///     Spawn entries for each chosen location.
+    /// </summary>
+    [DataField(required: true)]
+    public List<EntitySpawnEntry> Entities = default!;
+}

--- a/Content.Shared/EntityEffects/Effects/VariationPass/EntitySpawnVariationPassEntityEffect.cs
+++ b/Content.Shared/EntityEffects/Effects/VariationPass/EntitySpawnVariationPassEntityEffect.cs
@@ -92,16 +92,19 @@ public sealed partial class EntitySpawnVariationPassEntityEffectSystem : EntityE
 public sealed partial class EntitySpawnVariationPass : EntityEffectBase<EntitySpawnVariationPass>
 {
     /// <summary>
-    ///     Number of tiles before we spawn one entity on average.
+    /// Number of tiles before we spawn one entity on average.
     /// </summary>
     [DataField]
     public float TilesPerEntityAverage = 50f;
 
+    /// <summary>
+    /// Standard deviation for the randomness selection.
+    /// </summary>
     [DataField]
     public float TilesPerEntityStdDev = 7f;
 
     /// <summary>
-    ///     Spawn entries for each chosen location.
+    /// Spawn entries for each chosen location.
     /// </summary>
     [DataField(required: true)]
     public List<EntitySpawnEntry> Entities = default!;

--- a/Content.Shared/EntityEffects/Effects/VariationPass/EntitySpawnVariationPassEntityEffect.cs
+++ b/Content.Shared/EntityEffects/Effects/VariationPass/EntitySpawnVariationPassEntityEffect.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
+using Content.Shared.EntityTable;
+using Content.Shared.EntityTable.EntitySelectors;
 using Content.Shared.Physics;
-using Content.Shared.Storage;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
@@ -17,6 +18,7 @@ public sealed partial class EntitySpawnVariationPassEntityEffectSystem : EntityE
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
+    [Dependency] private EntityTableSystem _tables = default!;
 
     protected override void Effect(Entity<MapGridComponent> entity, ref EntityEffectEvent<EntitySpawnVariationPass> args)
     {
@@ -30,7 +32,7 @@ public sealed partial class EntitySpawnVariationPassEntityEffectSystem : EntityE
         {
             if (TryFindRandomTile(entity, tiles, out var coords))
             {
-                var ents = EntitySpawnCollection.GetSpawns(args.Effect.Entities, _random);
+                var ents = _tables.GetSpawns(args.Effect.Table, _random);
                 foreach (var spawn in ents)
                 {
                     SpawnAtPosition(spawn, coords);
@@ -46,45 +48,43 @@ public sealed partial class EntitySpawnVariationPassEntityEffectSystem : EntityE
     {
         targetCoords = EntityCoordinates.Invalid;
 
-        var found = false;
-
         for (var i = 0; i < 10; i++)
         {
             var tile = _random.Pick(tiles);
             var tileCoords = tile.GridIndices;
 
-            var intersectingEntities = new HashSet<EntityUid>();
-            _lookup.GetLocalEntitiesIntersecting(grid, tileCoords, intersectingEntities, -0.05f, LookupFlags.Uncontained);
-
-            var blocker = false;
-            foreach (var ent in intersectingEntities)
+            if (CheckTileEntities(grid, tileCoords))
             {
-                if (TryComp<FixturesComponent>(ent, out var fixtures))
-                {
-                    foreach (var fixture in fixtures.Fixtures.Values)
-                    {
-                        // Continue if no collision is possible
-                        if (!fixture.Hard || fixture.CollisionLayer <= 0 || (fixture.CollisionLayer & (int) CollisionGroup.Impassable) == 0)
-                            continue;
-
-                        blocker = true;
-                        break;
-                    }
-                }
-
-                if (blocker)
-                    break;
-            }
-
-            if (!blocker)
-            {
-                found = true;
                 targetCoords = _map.GridTileToLocal(grid, grid.Comp, tileCoords);
-                return found;
+                return true;
             }
         }
 
-        return found;
+        return false;
+    }
+
+    /// Returns false if the tile is occupied.
+    private bool CheckTileEntities(Entity<MapGridComponent> grid, Vector2i tileCoords)
+    {
+        var intersectingEntities = new HashSet<EntityUid>();
+        _lookup.GetLocalEntitiesIntersecting(grid, tileCoords, intersectingEntities, -0.05f, LookupFlags.Uncontained);
+
+        foreach (var ent in intersectingEntities)
+        {
+            if (TryComp<FixturesComponent>(ent, out var fixtures))
+            {
+                foreach (var fixture in fixtures.Fixtures.Values)
+                {
+                    // Continue if no collision is possible
+                    if (!fixture.Hard || fixture.CollisionLayer <= 0 || (fixture.CollisionLayer & (int) CollisionGroup.Impassable) == 0)
+                        continue;
+
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 }
 
@@ -104,8 +104,8 @@ public sealed partial class EntitySpawnVariationPass : EntityEffectBase<EntitySp
     public float TilesPerEntityStdDev = 7f;
 
     /// <summary>
-    /// Spawn entries for each chosen location.
+    /// Spawn table for each chosen location.
     /// </summary>
     [DataField(required: true)]
-    public List<EntitySpawnEntry> Entities = default!;
+    public EntityTableSelector Table = default!;
 }

--- a/Content.Shared/EntityEffects/EntityEffectOnInitComponent.cs
+++ b/Content.Shared/EntityEffects/EntityEffectOnInitComponent.cs
@@ -1,0 +1,15 @@
+﻿namespace Content.Shared.EntityEffects;
+
+/// <summary>
+/// Applies a set of EntityEffects to the entity upon map initialization.
+/// <remarks>Useful for e.g. station spawning.</remarks>
+/// </summary>
+[RegisterComponent]
+public sealed partial class EntityEffectOnInitComponent : Component
+{
+    /// <summary>
+    /// Effects that should be applied upon the map being initiated.
+    /// </summary>
+    [DataField(required: true)]
+    public EntityEffect[] Effects { get; set; } = default!;
+}

--- a/Content.Shared/EntityEffects/EntityEffectOnMapInitComponent.cs
+++ b/Content.Shared/EntityEffects/EntityEffectOnMapInitComponent.cs
@@ -5,7 +5,7 @@
 /// <remarks>Useful for e.g. station spawning.</remarks>
 /// </summary>
 [RegisterComponent]
-public sealed partial class EntityEffectOnInitComponent : Component
+public sealed partial class EntityEffectOnMapInitComponent : Component
 {
     /// <summary>
     /// Effects that should be applied upon the map being initiated.

--- a/Content.Shared/EntityEffects/SharedEntityEffectsSystem.cs
+++ b/Content.Shared/EntityEffects/SharedEntityEffectsSystem.cs
@@ -22,7 +22,7 @@ public sealed partial class SharedEntityEffectsSystem : EntitySystem, IEntityEff
     public override void Initialize()
     {
         SubscribeLocalEvent<ReactiveComponent, ReactionEntityEvent>(OnReactive);
-        SubscribeLocalEvent<EntityEffectOnInitComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<EntityEffectOnMapInitComponent, MapInitEvent>(OnMapInit);
     }
 
     private void OnReactive(Entity<ReactiveComponent> entity, ref ReactionEntityEvent args)
@@ -59,7 +59,7 @@ public sealed partial class SharedEntityEffectsSystem : EntitySystem, IEntityEff
         }
     }
 
-    private void OnMapInit(Entity<EntityEffectOnInitComponent> entity, ref MapInitEvent args)
+    private void OnMapInit(Entity<EntityEffectOnMapInitComponent> entity, ref MapInitEvent args)
     {
         ApplyEffects(entity, entity.Comp.Effects);
     }

--- a/Content.Shared/EntityEffects/SharedEntityEffectsSystem.cs
+++ b/Content.Shared/EntityEffects/SharedEntityEffectsSystem.cs
@@ -22,6 +22,7 @@ public sealed partial class SharedEntityEffectsSystem : EntitySystem, IEntityEff
     public override void Initialize()
     {
         SubscribeLocalEvent<ReactiveComponent, ReactionEntityEvent>(OnReactive);
+        SubscribeLocalEvent<EntityEffectOnInitComponent, MapInitEvent>(OnMapInit);
     }
 
     private void OnReactive(Entity<ReactiveComponent> entity, ref ReactionEntityEvent args)
@@ -56,6 +57,11 @@ public sealed partial class SharedEntityEffectsSystem : EntitySystem, IEntityEff
                     ApplyEffects(entity, entry.Effects, scale);
             }
         }
+    }
+
+    private void OnMapInit(Entity<EntityEffectOnInitComponent> entity, ref MapInitEvent args)
+    {
+        ApplyEffects(entity, entity.Comp.Effects);
     }
 
     /// <inheritdoc cref="ApplyEffects(EntityUid,EntityEffect[],float,EntityUid?)"/>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR adds a new entity effect, `EntitySpawnVariationPass`. It can be applied to grids using the EntityEffectSystem ApplyEffects, and this is also made possible with the new component `EntityEffectOnMapInit`, which is a simple event subscription applying an effect list on map initialization. 

Resolves #43636 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This can be used to replace/in place of the `EntitySpawnVariationPass` gamerule. The main advantage is that it can be applied to grids post-roundstart, whereas the gamerule version both necessitates being a gamerule and applying to the spawning station. 

This is mostly a proof-of-concept (though I intend to make a follow-up PR that removes the existing graffiti gamerule, so that it can be applied on a per-map basis) but the system is also intended to be utilized for BreakSalv to apply per-grid modifiers.

## Technical details
<!-- Summary of code changes for easier review. -->

The for `EntitySpawnVariationPassEntityEffect` uses similar logic to the gamerule, but not quite; this is due to not working with a station, and also being in Shared which doesn't have access to the same atmos logic. Should be close enough though. 

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Easiest way to test is the following:
1. Open Resources/Maps/Test/dev_map.yml
2. Add the following:
  ```
    - type: EntityEffectOnMapInit
      effects:
      - !type:EntitySpawnVariationPass
        tilesPerEntityAverage: 120
        tilesPerEntityStdDev: 5
        entities:
        - id: DecalSpawnerGraffiti
  ```
  to the grid entity (should be uid 1)
3. Build and run
4. The devmap should now have grafitti similar to stations. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="1520" height="1130" alt="image" src="https://github.com/user-attachments/assets/4102083a-9bbf-445f-a0f5-8e5ba4928183" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

none yet

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
Not playerfacing
