### PR TITLE
fix: dead/looc chat unselectable by nonadmin when turned off

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -189,6 +189,9 @@ public sealed partial class ChatUIController : UIController
 
         _speechBubbleRoot = new LayoutContainer();
 
+        _config.OnValueChanged(CCVars.LoocEnabled, _ => UpdateChannelPermissions());
+        _config.OnValueChanged(CCVars.DeadChatEnabled, _ => UpdateChannelPermissions());
+
         UpdateChannelPermissions();
 
         _input.SetInputCommand(ContentKeyFunctions.FocusChat,
@@ -520,9 +523,13 @@ public sealed partial class ChatUIController : UIController
 
         // can always send/recieve OOC
         CanSendChannels |= ChatSelectChannel.OOC;
-        CanSendChannels |= ChatSelectChannel.LOOC;
         FilterableChannels |= ChatChannel.OOC;
         FilterableChannels |= ChatChannel.LOOC;
+
+        if (_config.GetCVar(CCVars.LoocEnabled) || _admin.HasFlag(AdminFlags.Admin)) // admins can always send LOOC, even if disabled
+        {
+            CanSendChannels |= ChatSelectChannel.LOOC;
+        }
 
         // can always hear server (nobody can actually send server messages).
         FilterableChannels |= ChatChannel.Server;
@@ -551,7 +558,10 @@ public sealed partial class ChatUIController : UIController
         if (_admin.HasFlag(AdminFlags.Admin) || _ghost is {IsGhost: true})
         {
             FilterableChannels |= ChatChannel.Dead;
-            CanSendChannels |= ChatSelectChannel.Dead;
+            if (_config.GetCVar(CCVars.DeadChatEnabled) || _admin.HasFlag(AdminFlags.Admin)) // admins can always send deadchat, even if disabled
+            {
+                CanSendChannels |= ChatSelectChannel.Dead;
+            }
         }
 
         // only admins can see / filter asay


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
If you're not an admin the LOOC / dead chat is not selectable for you as long as it's disabled.

## Why / Balance
Fixes #44461

## Technical details
- Added OnValueChanged events for LoocEnabled / DeadChatEnabled which call UpdateChannelPermissions() when the CCVar changes
- In UpdateChannelPermissions I only set CanSendChannels to LOOC when enabled or admin and I handle Dead chat the same way

## Test plan
- I logged in with two clients, one admin, one without (I call him Player), killed the one without so he's a ghost
- Tested if LOOC and Dead work for both
- Switched to Dead Chat on Player 
- Admin deactivated Dead chat
- Player chat switched to OOC
- Tested same for LOOC

## Media
[44461-dead-looc-chat.webm](https://github.com/user-attachments/assets/bf255d2d-024b-4dde-b572-f2d71dca9d2e)


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: When an Admin deactivates the Dead or LOOC chat, players can no longer select these chats.

