### PR TITLE
Change DeathMatchRuleComponent to use EntityTables

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/DeathMatchRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/DeathMatchRuleComponent.cs
@@ -32,7 +32,7 @@ public sealed partial class DeathMatchRuleComponent : Component
     public NetUserId? Victor;
 
     /// <summary>
-    /// An entity spawned after a player is killed.
+    /// The EntityTable spawned after a player is killed.
     /// </summary>
     [DataField]
     public EntityTableSelector RewardSpawns = default!;

--- a/Content.Server/GameTicking/Rules/Components/DeathMatchRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/DeathMatchRuleComponent.cs
@@ -1,9 +1,8 @@
-﻿using Content.Shared.FixedPoint;
+﻿using Content.Shared.EntityTable.EntitySelectors;
+using Content.Shared.FixedPoint;
 using Content.Shared.Roles;
-using Content.Shared.Storage;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.GameTicking.Rules.Components;
 
@@ -16,31 +15,31 @@ public sealed partial class DeathMatchRuleComponent : Component
     /// <summary>
     /// The number of points a player has to get to win.
     /// </summary>
-    [DataField("killCap"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public FixedPoint2 KillCap = 31;
 
     /// <summary>
     /// How long until the round restarts
     /// </summary>
-    [DataField("restartDelay"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public TimeSpan RestartDelay = TimeSpan.FromSeconds(10f);
 
     /// <summary>
     /// The person who won.
     /// We store this here in case of some assist shenanigans.
     /// </summary>
-    [DataField("victor")]
+    [DataField]
     public NetUserId? Victor;
 
     /// <summary>
     /// An entity spawned after a player is killed.
     /// </summary>
-    [DataField("rewardSpawns")]
-    public List<EntitySpawnEntry> RewardSpawns = new();
+    [DataField]
+    public EntityTableSelector RewardSpawns = default!;
 
     /// <summary>
     /// The gear all players spawn with.
     /// </summary>
-    [DataField("gear", customTypeSerializer: typeof(PrototypeIdSerializer<StartingGearPrototype>)), ViewVariables(VVAccess.ReadWrite)]
-    public string Gear = "DeathMatchGear";
+    [DataField]
+    public ProtoId<StartingGearPrototype> Gear = "DeathMatchGear";
 }

--- a/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DeathMatchRuleSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server.Clothing.Systems;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.KillTracking;
@@ -6,11 +5,10 @@ using Content.Server.Mind;
 using Content.Server.Points;
 using Content.Server.RoundEnd;
 using Content.Server.Station.Systems;
+using Content.Shared.EntityTable;
 using Content.Shared.GameTicking;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Points;
-using Content.Shared.Storage;
-using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Utility;
 
@@ -28,7 +26,7 @@ public sealed partial class DeathMatchRuleSystem : GameRuleSystem<DeathMatchRule
     [Dependency] private RespawnRuleSystem _respawn = default!;
     [Dependency] private RoundEndSystem _roundEnd = default!;
     [Dependency] private StationSpawningSystem _stationSpawning = default!;
-    [Dependency] private TransformSystem _transform = default!;
+    [Dependency] private EntityTableSystem _entityTable = default!;
 
     public override void Initialize()
     {
@@ -100,8 +98,10 @@ public sealed partial class DeathMatchRuleSystem : GameRuleSystem<DeathMatchRule
             if (ev.Assist is KillPlayerSource assist && dm.Victor == null)
                 _point.AdjustPointValue(assist.PlayerId, 1, uid, point);
 
-            var spawns = EntitySpawnCollection.GetSpawns(dm.RewardSpawns).Cast<string?>().ToList();
-            EntityManager.SpawnEntities(_transform.GetMapCoordinates(ev.Entity), spawns);
+            foreach (var spawn in _entityTable.GetSpawns(dm.RewardSpawns))
+            {
+                SpawnNextToOrDrop(spawn, ev.Entity);
+            }
         }
     }
 

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -80,24 +80,19 @@
   parent: BaseGameRule
   components:
   - type: DeathMatchRule
-    rewardSpawns:
-    - id: HealingToolbox
-    - id: ClothingOuterArmorBasicSlim
-      orGroup: loot
-    - id: ClothingHeadHelmetBasic
-      orGroup: loot
-    - id: SoapNT
-      orGroup: loot
-    - id: Bola
-      orGroup: loot
-    - id: Spear
-      orGroup: loot
-    - id: ClothingShoesGaloshes
-      orGroup: loot
-    - id: FoodPieBananaCream
-      orGroup: loot
-    - id: Stimpack
-      orGroup: loot
+    rewardSpawns: !type:AllSelector
+      children:
+      - id: HealingToolbox
+      - !type:GroupSelector
+        children:
+        - id: ClothingOuterArmorBasicSlim
+        - id: ClothingHeadHelmetBasic
+        - id: SoapNT
+        - id: Bola
+        - id: Spear
+        - id: ClothingShoesGaloshes
+        - id: FoodPieBananaCream
+        - id: Stimpack
   - type: KillCalloutRule
   - type: PointManager
   - type: RespawnDeadRule


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title, removed some redundant tag specifications/vv read write and replaced a custom serialiser with a `ProtoId<StartingGearPrototype>`
Could probably try offsetting the drops as well but that's out of scope.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With the switch to IRobustRandom EntityTables can now fully obsolete EntitySpawnEntry.

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced EntitySpawnEntry GetSpawns with EntityTable GetSpawns, switched a SpawnEntities to iteration since only SpawnEntitiesAttachedTo accepts IEnumerables and SpawnNextToOrDrop should be fairly robust anyway.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Load up a couple clients and kill them to check the spawning still works properly. Should also be able to put stuff in containers if you can manage to kill someone in those.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`RewardSpawns` of `DeathMatchRuleComponent` is now an `EntityTableSelector` instead of a `List<EntitySpawnEntry>`

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
