### PR TITLE
Fix ammo counter not updating when loading the chamber of a gun

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -71,6 +71,9 @@ public abstract partial class SharedGunSystem
             ToggleBolt(uid, component, args.User);
     }
 
+    /// <summary>
+    /// Called when a entity is loaded into a slot in a gun
+    /// </summary>
     private void OnChamberMagazineSlotChange(EntityUid uid, ChamberMagazineAmmoProviderComponent component, ContainerModifiedMessage args)
     {
         GetMagazineEntity(uid);
@@ -88,6 +91,9 @@ public abstract partial class SharedGunSystem
         }
     }
 
+    /// <summary>
+    /// Called when a entity is loaded into the chamber of a gun
+    /// </summary>
     private void ChamberSlotChanged(Entity<ChamberMagazineAmmoProviderComponent> ent)
     {
         UpdateAmmoCount(ent);

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -30,8 +30,8 @@ public abstract partial class SharedGunSystem
         SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, ActivateInWorldEvent>(OnChamberActivate);
         SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, UseInHandEvent>(OnChamberUse);
 
-        SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, EntInsertedIntoContainerMessage>(OnMagazineSlotChange);
-        SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, EntRemovedFromContainerMessage>(OnMagazineSlotChange);
+        SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, EntInsertedIntoContainerMessage>(OnChamberMagazineSlotChange);
+        SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, EntRemovedFromContainerMessage>(OnChamberMagazineSlotChange);
         SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, ExaminedEvent>(OnChamberMagazineExamine);
     }
 
@@ -69,6 +69,33 @@ public abstract partial class SharedGunSystem
             UseChambered(uid, component, args.User);
         else
             ToggleBolt(uid, component, args.User);
+    }
+
+    private void OnChamberMagazineSlotChange(EntityUid uid, ChamberMagazineAmmoProviderComponent component, ContainerModifiedMessage args)
+    {
+        GetMagazineEntity(uid);
+
+        switch (args.Container.ID)
+        {
+            case ChamberSlot:
+                ChamberSlotChanged((uid, component));
+                break;
+            case MagazineSlot:
+                MagazineSlotChanged((uid, component));
+                break;
+            default:
+                return;
+        }
+    }
+
+    private void ChamberSlotChanged(Entity<ChamberMagazineAmmoProviderComponent> ent)
+    {
+        UpdateAmmoCount(ent);
+        if (!TryComp<AppearanceComponent>(ent, out var appearance))
+            return;
+
+        var chamberEnt = GetChamberEntity(ent);
+        Appearance.SetData(ent, AmmoVisuals.HasAmmo, chamberEnt != null, appearance);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes so the ammo counter UI is updated when (un)loading ammo directly to or from the chamber.
<!-- What did you change? -->

## Why / Balance
It was a visual bug.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Added the OnChamberMagazineSlotChange to stop the gun system from calling OnMagazineSlotChange when a bullet was loaded into a gun with ChamberMagazineAmmoProviderComponent.
the new method correctly updates the ui counter when a entity is loaded into the chamber component.
<!-- Summary of code changes for easier review. -->

## Test plan
- spawn a mk58
- spawn a .35 bullet
- ensure the bolt is open
- load the bullet into the gun
- check that the ammo counter ui has updated
- unload the bullet from the gun
- check that the ammo counter ui has updated
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
before:
https://github.com/user-attachments/assets/f8179ff3-b265-4450-84e9-9036d2a5c658

now:
https://github.com/user-attachments/assets/95cc9518-7f93-4e1b-86a2-e342b7674ad4

<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl: Samuka
- fix: Fixed the ammo counter not updating when (un)loading ammo directly from or to the chamber of a gun.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
