### PR TITLE
Workflow standardisation + prune dead runs

### DIFF
--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -8,6 +8,10 @@ on:
     types: [ opened, reopened, synchronize, ready_for_review ]
     branches: [ master, staging, stable ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   build:
     if: github.actor != 'PJBot' && github.event.pull_request.draft == false

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -8,6 +8,10 @@ on:
     types: [ opened, reopened, synchronize, ready_for_review ]
     branches: [ master, staging, stable ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   build:
     if: github.actor != 'PJBot' && github.event.pull_request.draft == false

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true  # We only care about latest.
+
 jobs:
   build:
     name: CRLF Check

--- a/.github/workflows/no-submodule-update.yml
+++ b/.github/workflows/no-submodule-update.yml
@@ -2,12 +2,18 @@ name: No submodule update checker
 
 on:
   pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
     paths:
       - 'RobustToolbox'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   this_aint_right:
     name: Submodule update in pr found
+    if: github.actor != 'PJBot' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Fail

--- a/.github/workflows/rsi-diff.yml
+++ b/.github/workflows/rsi-diff.yml
@@ -2,8 +2,13 @@ name: Diff RSIs
 
 on:
   pull_request_target:
+    types: [ opened, reopened, synchronize, ready_for_review ]
     paths:
       - '**.rsi/**.png'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   diff:

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -26,6 +26,10 @@ on:
       - 'RobustToolbox'
       - 'RobustToolbox/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   build:
     name: Test Packaging

--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   yaml-schema-validation:
     name: YAML RGA schema validator

--- a/.github/workflows/validate-rsis.yml
+++ b/.github/workflows/validate-rsis.yml
@@ -5,12 +5,18 @@ on:
     branches: [ master, staging, stable ]
   merge_group:
   pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
     paths:
       - '**.rsi/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   validate_rsis:
     name: Validate RSIs
+    if: github.actor != 'PJBot' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/validate_mapfiles.yml
+++ b/.github/workflows/validate_mapfiles.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   yaml-schema-validation:
     name: YAML map schema validator

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   build:
     name: YAML Linter


### PR DESCRIPTION
It annoys me if I do a couple pushes in a row that the old ones keep running and take up time. This should just kill them instead.

It's slightly worse for tracking down bad commits but 99% of the time people won't care and this saves \<UP TO TEST TIME\> of a runner's time.

Merge group semantics should be preservedTM.

I also want to make it skip the submodule check on engine updates to avoid the dummy error message but will do a separate pr when I figure out bash syntax.