### PR TITLE
SpawnOnDestroyed Component

### DIFF
--- a/Content.IntegrationTests/Tests/Stacks/StackInteractionTests.cs
+++ b/Content.IntegrationTests/Tests/Stacks/StackInteractionTests.cs
@@ -1,6 +1,7 @@
 using Content.IntegrationTests.Fixtures.Attributes;
 using Content.IntegrationTests.Tests.Interaction;
 using Content.Server.Stack;
+using static Content.IntegrationTests.Tests.Stacks.StackTestPrototypes;
 
 namespace Content.IntegrationTests.Tests.Stacks;
 
@@ -16,12 +17,12 @@ public sealed class StackInteractionTest : InteractionTest
     [Test]
     public async Task InteractUsingTest()
     {
-        var spawnCount = StackTestPrototypes.Count1 + StackTestPrototypes.Count1;
+        var spawnCount = Count1 + Count1;
 
-        var held = await Spawn(StackTestPrototypes.StackEnt1);
+        var held = await Spawn(StackEnt1);
         await Pickup(held);
 
-        await SpawnTarget(StackTestPrototypes.StackEnt1);
+        await SpawnTarget(StackEnt1);
         await Interact();
 
         Assert.Multiple(() =>
@@ -36,7 +37,7 @@ public sealed class StackInteractionTest : InteractionTest
     [Test]
     public async Task SplitTest()
     {
-        await SpawnTarget(StackTestPrototypes.StackEnt30);
+        await SpawnTarget(StackEnt30);
         await Interact(altInteract: true);
 
         Assert.That(_sStackSystem.GetCount(ToServer(Target).Value), Is.EqualTo(15));

--- a/Content.IntegrationTests/Tests/Stacks/StackInteractionTests.cs
+++ b/Content.IntegrationTests/Tests/Stacks/StackInteractionTests.cs
@@ -1,0 +1,51 @@
+using Content.IntegrationTests.Fixtures.Attributes;
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Server.Stack;
+
+namespace Content.IntegrationTests.Tests.Stacks;
+
+[TestFixture]
+[TestOf(typeof(StackSystem))]
+public sealed class StackInteractionTest : InteractionTest
+{
+    [SidedDependency(Side.Server)] private readonly StackSystem _sStackSystem = default!;
+
+    /// <summary>
+    /// Test that using a stack on a stack will combine them to the hand.
+    /// </summary>
+    [Test]
+    public async Task InteractUsingTest()
+    {
+        var spawnCount = StackTestPrototypes.Count1 + StackTestPrototypes.Count1;
+
+        var held = await Spawn(StackTestPrototypes.StackEnt1);
+        await Pickup(held);
+
+        await SpawnTarget(StackTestPrototypes.StackEnt1);
+        await Interact();
+
+        Assert.Multiple(() =>
+        {
+            // Assert that the held stack has the full count
+            // And the ground stack was deleted
+            Assert.That(_sStackSystem.GetCount(ToServer(held)), Is.EqualTo(spawnCount));
+            Assert.That(SEntMan.EntityExists(ToServer(Target)), Is.False);
+        });
+    }
+
+    [Test]
+    public async Task SplitTest()
+    {
+        await SpawnTarget(StackTestPrototypes.StackEnt30);
+        await Interact(altInteract: true);
+
+        Assert.That(_sStackSystem.GetCount(ToServer(Target).Value), Is.EqualTo(15));
+
+        // TODO test split verb
+        // I don't know how to navigate the right click menu in integration tests to find verbs
+    }
+
+    // TODO a test for eating a stack
+    // Currently the player supplied by InteractionTest doesn't have a body or a stomach to eat with
+    // And BodySystem has no API for cleanly adding the needed parts
+}

--- a/Content.IntegrationTests/Tests/Stacks/StackTestPrototypes.cs
+++ b/Content.IntegrationTests/Tests/Stacks/StackTestPrototypes.cs
@@ -1,0 +1,71 @@
+namespace Content.IntegrationTests.Tests.Stacks;
+
+public sealed class StackTestPrototypes
+{
+    public const string StackPrototype = "TestStack";
+
+    public const string StackEnt1 = "StackEnt1";
+    public const string StackEnt2 = "StackEnt2";
+    public const string StackEnt30 = "StackEnt30";
+    public const string StackEntEdible = "StackEntEdible";
+
+    private const string StackCount1 = "1";
+    public static readonly int Count1 = int.Parse(StackCount1);
+    private const string StackCount2 = "2";
+    public static readonly int Count2 = int.Parse(StackCount2);
+    private const string StackCount30 = "30"; // Also the maximum size of the test stack
+    public static readonly int Count30 = int.Parse(StackCount30);
+
+    [TestPrototypes]
+    public const string Prototypes =
+        @$"
+        - type: stack
+          id: {StackPrototype}
+          spawn: {StackEnt1}
+          maxCount: {StackCount30}
+
+        - type: entity
+          id: {StackEnt1}
+          components:
+          - type: Stack
+            stackType: {StackPrototype}
+            count: {StackCount1}
+          - type: Item
+          - type: Physics
+            bodyType: Dynamic
+          - type: Fixtures
+            fixtures:
+              fix1:
+                shape:
+                  !type:PhysShapeCircle
+                  radius: 0.35
+                layer:
+                - Impassable
+
+        - type: entity
+          parent: {StackEnt1}
+          id: {StackEnt2}
+          components:
+          - type: Stack
+            count: {StackCount2}
+
+        - type: entity
+          parent: {StackEnt1}
+          id: {StackEnt30}
+          components:
+          - type: Stack
+            count: {StackCount30}
+
+        - type: entity
+          parent: {StackEnt1}
+          id: {StackEntEdible}
+          components:
+          - type: Edible
+          - type: Solution
+            id: food
+            solution:
+              reagents:
+              - ReagentId: Nothing
+                Quantity: 5
+        ";
+}

--- a/Content.IntegrationTests/Tests/Stacks/StackTestPrototypes.cs
+++ b/Content.IntegrationTests/Tests/Stacks/StackTestPrototypes.cs
@@ -1,6 +1,6 @@
 namespace Content.IntegrationTests.Tests.Stacks;
 
-public sealed class StackTestPrototypes
+public static class StackTestPrototypes
 {
     public const string StackPrototype = "TestStack";
 
@@ -21,6 +21,7 @@ public sealed class StackTestPrototypes
         @$"
         - type: stack
           id: {StackPrototype}
+          name: stack-steel
           spawn: {StackEnt1}
           maxCount: {StackCount30}
 

--- a/Content.IntegrationTests/Tests/Stacks/StackTests.cs
+++ b/Content.IntegrationTests/Tests/Stacks/StackTests.cs
@@ -5,6 +5,7 @@ using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Server.Stack;
 using Content.Shared.Stacks;
 using Robust.Shared.GameObjects;
+using static Content.IntegrationTests.Tests.Stacks.StackTestPrototypes;
 
 namespace Content.IntegrationTests.Tests.Stacks;
 
@@ -20,19 +21,19 @@ public sealed class StackTest : GameTest
     [Test]
     public async Task SetTest()
     {
-        var stack = await Spawn(StackTestPrototypes.StackEnt1);
+        var stack = await Spawn(StackEnt1);
 
         // Raising the count
-        _sStackSystem.SetCount((stack, null), StackTestPrototypes.Count2);
-        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(StackTestPrototypes.Count2));
+        _sStackSystem.SetCount((stack, null), Count2);
+        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(Count2));
 
         // Lowering the count
-        _sStackSystem.SetCount((stack, null), StackTestPrototypes.Count1);
-        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(StackTestPrototypes.Count1));
+        _sStackSystem.SetCount((stack, null), Count1);
+        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(Count1));
 
         // Setting above the max count clamps to max
-        _sStackSystem.SetCount((stack, null), StackTestPrototypes.Count30 + 1);
-        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(StackTestPrototypes.Count30));
+        _sStackSystem.SetCount((stack, null), Count30 + 1);
+        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(Count30));
 
         // Setting to 0 deletes the stack
         _sStackSystem.SetCount((stack, null), 0);
@@ -47,14 +48,14 @@ public sealed class StackTest : GameTest
     public async Task MergeTest()
     {
         var stacks = new HashSet<EntityUid>();
-        var spawnCount = StackTestPrototypes.Count1 + StackTestPrototypes.Count2;
+        var spawnCount = Count1 + Count2;
 
         await Server.WaitPost(() =>
         {
             stacks =
             [
-                SSpawn(StackTestPrototypes.StackEnt1),
-                SSpawn(StackTestPrototypes.StackEnt2),
+                SSpawn(StackEnt1),
+                SSpawn(StackEnt2),
             ];
 
             _sStackSystem.MergeStacks(ref stacks);
@@ -82,15 +83,15 @@ public sealed class StackTest : GameTest
     public async Task MergeOverflowTest()
     {
         var stacks = new HashSet<EntityUid>();
-        var spawnCount = StackTestPrototypes.Count1 + StackTestPrototypes.Count2 +StackTestPrototypes.Count30;
+        var spawnCount = Count1 + Count2 +Count30;
 
         await Server.WaitPost(() =>
         {
              stacks =
              [
-                 SSpawn(StackTestPrototypes.StackEnt1),
-                 SSpawn(StackTestPrototypes.StackEnt2),
-                 SSpawn(StackTestPrototypes.StackEnt30),
+                 SSpawn(StackEnt1),
+                 SSpawn(StackEnt2),
+                 SSpawn(StackEnt30),
              ];
 
             _sStackSystem.MergeStacks(ref stacks);
@@ -123,14 +124,14 @@ public sealed class StackTest : GameTest
     [Test]
     public async Task MergeContactsTest()
     {
-        var spawnCount = StackTestPrototypes.Count1 + StackTestPrototypes.Count1;
+        var spawnCount = Count1 + Count1;
 
         var map = await Pair.CreateTestMap();
         await Server.WaitIdleAsync();
 
         // Spawn two stacks at the same position so they're contacting
-        var doner = await SpawnAtPosition(StackTestPrototypes.StackEnt1, map.GridCoords);
-        var receiver = await SpawnAtPosition(StackTestPrototypes.StackEnt1, map.GridCoords);
+        var doner = await SpawnAtPosition(StackEnt1, map.GridCoords);
+        var receiver = await SpawnAtPosition(StackEnt1, map.GridCoords);
 
         _sStackSystem.TryMergeToContacts(doner);
 
@@ -146,8 +147,8 @@ public sealed class StackTest : GameTest
         });
 
         // Now test for when there's more count than the receiver can hold
-        doner = await SpawnAtPosition(StackTestPrototypes.StackEnt30, map.GridCoords);
-        spawnCount += StackTestPrototypes.Count30;
+        doner = await SpawnAtPosition(StackEnt30, map.GridCoords);
+        spawnCount += Count30;
 
         _sStackSystem.TryMergeToContacts(doner);
 
@@ -155,8 +156,8 @@ public sealed class StackTest : GameTest
         {
             // Assert that the receiver is at its maximum count
             // And that the doner has the remainder of the spawned count
-            Assert.That(_sStackSystem.GetCount(receiver), Is.EqualTo(StackTestPrototypes.Count30));
-            Assert.That(_sStackSystem.GetCount(doner), Is.EqualTo(spawnCount - StackTestPrototypes.Count30));
+            Assert.That(_sStackSystem.GetCount(receiver), Is.EqualTo(Count30));
+            Assert.That(_sStackSystem.GetCount(doner), Is.EqualTo(spawnCount - Count30));
         });
     }
 }

--- a/Content.IntegrationTests/Tests/Stacks/StackTests.cs
+++ b/Content.IntegrationTests/Tests/Stacks/StackTests.cs
@@ -14,97 +14,28 @@ public sealed class StackTest : GameTest
 {
     [SidedDependency(Side.Server)] private readonly StackSystem _sStackSystem = default!;
 
-    private const string StackEnt1 = "StackEnt1";
-    private const string StackEnt2 = "StackEnt2";
-    private const string StackEnt3 = "StackEnt3";
-    private const string StackPrototype = "StackProtodsfsd";
-    private const string StackCount1 = "1";
-    private const string StackCount2 = "2";
-    private const string StackCount30 = "30";
-
-    [TestPrototypes]
-    private const string Prototypes =
-        @$"
-        - type: stack
-          id: {StackPrototype}
-          spawn: {StackEnt1}
-          maxCount: {StackCount30}
-
-        - type: entity
-          id: {StackEnt1}
-          components:
-          - type: Stack
-            stackType: {StackPrototype}
-            count: {StackCount1}
-          - type: Physics
-            bodyType: Dynamic
-          - type: Fixtures
-            fixtures:
-              fix1:
-                shape:
-                  !type:PhysShapeCircle
-                    bounds: ""-0.49,-0.49,0.49,0.49""
-                layer:
-                - Impassable
-
-        - type: entity
-          id: {StackEnt2}
-          components:
-          - type: Stack
-            stackType: {StackPrototype}
-            count: {StackCount2}
-          - type: Physics
-            bodyType: Dynamic
-          - type: Fixtures
-            fixtures:
-              fix1:
-                shape:
-                  !type:PhysShapeCircle
-                    bounds: ""-0.49,-0.49,0.49,0.49""
-                layer:
-                - Impassable
-
-        - type: entity
-          id: {StackEnt3}
-          components:
-          - type: Stack
-            stackType: {StackPrototype}
-            count: {StackCount30}
-          - type: Physics
-            bodyType: Dynamic
-          - type: Fixtures
-            fixtures:
-              fix1:
-                shape:
-                  !type:PhysShapeCircle
-                    bounds: ""-0.49,-0.49,0.49,0.49""
-                layer:
-                - Impassable
-        ";
-
-
     /// <summary>
     /// Tests for <see cref="SharedStackSystem.SetCount(Entity{StackComponent}, int)"/>.
     /// </summary>
     [Test]
     public async Task SetTest()
     {
-        var stack = await Spawn(StackEnt1);
+        var stack = await Spawn(StackTestPrototypes.StackEnt1);
 
         // Raising the count
-        _sStackSystem.SetCount(stack, int.Parse(StackCount2));
-        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(int.Parse(StackCount2)));
+        _sStackSystem.SetCount((stack, null), StackTestPrototypes.Count2);
+        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(StackTestPrototypes.Count2));
 
         // Lowering the count
-        _sStackSystem.SetCount(stack, int.Parse(StackCount1));
-        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(int.Parse(StackCount1)));
+        _sStackSystem.SetCount((stack, null), StackTestPrototypes.Count1);
+        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(StackTestPrototypes.Count1));
 
         // Setting above the max count clamps to max
-        _sStackSystem.SetCount(stack, int.Parse(StackCount30) + 1);
-        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(int.Parse(StackCount30)));
+        _sStackSystem.SetCount((stack, null), StackTestPrototypes.Count30 + 1);
+        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(StackTestPrototypes.Count30));
 
         // Setting to 0 deletes the stack
-        _sStackSystem.SetCount(stack, 0);
+        _sStackSystem.SetCount((stack, null), 0);
         await Server.WaitRunTicks(1);
         Assert.That(SEntMan.EntityCount, Is.Zero);
     }
@@ -116,14 +47,14 @@ public sealed class StackTest : GameTest
     public async Task MergeTest()
     {
         var stacks = new HashSet<EntityUid>();
-        var spawnCount = int.Parse(StackCount1) + int.Parse(StackCount2);
+        var spawnCount = StackTestPrototypes.Count1 + StackTestPrototypes.Count2;
 
         await Server.WaitPost(() =>
         {
             stacks =
             [
-                SSpawn(StackEnt1),
-                SSpawn(StackEnt2),
+                SSpawn(StackTestPrototypes.StackEnt1),
+                SSpawn(StackTestPrototypes.StackEnt2),
             ];
 
             _sStackSystem.MergeStacks(ref stacks);
@@ -151,15 +82,15 @@ public sealed class StackTest : GameTest
     public async Task MergeOverflowTest()
     {
         var stacks = new HashSet<EntityUid>();
-        var spawnCount = int.Parse(StackCount1) + int.Parse(StackCount2) + int.Parse(StackCount30);
+        var spawnCount = StackTestPrototypes.Count1 + StackTestPrototypes.Count2 +StackTestPrototypes.Count30;
 
         await Server.WaitPost(() =>
         {
              stacks =
              [
-                 SSpawn(StackEnt1),
-                 SSpawn(StackEnt2),
-                 SSpawn(StackEnt3),
+                 SSpawn(StackTestPrototypes.StackEnt1),
+                 SSpawn(StackTestPrototypes.StackEnt2),
+                 SSpawn(StackTestPrototypes.StackEnt30),
              ];
 
             _sStackSystem.MergeStacks(ref stacks);
@@ -192,32 +123,40 @@ public sealed class StackTest : GameTest
     [Test]
     public async Task MergeContactsTest()
     {
-        var spawnCount = int.Parse(StackCount1) + int.Parse(StackCount1);
+        var spawnCount = StackTestPrototypes.Count1 + StackTestPrototypes.Count1;
 
         var map = await Pair.CreateTestMap();
         await Server.WaitIdleAsync();
 
-        var doner = await SpawnAtPosition(StackEnt1, map.GridCoords);
-        var receiver = await SpawnAtPosition(StackEnt1, map.GridCoords);
+        // Spawn two stacks at the same position so they're contacting
+        var doner = await SpawnAtPosition(StackTestPrototypes.StackEnt1, map.GridCoords);
+        var receiver = await SpawnAtPosition(StackTestPrototypes.StackEnt1, map.GridCoords);
 
         _sStackSystem.TryMergeToContacts(doner);
 
+        // Wait for queue deletion
         await Server.WaitRunTicks(1);
 
         Assert.Multiple(() =>
         {
+            // Assert that the receiver has the total count
+            // And that the doner was deleted
             Assert.That(_sStackSystem.GetCount(receiver), Is.EqualTo(spawnCount));
             Assert.That(SEntMan.EntityExists(doner), Is.False);
         });
 
-        doner = await SpawnAtPosition(StackEnt3, map.GridCoords);
+        // Now test for when there's more count than the receiver can hold
+        doner = await SpawnAtPosition(StackTestPrototypes.StackEnt30, map.GridCoords);
+        spawnCount += StackTestPrototypes.Count30;
 
         _sStackSystem.TryMergeToContacts(doner);
 
         Assert.Multiple(() =>
         {
-            Assert.That(_sStackSystem.GetCount(receiver), Is.EqualTo(int.Parse(StackCount30)));
-            Assert.That(_sStackSystem.GetCount(doner), Is.EqualTo(spawnCount));
+            // Assert that the receiver is at its maximum count
+            // And that the doner has the remainder of the spawned count
+            Assert.That(_sStackSystem.GetCount(receiver), Is.EqualTo(StackTestPrototypes.Count30));
+            Assert.That(_sStackSystem.GetCount(doner), Is.EqualTo(spawnCount - StackTestPrototypes.Count30));
         });
     }
 }

--- a/Content.IntegrationTests/Tests/Stacks/StackTests.cs
+++ b/Content.IntegrationTests/Tests/Stacks/StackTests.cs
@@ -1,0 +1,223 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
+using Content.Server.Stack;
+using Content.Shared.Stacks;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.Stacks;
+
+[TestFixture]
+[TestOf(typeof(StackSystem))]
+public sealed class StackTest : GameTest
+{
+    [SidedDependency(Side.Server)] private readonly StackSystem _sStackSystem = default!;
+
+    private const string StackEnt1 = "StackEnt1";
+    private const string StackEnt2 = "StackEnt2";
+    private const string StackEnt3 = "StackEnt3";
+    private const string StackPrototype = "StackProtodsfsd";
+    private const string StackCount1 = "1";
+    private const string StackCount2 = "2";
+    private const string StackCount30 = "30";
+
+    [TestPrototypes]
+    private const string Prototypes =
+        @$"
+        - type: stack
+          id: {StackPrototype}
+          spawn: {StackEnt1}
+          maxCount: {StackCount30}
+
+        - type: entity
+          id: {StackEnt1}
+          components:
+          - type: Stack
+            stackType: {StackPrototype}
+            count: {StackCount1}
+          - type: Physics
+            bodyType: Dynamic
+          - type: Fixtures
+            fixtures:
+              fix1:
+                shape:
+                  !type:PhysShapeCircle
+                    bounds: ""-0.49,-0.49,0.49,0.49""
+                layer:
+                - Impassable
+
+        - type: entity
+          id: {StackEnt2}
+          components:
+          - type: Stack
+            stackType: {StackPrototype}
+            count: {StackCount2}
+          - type: Physics
+            bodyType: Dynamic
+          - type: Fixtures
+            fixtures:
+              fix1:
+                shape:
+                  !type:PhysShapeCircle
+                    bounds: ""-0.49,-0.49,0.49,0.49""
+                layer:
+                - Impassable
+
+        - type: entity
+          id: {StackEnt3}
+          components:
+          - type: Stack
+            stackType: {StackPrototype}
+            count: {StackCount30}
+          - type: Physics
+            bodyType: Dynamic
+          - type: Fixtures
+            fixtures:
+              fix1:
+                shape:
+                  !type:PhysShapeCircle
+                    bounds: ""-0.49,-0.49,0.49,0.49""
+                layer:
+                - Impassable
+        ";
+
+
+    /// <summary>
+    /// Tests for <see cref="SharedStackSystem.SetCount(Entity{StackComponent}, int)"/>.
+    /// </summary>
+    [Test]
+    public async Task SetTest()
+    {
+        var stack = await Spawn(StackEnt1);
+
+        // Raising the count
+        _sStackSystem.SetCount(stack, int.Parse(StackCount2));
+        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(int.Parse(StackCount2)));
+
+        // Lowering the count
+        _sStackSystem.SetCount(stack, int.Parse(StackCount1));
+        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(int.Parse(StackCount1)));
+
+        // Setting above the max count clamps to max
+        _sStackSystem.SetCount(stack, int.Parse(StackCount30) + 1);
+        Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(int.Parse(StackCount30)));
+
+        // Setting to 0 deletes the stack
+        _sStackSystem.SetCount(stack, 0);
+        await Server.WaitRunTicks(1);
+        Assert.That(SEntMan.EntityCount, Is.Zero);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="SharedStackSystem.MergeStacks"/> functions as expected with small numbers.
+    /// </summary>
+    [Test]
+    public async Task MergeTest()
+    {
+        var stacks = new HashSet<EntityUid>();
+        var spawnCount = int.Parse(StackCount1) + int.Parse(StackCount2);
+
+        await Server.WaitPost(() =>
+        {
+            stacks =
+            [
+                SSpawn(StackEnt1),
+                SSpawn(StackEnt2),
+            ];
+
+            _sStackSystem.MergeStacks(ref stacks);
+        });
+
+        // Wait for the queue deletion of the empty stacks
+        await Server.WaitRunTicks(1);
+
+        Assert.Multiple(() =>
+        {
+            // Assert that only one entity was returned
+            // And that it has the correct count
+            Assert.That(stacks, Has.Count.EqualTo(1));
+            Assert.That(_sStackSystem.GetCount(stacks.First()), Is.EqualTo(spawnCount));
+
+            // Assert that the other stack was set to zero and deleted
+            Assert.That(SEntMan.EntityCount, Is.EqualTo(1));
+        });
+    }
+
+    /// <summary>
+    /// Tests that <see cref="SharedStackSystem.MergeStacks"/> functions as expected with large numbers.
+    /// </summary>
+    [Test]
+    public async Task MergeOverflowTest()
+    {
+        var stacks = new HashSet<EntityUid>();
+        var spawnCount = int.Parse(StackCount1) + int.Parse(StackCount2) + int.Parse(StackCount30);
+
+        await Server.WaitPost(() =>
+        {
+             stacks =
+             [
+                 SSpawn(StackEnt1),
+                 SSpawn(StackEnt2),
+                 SSpawn(StackEnt3),
+             ];
+
+            _sStackSystem.MergeStacks(ref stacks);
+        });
+
+        // Wait for the queue deletion of the empty stacks
+        await Server.WaitRunTicks(1);
+
+        var count = 0;
+        foreach (var stack in stacks)
+        {
+            count += _sStackSystem.GetCount(stack);
+        }
+
+        Assert.Multiple(() =>
+        {
+            // Assert that both stacks were returned
+            // And that the empty stack was deleted
+            Assert.That(stacks, Has.Count.EqualTo(2));
+            Assert.That(SEntMan.EntityCount, Is.EqualTo(2));
+
+            // Assert we have the same count as what we spawned
+            Assert.That(count, Is.EqualTo(spawnCount));
+        });
+    }
+
+    /// <summary>
+    /// Test for <see cref="SharedStackSystem.TryMergeToContacts"/>.
+    /// </summary>
+    [Test]
+    public async Task MergeContactsTest()
+    {
+        var spawnCount = int.Parse(StackCount1) + int.Parse(StackCount1);
+
+        var map = await Pair.CreateTestMap();
+        await Server.WaitIdleAsync();
+
+        var doner = await SpawnAtPosition(StackEnt1, map.GridCoords);
+        var receiver = await SpawnAtPosition(StackEnt1, map.GridCoords);
+
+        _sStackSystem.TryMergeToContacts(doner);
+
+        await Server.WaitRunTicks(1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_sStackSystem.GetCount(receiver), Is.EqualTo(spawnCount));
+            Assert.That(SEntMan.EntityExists(doner), Is.False);
+        });
+
+        doner = await SpawnAtPosition(StackEnt3, map.GridCoords);
+
+        _sStackSystem.TryMergeToContacts(doner);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_sStackSystem.GetCount(receiver), Is.EqualTo(int.Parse(StackCount30)));
+            Assert.That(_sStackSystem.GetCount(doner), Is.EqualTo(spawnCount));
+        });
+    }
+}

--- a/Content.Server/Destructible/DestructibleSystem.Spawn.cs
+++ b/Content.Server/Destructible/DestructibleSystem.Spawn.cs
@@ -38,7 +38,7 @@ public sealed partial class DestructibleSystem
             }
         }
 
-        _stackSystem.MergeStacks(totalSpawned);
+        _stackSystem.MergeStacks(ref totalSpawned);
     }
 
     /// <summary>

--- a/Content.Server/Destructible/DestructibleSystem.Spawn.cs
+++ b/Content.Server/Destructible/DestructibleSystem.Spawn.cs
@@ -11,7 +11,7 @@ namespace Content.Server.Destructible;
 public sealed partial class DestructibleSystem
 {
     [SubscribeLocalEvent]
-    private void OnSpawnDestroy(Entity<SpawnOnDestroyedComponent> ent, ref DestructionEventArgs _)
+    private void OnDestroySpawnEntities(Entity<SpawnOnDestroyedComponent> ent, ref DestructionEventArgs _)
     {
         var xform = Transform(ent);
         var totalSpawned = new HashSet<EntityUid>();
@@ -20,9 +20,7 @@ public sealed partial class DestructibleSystem
         {
             foreach (var spawn in _entityTableSystem.GetSpawns(ent.Comp.Spawn))
             {
-                var position = xform.Coordinates;
-                if (ent.Comp.Offset is not null)
-                    position = position.Offset(Random.NextVector2(ent.Comp.Offset.Value));
+                var position = xform.Coordinates.Offset(Random.NextVector2(ent.Comp.Offset));
 
                 if (ent.Comp.SpawnAfter is not null)
                 {
@@ -31,7 +29,7 @@ public sealed partial class DestructibleSystem
                 }
                 else
                 {
-                    var spawned = SpawnNow(spawn, position, (ent.Owner, ent.Comp, xform));
+                    var spawned = SpawnNow(spawn, position, (ent.Owner, xform));
                     CopyForensics(ent, spawned);
                     totalSpawned.Add(spawned);
                 }
@@ -57,10 +55,10 @@ public sealed partial class DestructibleSystem
         return spawner;
     }
 
-    private EntityUid SpawnNow(EntProtoId toSpawn, EntityCoordinates position, Entity<SpawnOnDestroyedComponent, TransformComponent> source)
+    private EntityUid SpawnNow(EntProtoId toSpawn, EntityCoordinates position, Entity<TransformComponent> source)
     {
         if (ContainerSystem.IsEntityInContainer(source))
-            return SpawnNextToOrDrop(toSpawn, source, source.Comp2);
+            return SpawnNextToOrDrop(toSpawn, source, source.Comp);
 
         // If spawned isn't in a container, give it a random rotation so that everything doesn't have the same angle.
         var spawned = SpawnAtPosition(toSpawn, position);

--- a/Content.Server/Destructible/DestructibleSystem.Spawn.cs
+++ b/Content.Server/Destructible/DestructibleSystem.Spawn.cs
@@ -68,7 +68,7 @@ public sealed partial class DestructibleSystem
 
     private void CopyForensics(Entity<SpawnOnDestroyedComponent> original, EntityUid copy)
     {
-        if (!original.Comp.TransferForensics || !Random.Prob(original.Comp.ForensicsChance))
+        if (original.Comp.ForensicsChance is null || !Random.Prob(original.Comp.ForensicsChance.Value))
             return;
 
         _forensicsSystem.CopyForensicsFrom(original.Owner, copy);

--- a/Content.Server/Destructible/DestructibleSystem.Spawn.cs
+++ b/Content.Server/Destructible/DestructibleSystem.Spawn.cs
@@ -1,9 +1,5 @@
-using Content.Server.Forensics;
 using Content.Server.Spawners.Components;
-using Content.Server.Spawners.EntitySystems;
 using Content.Shared.Destructible;
-using Content.Shared.EntityTable;
-using Content.Shared.Stacks;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -14,38 +10,41 @@ namespace Content.Server.Destructible;
 // Partial for spawning entities on destruction.
 public sealed partial class DestructibleSystem
 {
-    [Dependency] private SharedStackSystem _stackSystem = default!;
-    [Dependency] private SharedTransformSystem _xformSystem = default!;
-    [Dependency] private EntityTableSystem _entityTableSystem = default!;
-    [Dependency] private SpawnOnDespawnSystem _spawnOnDespawnSystem = default!;
-    [Dependency] private ForensicsSystem _forensicsSystem = default!;
-
     [SubscribeLocalEvent]
     private void OnSpawnDestroy(Entity<SpawnOnDestroyedComponent> ent, ref DestructionEventArgs _)
     {
         var xform = Transform(ent);
+        var totalSpawned = new HashSet<EntityUid>();
 
         for (var i = 0; i < _stackSystem.GetCount(ent.Owner); i++)
         {
             foreach (var spawn in _entityTableSystem.GetSpawns(ent.Comp.Spawn))
             {
-                var position = xform.Coordinates.Offset(Random.NextVector2(ent.Comp.Offset));
+                var position = xform.Coordinates;
+                if (ent.Comp.Offset is not null)
+                    position = position.Offset(Random.NextVector2(ent.Comp.Offset.Value));
 
                 if (ent.Comp.SpawnAfter is not null)
-                    SpawnDelayed(spawn, position, ent.Comp.SpawnAfter.Value);
+                {
+                    var spawned = SpawnDelayed(spawn, position, ent.Comp.SpawnAfter.Value);
+                    totalSpawned.Add(spawned);
+                }
                 else
                 {
                     var spawned = SpawnNow(spawn, position, (ent.Owner, ent.Comp, xform));
                     CopyForensics(ent, spawned);
+                    totalSpawned.Add(spawned);
                 }
             }
         }
+
+        _stackSystem.MergeStacks(totalSpawned);
     }
 
     /// <summary>
     /// Delayed spawning is done here. Entities spawned this way can't be in containers or have forensics.
     /// </summary>
-    private void SpawnDelayed(EntProtoId toSpawn, EntityCoordinates position, TimeSpan delay)
+    private EntityUid SpawnDelayed(EntProtoId toSpawn, EntityCoordinates position, TimeSpan delay)
     {
         var spawner = Spawn(SpawnOnDestroyedComponent.TempEntity, position);
 
@@ -54,6 +53,8 @@ public sealed partial class DestructibleSystem
 
         EnsureComp<SpawnOnDespawnComponent>(spawner, out var spawnOnDespawnComponent);
         _spawnOnDespawnSystem.SetPrototype((spawner, spawnOnDespawnComponent), toSpawn);
+
+        return spawner;
     }
 
     private EntityUid SpawnNow(EntProtoId toSpawn, EntityCoordinates position, Entity<SpawnOnDestroyedComponent, TransformComponent> source)

--- a/Content.Server/Destructible/DestructibleSystem.Spawn.cs
+++ b/Content.Server/Destructible/DestructibleSystem.Spawn.cs
@@ -1,0 +1,77 @@
+using Content.Server.Forensics;
+using Content.Server.Spawners.Components;
+using Content.Server.Spawners.EntitySystems;
+using Content.Shared.Destructible;
+using Content.Shared.EntityTable;
+using Content.Shared.Stacks;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Spawners;
+
+namespace Content.Server.Destructible;
+
+// Partial for spawning entities on destruction.
+public sealed partial class DestructibleSystem
+{
+    [Dependency] private SharedStackSystem _stackSystem = default!;
+    [Dependency] private SharedTransformSystem _xformSystem = default!;
+    [Dependency] private EntityTableSystem _entityTableSystem = default!;
+    [Dependency] private SpawnOnDespawnSystem _spawnOnDespawnSystem = default!;
+    [Dependency] private ForensicsSystem _forensicsSystem = default!;
+
+    [SubscribeLocalEvent]
+    private void OnSpawnDestroy(Entity<SpawnOnDestroyedComponent> ent, ref DestructionEventArgs _)
+    {
+        var xform = Transform(ent);
+
+        for (var i = 0; i < _stackSystem.GetCount(ent.Owner); i++)
+        {
+            foreach (var spawn in _entityTableSystem.GetSpawns(ent.Comp.Spawn))
+            {
+                var position = xform.Coordinates.Offset(Random.NextVector2(ent.Comp.Offset));
+
+                if (ent.Comp.SpawnAfter is not null)
+                    SpawnDelayed(spawn, position, ent.Comp.SpawnAfter.Value);
+                else
+                {
+                    var spawned = SpawnNow(spawn, position, (ent.Owner, ent.Comp, xform));
+                    CopyForensics(ent, spawned);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Delayed spawning is done here. Entities spawned this way can't be in containers or have forensics.
+    /// </summary>
+    private void SpawnDelayed(EntProtoId toSpawn, EntityCoordinates position, TimeSpan delay)
+    {
+        var spawner = Spawn(SpawnOnDestroyedComponent.TempEntity, position);
+
+        EnsureComp<TimedDespawnComponent>(spawner, out var timedDespawnComponent);
+        timedDespawnComponent.Lifetime = (float)delay.TotalSeconds;
+
+        EnsureComp<SpawnOnDespawnComponent>(spawner, out var spawnOnDespawnComponent);
+        _spawnOnDespawnSystem.SetPrototype((spawner, spawnOnDespawnComponent), toSpawn);
+    }
+
+    private EntityUid SpawnNow(EntProtoId toSpawn, EntityCoordinates position, Entity<SpawnOnDestroyedComponent, TransformComponent> source)
+    {
+        if (ContainerSystem.IsEntityInContainer(source))
+            return SpawnNextToOrDrop(toSpawn, source, source.Comp2);
+
+        // If spawned isn't in a container, give it a random rotation so that everything doesn't have the same angle.
+        var spawned = SpawnAtPosition(toSpawn, position);
+        _xformSystem.SetLocalRotation(spawned, Random.NextAngle());
+        return spawned;
+    }
+
+    private void CopyForensics(Entity<SpawnOnDestroyedComponent> original, EntityUid copy)
+    {
+        if (!original.Comp.TransferForensics || !Random.Prob(original.Comp.ForensicsChance))
+            return;
+
+        _forensicsSystem.CopyForensicsFrom(original.Owner, copy);
+    }
+}

--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -7,15 +7,19 @@ using Content.Server.Destructible.Thresholds;
 using Content.Server.Destructible.Thresholds.Behaviors;
 using Content.Server.Explosion.EntitySystems;
 using Content.Server.Fluids.EntitySystems;
+using Content.Server.Forensics;
+using Content.Server.Spawners.EntitySystems;
 using Content.Server.Stack;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
 using Content.Shared.Destructible;
 using Content.Shared.Destructible.Thresholds.Triggers;
+using Content.Shared.EntityTable;
 using Content.Shared.FixedPoint;
 using Content.Shared.Gibbing;
 using Content.Shared.Humanoid;
+using Content.Shared.Stacks;
 using Content.Shared.Trigger.Systems;
 using JetBrains.Annotations;
 using Robust.Shared.Containers;
@@ -41,6 +45,12 @@ public sealed partial class DestructibleSystem : SharedDestructibleSystem
     [Dependency] public SharedSolutionContainerSystem SolutionContainerSystem = default!;
     [Dependency] public StackSystem StackSystem = default!;
     [Dependency] public TriggerSystem TriggerSystem = default!;
+
+    [Dependency] private EntityTableSystem _entityTableSystem = default!;
+    [Dependency] private ForensicsSystem _forensicsSystem = default!;
+    [Dependency] private SharedStackSystem _stackSystem = default!;
+    [Dependency] private SharedTransformSystem _xformSystem = default!;
+    [Dependency] private SpawnOnDespawnSystem _spawnOnDespawnSystem = default!;
 
     /// <summary>
     /// Minimum damage to invoke overkill behavior.

--- a/Content.Server/Forensics/Systems/ForensicsSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicsSystem.cs
@@ -23,6 +23,7 @@ using Robust.Shared.Random;
 using Content.Shared.Verbs;
 using Robust.Shared.Utility;
 using Content.Shared.Hands.Components;
+using JetBrains.Annotations;
 
 namespace Content.Server.Forensics
 {
@@ -33,6 +34,8 @@ namespace Content.Server.Forensics
         [Dependency] private DoAfterSystem _doAfterSystem = default!;
         [Dependency] private PopupSystem _popupSystem = default!;
         [Dependency] private SharedSolutionContainerSystem _solutionContainerSystem = default!;
+
+        [Dependency] private EntityQuery<ForensicsComponent> _forensicsQuery;
 
         public override void Initialize()
         {
@@ -147,6 +150,16 @@ namespace Content.Server.Forensics
             {
                 dest.Residues.Add(residue);
             }
+        }
+
+        /// <inheritdoc cref="CopyForensicsFrom(ForensicsComponent, EntityUid)"/>
+        [PublicAPI]
+        public void CopyForensicsFrom(Entity<ForensicsComponent?> source, EntityUid target)
+        {
+            if (!_forensicsQuery.Resolve(source, ref source.Comp, false))
+                return;
+
+            CopyForensicsFrom(source.Comp, target);
         }
 
         public List<string> GetSolutionsDNA(EntityUid uid)

--- a/Content.Server/Stack/StackSystem.cs
+++ b/Content.Server/Stack/StackSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.Stacks;
 using JetBrains.Annotations;
@@ -13,6 +14,11 @@ namespace Content.Server.Stack
     [UsedImplicitly]
     public sealed partial class StackSystem : SharedStackSystem
     {
+        [Dependency] private SharedHandsSystem _hands = default!;
+        [Dependency] private SharedPopupSystem _popup = default!;
+
+        [Dependency] private EntityQuery<StackComponent> _stackQuery;
+
         #region Spawning
 
         /// <summary>
@@ -26,7 +32,7 @@ namespace Content.Server.Stack
         [PublicAPI]
         public EntityUid? Split(Entity<StackComponent?> ent, int amount, EntityCoordinates spawnPosition)
         {
-            if (!Resolve(ent.Owner, ref ent.Comp))
+            if (!_stackQuery.Resolve(ent.Owner, ref ent.Comp))
                 return null;
 
             // Try to remove the amount of things we want to split from the original stack...
@@ -40,7 +46,7 @@ namespace Content.Server.Stack
             var newEntity = SpawnAtPosition(stackType.Spawn, spawnPosition);
 
             // There should always be a StackComponent
-            var stackComp = Comp<StackComponent>(newEntity);
+            var stackComp = _stackQuery.Comp(newEntity);
 
             SetCount((newEntity, stackComp), amount);
             stackComp.Unlimited = false; // Don't let people dupe unlimited stacks
@@ -288,16 +294,16 @@ namespace Content.Server.Stack
 
             if (amount <= 0)
             {
-                Popup.PopupCursor(Loc.GetString("comp-stack-split-too-small"), user.Owner, PopupType.Medium);
+                _popup.PopupCursor(Loc.GetString("comp-stack-split-too-small"), user.Owner, PopupType.Medium);
                 return;
             }
 
             if (Split(stack.AsNullable(), amount, user.Comp.Coordinates) is not { } split)
                 return;
 
-            Hands.PickupOrDrop(user.Owner, split);
+            _hands.PickupOrDrop(user.Owner, split);
 
-            Popup.PopupCursor(Loc.GetString("comp-stack-split"), user.Owner);
+            _popup.PopupCursor(Loc.GetString("comp-stack-split"), user.Owner);
         }
         #endregion
     }

--- a/Content.Shared/Destructible/SpawnOnDestroyedComponent.cs
+++ b/Content.Shared/Destructible/SpawnOnDestroyedComponent.cs
@@ -28,7 +28,7 @@ public sealed partial class SpawnOnDestroyedComponent : Component
     /// Time in seconds to wait before spawning entities. Useful when your entity also explodes.
     /// </summary>
     /// <remarks>
-    /// Overrides <see cref="TransferForensics"/> and won't spawn in containers.
+    /// Overrides forensics transfering and won't spawn in containers.
     /// </remarks>
     [DataField]
     public TimeSpan? SpawnAfter;
@@ -40,15 +40,10 @@ public sealed partial class SpawnOnDestroyedComponent : Component
     public float Offset = 0.5f;
 
     /// <summary>
-    /// Spawned items will try to copy the forensics of the destroyed entity.
+    /// Chance for forensics to be transferred.
+    /// Transferring is skipped if null.
     /// </summary>
     [DataField]
-    public bool TransferForensics = true;
-
-    /// <summary>
-    /// Chance for forensics to be transferred if <see cref="TransferForensics"/> is true.
-    /// </summary>
-    [DataField]
-    public float ForensicsChance = .4f;
+    public float? ForensicsChance = .4f;
 
 }

--- a/Content.Shared/Destructible/SpawnOnDestroyedComponent.cs
+++ b/Content.Shared/Destructible/SpawnOnDestroyedComponent.cs
@@ -5,8 +5,12 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Destructible;
 
 /// <summary>
-/// This entity will spawn things at its location while getting *destroyed*.
+/// This entity will spawn things at its location when getting *destroyed* through <see cref="SharedDestructibleSystem"/>.
 /// </summary>
+/// <remarks>
+/// This component recreates the spawning functionality from <see cref="DestructibleComponent"/> thresholds,
+/// specifically <c>SpawnEntitiesBehavior</c> and <c>WeightedSpawnEntityBehavior</c>.
+/// </remarks>
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(SharedDestructibleSystem))]
 public sealed partial class SpawnOnDestroyedComponent : Component
@@ -33,7 +37,7 @@ public sealed partial class SpawnOnDestroyedComponent : Component
     /// How far from the destroyed entity to spawn.
     /// </summary>
     [DataField]
-    public float? Offset = 0.5f;
+    public float Offset = 0.5f;
 
     /// <summary>
     /// Spawned items will try to copy the forensics of the destroyed entity.

--- a/Content.Shared/Destructible/SpawnOnDestroyedComponent.cs
+++ b/Content.Shared/Destructible/SpawnOnDestroyedComponent.cs
@@ -1,0 +1,50 @@
+using Content.Shared.EntityTable.EntitySelectors;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Destructible;
+
+/// <summary>
+/// This entity will spawn things at its location while getting destroyed.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SharedDestructibleSystem))]
+public sealed partial class SpawnOnDestroyedComponent : Component
+{
+    public static readonly EntProtoId TempEntity = "TemporaryEntityForTimedDespawnSpawners";
+
+    /// <summary>
+    ///     Entity table to spawn from.
+    /// </summary>
+    [DataField(required: true)]
+    public EntityTableSelector Spawn;
+
+    /// <summary>
+    /// Time in seconds to wait before spawning entities. Useful when your entity also explodes.
+    /// </summary>
+    /// <remarks>
+    /// Overrides <see cref="TransferForensics"/> and won't spawn
+    /// </remarks>
+    [DataField]
+    public TimeSpan? SpawnAfter;
+
+    /// <summary>
+    /// How far from the destroyed entity to spawn, using ((-Offset, Offset), (-Offset, Offset)).
+    /// todo make radius?
+    /// </summary>
+    [DataField]
+    public float Offset = 0.5f;
+
+    /// <summary>
+    /// Spawned items will try to copy the forensics of the destroyed entity.
+    /// </summary>
+    [DataField]
+    public bool TransferForensics = true;
+
+    /// <summary>
+    /// Chance for forensics to be transferred if <see cref="TransferForensics"/> is true.
+    /// </summary>
+    [DataField]
+    public float ForensicsChance = .4f;
+
+}

--- a/Content.Shared/Destructible/SpawnOnDestroyedComponent.cs
+++ b/Content.Shared/Destructible/SpawnOnDestroyedComponent.cs
@@ -5,16 +5,17 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared.Destructible;
 
 /// <summary>
-/// This entity will spawn things at its location while getting destroyed.
+/// This entity will spawn things at its location while getting *destroyed*.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(SharedDestructibleSystem))]
 public sealed partial class SpawnOnDestroyedComponent : Component
 {
+    // Filthy dummy entity for spawning delayed.
     public static readonly EntProtoId TempEntity = "TemporaryEntityForTimedDespawnSpawners";
 
     /// <summary>
-    ///     Entity table to spawn from.
+    /// Entities that will spawn from this entity.
     /// </summary>
     [DataField(required: true)]
     public EntityTableSelector Spawn;
@@ -23,17 +24,16 @@ public sealed partial class SpawnOnDestroyedComponent : Component
     /// Time in seconds to wait before spawning entities. Useful when your entity also explodes.
     /// </summary>
     /// <remarks>
-    /// Overrides <see cref="TransferForensics"/> and won't spawn
+    /// Overrides <see cref="TransferForensics"/> and won't spawn in containers.
     /// </remarks>
     [DataField]
     public TimeSpan? SpawnAfter;
 
     /// <summary>
-    /// How far from the destroyed entity to spawn, using ((-Offset, Offset), (-Offset, Offset)).
-    /// todo make radius?
+    /// How far from the destroyed entity to spawn.
     /// </summary>
     [DataField]
-    public float Offset = 0.5f;
+    public float? Offset = 0.5f;
 
     /// <summary>
     /// Spawned items will try to copy the forensics of the destroyed entity.

--- a/Content.Shared/Stacks/SharedStackSystem.API.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.API.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Hands.Components;
 using JetBrains.Annotations;
+using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Stacks;
@@ -36,9 +37,74 @@ public abstract partial class SharedStackSystem
     #region Merge Stacks
 
     /// <summary>
+    /// Merges together the counts from a set of stacks into the smallest number of entities.
+    /// </summary>
+    /// <param name="stacks">Entities to merge. Returns stack entities with non-zero count.</param>
+    [PublicAPI]
+    public void MergeStacks(ref HashSet<EntityUid> stacks)
+    {
+        // Filter out the non-stacks and separate them by their stack types
+        var stacksByType = new Dictionary<ProtoId<StackPrototype>, List<Entity<StackComponent>>>();
+        foreach (var uid in stacks)
+        {
+            if (!_stackQuery.TryComp(uid, out var stackComponent))
+                continue;
+
+            if (stacksByType.TryGetValue(stackComponent.StackTypeId, out var list))
+                list.Add((uid, stackComponent));
+            else
+            {
+                list = new List<Entity<StackComponent>>();
+                list.Add((uid, stackComponent));
+                stacksByType[stackComponent.StackTypeId] = list;
+            }
+        }
+
+        // Set the count
+        foreach (var (type, stackList) in stacksByType)
+        {
+            var count = GetCount(stackList, type);
+
+            foreach (var stack in stackList)
+            {
+                // We've already moved all our stacks, so we clear the count of the remaining ones.
+                if (count == 0)
+                {
+                    SetCount(stack.AsNullable(), count);
+                    stacks.Remove(stack);
+                    continue;
+                }
+
+                var amount = Math.Min(count, GetMaxCount(stack.Comp));
+                SetCount(stack.AsNullable(), amount);
+
+                count -= amount;
+            }
+        }
+    }
+
+    /// <summary>
+    /// This will find all the stacks in an area and merge them together.
+    /// </summary>
+    /// <remarks>
+    /// Useful for when you're spawning an unknown number of stacks like from an entity table
+    /// and want to combine them together at the end.
+    /// </remarks>
+    /// <returns>Stack entities with non-zero counts.</returns>
+    [PublicAPI]
+    public HashSet<EntityUid> MergeStacksAtPosition(MapCoordinates pos, float range = 0.5f, LookupFlags flags = EntityLookupSystem.DefaultFlags)
+    {
+        var entities = _entityLookup.GetEntitiesInRange(pos, range, flags);
+        MergeStacks(ref entities);
+        return entities;
+    }
+
+    /// <summary>
     /// Moves as much stack count as we can from the donor to the recipient.
     /// Deletes the donor if count goes to 0.
     /// </summary>
+    /// <param name="donor">Entity losing count.</param>
+    /// <param name="recipient">Entity gaining count.</param>
     /// <param name="transferred">How much stack count was moved.</param>
     /// <param name="amount">Optional. Limits amount of stack count to move from the donor.</param>
     /// <returns> True if transferred is greater than 0. </returns>
@@ -53,10 +119,10 @@ public abstract partial class SharedStackSystem
         if (donor == recipient)
             return false;
 
-        if (!Resolve(recipient, ref recipient.Comp, false) || !Resolve(donor, ref donor.Comp, false))
-            return false;
-
-        if (recipient.Comp.StackTypeId != donor.Comp.StackTypeId)
+        // Check they're stacks of the same type
+        if (!_stackQuery.Resolve(recipient, ref recipient.Comp, false)
+            || !_stackQuery.Resolve(donor, ref donor.Comp, false)
+            || recipient.Comp.StackTypeId != donor.Comp.StackTypeId)
             return false;
 
         // The most we can transfer
@@ -121,22 +187,40 @@ public abstract partial class SharedStackSystem
         var intersecting = new HashSet<Entity<StackComponent>>(); // Should we reuse a HashSet instead of making a new one?
         _entityLookup.GetEntitiesIntersecting(map, bounds, intersecting, LookupFlags.Dynamic | LookupFlags.Sundries);
 
-        var merged = false;
-        foreach (var recipientStack in intersecting)
+        return TryMergeToStacks((uid, stack), intersecting);
+    }
+
+    /// <summary>
+    /// Moves the count from the doner into the collection of entities.
+    /// </summary>
+    /// <returns>True if anything moved.</returns>
+    [PublicAPI]
+    public bool TryMergeToStacks(Entity<StackComponent?> doner, HashSet<Entity<StackComponent>> stacks)
+    {
+        if (!_stackQuery.Resolve(doner.Owner, ref doner.Comp, false))
+            return false;
+
+        // Filter out the non-stacks and non-matching stacks
+        var validTargets = new List<Entity<StackComponent>>();
+        foreach (var stack in stacks)
         {
-            var otherEnt = recipientStack.Owner;
-            // if you merge a ton of stacks together, you will end up deleting a few by accident.
-            if (TerminatingOrDeleted(otherEnt) || EntityManager.IsQueuedForDeletion(otherEnt))
+            if (stack.Comp.StackTypeId != doner.Comp.StackTypeId)
                 continue;
 
-            if (!TryMergeStacks((uid, stack), recipientStack.AsNullable(), out _))
-                continue;
-            merged = true;
+            validTargets.Add(stack);
+        }
 
-            if (stack.Count <= 0)
+        var count = GetCount(doner);
+        foreach (var stack in validTargets)
+        {
+            TryMergeStacks(doner, stack.AsNullable(), out var transferred);
+
+            count -= transferred;
+            if (count == 0)
                 break;
         }
-        return merged;
+
+        return true;
     }
 
     #endregion
@@ -240,6 +324,24 @@ public abstract partial class SharedStackSystem
     public int GetCount(Entity<StackComponent?> ent)
     {
         return Resolve(ent.Owner, ref ent.Comp, false) ? ent.Comp.Count : 1;
+    }
+
+    /// <summary>
+    /// Gets the total count from a list of stacks.
+    /// </summary>
+    private int GetCount(List<Entity<StackComponent>> stacks, ProtoId<StackPrototype> id)
+    {
+        var count = 0;
+        foreach (var stack in stacks)
+        {
+            var (uid, stackComponent) = stack;
+            if (stackComponent.StackTypeId != id)
+                continue;
+
+            count += GetCount(stack.AsNullable());
+        }
+
+        return count;
     }
 
     /// <summary>

--- a/Content.Shared/Stacks/SharedStackSystem.API.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.API.cs
@@ -60,6 +60,8 @@ public abstract partial class SharedStackSystem
             }
         }
 
+        stacks.Clear();
+
         // Set the count
         foreach (var (type, stackList) in stacksByType)
         {
@@ -71,7 +73,6 @@ public abstract partial class SharedStackSystem
                 if (count == 0)
                 {
                     SetCount(stack.AsNullable(), count);
-                    stacks.Remove(stack);
                     continue;
                 }
 
@@ -79,6 +80,7 @@ public abstract partial class SharedStackSystem
                 SetCount(stack.AsNullable(), amount);
 
                 count -= amount;
+                stacks.Add(stack);
             }
         }
     }
@@ -152,22 +154,22 @@ public abstract partial class SharedStackSystem
         if (!Resolve(user.Owner, ref user.Comp, false))
             return;
 
-        if (!Resolve(item.Owner, ref item.Comp, false))
+        if (!_stackQuery.Resolve(item.Owner, ref item.Comp, false))
         {
             // This isn't even a stack. Just try to pickup as normal.
-            Hands.PickupOrDrop(user.Owner, item.Owner, handsComp: user.Comp);
+            _hands.PickupOrDrop(user.Owner, item.Owner, handsComp: user.Comp);
             return;
         }
 
-        foreach (var held in Hands.EnumerateHeld(user))
+        foreach (var held in _hands.EnumerateHeld(user))
         {
             TryMergeStacks(item, held, out _);
 
-            if (item.Comp.Count == 0)
+            if (GetCount(item) == 0)
                 return;
         }
 
-        Hands.PickupOrDrop(user.Owner, item.Owner, handsComp: user.Comp);
+        _hands.PickupOrDrop(user.Owner, item.Owner, handsComp: user.Comp);
     }
 
     /// <summary>
@@ -233,7 +235,7 @@ public abstract partial class SharedStackSystem
     /// <remarks> All setter functions should end up here. </remarks>
     public void SetCount(Entity<StackComponent?> ent, int amount)
     {
-        if (!Resolve(ent.Owner, ref ent.Comp))
+        if (!_stackQuery.Resolve(ent.Owner, ref ent.Comp))
             return;
 
         // Do nothing if amount is already the same.
@@ -251,7 +253,7 @@ public abstract partial class SharedStackSystem
         ent.Comp.UiUpdateNeeded = true;
         Dirty(ent);
 
-        Appearance.SetData(ent.Owner, StackVisuals.Actual, ent.Comp.Count);
+        _appearance.SetData(ent.Owner, StackVisuals.Actual, ent.Comp.Count);
         RaiseLocalEvent(ent.Owner, new StackCountChangedEvent(old, ent.Comp.Count));
 
         // Queue delete stack if count reaches zero.
@@ -280,7 +282,7 @@ public abstract partial class SharedStackSystem
     [PublicAPI]
     public void ReduceCount(Entity<StackComponent?> ent, int amount)
     {
-        if (!Resolve(ent.Owner, ref ent.Comp))
+        if (!_stackQuery.Resolve(ent.Owner, ref ent.Comp))
             return;
 
         // Don't reduce unlimited stacks
@@ -298,7 +300,7 @@ public abstract partial class SharedStackSystem
     [PublicAPI]
     public bool TryUse(Entity<StackComponent?> ent, int amount)
     {
-        if (!Resolve(ent.Owner, ref ent.Comp))
+        if (!_stackQuery.Resolve(ent.Owner, ref ent.Comp))
             return false;
 
         // We're unlimited and always greater than amount
@@ -323,7 +325,7 @@ public abstract partial class SharedStackSystem
     [PublicAPI]
     public int GetCount(Entity<StackComponent?> ent)
     {
-        return Resolve(ent.Owner, ref ent.Comp, false) ? ent.Comp.Count : 1;
+        return _stackQuery.Resolve(ent.Owner, ref ent.Comp, false) ? ent.Comp.Count : 1;
     }
 
     /// <summary>
@@ -334,8 +336,7 @@ public abstract partial class SharedStackSystem
         var count = 0;
         foreach (var stack in stacks)
         {
-            var (uid, stackComponent) = stack;
-            if (stackComponent.StackTypeId != id)
+            if (stack.Comp.StackTypeId != id)
                 continue;
 
             count += GetCount(stack.AsNullable());
@@ -381,7 +382,9 @@ public abstract partial class SharedStackSystem
     [PublicAPI]
     public int GetMaxCount(EntityPrototype entityId)
     {
-        entityId.TryComp<StackComponent>(out var stackComp, EntityManager.ComponentFactory);
+        if (!entityId.TryComp<StackComponent>(out var stackComp, EntityManager.ComponentFactory))
+            return 1;
+
         return GetMaxCount(stackComp);
     }
 
@@ -389,7 +392,7 @@ public abstract partial class SharedStackSystem
     [PublicAPI]
     public int GetMaxCount(EntityUid uid)
     {
-        return GetMaxCount(CompOrNull<StackComponent>(uid));
+        return GetMaxCount(_stackQuery.CompOrNull(uid));
     }
 
     /// <summary>

--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -20,12 +20,11 @@ namespace Content.Shared.Stacks;
 public abstract partial class SharedStackSystem : EntitySystem
 {
     [Dependency] private IViewVariablesManager _vvm = default!;
-    [Dependency] protected SharedAppearanceSystem Appearance = default!;
-    [Dependency] protected SharedHandsSystem Hands = default!;
-    [Dependency] protected SharedTransformSystem Xform = default!;
+    [Dependency] private SharedAppearanceSystem _appearance = default!;
+    [Dependency] private SharedHandsSystem _hands = default!;
     [Dependency] private EntityLookupSystem _entityLookup = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
-    [Dependency] protected SharedPopupSystem Popup = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedStorageSystem _storage = default!;
 
     [Dependency] private EntityQuery<StackComponent> _stackQuery;
@@ -36,16 +35,6 @@ public abstract partial class SharedStackSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-
-        SubscribeLocalEvent<StackComponent, InteractUsingEvent>(OnStackInteractUsing);
-        SubscribeLocalEvent<StackComponent, ComponentGetState>(OnStackGetState);
-        SubscribeLocalEvent<StackComponent, ComponentHandleState>(OnStackHandleState);
-        SubscribeLocalEvent<StackComponent, ComponentStartup>(OnStackStarted);
-        SubscribeLocalEvent<StackComponent, ExaminedEvent>(OnStackExamined);
-
-        SubscribeLocalEvent<StackComponent, BeforeIngestedEvent>(OnBeforeEaten);
-        SubscribeLocalEvent<StackComponent, IngestedEvent>(OnEaten);
-        SubscribeLocalEvent<StackComponent, GetVerbsEvent<AlternativeVerb>>(OnStackAlternativeInteract);
 
         _vvm.GetTypeHandler<StackComponent>()
             .AddPath(nameof(StackComponent.Count), (_, comp) => comp.Count, SetCount);
@@ -59,12 +48,15 @@ public abstract partial class SharedStackSystem : EntitySystem
             .RemovePath(nameof(StackComponent.Count));
     }
 
+    #region Subscriptions
+
+    [SubscribeLocalEvent]
     private void OnStackInteractUsing(Entity<StackComponent> ent, ref InteractUsingEvent args)
     {
         if (args.Handled)
             return;
 
-        if (!TryComp<StackComponent>(args.Used, out var recipientStack))
+        if (!_stackQuery.TryComp(args.Used, out var recipientStack))
             return;
 
         // Transfer stacks from ground to hand
@@ -86,11 +78,11 @@ public abstract partial class SharedStackSystem : EntitySystem
         switch (transferred)
         {
             case > 0:
-                Popup.PopupClient($"+{transferred}", popupPos, args.User);
+                _popup.PopupClient($"+{transferred}", popupPos, args.User);
 
                 if (GetAvailableSpace(recipientStack) == 0)
                 {
-                    Popup.PopupClient(Loc.GetString("comp-stack-becomes-full"),
+                    _popup.PopupClient(Loc.GetString("comp-stack-becomes-full"),
                         popupPos.Offset(new Vector2(0, -0.5f)),
                         args.User);
                 }
@@ -98,7 +90,7 @@ public abstract partial class SharedStackSystem : EntitySystem
                 break;
 
             case 0 when GetAvailableSpace(recipientStack) == 0:
-                Popup.PopupClient(Loc.GetString("comp-stack-already-full"), popupPos, args.User);
+                _popup.PopupClient(Loc.GetString("comp-stack-already-full"), popupPos, args.User);
                 break;
         }
 
@@ -106,21 +98,24 @@ public abstract partial class SharedStackSystem : EntitySystem
         _storage.PlayPickupAnimation(args.Used, popupPos, userCoords, localRotation, args.User);
     }
 
+    [SubscribeLocalEvent]
     private void OnStackStarted(Entity<StackComponent> ent, ref ComponentStartup args)
     {
         if (!TryComp(ent.Owner, out AppearanceComponent? appearance))
             return;
 
-        Appearance.SetData(ent.Owner, StackVisuals.Actual, ent.Comp.Count, appearance);
-        Appearance.SetData(ent.Owner, StackVisuals.MaxCount, GetMaxCount(ent.Comp), appearance);
-        Appearance.SetData(ent.Owner, StackVisuals.Hide, false, appearance);
+        _appearance.SetData(ent.Owner, StackVisuals.Actual, ent.Comp.Count, appearance);
+        _appearance.SetData(ent.Owner, StackVisuals.MaxCount, GetMaxCount(ent.Comp), appearance);
+        _appearance.SetData(ent.Owner, StackVisuals.Hide, false, appearance);
     }
 
+    [SubscribeLocalEvent]
     private void OnStackGetState(Entity<StackComponent> ent, ref ComponentGetState args)
     {
         args.State = new StackComponentState(ent.Comp.Count, ent.Comp.MaxCountOverride, ent.Comp.Unlimited);
     }
 
+    [SubscribeLocalEvent]
     private void OnStackHandleState(Entity<StackComponent> ent, ref ComponentHandleState args)
     {
         if (args.Current is not StackComponentState cast)
@@ -132,6 +127,7 @@ public abstract partial class SharedStackSystem : EntitySystem
         SetCount(ent.AsNullable(), cast.Count);
     }
 
+    [SubscribeLocalEvent]
     private void OnStackExamined(Entity<StackComponent> ent, ref ExaminedEvent args)
     {
         if (!args.IsInDetailsRange)
@@ -145,6 +141,7 @@ public abstract partial class SharedStackSystem : EntitySystem
         );
     }
 
+    [SubscribeLocalEvent]
     private void OnBeforeEaten(Entity<StackComponent> eaten, ref BeforeIngestedEvent args)
     {
         if (args.Cancelled)
@@ -177,11 +174,13 @@ public abstract partial class SharedStackSystem : EntitySystem
         args.Cancelled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnEaten(Entity<StackComponent> eaten, ref IngestedEvent args)
     {
         ReduceCount(eaten.AsNullable(), 1);
     }
 
+    [SubscribeLocalEvent]
     private void OnStackAlternativeInteract(Entity<StackComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
         if (!args.CanAccess || !args.CanInteract || args.Hands == null || ent.Comp.Count == 1)
@@ -218,6 +217,8 @@ public abstract partial class SharedStackSystem : EntitySystem
             args.Verbs.Add(verb);
         }
     }
+
+    #endregion
 
     /// <remarks>
     ///     OnStackAlternativeInteract() was moved to shared in order to faciliate prediction of stack splitting verbs.

--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -28,6 +28,8 @@ public abstract partial class SharedStackSystem : EntitySystem
     [Dependency] protected SharedPopupSystem Popup = default!;
     [Dependency] private SharedStorageSystem _storage = default!;
 
+    [Dependency] private EntityQuery<StackComponent> _stackQuery;
+
     // TODO: These should be in the prototype.
     public static readonly int[] DefaultSplitAmounts = { 1, 5, 10, 20, 30, 50 };
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
requires #44496
sequel to #36985

This PR looks at two of the threshold behaviors (specifically the two that spawn) from `DestructibleSystem` and implements them as a component.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The `SpawnEntitiesBehavior` and `WeightedSpawnEntityBehavior` are used almost exclusively for when an entity is destroyed. By pulling them out of the `DestructibleComponent` tree and implementing them as a component listening to `DestructionEventArgs` it massively simplifies my efforts to refactor structures and their damage thresholds. It allows me to use inheritance in many instances without having to immediately overwrite the parent's `DestructibleComponent` to change what drops from the entity.

## Technical details
<!-- Summary of code changes for easier review. -->
This is a very shallow refactor of `DestructibleSystem`. I consider it acceptable because I have it hinging on an event subscription that's unlikely to be removed. The implementation is a little messy due to maintaining parity with the existing behavior, namely the delayed spawning. `SpawnOnDespawnComponent` was made bespoke for `WeightedSpawnEntityBehavior` and there's certainly a more robust way to do it. For now I'm just redoing what was done before but I can find a better way if asked.

Uses a new method added in #44496 to squish the stacks that spawn.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Test prototype:
```
- type: entity
  parent: BaseSheet
  id: TestSheet
  name: '#Test Sheet'
  components:
  - type: Sprite
    sprite: Objects/Materials/Sheets/glass.rsi
    state: glass_3
    layers:
    - state: glass_3
      map: ["base"]
  - type: Item
    sprite: Objects/Materials/Sheets/glass.rsi
  - type: Damageable
    damageModifierSet: Glass
  - type: Destructible
    thresholds:
    - trigger:
        !type:DamageTrigger
        damage: 1
      behaviors:
      - !type:DoActsBehavior
        acts: [ "Destruction" ]
  - type: SpawnOnDestroyed
    spawn: !type:GroupSelector
      children:
      - id: SheetSteel1
      - id: SheetPlastic1
      - id: BikeHorn
  - type: Stack
    stackType: Glass
    baseLayer: base
    layerStates:
    - glass
    - glass_2
    - glass_3
```

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/259851ed-dbdc-4f20-9c5d-f258ff2cfdfb

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->