### PR TITLE
Inline DamageAllPrototypes test

### DIFF
--- a/Content.IntegrationTests/Tests/Damageable/DamageAllPrototypes.cs
+++ b/Content.IntegrationTests/Tests/Damageable/DamageAllPrototypes.cs
@@ -6,7 +6,6 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;
-using Robust.Shared.Map;
 
 namespace Content.IntegrationTests.Tests.Damageable;
 

--- a/Content.IntegrationTests/Tests/Damageable/DamageAllPrototypes.cs
+++ b/Content.IntegrationTests/Tests/Damageable/DamageAllPrototypes.cs
@@ -1,5 +1,3 @@
-using System.Numerics;
-using System.Runtime.CompilerServices;
 using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Fixtures.Attributes;
 using Content.IntegrationTests.Utility;
@@ -19,42 +17,60 @@ public sealed class DamageAllPrototypesTest : GameTest
 {
     [SidedDependency(Side.Server)] private readonly DamageableSystem _damageableSystem = default!;
 
-    private static string[] _damageables = GameDataScrounger.EntitiesWithComponent("Damageable");
-
     [Test]
     [TestOf(typeof(DamageableSystem))]
-    [TestCaseSource(nameof(_damageables))]
     [Description("Ensures all Entity Prototypes with damageable can be damaged.")]
-    public async Task TestDamageableComponents(string damageable)
+    public async Task TestDamageableComponents()
     {
         var map = await Pair.CreateTestMap();
 
-        var entity = await SpawnAtPosition(damageable, map.GridCoords);
-
-        // Intentionally cannot take damage, ignore it.
-        if (SEntMan.HasComponent<GodmodeComponent>(entity))
-            return;
-
-        var canBeDamaged = false;
-
-        foreach (var type in SProtoMan.EnumeratePrototypes<DamageTypePrototype>())
+        try
         {
-            if (!_damageableSystem.CanBeDamagedBy(entity, type))
-                continue;
-
-            canBeDamaged = true;
-
-            await Server.WaitPost(() =>
+            foreach (var damageable in GameDataScrounger.EntitiesWithComponent("Damageable"))
             {
-                var damage = new DamageSpecifier(type, FixedPoint2.Epsilon);
-                var previousDamage = _damageableSystem.GetTotalDamage(entity);
-                _damageableSystem.ChangeDamage(entity, damage, ignoreResistances: true);
-                Assert.That(_damageableSystem.GetTotalDamage(entity) == FixedPoint2.Epsilon + previousDamage);
-                _damageableSystem.ClearAllDamage(entity);
-            });
-        }
+                var entity = await SpawnAtPosition(damageable, map.GridCoords);
 
-        // Ensure that this entity can actually be damaged.
-        Assert.That(canBeDamaged);
+                try
+                {
+                    // Intentionally cannot take damage, ignore it.
+                    if (SEntMan.HasComponent<GodmodeComponent>(entity))
+                        continue;
+
+                    var canBeDamaged = false;
+
+                    foreach (var type in SProtoMan.EnumeratePrototypes<DamageTypePrototype>())
+                    {
+                        if (!_damageableSystem.CanBeDamagedBy(entity, type))
+                            continue;
+
+                        canBeDamaged = true;
+
+                        await Server.WaitAssertion(() =>
+                        {
+                            var damage = new DamageSpecifier(type, FixedPoint2.Epsilon);
+                            var previousDamage = _damageableSystem.GetTotalDamage(entity);
+                            _damageableSystem.ChangeDamage(entity, damage, ignoreResistances: true);
+                            Assert.That(
+                                _damageableSystem.GetTotalDamage(entity),
+                                Is.EqualTo(FixedPoint2.Epsilon + previousDamage),
+                                $"{damageable} should take {type.ID} damage.");
+
+                            _damageableSystem.ClearAllDamage(entity);
+                        });
+                    }
+
+                    // Ensure that this entity can actually be damaged.
+                    Assert.That(canBeDamaged, Is.True, $"{damageable} cannot be damaged by any damage type.");
+                }
+                finally
+                {
+                    await Server.WaitPost(() => SEntMan.DeleteEntity(entity));
+                }
+            }
+        }
+        finally
+        {
+            await Server.WaitPost(() => SEntMan.DeleteEntity(map.MapUid));
+        }
     }
 }


### PR DESCRIPTION
Previously it was half of all tests and added significant test recycling overhead.