### PR TITLE
HandCompState changes

### DIFF
--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Client.DisplacementMap;
 using Content.Client.Examine;
-using Content.Client.Strip;
 using Content.Client.Verbs.UI;
 using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
@@ -27,7 +26,6 @@ namespace Content.Client.Hands.Systems
         [Dependency] private IPlayerManager _playerManager = default!;
         [Dependency] private IUserInterfaceManager _ui = default!;
 
-        [Dependency] private StrippableSystem _stripSys = default!;
         [Dependency] private SpriteSystem _sprite = default!;
         [Dependency] private ExamineSystem _examine = default!;
         [Dependency] private DisplacementMapSystem _displacement = default!;
@@ -48,6 +46,7 @@ namespace Content.Client.Hands.Systems
             SubscribeLocalEvent<HandsComponent, LocalPlayerDetachedEvent>(HandlePlayerDetached);
             SubscribeLocalEvent<HandsComponent, ComponentStartup>(OnHandsStartup);
             SubscribeLocalEvent<HandsComponent, ComponentShutdown>(OnHandsShutdown);
+            SubscribeLocalEvent<HandsComponent, ComponentGetState>(GetComponentState);
             SubscribeLocalEvent<HandsComponent, ComponentHandleState>(HandleComponentState);
             SubscribeLocalEvent<HandsComponent, VisualsChangedEvent>(OnVisualsChanged);
 
@@ -55,28 +54,117 @@ namespace Content.Client.Hands.Systems
         }
 
         #region StateHandling
+        private void GetComponentState(EntityUid uid, HandsComponent hands, ref ComponentGetState args)
+        {
+            args.State = new HandsComponentState
+            {
+                Hands = new(hands.Hands),
+                SortedHands = new(hands.SortedHands),
+                ActiveHandId = hands.ActiveHandId,
+            };
+        }
+
         private void HandleComponentState(Entity<HandsComponent> ent, ref ComponentHandleState args)
         {
-            if (args.Current is not HandsComponentState state)
-                return;
+            switch (args.Current)
+            {
+                case HandsComponentState state:
+                    ApplyFullState(ent, state);
+                    break;
+                case HandsComponentDeltaState delta:
+                    ApplyDeltaState(ent, delta);
+                    break;
+            }
+        }
 
-            var newHands = state.Hands.Keys.Except(ent.Comp.Hands.Keys); // hands that were added between states
-            var oldHands = ent.Comp.Hands.Keys.Except(state.Hands.Keys); // hands that were removed between states
+        private bool ApplyFullState(Entity<HandsComponent> ent, HandsComponentState state)
+        {
+            var changed = false;
+            var newHands = state.Hands.Keys.Except(ent.Comp.Hands.Keys).ToList();
+            var oldHands = ent.Comp.Hands.Keys.Except(state.Hands.Keys).ToList();
 
             foreach (var handId in oldHands)
             {
                 RemoveHand(ent.AsNullable(), handId);
+                changed = true;
             }
 
             foreach (var handId in state.SortedHands.Intersect(newHands))
             {
                 AddHand(ent.AsNullable(), handId, state.Hands[handId]);
+                changed = true;
             }
-            ent.Comp.SortedHands = new (state.SortedHands);
 
-            SetActiveHand(ent.AsNullable(), state.ActiveHandId);
+            foreach (var (handId, hand) in state.Hands)
+            {
+                if (!ent.Comp.Hands.TryGetValue(handId, out var oldHand) || oldHand.Equals(hand))
+                    continue;
 
-            _stripSys.UpdateUi(ent);
+                ent.Comp.Hands[handId] = hand;
+                changed = true;
+            }
+
+            if (!ent.Comp.SortedHands.SequenceEqual(state.SortedHands))
+            {
+                ent.Comp.SortedHands = new(state.SortedHands);
+                changed = true;
+            }
+
+            if (SetActiveHand(ent.AsNullable(), state.ActiveHandId))
+                changed = true;
+
+            return changed;
+        }
+
+        private bool ApplyDeltaState(Entity<HandsComponent> ent, HandsComponentDeltaState state)
+        {
+            var changed = false;
+
+            if ((state.DirtyFields & HandsComponent.HandsField) != 0 && state.Hands != null)
+            {
+                var oldHands = ent.Comp.Hands.Keys.Except(state.Hands.Keys).ToList();
+                foreach (var handId in oldHands)
+                {
+                    RemoveHand(ent.AsNullable(), handId);
+                    changed = true;
+                }
+
+                IEnumerable<string> sortedHands = state.SortedHands != null ? state.SortedHands : state.Hands.Keys;
+                var newHands = state.Hands.Keys.Except(ent.Comp.Hands.Keys).ToHashSet();
+                foreach (var handId in sortedHands)
+                {
+                    if (!newHands.Contains(handId))
+                        continue;
+
+                    AddHand(ent.AsNullable(), handId, state.Hands[handId]);
+                    changed = true;
+                }
+
+                foreach (var (handId, hand) in state.Hands)
+                {
+                    if (!ent.Comp.Hands.TryGetValue(handId, out var oldHand) || oldHand.Equals(hand))
+                        continue;
+
+                    ent.Comp.Hands[handId] = hand;
+                    changed = true;
+                }
+            }
+
+            if ((state.DirtyFields & HandsComponent.SortedHandsField) != 0
+                && state.SortedHands != null
+                && !ent.Comp.SortedHands.SequenceEqual(state.SortedHands))
+            {
+                ent.Comp.SortedHands = new(state.SortedHands);
+                changed = true;
+            }
+
+            if ((state.DirtyFields & HandsComponent.ActiveHandIdField) != 0
+                && SetActiveHand(ent.AsNullable(), state.ActiveHandId))
+            {
+                changed = true;
+            }
+
+            return changed;
         }
         #endregion
 
@@ -213,7 +301,6 @@ namespace Content.Client.Hands.Systems
                 return;
 
             UpdateHandVisuals(uid, args.Entity, args.Container.ID);
-            _stripSys.UpdateUi(uid);
 
             if (uid != _playerManager.LocalEntity)
                 return;
@@ -232,7 +319,6 @@ namespace Content.Client.Hands.Systems
                 return;
 
             UpdateHandVisuals(uid, args.Entity, args.Container.ID);
-            _stripSys.UpdateUi(uid);
 
             if (uid != _playerManager.LocalEntity)
                 return;

--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -77,22 +77,19 @@ namespace Content.Client.Hands.Systems
             }
         }
 
-        private bool ApplyFullState(Entity<HandsComponent> ent, HandsComponentState state)
+        private void ApplyFullState(Entity<HandsComponent> ent, HandsComponentState state)
         {
-            var changed = false;
             var newHands = state.Hands.Keys.Except(ent.Comp.Hands.Keys).ToList();
             var oldHands = ent.Comp.Hands.Keys.Except(state.Hands.Keys).ToList();
 
             foreach (var handId in oldHands)
             {
                 RemoveHand(ent.AsNullable(), handId);
-                changed = true;
             }
 
             foreach (var handId in state.SortedHands.Intersect(newHands))
             {
                 AddHand(ent.AsNullable(), handId, state.Hands[handId]);
-                changed = true;
             }
 
             foreach (var (handId, hand) in state.Hands)
@@ -101,32 +98,24 @@ namespace Content.Client.Hands.Systems
                     continue;
 
                 ent.Comp.Hands[handId] = hand;
-                changed = true;
             }
 
             if (!ent.Comp.SortedHands.SequenceEqual(state.SortedHands))
             {
                 ent.Comp.SortedHands = new(state.SortedHands);
-                changed = true;
             }
 
-            if (SetActiveHand(ent.AsNullable(), state.ActiveHandId))
-                changed = true;
-
-            return changed;
+            SetActiveHand(ent.AsNullable(), state.ActiveHandId);
         }
 
-        private bool ApplyDeltaState(Entity<HandsComponent> ent, HandsComponentDeltaState state)
+        private void ApplyDeltaState(Entity<HandsComponent> ent, HandsComponentDeltaState state)
         {
-            var changed = false;
-
             if ((state.DirtyFields & HandsComponent.HandsField) != 0 && state.Hands != null)
             {
                 var oldHands = ent.Comp.Hands.Keys.Except(state.Hands.Keys).ToList();
                 foreach (var handId in oldHands)
                 {
                     RemoveHand(ent.AsNullable(), handId);
-                    changed = true;
                 }
 
                 IEnumerable<string> sortedHands = state.SortedHands != null ? state.SortedHands : state.Hands.Keys;
@@ -137,7 +126,6 @@ namespace Content.Client.Hands.Systems
                         continue;
 
                     AddHand(ent.AsNullable(), handId, state.Hands[handId]);
-                    changed = true;
                 }
 
                 foreach (var (handId, hand) in state.Hands)
@@ -146,7 +134,6 @@ namespace Content.Client.Hands.Systems
                         continue;
 
                     ent.Comp.Hands[handId] = hand;
-                    changed = true;
                 }
             }
 
@@ -155,16 +142,12 @@ namespace Content.Client.Hands.Systems
                 && !ent.Comp.SortedHands.SequenceEqual(state.SortedHands))
             {
                 ent.Comp.SortedHands = new(state.SortedHands);
-                changed = true;
             }
 
-            if ((state.DirtyFields & HandsComponent.ActiveHandIdField) != 0
-                && SetActiveHand(ent.AsNullable(), state.ActiveHandId))
+            if ((state.DirtyFields & HandsComponent.ActiveHandIdField) != 0)
             {
-                changed = true;
+                SetActiveHand(ent.AsNullable(), state.ActiveHandId);
             }
-
-            return changed;
         }
         #endregion
 

--- a/Content.Client/Strip/StrippableSystem.cs
+++ b/Content.Client/Strip/StrippableSystem.cs
@@ -22,6 +22,7 @@ public sealed class StrippableSystem : SharedStrippableSystem
         SubscribeLocalEvent<StrippableComponent, DidUnequipEvent>(UpdateUi);
         SubscribeLocalEvent<StrippableComponent, DidEquipHandEvent>(UpdateUi);
         SubscribeLocalEvent<StrippableComponent, DidUnequipHandEvent>(UpdateUi);
+        SubscribeLocalEvent<StrippableComponent, HandCountChangedEvent>(UpdateUi);
         SubscribeLocalEvent<StrippableComponent, EnsnaredChangedEvent>(UpdateUi);
     }
 

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -67,7 +67,27 @@ namespace Content.Server.Hands.Systems
 
         private void GetComponentState(EntityUid uid, HandsComponent hands, ref ComponentGetState args)
         {
-            args.State = new HandsComponentState(hands);
+            if (args.FromTick > hands.CreationTick && hands.LastFieldUpdate >= args.FromTick)
+            {
+                var dirtyFields = EntityManager.GetModifiedFields(hands, args.FromTick);
+
+                args.State = new HandsComponentDeltaState
+                {
+                    DirtyFields = dirtyFields,
+                    Hands = (dirtyFields & HandsComponent.HandsField) != 0 ? hands.Hands : null,
+                    SortedHands = (dirtyFields & HandsComponent.SortedHandsField) != 0 ? hands.SortedHands : null,
+                    ActiveHandId = hands.ActiveHandId,
+                };
+
+                return;
+            }
+
+            args.State = new HandsComponentState
+            {
+                Hands = hands.Hands,
+                SortedHands = hands.SortedHands,
+                ActiveHandId = hands.ActiveHandId,
+            };
         }
 
 

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -70,16 +70,24 @@ namespace Content.Server.Hands.Systems
             if (args.FromTick > hands.CreationTick && hands.LastFieldUpdate >= args.FromTick)
             {
                 var dirtyFields = EntityManager.GetModifiedFields(hands, args.FromTick);
+                const uint allFields = HandsComponent.HandsField
+                    | HandsComponent.SortedHandsField
+                    | HandsComponent.ActiveHandIdField;
 
-                args.State = new HandsComponentDeltaState
+                // If every field is dirty, this is effectively an initial state. Send a full state so the client
+                // does not receive a component delta before it has a full component state cached.
+                if ((dirtyFields & allFields) != allFields)
                 {
-                    DirtyFields = dirtyFields,
-                    Hands = (dirtyFields & HandsComponent.HandsField) != 0 ? hands.Hands : null,
-                    SortedHands = (dirtyFields & HandsComponent.SortedHandsField) != 0 ? hands.SortedHands : null,
-                    ActiveHandId = hands.ActiveHandId,
-                };
+                    args.State = new HandsComponentDeltaState
+                    {
+                        DirtyFields = dirtyFields,
+                        Hands = (dirtyFields & HandsComponent.HandsField) != 0 ? hands.Hands : null,
+                        SortedHands = (dirtyFields & HandsComponent.SortedHandsField) != 0 ? hands.SortedHands : null,
+                        ActiveHandId = hands.ActiveHandId,
+                    };
 
-                return;
+                    return;
+                }
             }
 
             args.State = new HandsComponentState

--- a/Content.Shared/Hands/Components/HandsComponent.cs
+++ b/Content.Shared/Hands/Components/HandsComponent.cs
@@ -4,13 +4,24 @@ using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Hands.Components;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
 [Access(typeof(SharedHandsSystem))]
-public sealed partial class HandsComponent : Component
+public sealed partial class HandsComponent : Component, IComponentDelta
 {
+    public const uint HandsField = 1 << 0;
+    public const uint SortedHandsField = 1 << 1;
+    public const uint ActiveHandIdField = 1 << 2;
+
+    /// <inheritdoc />
+    public GameTick LastFieldUpdate { get; set; }
+
+    /// <inheritdoc />
+    public GameTick[] LastModifiedFields { get; set; } = default!;
+
     /// <summary>
     ///     The currently active hand.
     /// </summary>
@@ -153,16 +164,42 @@ public partial record struct Hand
 [Serializable, NetSerializable]
 public sealed class HandsComponentState : ComponentState
 {
-    public readonly Dictionary<string, Hand> Hands;
-    public readonly List<string> SortedHands;
-    public readonly string? ActiveHandId;
+    public Dictionary<string, Hand> Hands = default!;
+    public List<string> SortedHands = default!;
+    public string? ActiveHandId;
+}
 
-    public HandsComponentState(HandsComponent handComp)
+[Serializable, NetSerializable]
+public sealed class HandsComponentDeltaState : ComponentState, IComponentDeltaState<HandsComponentState>
+{
+    public uint DirtyFields;
+    public Dictionary<string, Hand>? Hands;
+    public List<string>? SortedHands;
+    public string? ActiveHandId;
+
+    public void ApplyToFullState(HandsComponentState state)
     {
-        // cloning lists because of test networking.
-        Hands = new(handComp.Hands);
-        SortedHands = new(handComp.SortedHands);
-        ActiveHandId = handComp.ActiveHandId;
+        if ((DirtyFields & HandsComponent.HandsField) != 0 && Hands != null)
+            state.Hands = Hands;
+
+        if ((DirtyFields & HandsComponent.SortedHandsField) != 0 && SortedHands != null)
+            state.SortedHands = SortedHands;
+
+        if ((DirtyFields & HandsComponent.ActiveHandIdField) != 0)
+            state.ActiveHandId = ActiveHandId;
+    }
+
+    public HandsComponentState CreateNewFullState(HandsComponentState state)
+    {
+        var fullState = new HandsComponentState
+        {
+            Hands = new(state.Hands),
+            SortedHands = new(state.SortedHands),
+            ActiveHandId = state.ActiveHandId,
+        };
+
+        ApplyToFullState(fullState);
+        return fullState;
     }
 }
 

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -41,6 +41,11 @@ public abstract partial class SharedHandsSystem
         InitializeRelay();
         InitializeEventListeners();
 
+        EntityManager.ComponentFactory.RegisterNetworkedFields<HandsComponent>(
+            nameof(HandsComponent.Hands),
+            nameof(HandsComponent.SortedHands),
+            nameof(HandsComponent.ActiveHandId));
+
         SubscribeLocalEvent<HandsComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<HandsComponent, MapInitEvent>(OnMapInit);
     }
@@ -92,7 +97,7 @@ public abstract partial class SharedHandsSystem
         ent.Comp.SortedHands.Add(handName);
         // we use LINQ + ToList instead of the list sort because it's a stable sort vs the list sort
         ent.Comp.SortedHands = ent.Comp.SortedHands.OrderBy(handId => ent.Comp.Hands[handId].Location).ToList();
-        Dirty(ent);
+        DirtyFields(ent, null, nameof(HandsComponent.Hands), nameof(HandsComponent.SortedHands));
 
         OnPlayerAddHand?.Invoke((ent, ent.Comp), handName, hand.Location);
 
@@ -121,6 +126,8 @@ public abstract partial class SharedHandsSystem
             return;
 
         ent.Comp.SortedHands.Remove(handName);
+        DirtyFields(ent, null, nameof(HandsComponent.Hands), nameof(HandsComponent.SortedHands));
+
         if (ent.Comp.ActiveHandId == handName)
             TrySetActiveHand(ent, ent.Comp.SortedHands.FirstOrDefault());
 
@@ -328,6 +335,8 @@ public abstract partial class SharedHandsSystem
         if (handId == null)
         {
             ent.Comp.ActiveHandId = null;
+            OnHandSetActive?.Invoke((ent, ent.Comp));
+            DirtyField(ent, nameof(HandsComponent.ActiveHandId));
             return true;
         }
 
@@ -337,7 +346,7 @@ public abstract partial class SharedHandsSystem
         if (TryGetHeldItem(ent, handId, out var newHeld))
             RaiseLocalEvent(newHeld.Value, new HandSelectedEvent(ent));
 
-        Dirty(ent);
+        DirtyField(ent, nameof(HandsComponent.ActiveHandId));
         return true;
     }
 


### PR DESCRIPTION
- Removed strippable being hardcoded.
- Use delta states. This should cut down allocations a lot as swapping active hand will send a much smaller state.
- Optimise the serverside to avoid the unnecessary collections. On RMC this was no.1 compstate allocation.

<img width="1228" height="439" alt="image" src="https://github.com/user-attachments/assets/0d1aa7b8-5282-4499-be16-0fcc8cd4f803" />

## Breaking changes
- Hands now use delta states to optimise networking.
- Hand networking no longer calls strippable directly and uses handscountchangedevent.

