### PR TITLE
DunGen.AutoCabling: prevent missing key lookup when frontier exhausted

### DIFF
--- a/Content.Server/Procedural/DungeonJob/DungeonJob.AutoCabling.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.AutoCabling.cs
@@ -65,6 +65,8 @@ public sealed partial class DungeonJob
             {
                 var newStart = remaining.First();
                 frontier.Enqueue(newStart, 0f);
+                if (!costSoFar.ContainsKey(newStart))
+                    costSoFar[newStart] = 0f;
                 lastDirection[newStart] = Direction.Invalid;
             }
 


### PR DESCRIPTION
## About the PR

Ensures costSoFar is populated [with the newly selected starting point] when the frontier is exhausted of points.  Helpful for disconnected graphs (e.g. a dungeon split between multiple asteroids).

## Why / Balance

Resolves https://github.com/space-wizards/space-station-14/issues/44498

## Technical details

costSoFar has a lookup later that just assumes the point exists.  If this is impossible (as the dungeon may be split by reserved tiles), then lookup will eventually fail when the reachable nodes from the starting point are exhausted.

## Test plan

1. Remove the corridor layers from a dungeon generation type.
2. Place multiple APC cables within each room in that dungeon's atlas.
3. Add the following condition to DungeonJob.AutoCabling.cs above TryGetTileRef (this skips tiles outside of the dungeon)
```
            if (!allTiles.Contains(node))
                continue;
```
4. Generate a dungeon of that type.  The APC cables should be connected within each room, but nothing that goes between the rooms.

## Media
TBD

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
no
