### PR TITLE
Cleanup: remove more redundantly defined EntitySystem members

### DIFF
--- a/Content.Client/Audio/ContentAudioSystem.AmbientMusic.cs
+++ b/Content.Client/Audio/ContentAudioSystem.AmbientMusic.cs
@@ -22,7 +22,6 @@ public sealed partial class ContentAudioSystem
 {
     [Dependency] private IConfigurationManager _configManager = default!;
     [Dependency] private IGameTiming _timing = default!;
-    [Dependency] private ILogManager _logManager = default!;
     [Dependency] private IPlayerManager _player = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IStateManager _state = default!;
@@ -59,7 +58,7 @@ public sealed partial class ContentAudioSystem
     private void InitializeAmbientMusic()
     {
         Subs.CVar(_configManager, CCVars.AmbientMusicVolume, AmbienceCVarChanged, true);
-        _sawmill = _logManager.GetSawmill("audio.ambience");
+        _sawmill = LogManager.GetSawmill("audio.ambience");
 
         // Reset audio
         _nextAudio = TimeSpan.MaxValue;

--- a/Content.Client/Crayon/CrayonSystem.cs
+++ b/Content.Client/Crayon/CrayonSystem.cs
@@ -13,13 +13,12 @@ namespace Content.Client.Crayon;
 public sealed partial class CrayonSystem : SharedCrayonSystem
 {
     [Dependency] private SharedChargesSystem _charges = default!;
-    [Dependency] private EntityManager _entityManager = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        Subs.ItemStatus<CrayonComponent>(ent => new StatusControl(ent, _charges, _entityManager));
+        Subs.ItemStatus<CrayonComponent>(ent => new StatusControl(ent, _charges, EntityManager));
     }
 
     private sealed class StatusControl : Control
@@ -43,8 +42,8 @@ public sealed partial class CrayonSystem : SharedCrayonSystem
             base.FrameUpdate(args);
 
             _label.SetMarkup(Robust.Shared.Localization.Loc.GetString("crayon-drawing-label",
-                ("color",_crayon.Comp.Color),
-                ("state",_crayon.Comp.SelectedState),
+                ("color", _crayon.Comp.Color),
+                ("state", _crayon.Comp.SelectedState),
                 ("charges", _charges.GetCurrentCharges(_crayon.Owner)),
                 ("capacity", _capacity)));
         }

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -94,7 +94,7 @@ namespace Content.Server.Administration.Systems
             Subs.CVar(_config, CVars.GameHostName, OnServerNameChanged, true);
             Subs.CVar(_config, CCVars.AdminAhelpOverrideClientName, OnOverrideChanged, true);
             Subs.CVar(_config, CCVars.AhelpQuickInfoStartWordSize, v => _startWordMinSize = v, true);
-            _sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("AHELP");
+            _sawmill = LogManager.GetSawmill("AHELP");
 
             var defaultParams = new AHelpMessageParams(
                 string.Empty,
@@ -714,7 +714,7 @@ namespace Content.Server.Administration.Systems
 
             if (_rateLimit.CountAction(eventArgs.SenderSession, RateLimitKey) != RateLimitStatus.Allowed)
                 return;
-                
+
             _afkManager.PlayerDidAction(senderSession);
 
             // If it's not an admin / admin chooses to keep the sound and message is not an admin only message, then play it.

--- a/Content.Server/Chat/Systems/ChatNotificationSystem.cs
+++ b/Content.Server/Chat/Systems/ChatNotificationSystem.cs
@@ -19,6 +19,8 @@ public sealed partial class ChatNotificationSystem : EntitySystem
     [Dependency] private SharedRoleSystem _roles = default!;
     [Dependency] private IGameTiming _timing = default!;
 
+    private ISawmill _sawmill = default!;
+
     // The following data does not need to be saved
 
     // Local cache for rate limiting chat notifications by source
@@ -34,6 +36,8 @@ public sealed partial class ChatNotificationSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<ActorComponent, ChatNotificationEvent>(OnChatNotification);
+
+        _sawmill = LogManager.GetSawmill("chatnotification");
     }
 
     /// <summary>
@@ -45,7 +49,7 @@ public sealed partial class ChatNotificationSystem : EntitySystem
     {
         if (!ProtoMan.TryIndex(args.ChatNotification, out var chatNotification))
         {
-            Log.Warning("Attempted to index ChatNotificationPrototype " + args.ChatNotification + " but the prototype does not exist.");
+            _sawmill.Warning("Attempted to index ChatNotificationPrototype " + args.ChatNotification + " but the prototype does not exist.");
             return;
         }
 

--- a/Content.Server/Chat/Systems/ChatNotificationSystem.cs
+++ b/Content.Server/Chat/Systems/ChatNotificationSystem.cs
@@ -18,9 +18,6 @@ public sealed partial class ChatNotificationSystem : EntitySystem
     [Dependency] private SharedMindSystem _mind = default!;
     [Dependency] private SharedRoleSystem _roles = default!;
     [Dependency] private IGameTiming _timing = default!;
-    [Dependency] private ILogManager _logManager = default!;
-
-    private ISawmill _sawmill = default!;
 
     // The following data does not need to be saved
 
@@ -37,8 +34,6 @@ public sealed partial class ChatNotificationSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<ActorComponent, ChatNotificationEvent>(OnChatNotification);
-
-        _sawmill = _logManager.GetSawmill("chatnotification");
     }
 
     /// <summary>
@@ -50,7 +45,7 @@ public sealed partial class ChatNotificationSystem : EntitySystem
     {
         if (!ProtoMan.TryIndex(args.ChatNotification, out var chatNotification))
         {
-            _sawmill.Warning("Attempted to index ChatNotificationPrototype " + args.ChatNotification + " but the prototype does not exist.");
+            Log.Warning("Attempted to index ChatNotificationPrototype " + args.ChatNotification + " but the prototype does not exist.");
             return;
         }
 

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -43,7 +43,6 @@ public sealed partial class GhostRoleSystem : EntitySystem
 {
     [Dependency] private IBanManager _ban = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
-    [Dependency] private IEntityManager _ent = default!;
     [Dependency] private EuiManager _euiManager = default!;
     [Dependency] private IPlayerManager _playerManager = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
@@ -532,9 +531,8 @@ public sealed partial class GhostRoleSystem : EntitySystem
         foreach (var proto in roleEnt.Comp.MindRoles)
         {
             if (!ProtoMan.TryIndex(proto, out var indexed)
-                || !indexed.TryComp<MindRoleComponent>(out var comp, _ent.ComponentFactory))
+                || !indexed.TryComp<MindRoleComponent>(out var roleComp, Factory))
                 continue;
-            var roleComp = (MindRoleComponent)comp;
 
             if (roleComp.JobPrototype is not null)
                 jobs.Add(roleComp.JobPrototype.Value);

--- a/Content.Server/NodeContainer/EntitySystems/NodeGroupSystem.cs
+++ b/Content.Server/NodeContainer/EntitySystems/NodeGroupSystem.cs
@@ -24,7 +24,6 @@ namespace Content.Server.NodeContainer.EntitySystems
         [Dependency] private IPlayerManager _playerManager = default!;
         [Dependency] private IAdminManager _adminManager = default!;
         [Dependency] private INodeGroupFactory _nodeGroupFactory = default!;
-        [Dependency] private ILogManager _logManager = default!;
         [Dependency] private EntityQuery<NodeContainerComponent> _nodeContainerQuery = default!;
         [Dependency] private EntityQuery<TransformComponent> _xformQuery = default!;
 
@@ -60,7 +59,7 @@ namespace Content.Server.NodeContainer.EntitySystems
         {
             base.Initialize();
 
-            _sawmill = _logManager.GetSawmill("nodegroup");
+            _sawmill = LogManager.GetSawmill("nodegroup");
 
             _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
 

--- a/Content.Server/Salvage/SalvageSystem.Expeditions.cs
+++ b/Content.Server/Salvage/SalvageSystem.Expeditions.cs
@@ -168,7 +168,7 @@ public sealed partial class SalvageSystem
             SalvageJobTime,
             EntityManager,
             _timing,
-            _logManager,
+            LogManager,
             ProtoMan,
             _anchorable,
             _biome,

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -24,7 +24,6 @@ namespace Content.Server.Salvage
         [Dependency] private IChatManager _chat = default!;
         [Dependency] private IConfigurationManager _configurationManager = default!;
         [Dependency] private IGameTiming _timing = default!;
-        [Dependency] private ILogManager _logManager = default!;
         [Dependency] private IRobustRandom _random = default!;
         [Dependency] private AnchorableSystem _anchorable = default!;
         [Dependency] private BiomeSystem _biome = default!;

--- a/Content.Server/Silicons/Laws/IonLawLocalizationSystem.cs
+++ b/Content.Server/Silicons/Laws/IonLawLocalizationSystem.cs
@@ -2,50 +2,44 @@
 
 public sealed partial class IonLawLocalizationSystem : EntitySystem
 {
-    [Dependency] private ILocalizationManager _loc = default!;
     [Dependency] private IonLawSystem _ionLaw = default!;
-    [Dependency] private ILogManager _logManager = default!;
-
-    private ISawmill _sawmill = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        _sawmill = _logManager.GetSawmill("ion-law");
-
-        var culture = _loc.DefaultCulture;
+        var culture = Loc.DefaultCulture;
 
         if (culture == null)
         {
-            _sawmill.Error("Culture was null when trying to generate Ion Law");
+            Log.Error("Culture was null when trying to generate Ion Law");
             return;
         }
 
-        _loc.AddFunction(culture, "ION-NUMBER-BASE", _ => GetIonLawValue("ION-NUMBER-BASE"));
-        _loc.AddFunction(culture, "ION-NUMBER-MOD", _ => GetIonLawValue("ION-NUMBER-MOD"));
-        _loc.AddFunction(culture, "ION-ADJECTIVE", _ => GetIonLawValue("ION-ADJECTIVE"));
-        _loc.AddFunction(culture, "ION-SUBJECT", _ => GetIonLawValue("ION-SUBJECT"));
-        _loc.AddFunction(culture, "ION-WHO", _ => GetIonLawValue("ION-WHO"));
-        _loc.AddFunction(culture, "ION-MUST", _ => GetIonLawValue("ION-MUST"));
-        _loc.AddFunction(culture, "ION-THING", _ => GetIonLawValue("ION-THING"));
-        _loc.AddFunction(culture, "ION-JOB", _ => GetIonLawValue("ION-JOB"));
-        _loc.AddFunction(culture, "ION-WHO-GENERAL", _ => GetIonLawValue("ION-WHO-GENERAL"));
-        _loc.AddFunction(culture, "ION-PLURAL", _ => GetIonLawValue("ION-PLURAL"));
-        _loc.AddFunction(culture, "ION-REQUIRE", _ => GetIonLawValue("ION-REQUIRE"));
-        _loc.AddFunction(culture, "ION-SEVERITY", _ => GetIonLawValue("ION-SEVERITY"));
-        _loc.AddFunction(culture, "ION-ALLERGY", _ => GetIonLawValue("ION-ALLERGY"));
-        _loc.AddFunction(culture, "ION-FEELING", _ => GetIonLawValue("ION-FEELING"));
-        _loc.AddFunction(culture, "ION-CONCEPT", _ => GetIonLawValue("ION-CONCEPT"));
-        _loc.AddFunction(culture, "ION-FOOD", _ => GetIonLawValue("ION-FOOD"));
-        _loc.AddFunction(culture, "ION-DRINK", _ => GetIonLawValue("ION-DRINK"));
-        _loc.AddFunction(culture, "ION-CHANGE", _ => GetIonLawValue("ION-CHANGE"));
-        _loc.AddFunction(culture, "ION-WHO-RANDOM", _ => GetIonLawValue("ION-WHO-RANDOM"));
-        _loc.AddFunction(culture, "ION-AREA", _ => GetIonLawValue("ION-AREA"));
-        _loc.AddFunction(culture, "ION-PART", _ => GetIonLawValue("ION-PART"));
-        _loc.AddFunction(culture, "ION-OBJECT", _ => GetIonLawValue("ION-OBJECT"));
-        _loc.AddFunction(culture, "ION-HARM-PROTECT", _ => GetIonLawValue("ION-HARM-PROTECT"));
-        _loc.AddFunction(culture, "ION-VERB", _ => GetIonLawValue("ION-VERB"));
+        Loc.AddFunction(culture, "ION-NUMBER-BASE", _ => GetIonLawValue("ION-NUMBER-BASE"));
+        Loc.AddFunction(culture, "ION-NUMBER-MOD", _ => GetIonLawValue("ION-NUMBER-MOD"));
+        Loc.AddFunction(culture, "ION-ADJECTIVE", _ => GetIonLawValue("ION-ADJECTIVE"));
+        Loc.AddFunction(culture, "ION-SUBJECT", _ => GetIonLawValue("ION-SUBJECT"));
+        Loc.AddFunction(culture, "ION-WHO", _ => GetIonLawValue("ION-WHO"));
+        Loc.AddFunction(culture, "ION-MUST", _ => GetIonLawValue("ION-MUST"));
+        Loc.AddFunction(culture, "ION-THING", _ => GetIonLawValue("ION-THING"));
+        Loc.AddFunction(culture, "ION-JOB", _ => GetIonLawValue("ION-JOB"));
+        Loc.AddFunction(culture, "ION-WHO-GENERAL", _ => GetIonLawValue("ION-WHO-GENERAL"));
+        Loc.AddFunction(culture, "ION-PLURAL", _ => GetIonLawValue("ION-PLURAL"));
+        Loc.AddFunction(culture, "ION-REQUIRE", _ => GetIonLawValue("ION-REQUIRE"));
+        Loc.AddFunction(culture, "ION-SEVERITY", _ => GetIonLawValue("ION-SEVERITY"));
+        Loc.AddFunction(culture, "ION-ALLERGY", _ => GetIonLawValue("ION-ALLERGY"));
+        Loc.AddFunction(culture, "ION-FEELING", _ => GetIonLawValue("ION-FEELING"));
+        Loc.AddFunction(culture, "ION-CONCEPT", _ => GetIonLawValue("ION-CONCEPT"));
+        Loc.AddFunction(culture, "ION-FOOD", _ => GetIonLawValue("ION-FOOD"));
+        Loc.AddFunction(culture, "ION-DRINK", _ => GetIonLawValue("ION-DRINK"));
+        Loc.AddFunction(culture, "ION-CHANGE", _ => GetIonLawValue("ION-CHANGE"));
+        Loc.AddFunction(culture, "ION-WHO-RANDOM", _ => GetIonLawValue("ION-WHO-RANDOM"));
+        Loc.AddFunction(culture, "ION-AREA", _ => GetIonLawValue("ION-AREA"));
+        Loc.AddFunction(culture, "ION-PART", _ => GetIonLawValue("ION-PART"));
+        Loc.AddFunction(culture, "ION-OBJECT", _ => GetIonLawValue("ION-OBJECT"));
+        Loc.AddFunction(culture, "ION-HARM-PROTECT", _ => GetIonLawValue("ION-HARM-PROTECT"));
+        Loc.AddFunction(culture, "ION-VERB", _ => GetIonLawValue("ION-VERB"));
     }
 
     /// <summary>

--- a/Content.Server/Silicons/Laws/IonLawLocalizationSystem.cs
+++ b/Content.Server/Silicons/Laws/IonLawLocalizationSystem.cs
@@ -12,7 +12,7 @@ public sealed partial class IonLawLocalizationSystem : EntitySystem
 
         if (culture == null)
         {
-            Log.Error("Culture was null when trying to generate Ion Law");
+            _ionLaw.Sawmill.Error("Culture was null when trying to generate Ion Law");
             return;
         }
 

--- a/Content.Server/Silicons/Laws/IonLawLocalizationSystem.cs
+++ b/Content.Server/Silicons/Laws/IonLawLocalizationSystem.cs
@@ -12,7 +12,7 @@ public sealed partial class IonLawLocalizationSystem : EntitySystem
 
         if (culture == null)
         {
-            _ionLaw.Sawmill.Error("Culture was null when trying to generate Ion Law");
+            Log.Error("Culture was null when trying to generate Ion Law");
             return;
         }
 

--- a/Content.Server/Silicons/Laws/IonLawSystem.cs
+++ b/Content.Server/Silicons/Laws/IonLawSystem.cs
@@ -18,7 +18,7 @@ public sealed partial class IonLawSystem : EntitySystem
     [Dependency] private SharedStationSystem _stationSystem = default!;
     [Dependency] private StationRecordsSystem _stationRecordsSystem = default!;
 
-    private ISawmill _sawmill = default!;
+    public ISawmill Sawmill = default!;
     private readonly Dictionary<string, List<IonLawSelector>> _selectors = new();
     private IonLawPrototype? _ionLaw;
 
@@ -26,7 +26,7 @@ public sealed partial class IonLawSystem : EntitySystem
     {
         base.Initialize();
 
-        _sawmill = LogManager.GetSawmill("ion-law");
+        Sawmill = LogManager.GetSawmill("ion-law");
 
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
         BuildSelectors();
@@ -135,7 +135,7 @@ public sealed partial class IonLawSystem : EntitySystem
         var laws = ProtoMan.EnumeratePrototypes<IonLawPrototype>().ToList();
         if (laws.Count == 0)
         {
-            _sawmill.Error("No Ion Laws found");
+            Sawmill.Error("No Ion Laws found");
             return Loc.GetString("ion-law-error-no-protos");
         }
 
@@ -167,7 +167,7 @@ public sealed partial class IonLawSystem : EntitySystem
 
         if (_ionLaw == null)
         {
-            _sawmill.Error("Ion Law was null");
+            Sawmill.Error("Ion Law was null");
             return Loc.GetString("ion-law-error-was-null");
         }
 
@@ -184,7 +184,7 @@ public sealed partial class IonLawSystem : EntitySystem
     {
         if (!_selectors.TryGetValue(selectorName, out var selectors))
         {
-            _sawmill.Error("No selectors for Ion Laws found");
+            Sawmill.Error("No selectors for Ion Laws found");
             return Loc.GetString("ion-law-error-no-selectors");
         }
 
@@ -205,7 +205,7 @@ public sealed partial class IonLawSystem : EntitySystem
             return newValue;
         }
 
-        _sawmill.Error("No available selectors found for the Ion Law found - this should never happen, selector was: " + selectorName);
+        Sawmill.Error("No available selectors found for the Ion Law found - this should never happen, selector was: " + selectorName);
         return Loc.GetString("ion-law-error-no-available-selectors");
     }
 
@@ -257,7 +257,7 @@ public sealed partial class IonLawSystem : EntitySystem
                 {
                     return _random.Pick(dataset.Values);
                 }
-                _sawmill.Error("Selected DataSet (" + selector + ") was empty or not found" );
+                Sawmill.Error("Selected DataSet (" + selector + ") was empty or not found" );
                 return Loc.GetString("ion-law-error-dataset-empty-or-not-found");
             case RandomManifestFill randomManifestFill:
                 var stations = _stationSystem.GetStations();
@@ -277,15 +277,15 @@ public sealed partial class IonLawSystem : EntitySystem
                 {
                     return _random.Pick(fallbackDataset.Values);
                 }
-                _sawmill.Error("Fallback DataSet (" + selector + ") was empty or not found" );
+                Sawmill.Error("Fallback DataSet (" + selector + ") was empty or not found" );
                 return Loc.GetString("ion-law-error-fallback-dataset-empty-or-not-found");
             case ConstantFill constantFill:
                 if (constantFill.BoolValue.HasValue)
                     return constantFill.BoolValue.Value;
-                _sawmill.Error("The selected Constant Fill did not have a value: " + constantFill );
+                Sawmill.Error("The selected Constant Fill did not have a value: " + constantFill );
                 return Loc.GetString("ion-law-error-no-bool-value");
             default:
-                _sawmill.Error("Selected DataSet (" + selector + ") was not selected" );
+                Sawmill.Error("Selected DataSet (" + selector + ") was not selected" );
                 return Loc.GetString("ion-law-error-no-selector-selected");
         }
     }

--- a/Content.Server/Silicons/Laws/IonLawSystem.cs
+++ b/Content.Server/Silicons/Laws/IonLawSystem.cs
@@ -18,12 +18,15 @@ public sealed partial class IonLawSystem : EntitySystem
     [Dependency] private SharedStationSystem _stationSystem = default!;
     [Dependency] private StationRecordsSystem _stationRecordsSystem = default!;
 
+    private ISawmill _sawmill = default!;
     private readonly Dictionary<string, List<IonLawSelector>> _selectors = new();
     private IonLawPrototype? _ionLaw;
 
     public override void Initialize()
     {
         base.Initialize();
+
+        _sawmill = LogManager.GetSawmill("ion-law");
 
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
         BuildSelectors();
@@ -132,7 +135,7 @@ public sealed partial class IonLawSystem : EntitySystem
         var laws = ProtoMan.EnumeratePrototypes<IonLawPrototype>().ToList();
         if (laws.Count == 0)
         {
-            Log.Error("No Ion Laws found");
+            _sawmill.Error("No Ion Laws found");
             return Loc.GetString("ion-law-error-no-protos");
         }
 
@@ -164,7 +167,7 @@ public sealed partial class IonLawSystem : EntitySystem
 
         if (_ionLaw == null)
         {
-            Log.Error("Ion Law was null");
+            _sawmill.Error("Ion Law was null");
             return Loc.GetString("ion-law-error-was-null");
         }
 
@@ -181,7 +184,7 @@ public sealed partial class IonLawSystem : EntitySystem
     {
         if (!_selectors.TryGetValue(selectorName, out var selectors))
         {
-            Log.Error("No selectors for Ion Laws found");
+            _sawmill.Error("No selectors for Ion Laws found");
             return Loc.GetString("ion-law-error-no-selectors");
         }
 
@@ -202,7 +205,7 @@ public sealed partial class IonLawSystem : EntitySystem
             return newValue;
         }
 
-        Log.Error("No available selectors found for the Ion Law found - this should never happen, selector was: " + selectorName);
+        _sawmill.Error("No available selectors found for the Ion Law found - this should never happen, selector was: " + selectorName);
         return Loc.GetString("ion-law-error-no-available-selectors");
     }
 
@@ -254,7 +257,7 @@ public sealed partial class IonLawSystem : EntitySystem
                 {
                     return _random.Pick(dataset.Values);
                 }
-                Log.Error("Selected DataSet (" + selector + ") was empty or not found" );
+                _sawmill.Error("Selected DataSet (" + selector + ") was empty or not found" );
                 return Loc.GetString("ion-law-error-dataset-empty-or-not-found");
             case RandomManifestFill randomManifestFill:
                 var stations = _stationSystem.GetStations();
@@ -274,18 +277,16 @@ public sealed partial class IonLawSystem : EntitySystem
                 {
                     return _random.Pick(fallbackDataset.Values);
                 }
-                Log.Error("Fallback DataSet (" + selector + ") was empty or not found" );
+                _sawmill.Error("Fallback DataSet (" + selector + ") was empty or not found" );
                 return Loc.GetString("ion-law-error-fallback-dataset-empty-or-not-found");
             case ConstantFill constantFill:
                 if (constantFill.BoolValue.HasValue)
                     return constantFill.BoolValue.Value;
-                Log.Error("The selected Constant Fill did not have a value: " + constantFill );
+                _sawmill.Error("The selected Constant Fill did not have a value: " + constantFill );
                 return Loc.GetString("ion-law-error-no-bool-value");
             default:
-            {
-                Log.Error("Selected DataSet (" + selector + ") was not selected" );
+                _sawmill.Error("Selected DataSet (" + selector + ") was not selected" );
                 return Loc.GetString("ion-law-error-no-selector-selected");
-            }
         }
     }
 }

--- a/Content.Server/Silicons/Laws/IonLawSystem.cs
+++ b/Content.Server/Silicons/Laws/IonLawSystem.cs
@@ -18,7 +18,7 @@ public sealed partial class IonLawSystem : EntitySystem
     [Dependency] private SharedStationSystem _stationSystem = default!;
     [Dependency] private StationRecordsSystem _stationRecordsSystem = default!;
 
-    public ISawmill Sawmill = default!;
+    private ISawmill _sawmill = default!;
     private readonly Dictionary<string, List<IonLawSelector>> _selectors = new();
     private IonLawPrototype? _ionLaw;
 
@@ -26,7 +26,7 @@ public sealed partial class IonLawSystem : EntitySystem
     {
         base.Initialize();
 
-        Sawmill = LogManager.GetSawmill("ion-law");
+        _sawmill = LogManager.GetSawmill("ion-law");
 
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
         BuildSelectors();
@@ -135,7 +135,7 @@ public sealed partial class IonLawSystem : EntitySystem
         var laws = ProtoMan.EnumeratePrototypes<IonLawPrototype>().ToList();
         if (laws.Count == 0)
         {
-            Sawmill.Error("No Ion Laws found");
+            _sawmill.Error("No Ion Laws found");
             return Loc.GetString("ion-law-error-no-protos");
         }
 
@@ -167,7 +167,7 @@ public sealed partial class IonLawSystem : EntitySystem
 
         if (_ionLaw == null)
         {
-            Sawmill.Error("Ion Law was null");
+            _sawmill.Error("Ion Law was null");
             return Loc.GetString("ion-law-error-was-null");
         }
 
@@ -184,7 +184,7 @@ public sealed partial class IonLawSystem : EntitySystem
     {
         if (!_selectors.TryGetValue(selectorName, out var selectors))
         {
-            Sawmill.Error("No selectors for Ion Laws found");
+            _sawmill.Error("No selectors for Ion Laws found");
             return Loc.GetString("ion-law-error-no-selectors");
         }
 
@@ -205,7 +205,7 @@ public sealed partial class IonLawSystem : EntitySystem
             return newValue;
         }
 
-        Sawmill.Error("No available selectors found for the Ion Law found - this should never happen, selector was: " + selectorName);
+        _sawmill.Error("No available selectors found for the Ion Law found - this should never happen, selector was: " + selectorName);
         return Loc.GetString("ion-law-error-no-available-selectors");
     }
 
@@ -257,7 +257,7 @@ public sealed partial class IonLawSystem : EntitySystem
                 {
                     return _random.Pick(dataset.Values);
                 }
-                Sawmill.Error("Selected DataSet (" + selector + ") was empty or not found" );
+                _sawmill.Error("Selected DataSet (" + selector + ") was empty or not found");
                 return Loc.GetString("ion-law-error-dataset-empty-or-not-found");
             case RandomManifestFill randomManifestFill:
                 var stations = _stationSystem.GetStations();
@@ -277,15 +277,15 @@ public sealed partial class IonLawSystem : EntitySystem
                 {
                     return _random.Pick(fallbackDataset.Values);
                 }
-                Sawmill.Error("Fallback DataSet (" + selector + ") was empty or not found" );
+                _sawmill.Error("Fallback DataSet (" + selector + ") was empty or not found");
                 return Loc.GetString("ion-law-error-fallback-dataset-empty-or-not-found");
             case ConstantFill constantFill:
                 if (constantFill.BoolValue.HasValue)
                     return constantFill.BoolValue.Value;
-                Sawmill.Error("The selected Constant Fill did not have a value: " + constantFill );
+                _sawmill.Error("The selected Constant Fill did not have a value: " + constantFill);
                 return Loc.GetString("ion-law-error-no-bool-value");
             default:
-                Sawmill.Error("Selected DataSet (" + selector + ") was not selected" );
+                _sawmill.Error("Selected DataSet (" + selector + ") was not selected");
                 return Loc.GetString("ion-law-error-no-selector-selected");
         }
     }

--- a/Content.Server/Silicons/Laws/IonLawSystem.cs
+++ b/Content.Server/Silicons/Laws/IonLawSystem.cs
@@ -17,17 +17,13 @@ public sealed partial class IonLawSystem : EntitySystem
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SharedStationSystem _stationSystem = default!;
     [Dependency] private StationRecordsSystem _stationRecordsSystem = default!;
-    [Dependency] private ILogManager _logManager = default!;
 
-    private ISawmill _sawmill = default!;
     private readonly Dictionary<string, List<IonLawSelector>> _selectors = new();
     private IonLawPrototype? _ionLaw;
 
     public override void Initialize()
     {
         base.Initialize();
-
-        _sawmill = _logManager.GetSawmill("ion-law");
 
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
         BuildSelectors();
@@ -136,7 +132,7 @@ public sealed partial class IonLawSystem : EntitySystem
         var laws = ProtoMan.EnumeratePrototypes<IonLawPrototype>().ToList();
         if (laws.Count == 0)
         {
-            _sawmill.Error("No Ion Laws found");
+            Log.Error("No Ion Laws found");
             return Loc.GetString("ion-law-error-no-protos");
         }
 
@@ -168,7 +164,7 @@ public sealed partial class IonLawSystem : EntitySystem
 
         if (_ionLaw == null)
         {
-            _sawmill.Error("Ion Law was null");
+            Log.Error("Ion Law was null");
             return Loc.GetString("ion-law-error-was-null");
         }
 
@@ -185,7 +181,7 @@ public sealed partial class IonLawSystem : EntitySystem
     {
         if (!_selectors.TryGetValue(selectorName, out var selectors))
         {
-            _sawmill.Error("No selectors for Ion Laws found");
+            Log.Error("No selectors for Ion Laws found");
             return Loc.GetString("ion-law-error-no-selectors");
         }
 
@@ -206,7 +202,7 @@ public sealed partial class IonLawSystem : EntitySystem
             return newValue;
         }
 
-        _sawmill.Error("No available selectors found for the Ion Law found - this should never happen, selector was: " + selectorName);
+        Log.Error("No available selectors found for the Ion Law found - this should never happen, selector was: " + selectorName);
         return Loc.GetString("ion-law-error-no-available-selectors");
     }
 
@@ -258,7 +254,7 @@ public sealed partial class IonLawSystem : EntitySystem
                 {
                     return _random.Pick(dataset.Values);
                 }
-                _sawmill.Error("Selected DataSet (" + selector + ") was empty or not found" );
+                Log.Error("Selected DataSet (" + selector + ") was empty or not found" );
                 return Loc.GetString("ion-law-error-dataset-empty-or-not-found");
             case RandomManifestFill randomManifestFill:
                 var stations = _stationSystem.GetStations();
@@ -278,16 +274,16 @@ public sealed partial class IonLawSystem : EntitySystem
                 {
                     return _random.Pick(fallbackDataset.Values);
                 }
-                _sawmill.Error("Fallback DataSet (" + selector + ") was empty or not found" );
+                Log.Error("Fallback DataSet (" + selector + ") was empty or not found" );
                 return Loc.GetString("ion-law-error-fallback-dataset-empty-or-not-found");
             case ConstantFill constantFill:
                 if (constantFill.BoolValue.HasValue)
                     return constantFill.BoolValue.Value;
-                _sawmill.Error("The selected Constant Fill did not have a value: " + constantFill );
+                Log.Error("The selected Constant Fill did not have a value: " + constantFill );
                 return Loc.GetString("ion-law-error-no-bool-value");
             default:
             {
-                _sawmill.Error("Selected DataSet (" + selector + ") was not selected" );
+                Log.Error("Selected DataSet (" + selector + ") was not selected" );
                 return Loc.GetString("ion-law-error-no-selector-selected");
             }
         }

--- a/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ReplacementAccentSystem.cs
@@ -16,7 +16,6 @@ namespace Content.Server.Speech.EntitySystems
     public sealed partial class ReplacementAccentSystem : EntitySystem
     {
         [Dependency] private IRobustRandom _random = default!;
-        [Dependency] private ILocalizationManager _loc = default!;
 
         private readonly Dictionary<ProtoId<ReplacementAccentPrototype>, (Regex regex, string replacement)[]>
             _cachedReplacements = new();
@@ -124,8 +123,8 @@ namespace Content.Server.Speech.EntitySystems
             return replacements.Select(kv =>
                 {
                     var (first, replace) = kv;
-                    var firstLoc = _loc.GetString(first);
-                    var replaceLoc = _loc.GetString(replace);
+                    var firstLoc = Loc.GetString(first);
+                    var replaceLoc = Loc.GetString(replace);
 
                     var regex = new Regex($@"(?<![\w']){firstLoc}(?![\w'])", RegexOptions.IgnoreCase);
 

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -25,7 +25,6 @@ namespace Content.Server.Station.Systems;
 [PublicAPI]
 public sealed partial class StationSystem : SharedStationSystem
 {
-    [Dependency] private ILogManager _logManager = default!;
     [Dependency] private IPlayerManager _player = default!;
     [Dependency] private ChatSystem _chatSystem = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
@@ -43,7 +42,7 @@ public sealed partial class StationSystem : SharedStationSystem
     {
         base.Initialize();
 
-        _sawmill = _logManager.GetSawmill("station");
+        _sawmill = LogManager.GetSawmill("station");
 
         SubscribeLocalEvent<GameRunLevelChangedEvent>(OnRoundEnd);
         SubscribeLocalEvent<PostGameMapLoad>(OnPostGameMapLoad);

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -27,7 +27,7 @@ public abstract partial class StationEventSystem<T> : GameRuleSystem<T> where T 
     {
         base.Initialize();
 
-        Sawmill = Logger.GetSawmill("stationevents");
+        Sawmill = LogManager.GetSawmill("stationevents");
     }
 
     /// <inheritdoc/>

--- a/Content.Shared/Access/Systems/SharedAccessOverriderSystem.cs
+++ b/Content.Shared/Access/Systems/SharedAccessOverriderSystem.cs
@@ -10,7 +10,6 @@ namespace Content.Shared.Access.Systems
     public abstract partial class SharedAccessOverriderSystem : EntitySystem
     {
         [Dependency] private ItemSlotsSystem _itemSlotsSystem = default!;
-        [Dependency] private ILogManager _log = default!;
 
         public const string Sawmill = "accessoverrider";
         protected ISawmill _sawmill = default!;
@@ -18,7 +17,7 @@ namespace Content.Shared.Access.Systems
         public override void Initialize()
         {
             base.Initialize();
-            _sawmill = _log.GetSawmill(Sawmill);
+            _sawmill = LogManager.GetSawmill(Sawmill);
 
             SubscribeLocalEvent<AccessOverriderComponent, ComponentInit>(OnComponentInit);
             SubscribeLocalEvent<AccessOverriderComponent, ComponentRemove>(OnComponentRemove);

--- a/Content.Shared/Access/Systems/SharedIdCardConsoleSystem.cs
+++ b/Content.Shared/Access/Systems/SharedIdCardConsoleSystem.cs
@@ -1,9 +1,7 @@
 using Content.Shared.Access.Components;
 using Content.Shared.Containers.ItemSlots;
 using JetBrains.Annotations;
-using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
-using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Access.Systems
 {
@@ -11,7 +9,6 @@ namespace Content.Shared.Access.Systems
     public abstract partial class SharedIdCardConsoleSystem : EntitySystem
     {
         [Dependency] private ItemSlotsSystem _itemSlotsSystem = default!;
-        [Dependency] private ILogManager _log = default!;
 
         public const string Sawmill = "idconsole";
         protected ISawmill _sawmill = default!;
@@ -19,7 +16,7 @@ namespace Content.Shared.Access.Systems
         public override void Initialize()
         {
             base.Initialize();
-            _sawmill = _log.GetSawmill(Sawmill);
+            _sawmill = LogManager.GetSawmill(Sawmill);
 
             SubscribeLocalEvent<IdCardConsoleComponent, ComponentInit>(OnComponentInit);
             SubscribeLocalEvent<IdCardConsoleComponent, ComponentRemove>(OnComponentRemove);

--- a/Content.Shared/Mobs/Systems/MobStateSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.cs
@@ -14,7 +14,6 @@ public partial class MobStateSystem : EntitySystem
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private StandingStateSystem _standing = default!;
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
-    [Dependency] private ILogManager _logManager = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     private ISawmill _sawmill = default!;
@@ -23,7 +22,7 @@ public partial class MobStateSystem : EntitySystem
 
     public override void Initialize()
     {
-        _sawmill = _logManager.GetSawmill("MobState");
+        _sawmill = LogManager.GetSawmill("MobState");
         base.Initialize();
         SubscribeEvents();
     }

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -24,7 +24,6 @@ namespace Content.Shared.Weapons.Misc;
 public abstract partial class SharedGrapplingGunSystem : VirtualController
 {
     [Dependency] protected IGameTiming Timing = default!;
-    [Dependency] private IEntityManager _entities = default!;
     [Dependency] private INetManager _netManager = default!;
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
@@ -196,7 +195,7 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         {
             if (!jointComp.GetJoints.TryGetValue(GrapplingJoint, out var joint) ||
                 joint is not DistanceJoint distance ||
-                !_entities.TryGetComponent<JointComponent>(joint.BodyAUid, out var hookJointComp))
+                !TryComp<JointComponent>(joint.BodyAUid, out var hookJointComp))
             {
                 if (_netManager.IsServer) // Client might not receive the joint due to PVS culling, so lets not spam them with 23895739 mispredicted ungrapples
                     Ungrapple((uid, grappling), true);
@@ -300,7 +299,7 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
 
     private void OnGrappleCollide(EntityUid uid, GrapplingProjectileComponent component, ref ProjectileEmbedEvent args)
     {
-        if (!Timing.IsFirstTimePredicted || !args.Weapon.HasValue || !_entities.TryGetComponent<GrapplingGunComponent>(args.Weapon, out var grapple))
+        if (!Timing.IsFirstTimePredicted || !args.Weapon.HasValue || !TryComp<GrapplingGunComponent>(args.Weapon, out var grapple))
             return;
 
         var grapplePos = _transform.GetWorldPosition(args.Weapon.Value);
@@ -317,8 +316,8 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         joint.MinLength = grapple.RopeMinLength; // Length of a tile to prevent pulling yourself into / through walls
         joint.Breakpoint = grapple.RopeBreakPoint;
 
-        var jointCompHook = _entities.GetComponent<JointComponent>(uid); // we use get here because if the component doesn't exist then something has fucked up bigtime
-        var jointCompGrapple = _entities.GetComponent<JointComponent>(args.Weapon.Value);
+        var jointCompHook = Comp<JointComponent>(uid); // we use get here because if the component doesn't exist then something has fucked up bigtime
+        var jointCompGrapple = Comp<JointComponent>(args.Weapon.Value);
 
         _joints.SetRelay(uid, args.Embedded, jointCompHook);
         _joints.RefreshRelay(args.Weapon.Value, jointCompGrapple);


### PR DESCRIPTION
## About the PR

More cleanup of redundantly defined fields.

~~Ion law and chat logs changed to use the default system name for logs.  If that's undesirable, it can be reverted, though they do only seem to be used for printing warnings, so the loss doesn't seem too great.~~ Resolved.  All named Sawmills* stay as they are.

*Edit: IonLawLocalization still using the default system-named sawmill.  Should be a part of the IonLawSystem if it really needs to share that sawmill.

## Why / Balance

Cleanup.

## Technical details

Relying on EntitySystem.EntityManager, EntitySystem.Log, EntitySystem.Loc, EntitySystem.LogManager.

IonLawSystem's named ISawmill made public for use in IonLawLocalizationSystem (why aren't they part of the same system?)

## Test plan

Compilation and integration tests should be sufficient for this.

Use a grappling gun.

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
no
