### PR TITLE
Chat highlights tweak: put 'command' and 'bridge' in quotes

### DIFF
--- a/Resources/Locale/en-US/chat/highlights.ftl
+++ b/Resources/Locale/en-US/chat/highlights.ftl
@@ -1,11 +1,11 @@
 # Command
-highlights-captain = Captain, "Cap", Bridge, Command
-highlights-head-of-personnel = Head Of Personnel, "HoP", Service, Bridge, Command
-highlights-chief-engineer = Chief Engineer, "CE", Engineering, Engineer, "Engi", Bridge, Command
-highlights-chief-medical-officer = Chief Medical Officer, "CMO", Medbay, Medical, "Med", Bridge, Command
-highlights-head-of-security = Head of Security, "HoS", Armory, Security, "Sec", Bridge, Command
-highlights-quartermaster = Quartermaster, "QM", Cargo, Supply, Bridge, Command
-highlights-research-director = Research Director, "RD", Science, "Sci", "RND", "R&D", Bridge, Command
+highlights-captain = Captain, "Cap", "Bridge", "Command"
+highlights-head-of-personnel = Head Of Personnel, "HoP", Service, "Bridge", "Command"
+highlights-chief-engineer = Chief Engineer, "CE", Engineering, Engineer, "Engi", "Bridge", "Command"
+highlights-chief-medical-officer = Chief Medical Officer, "CMO", Medbay, Medical, "Med", "Bridge", "Command"
+highlights-head-of-security = Head of Security, "HoS", Armory, Security, "Sec", "Bridge", "Command"
+highlights-quartermaster = Quartermaster, "QM", Cargo, Supply, "Bridge", "Command"
+highlights-research-director = Research Director, "RD", Science, "Sci", "RND", "R&D", "Bridge", "Command"
 
 # Security
 highlights-detective = Detective, "Det", Armory, Security, "Sec"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About
Chat highlights tweak: put command highlight words 'command' and 'bridge' in quotes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1. Without quotes, 'Command' gets highlighted in things like "Commander Zeta", and 'Bridge' in 'Bridgerton' or 'abridged'.
2.  We never care about longer words containing 'Bridge' or 'Command' in this context, so the quotes should be added.

