### PR TITLE
You can no longer rotate stairs and catwalks

### DIFF
--- a/Resources/Prototypes/Entities/Structures/catwalk.yml
+++ b/Resources/Prototypes/Entities/Structures/catwalk.yml
@@ -9,7 +9,6 @@
   - type: Anchorable
     flags:
     - Anchorable
-  - type: Rotatable
   - type: Clickable
   - type: Sprite
     sprite: Structures/catwalk.rsi

--- a/Resources/Prototypes/Entities/Structures/stairs.yml
+++ b/Resources/Prototypes/Entities/Structures/stairs.yml
@@ -20,7 +20,6 @@
   - type: Anchorable
     flags:
     - Anchorable
-  - type: Rotatable
   - type: Sprite
     sprite: Structures/stairs.rsi
     state: stairs_steel


### PR DESCRIPTION
## About the PR
Removed rotatable component from stairs and catwalks

## Why / Balance
You shouldn't be able to rotate stairs, THEY ARE STAIRS, they are supposed to point in to correct direction and you should not be able to change that smh
You shouldn't be able to rotate catwalks, there's no point of rotating catwalks, you can mess the sprite up, but when you re-render it will go back to normal anyway

## Technical details

## Test plan
Spawn any stair and any catwalk
try to rotate them
if you can't, that's good

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
:cl:
- fix: You can no longer rotate stairs
- fix: You can no longer rotate catwalks
