### PR TITLE
Bugfix: Only raise ToolRefineAttemptEvent if used item has needed tool qualities

### DIFF
--- a/Content.Shared/Tools/Systems/ToolRefinableSystem.cs
+++ b/Content.Shared/Tools/Systems/ToolRefinableSystem.cs
@@ -47,7 +47,7 @@ public sealed partial class ToolRefinablSystem : EntitySystem
     /// <summary> Normal interactions. </summary>
     private void OnInteractUsing(Entity<ToolRefinableComponent> ent, ref InteractUsingEvent args)
     {
-        if (args.Handled)
+        if (args.Handled || !_toolSystem.HasQuality(args.Used, ent.Comp.QualityNeeded))
             return;
 
         var component = ent.Comp;
@@ -86,14 +86,17 @@ public sealed partial class ToolRefinablSystem : EntitySystem
                 ? null
                 : Loc.GetString(ent.Comp.ToolMissingQualityTooltip, ("target", ent.Owner));
         }
-        // make an attempt to ensure refinement is not blocked.
-        var attemptEvent = new AttemptToolRefineEvent(tool);
-        RaiseLocalEvent(args.Target, ref attemptEvent);
-
-        if (attemptEvent.IsCancelled)
+        else
         {
-            verbDisabled = true;
-            verbMessage = attemptEvent.BlockCause;
+            // We have the necessary tool, make an attempt to ensure refinement is not blocked.
+            var attemptEvent = new AttemptToolRefineEvent(tool);
+            RaiseLocalEvent(args.Target, ref attemptEvent);
+
+            if (attemptEvent.IsCancelled)
+            {
+                verbDisabled = true;
+                verbMessage = attemptEvent.BlockCause;
+            }
         }
 
         verbMessage ??= component.VerbDefaultTooltip == null


### PR DESCRIPTION
## About the PR

Bugfix for ToolRefinableSystem that checks that an item can be a matching tool before actually raising an attempt event.

## Why / Balance

Regression introduced in #36895.

Found this in #44427, figured it was worth a small bugfix.

Motivation: If I have an apple and select a cow, I will never be able to slice the cow with my apple - the apple isn't capable of slicing.  The slice verb shouldn't tell me the cow needs to be dead, it should tell me that I need a knife.

## Technical details

Both the verb and interaction events now need for the used item to be a tool with the required qualities before raising the event.

## Test plan

Spawn a cow, pick up an apple and a kitchen knife.
Equip the apple, right click on the cow.  The verb text for Slice should tell you that you need another tool.
Equip the knife, right click on the cow.  The verb text for Slice should tell you that the cow needs to be dead.
Feed the cow with the apple.  No popups.
Use the knife on the cow.  It should tell you that the cow needs to be dead first.
Kill the cow.  Poor cow.
Use the knife on the cow.  You should butcher the cow.

## Media

Showing the change in use.  When using the apple on the cow, it feeds it successfully.  If trying to feed it with something it can't digest, you'll get a popup telling you that instead!

https://github.com/user-attachments/assets/6314a413-abf7-4a77-9235-a0035e3373bf

Previous behaviour: nasty popup when trying to feed the cow.

https://github.com/user-attachments/assets/4b7d3989-a508-4a3e-a66b-ae4978d10b3e

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
Small fix, no changelog needed.