### PR TITLE
Most of the signs no longer have "unanchored" text

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
@@ -20,5 +20,3 @@
     snapCardinals: true
   - type: StaticPrice
     price: 20
-  - type: Transform
-    anchored: false

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
@@ -20,3 +20,7 @@
     snapCardinals: true
   - type: StaticPrice
     price: 20
+  # Hacky wacky - It inherit anchorable from "BaseWallmount", none of the BaseSign children are designed to be anchorable
+  - type: Anchorable
+    flags:
+    - None

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
@@ -16,13 +16,10 @@
   components:
     - type: Sprite
       snapCardinals: false
+      # The way that Directonal Guide Signs are mapped are unaligned on the wall, making them anchored makes them all be placed in the middle of the wall
+      # TODO: Combine all the directional guide signs in to some modular prototype so it's easier to map and remove the overlap when rotating the camera
     - type: Transform
       anchored: false
-    - type: Anchorable
-      flags:
-      - None
-# The way that Directonal Guide Signs are mapped are unaligned on the wall, making them anchored makes them all be placed in the middle of the wall
-# TODO: Combine all the directional guide signs in to some modular prototype so it's easier to map and remove the overlap when rotating the camera
 
 - type: entity
   parent: BaseSignDirectional

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
@@ -18,6 +18,9 @@
       snapCardinals: false
     - type: Transform
       anchored: false
+    - type: Anchorable
+      flags:
+      - None
 # The way that Directonal Guide Signs are mapped are unaligned on the wall, making them anchored makes them all be placed in the middle of the wall
 # TODO: Combine all the directional guide signs in to some modular prototype so it's easier to map and remove the overlap when rotating the camera
 

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
@@ -8,6 +8,7 @@
     state: monkey_painting
 
 # Directional Station Guide Signs
+
 - type: entity
   parent: BaseSign
   id: BaseSignDirectional
@@ -15,6 +16,10 @@
   components:
     - type: Sprite
       snapCardinals: false
+    - type: Transform
+      anchored: false
+# The way that Directonal Guide Signs are mapped are unaligned on the wall, making them anchored makes them all be placed in the middle of the wall
+# TODO: Combine all the directional guide signs in to some modular prototype so it's easier to map and remove the overlap when rotating the camera
 
 - type: entity
   parent: BaseSignDirectional


### PR DESCRIPTION
## About the PR
Moved the Transform component with "anchored: false" from `BaseSign` to `BaseSignDirectional` and added Anchored component with `flag: none`, that removes "unanchored" text from signs and posters.
Added a comment explaining why is it there and a TODO for someone more telented to do my plan for me

## Why / Balance
`BaseSign` is a parent for most of the posters and signs you see on the station, there was a Transform component there with "anchored: false" which I assume was there to fix Directional Guide Signs (the signs that point to departments, like "SEC ->") being aligned in to the middle of the tile. As they are mapped rn they have to be offset by 0.2 up or down to fit neatly on the wall.
But rest of the signs and posters don't have to be misaligned like that, so i moved the component to `BaseSignDirectional` which is parent for all those Directional Guide Signs.
Also added as suggested Anchored component to remove the "unanchored" text and interaction

## Technical details

## Test plan
1. Start a session on a map (i recommend plasma station)
2. Inspect regular posters and signs, notice no "unanchored" text
3. Inspect the  Directional Guide Signs (they are below Plasma's bridge), they should be not aligned to the middle of the tile
If that is correct then everything works

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
:cl:
- fix: Signs and posters no longer display "unanchored" message
