### PR TITLE
Fix Flare Copyright

### DIFF
--- a/Resources/Textures/Objects/Misc/flare.rsi/meta.json
+++ b/Resources/Textures/Objects/Misc/flare.rsi/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "license": "CC-BY-SA-3.0",
-  "copyright": "Taken from tgstation at commit https://github.com/tgstation/tgstation/commit/0f6496a55ceefa0f1bf1668fcef49b5182471695",
+  "copyright": "Sprites created by https://github.com/nuke-makes-games",
   "size": {
     "x": 32,
     "y": 32

--- a/Resources/Textures/Objects/Misc/flare.rsi/meta.json
+++ b/Resources/Textures/Objects/Misc/flare.rsi/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "license": "CC-BY-SA-3.0",
-  "copyright": "Sprites created by https://github.com/nuke-makes-games",
+  "copyright": "Sprites created by https://github.com/nuke-haus",
   "size": {
     "x": 32,
     "y": 32


### PR DESCRIPTION
## About the PR
Restores the copyright that the flare.json file had in it's original PR, #1886.

## Why / Balance
As far as I'm aware, this sprite is wholly unique to SS14 and was mistakenly attributed to TG in #2991. I'm sure there's so many others out there but this is just one that I caught off hand when editing the flare sprite.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
Entirely code facing.