### PR TITLE
Half packaging checked platforms for PRs

### DIFF
--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -61,6 +61,11 @@ jobs:
         run: dotnet build Content.Packaging --configuration Release --no-restore /m
 
       - name: Package server
+        if: github.event_name == 'pull_request'
+        run: dotnet run --project Content.Packaging server --log-build --platform win-x64 --platform linux-x64 --platform linux-arm64
+
+      - name: Package server
+        if: github.event_name != 'pull_request'
         run: dotnet run --project Content.Packaging server --log-build --platform win-x64 --platform win-arm64 --platform linux-x64 --platform linux-arm64 --platform osx-x64 --platform osx-arm64
 
       - name: Package client


### PR DESCRIPTION
ATM packaging checks take 10 minutes so just skip the 3 minor usecases and only keep the 3 major ones.

IDK if this one itself counts as a breaking change but probably does for any forks not running merge queue so that will need a codebase-changes post.