### PR TITLE
Packaging changes

### DIFF
--- a/Content.Packaging/ClientPackaging.cs
+++ b/Content.Packaging/ClientPackaging.cs
@@ -1,5 +1,6 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.IO.Compression;
+using System.Runtime.InteropServices;
 using Robust.Packaging;
 using Robust.Packaging.AssetProcessing;
 using Robust.Packaging.AssetProcessing.Passes;
@@ -10,11 +11,40 @@ namespace Content.Packaging;
 
 public static class ClientPackaging
 {
+    private static readonly List<PlatformReg> Platforms =
+    [
+        new("win-x64", "Windows"),
+        new("win-arm64", "Windows"),
+        new("linux-x64", "Linux"),
+        new("linux-arm64", "Linux"),
+        new("osx-x64", "MacOS"),
+        new("osx-arm64", "MacOS"),
+    ];
+
+    private static readonly HashSet<string> BinSkipFolders =
+    [
+        "cs",
+        "de",
+        "es",
+        "fr",
+        "it",
+        "ja",
+        "ko",
+        "pl",
+        "pt-BR",
+        "ru",
+        "tr",
+        "zh-Hans",
+        "zh-Hant",
+    ];
+
     /// <summary>
     /// Be advised this can be called from server packaging during a HybridACZ build.
     /// </summary>
     public static async Task PackageClient(bool skipBuild, bool logBuild, string configuration, IPackageLogger logger)
     {
+        var packagePath = Path.GetFullPath(Path.Combine("release", "SS14.Client.zip"));
+
         logger.Info("Building client...");
 
         if (!skipBuild)
@@ -29,15 +59,16 @@ public static class ClientPackaging
                     "-c", configuration,
                     "--nologo",
                     "/v:m",
-                    "/t:Rebuild",
                     "/p:FullRelease=true",
-                    "/m"
-                }
+                    "/m",
+                },
             };
 
             if (logBuild)
             {
-                startInfo.ArgumentList.Add($"/bl:{Path.Combine("release", "client.binlog")}");
+                var binlogPath = Path.GetFullPath(Path.Combine("release", "client.binlog"));
+                logger.Info($"Client build log: {binlogPath}");
+                startInfo.ArgumentList.Add($"/bl:{binlogPath}");
                 startInfo.ArgumentList.Add("/p:ReportAnalyzer=true");
             }
 
@@ -45,23 +76,171 @@ public static class ClientPackaging
         }
 
         logger.Info("Packaging client...");
+        logger.Info($"Client package output: {packagePath}");
 
         var sw = RStopwatch.StartNew();
         {
-            await using var zipFile =
-                File.Open(Path.Combine("release", "SS14.Client.zip"), FileMode.Create, FileAccess.ReadWrite);
-            using var zip = new ZipArchive(zipFile, ZipArchiveMode.Update);
+            await using var zipFile = File.Open(packagePath, FileMode.Create, FileAccess.ReadWrite);
+            await using var zip = new ZipArchive(zipFile, ZipArchiveMode.Create);
             var writer = new AssetPassZipWriter(zip);
 
             await WriteResources("", writer, logger, default);
             await writer.FinishedTask;
         }
 
-        logger.Info($"Finished packaging client in {sw.Elapsed}");
+        logger.Info($"Finished packaging client in {sw.Elapsed}: {packagePath}");
+    }
+
+    public static async Task PackageStandaloneClient(
+        bool skipBuild,
+        bool logBuild,
+        string configuration,
+        IPackageLogger logger,
+        List<string>? platforms = null)
+    {
+        platforms ??= [GetCurrentRid()];
+
+        var selectedPlatforms = Platforms
+            .Where(o => platforms.Contains(o.Rid))
+            .ToList();
+
+        if (selectedPlatforms.Count != platforms.Count)
+        {
+            var supportedPlatforms = string.Join(", ", Platforms.Select(o => o.Rid));
+            throw new InvalidOperationException($"Invalid standalone client platform. Supported platforms: {supportedPlatforms}");
+        }
+
+        Dictionary<string, string> contentBinDirs;
+        if (skipBuild)
+        {
+            contentBinDirs = selectedPlatforms
+                .Select(o => o.TargetOs)
+                .Distinct()
+                .ToDictionary(o => o, _ => "Content.Client");
+        }
+        else
+        {
+            var targetOperatingSystems = selectedPlatforms
+                .Select(o => o.TargetOs)
+                .Distinct()
+                .ToList();
+
+            foreach (var targetOs in targetOperatingSystems)
+            {
+                await BuildContentClient(targetOs, logBuild, configuration, logger);
+            }
+
+            foreach (var platform in selectedPlatforms)
+            {
+                await PublishRobustClient(platform.Rid, platform.TargetOs, configuration, logger);
+            }
+
+            contentBinDirs = targetOperatingSystems
+                .ToDictionary(o => o, GetContentClientBinDir);
+        }
+
+        await Task.WhenAll(selectedPlatforms.Select(platform =>
+            PackageStandalonePlatform(platform, contentBinDirs[platform.TargetOs], logger)));
     }
 
     public static async Task WriteResources(
         string contentDir,
+        AssetPass pass,
+        IPackageLogger logger,
+        CancellationToken cancel)
+    {
+        await WriteResources(contentDir, "Content.Client", pass, logger, cancel);
+    }
+
+    private static async Task BuildContentClient(
+        string targetOs,
+        bool logBuild,
+        string configuration,
+        IPackageLogger logger)
+    {
+        logger.Info($"Building content client for {targetOs}...");
+        logger.Info($"Content client build output for {targetOs}: {GetContentClientOutputPath(targetOs)}");
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            ArgumentList =
+            {
+                "build",
+                Path.Combine("Content.Client", "Content.Client.csproj"),
+                "-c", configuration,
+                "--nologo",
+                "/v:m",
+                $"/p:TargetOs={targetOs}",
+                $"/p:OutputPath={GetContentClientOutputPath(targetOs)}",
+                "/p:FullRelease=true",
+                "/m",
+            },
+        };
+
+        if (logBuild)
+        {
+            var binlogPath = Path.GetFullPath(Path.Combine("release", $"client-content-{targetOs}.binlog"));
+            logger.Info($"Content client build log for {targetOs}: {binlogPath}");
+            startInfo.ArgumentList.Add($"/bl:{binlogPath}");
+            startInfo.ArgumentList.Add("/p:ReportAnalyzer=true");
+        }
+
+        await ProcessHelpers.RunCheck(startInfo);
+    }
+
+    private static async Task PublishRobustClient(string runtime, string targetOs, string configuration, IPackageLogger logger)
+    {
+        var publishPath = Path.GetFullPath(Path.Combine("RobustToolbox", "bin", "Client", runtime, "publish"));
+        logger.Info($"Robust.Client publish output for {runtime}: {publishPath}");
+
+        await ProcessHelpers.RunCheck(new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            ArgumentList =
+            {
+                "publish",
+                "--runtime", runtime,
+                "--no-self-contained",
+                "-c", configuration,
+                $"/p:TargetOS={targetOs}",
+                "/p:FullRelease=True",
+                "/p:UseAppHost=True",
+                "/m",
+                "RobustToolbox/Robust.Client/Robust.Client.csproj",
+            },
+        });
+    }
+
+    private static async Task PackageStandalonePlatform(PlatformReg platform, string contentBinDir, IPackageLogger logger)
+    {
+        var packagePath = Path.GetFullPath(Path.Combine("release", $"SS14.Client_{platform.Rid}.zip"));
+
+        logger.Info($"Packaging standalone {platform.Rid} client...");
+        logger.Info($"Standalone client package output for {platform.Rid}: {packagePath}");
+
+        var sw = RStopwatch.StartNew();
+        {
+            await using var zipFile = File.Open(packagePath, FileMode.Create, FileAccess.ReadWrite);
+            await using var zip = new ZipArchive(zipFile, ZipArchiveMode.Create);
+            var writer = new AssetPassZipWriter(zip);
+
+            await RobustSharedPackaging.DoResourceCopy(
+                Path.Combine("RobustToolbox", "bin", "Client", platform.Rid, "publish"),
+                writer,
+                BinSkipFolders,
+                cancel: default);
+
+            await WriteStandaloneResources(contentBinDir, writer, logger, default);
+            await writer.FinishedTask;
+        }
+
+        logger.Info($"Finished packaging standalone {platform.Rid} client in {sw.Elapsed}: {packagePath}");
+    }
+
+    private static async Task WriteResources(
+        string contentDir,
+        string contentBinDir,
         AssetPass pass,
         IPackageLogger logger,
         CancellationToken cancel)
@@ -82,7 +261,7 @@ public static class ClientPackaging
         await RobustSharedPackaging.WriteContentAssemblies(
             inputPass,
             contentDir,
-            "Content.Client",
+            contentBinDir,
             new[] { "Content.Client", "Content.Shared", "Content.Shared.Database" },
             cancel: cancel);
 
@@ -94,4 +273,87 @@ public static class ClientPackaging
 
         inputPass.InjectFinished();
     }
+
+    private static async Task WriteStandaloneResources(
+        string contentBinDir,
+        AssetPass pass,
+        IPackageLogger logger,
+        CancellationToken cancel)
+    {
+        await RobustSharedPackaging.DoResourceCopy(
+            Path.Combine("RobustToolbox", "Resources"),
+            pass,
+            RobustSharedPackaging.SharedIgnoredResources,
+            targetDir: "Resources",
+            cancel: cancel);
+
+        await RobustSharedPackaging.WriteContentAssemblies(
+            pass,
+            "",
+            contentBinDir,
+            new[] { "Content.Client", "Content.Shared", "Content.Shared.Database" },
+            targetDir: "Resources/Assemblies",
+            cancel: cancel);
+
+        await WriteStandaloneClientResources(pass, logger, cancel);
+    }
+
+    private static async Task WriteStandaloneClientResources(
+        AssetPass pass,
+        IPackageLogger logger,
+        CancellationToken cancel)
+    {
+        var graph = new RobustClientAssetGraph();
+
+        var prefixPass = new AssetPassPrefix("Resources/")
+        {
+            Name = "StandaloneClientResourcePrefix",
+        };
+        prefixPass.AddDependency(graph.Output);
+        pass.AddDependency(prefixPass);
+
+        var dropSvgPass = new AssetPassFilterDrop(f => f.Path.EndsWith(".svg"))
+        {
+            Name = "DropSvgPass",
+        };
+        dropSvgPass.AddDependency(graph.Input).AddBefore(graph.PresetPasses);
+
+        AssetGraph.CalculateGraph([pass, prefixPass, dropSvgPass, ..graph.AllPasses], logger);
+
+        var inputPass = graph.Input;
+        await RobustClientPackaging.WriteClientResources(
+            "",
+            inputPass,
+            SharedPackaging.AdditionalIgnoredResources,
+            cancel);
+
+        inputPass.InjectFinished();
+    }
+
+    private static string GetContentClientBinDir(string targetOs)
+    {
+        return Path.Combine("Packaging", "Content.Client", targetOs);
+    }
+
+    private static string GetContentClientOutputPath(string targetOs)
+    {
+        return EnsureTrailingDirectorySeparator(Path.GetFullPath(Path.Combine("bin", GetContentClientBinDir(targetOs))));
+    }
+
+    private static string EnsureTrailingDirectorySeparator(string path)
+    {
+        return Path.EndsInDirectorySeparator(path)
+            ? path
+            : path + Path.DirectorySeparatorChar;
+    }
+
+    private static string GetCurrentRid()
+    {
+        var rid = RuntimeInformation.RuntimeIdentifier;
+        return Platforms.Any(o => o.Rid == rid)
+            ? rid
+            : throw new InvalidOperationException($"Unsupported current runtime identifier: {rid}");
+    }
+
+    private readonly record struct PlatformReg(string Rid, string TargetOs);
 }

--- a/Content.Packaging/CommandLineArgs.cs
+++ b/Content.Packaging/CommandLineArgs.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 
 namespace Content.Packaging;
 
@@ -32,6 +33,11 @@ public sealed class CommandLineArgs
     public bool HybridAcz { get; set; }
 
     /// <summary>
+    /// Build a standalone runnable client package instead of a client content package.
+    /// </summary>
+    public bool Standalone { get; set; }
+
+    /// <summary>
     /// Configuration used for when packaging the server. (Release, Debug, Tools)
     /// </summary>
     public string Configuration { get; set; }
@@ -41,16 +47,37 @@ public sealed class CommandLineArgs
     /// </summary>
     public bool LogBuild { get; set; }
 
+    /// <summary>
+    /// Root directory of the content repository to package.
+    /// </summary>
+    public string ContentRoot { get; set; }
+
+    /// <summary>
+    /// Whether help was requested.
+    /// </summary>
+    public bool Help { get; set; }
+
     // CommandLineArgs, 3rd of her name.
-    public static bool TryParse(IReadOnlyList<string> args, [NotNullWhen(true)] out CommandLineArgs? parsed)
+    public static bool TryParse(IReadOnlyList<string> args, [NotNullWhen(true)] out CommandLineArgs? parsed, out bool help)
     {
         parsed = null;
+        help = false;
+
+        if (args.Contains("--help"))
+        {
+            PrintHelp();
+            help = true;
+            return false;
+        }
+
         bool? client = null;
         var skipBuild = false;
         var wipeRelease = true;
         var hybridAcz = false;
+        var standalone = false;
         var logBuild = false;
         var configuration = "Release";
+        var contentRoot = Directory.GetCurrentDirectory();
         List<string>? platforms = null;
 
         using var enumerator = args.GetEnumerator();
@@ -90,6 +117,10 @@ public sealed class CommandLineArgs
             {
                 hybridAcz = true;
             }
+            else if (arg == "--standalone")
+            {
+                standalone = true;
+            }
             else if (arg == "--log-build")
             {
                 logBuild = true;
@@ -103,7 +134,9 @@ public sealed class CommandLineArgs
                 }
 
                 platforms ??= new List<string>();
-                platforms.Add(enumerator.Current);
+                platforms.Add(enumerator.Current == "current"
+                    ? RuntimeInformation.RuntimeIdentifier
+                    : enumerator.Current);
             }
             else if (arg == "--configuration")
             {
@@ -115,14 +148,20 @@ public sealed class CommandLineArgs
 
                 configuration = enumerator.Current;
             }
-            else if (arg == "--help")
+            else if (arg == "--content-root")
             {
-                PrintHelp();
-                return false;
+                if (!enumerator.MoveNext())
+                {
+                    Console.WriteLine("No content root provided");
+                    return false;
+                }
+
+                contentRoot = enumerator.Current;
             }
             else
             {
                 Console.WriteLine("Unknown argument: {0}", arg);
+                return false;
             }
         }
 
@@ -132,7 +171,7 @@ public sealed class CommandLineArgs
             return false;
         }
 
-        parsed = new CommandLineArgs(client.Value, skipBuild, wipeRelease, hybridAcz, logBuild, platforms, configuration);
+        parsed = new CommandLineArgs(client.Value, skipBuild, wipeRelease, hybridAcz, standalone, logBuild, platforms, configuration, contentRoot, help);
         return true;
     }
 
@@ -145,8 +184,10 @@ Options:
   --skip-build          Should we skip building the project and use what's already there.
   --no-wipe-release     Don't wipe the release folder before creating files.
   --hybrid-acz          Use HybridACZ for server builds.
-  --platform            Platform for server builds. Default will output several x64 targets.
+  --standalone          Build a runnable standalone client package.
+  --platform            Platform for server or standalone client builds. Use 'current' for this machine.
   --configuration       Configuration to use for building the server (Release, Debug, Tools). Default is Release.
+  --content-root        Root directory of the content repository to package. Defaults to the current directory.
   --log-build           Log builds with MSBuild binlog. Logs get saved to release/
 ");
     }
@@ -156,16 +197,22 @@ Options:
         bool skipBuild,
         bool wipeRelease,
         bool hybridAcz,
+        bool standalone,
         bool logBuild,
         List<string>? platforms,
-        string configuration)
+        string configuration,
+        string contentRoot,
+        bool help)
     {
         Client = client;
         SkipBuild = skipBuild;
         WipeRelease = wipeRelease;
         HybridAcz = hybridAcz;
+        Standalone = standalone;
         Platforms = platforms;
         Configuration = configuration;
         LogBuild = logBuild;
+        ContentRoot = contentRoot;
+        Help = help;
     }
 }

--- a/Content.Packaging/Program.cs
+++ b/Content.Packaging/Program.cs
@@ -3,11 +3,24 @@ using Robust.Packaging;
 
 IPackageLogger logger = new PackageLoggerConsole();
 
-if (!CommandLineArgs.TryParse(args, out var parsed))
+if (!CommandLineArgs.TryParse(args, out var parsed, out var help))
 {
-    logger.Error("Unable to parse args, aborting.");
-    return;
+    if (!help)
+        logger.Error("Unable to parse args, aborting.");
+
+    return help ? 0 : 1;
 }
+
+var contentRoot = Path.GetFullPath(parsed.ContentRoot);
+if (!IsContentRoot(contentRoot))
+{
+    logger.Error(
+        $"Invalid content root '{contentRoot}'. Expected to find Content.Server/Content.Server.csproj and RobustToolbox/.");
+    return 1;
+}
+
+Directory.SetCurrentDirectory(contentRoot);
+logger.Info($"Packaging content root: {contentRoot}");
 
 if (parsed.WipeRelease)
     WipeRelease();
@@ -17,16 +30,29 @@ else
     Directory.CreateDirectory("release");
 }
 
+logger.Info($"Package output directory: {Path.GetFullPath("release")}");
+
 if (!parsed.SkipBuild)
     WipeBin();
 
 if (parsed.Client)
 {
-    await ClientPackaging.PackageClient(parsed.SkipBuild, parsed.LogBuild, parsed.Configuration, logger);
+    if (parsed.Standalone)
+        await ClientPackaging.PackageStandaloneClient(parsed.SkipBuild, parsed.LogBuild, parsed.Configuration, logger, parsed.Platforms);
+    else
+        await ClientPackaging.PackageClient(parsed.SkipBuild, parsed.LogBuild, parsed.Configuration, logger);
 }
 else
 {
     await ServerPackaging.PackageServer(parsed.SkipBuild, parsed.HybridAcz, parsed.LogBuild, logger, parsed.Configuration, parsed.Platforms);
+}
+
+return 0;
+
+static bool IsContentRoot(string path)
+{
+    return File.Exists(Path.Combine(path, "Content.Server", "Content.Server.csproj"))
+        && Directory.Exists(Path.Combine(path, "RobustToolbox"));
 }
 
 void WipeBin()

--- a/Content.Packaging/ServerPackaging.cs
+++ b/Content.Packaging/ServerPackaging.cs
@@ -67,82 +67,120 @@ public static class ServerPackaging
             platforms ??= PlatformRidsDefault;
         }
 
+        var selectedPlatforms = Platforms
+            .Where(o => platforms.Contains(o.Rid))
+            .ToList();
+
         if (hybridAcz)
         {
             // Hybrid ACZ involves a file "Content.Client.zip" in the server executable directory.
             // Rather than hosting the client ZIP on the watchdog or on a separate server,
             //  Hybrid ACZ uses the ACZ hosting functionality to host it as part of the status host,
             //  which means that features such as automatic UPnP forwarding still work properly.
+            logger.Info("Hybrid ACZ enabled; server packages will include release/SS14.Client.zip for client delivery.");
             await ClientPackaging.PackageClient(skipBuild, logBuild, configuration, logger);
         }
 
-        // Good variable naming right here.
-        foreach (var platform in Platforms)
+        Dictionary<string, string> contentBinDirs;
+        if (skipBuild)
         {
-            if (!platforms.Contains(platform.Rid))
-                continue;
-
-            await BuildPlatform(platform, skipBuild, hybridAcz, logBuild, configuration, logger);
+            contentBinDirs = selectedPlatforms
+                .Select(o => o.TargetOs)
+                .Distinct()
+                .ToDictionary(o => o, _ => "Content.Server");
         }
+        else
+        {
+            var targetOperatingSystems = selectedPlatforms
+                .Select(o => o.TargetOs)
+                .Distinct()
+                .ToList();
+
+            foreach (var targetOs in targetOperatingSystems)
+            {
+                await BuildContentServer(targetOs, logBuild, configuration, logger);
+            }
+
+            foreach (var platform in selectedPlatforms)
+            {
+                await PublishClientServer(platform.Rid, platform.TargetOs, configuration, logger);
+            }
+
+            contentBinDirs = targetOperatingSystems
+                .ToDictionary(o => o, GetContentServerBinDir);
+        }
+
+        await Task.WhenAll(selectedPlatforms.Select(platform =>
+            PackagePlatform(platform, contentBinDirs[platform.TargetOs], hybridAcz, logger)));
     }
 
-    private static async Task BuildPlatform(PlatformReg platform,
-        bool skipBuild,
-        bool hybridAcz,
+    private static async Task BuildContentServer(
+        string targetOs,
         bool logBuild,
         string configuration,
         IPackageLogger logger)
     {
-        logger.Info($"Building project for {platform.TargetOs}...");
+        logger.Info($"Building content server for {targetOs}...");
+        logger.Info($"Content server build output for {targetOs}: {GetContentServerOutputPath(targetOs)}");
 
-        if (!skipBuild)
+        var startInfo = new ProcessStartInfo
         {
-            var startInfo = new ProcessStartInfo
+            FileName = "dotnet",
+            ArgumentList =
             {
-                FileName = "dotnet",
-                ArgumentList =
-                {
-                    "build",
-                    Path.Combine("Content.Server", "Content.Server.csproj"),
-                    "-c", configuration,
-                    "--nologo",
-                    "/v:m",
-                    $"/p:TargetOs={platform.TargetOs}",
-                    "/t:Rebuild",
-                    "/p:FullRelease=true",
-                    "/m"
-                }
-            };
-
-            if (logBuild)
-            {
-                startInfo.ArgumentList.Add($"/bl:{Path.Combine("release", $"server-{platform.Rid}.binlog")}");
-                startInfo.ArgumentList.Add("/p:ReportAnalyzer=true");
+                "build",
+                Path.Combine("Content.Server", "Content.Server.csproj"),
+                "-c", configuration,
+                "--nologo",
+                "/v:m",
+                $"/p:TargetOs={targetOs}",
+                $"/p:OutputPath={GetContentServerOutputPath(targetOs)}",
+                "/p:FullRelease=true",
+                "/m"
             }
+        };
 
-            await ProcessHelpers.RunCheck(startInfo);
-
-            await PublishClientServer(platform.Rid, platform.TargetOs, configuration);
+        if (logBuild)
+        {
+            var binlogPath = Path.GetFullPath(Path.Combine("release", $"server-content-{targetOs}.binlog"));
+            logger.Info($"Content server build log for {targetOs}: {binlogPath}");
+            startInfo.ArgumentList.Add($"/bl:{binlogPath}");
+            startInfo.ArgumentList.Add("/p:ReportAnalyzer=true");
         }
 
+        await ProcessHelpers.RunCheck(startInfo);
+    }
+
+    private static async Task PackagePlatform(
+        PlatformReg platform,
+        string contentBinDir,
+        bool hybridAcz,
+        IPackageLogger logger)
+    {
+        var packagePath = Path.GetFullPath(Path.Combine("release", $"SS14.Server_{platform.Rid}.zip"));
+
         logger.Info($"Packaging {platform.Rid} server...");
+        logger.Info($"Server package output for {platform.Rid}: {packagePath}");
 
         var sw = RStopwatch.StartNew();
         {
             await using var zipFile =
-                File.Open(Path.Combine("release", $"SS14.Server_{platform.Rid}.zip"), FileMode.Create, FileAccess.ReadWrite);
-            using var zip = new ZipArchive(zipFile, ZipArchiveMode.Update);
+                File.Open(packagePath, FileMode.Create, FileAccess.ReadWrite);
+            await using var zip = new ZipArchive(zipFile, ZipArchiveMode.Create);
             var writer = new AssetPassZipWriter(zip);
 
-            await WriteServerResources(platform, "", writer, logger, hybridAcz, default);
+            await WriteServerResources(platform, "", contentBinDir, writer, logger, hybridAcz, default);
             await writer.FinishedTask;
         }
 
-        logger.Info($"Finished packaging server in {sw.Elapsed}");
+        logger.Info($"Finished packaging {platform.Rid} server in {sw.Elapsed}: {packagePath}");
     }
 
-    private static async Task PublishClientServer(string runtime, string targetOs, string configuration)
+    private static async Task PublishClientServer(string runtime, string targetOs, string configuration, IPackageLogger logger)
     {
+        var publishPath = Path.GetFullPath(Path.Combine("RobustToolbox", "bin", "Server", runtime, "publish"));
+        logger.Info($"Robust.Server publish output for {runtime}: {publishPath}");
+
         await ProcessHelpers.RunCheck(new ProcessStartInfo
         {
             FileName = "dotnet",
@@ -163,6 +201,7 @@ public static class ServerPackaging
     private static async Task WriteServerResources(
         PlatformReg platform,
         string contentDir,
+        string contentBinDir,
         AssetPass pass,
         IPackageLogger logger,
         bool hybridAcz,
@@ -180,7 +219,7 @@ public static class ServerPackaging
         var inputPassResources = graph.InputResources;
 
         // Additional assemblies that need to be copied such as EFCore.
-        var sourcePath = Path.Combine(contentDir, "bin", "Content.Server");
+        var sourcePath = Path.Combine(contentDir, "bin", contentBinDir);
 
         var deps = DepsHandler.Load(Path.Combine(sourcePath, "Content.Server.deps.json"));
 
@@ -197,7 +236,7 @@ public static class ServerPackaging
         await RobustSharedPackaging.WriteContentAssemblies(
             inputPassResources,
             contentDir,
-            "Content.Server",
+            contentBinDir,
             contentAssemblies,
             cancel: cancel);
 
@@ -230,6 +269,23 @@ public static class ServerPackaging
         return names;
 
         IEnumerable<string> GetLibraryNames(string library) => deps.Libraries[library].GetDllNames();
+    }
+
+    private static string GetContentServerBinDir(string targetOs)
+    {
+        return Path.Combine("Packaging", "Content.Server", targetOs);
+    }
+
+    private static string GetContentServerOutputPath(string targetOs)
+    {
+        return EnsureTrailingDirectorySeparator(Path.GetFullPath(Path.Combine("bin", GetContentServerBinDir(targetOs))));
+    }
+
+    private static string EnsureTrailingDirectorySeparator(string path)
+    {
+        return Path.EndsInDirectorySeparator(path)
+            ? path
+            : path + Path.DirectorySeparatorChar;
     }
 
     private readonly record struct PlatformReg(string Rid, string TargetOs, bool BuildByDefault);

--- a/Content.Packaging/package-client-manifest.bat
+++ b/Content.Packaging/package-client-manifest.bat
@@ -1,0 +1,7 @@
+@echo off
+rem Builds the client content package used by the launcher, CDN manifests, and Hybrid ACZ server delivery.
+setlocal
+dotnet run --project "%~dp0Content.Packaging.csproj" client --content-root "%~dp0.." %*
+set EXIT_CODE=%ERRORLEVEL%
+pause
+exit /b %EXIT_CODE%

--- a/Content.Packaging/package-client-manifest.sh
+++ b/Content.Packaging/package-client-manifest.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Builds the client content package used by the launcher, CDN manifests, and Hybrid ACZ server delivery.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dotnet run --project "$SCRIPT_DIR/Content.Packaging.csproj" client --content-root "$SCRIPT_DIR/.." "$@"
+exit_code=$?
+read -r -p "Press enter to continue"
+exit "$exit_code"

--- a/Content.Packaging/package-server.bat
+++ b/Content.Packaging/package-server.bat
@@ -1,0 +1,7 @@
+@echo off
+rem Builds standalone server packages without bundling a client for delivery.
+setlocal
+dotnet run --project "%~dp0Content.Packaging.csproj" server --platform current --content-root "%~dp0.." %*
+set EXIT_CODE=%ERRORLEVEL%
+pause
+exit /b %EXIT_CODE%

--- a/Content.Packaging/package-server.sh
+++ b/Content.Packaging/package-server.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Builds standalone server packages without bundling a client for delivery.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dotnet run --project "$SCRIPT_DIR/Content.Packaging.csproj" server --platform current --content-root "$SCRIPT_DIR/.." "$@"
+exit_code=$?
+read -r -p "Press enter to continue"
+exit "$exit_code"

--- a/Content.Packaging/package-standalone-client.bat
+++ b/Content.Packaging/package-standalone-client.bat
@@ -1,0 +1,7 @@
+@echo off
+rem Builds a standalone client package for people who want a runnable client zip.
+setlocal
+dotnet run --project "%~dp0Content.Packaging.csproj" client --standalone --content-root "%~dp0.." %*
+set EXIT_CODE=%ERRORLEVEL%
+pause
+exit /b %EXIT_CODE%

--- a/Content.Packaging/package-standalone-client.sh
+++ b/Content.Packaging/package-standalone-client.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Builds a standalone client package for people who want a runnable client zip.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dotnet run --project "$SCRIPT_DIR/Content.Packaging.csproj" client --standalone --content-root "$SCRIPT_DIR/.." "$@"
+exit_code=$?
+read -r -p "Press enter to continue"
+exit "$exit_code"


### PR DESCRIPTION
Should be backwards compat.
1. Can now package fully standalone builds with engine include. We needed this for the trailer and it was painful to do it manually every time sparky needed changes. Average usecase doesn't need it but no harm in making this easy for custom builds.
2. Add 1-click basic packaging scripts to make starting a server easier.
3. Use ZipArchiveMode.Create for client output like we do for server.
4. Log packaged directories because I forgot it goes to release/ and TimmyTider isn't going to know.
5. Avoid full rebuilds and just copy each build into its own directory. More space taken but makes repeated rebuilds much faster.

Requires https://github.com/space-wizards/RobustToolbox/pull/6728