### PR TITLE
Make glue/lube apply their effects immediately on held items

### DIFF
--- a/Content.Shared/Damage/Systems/SharedGodmodeSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedGodmodeSystem.cs
@@ -1,6 +1,8 @@
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Events;
 using Content.Shared.Destructible;
+using Content.Shared.Glue;
+using Content.Shared.Lube;
 using Content.Shared.Nutrition;
 using Content.Shared.Prototypes;
 using Content.Shared.Rejuvenate;
@@ -59,6 +61,18 @@ public abstract partial class SharedGodmodeSystem : EntitySystem
     }
 
     private void BeforeEdible(Entity<GodmodeComponent> ent, ref IngestibleEvent args)
+    {
+        args.Cancelled = true;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnGluedEffectAttemptEvent(Entity<GodmodeComponent> entity, ref GluedEffectAttemptEvent args)
+    {
+        args.Cancelled = true;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnGluedEffectAttemptEvent(Entity<GodmodeComponent> entity, ref LubedEffectAttemptEvent args)
     {
         args.Cancelled = true;
     }

--- a/Content.Shared/Glue/GlueSystem.cs
+++ b/Content.Shared/Glue/GlueSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Database;
 using Content.Shared.Hands;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Item;
@@ -10,6 +11,7 @@ using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.Glue;
@@ -23,6 +25,8 @@ public sealed partial class GlueSystem : EntitySystem
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedSolutionContainerSystem _solutionContainer = default!;
+    [Dependency] private SharedHandsSystem _hands = default!;
+    [Dependency] private SharedContainerSystem _container = default!;
 
     public override void Initialize()
     {
@@ -88,6 +92,9 @@ public sealed partial class GlueSystem : EntitySystem
                 _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(actor):actor} glued {ToPrettyString(target):subject} with {ToPrettyString(entity.Owner):tool}");
                 var gluedComp = EnsureComp<GluedComponent>(target);
                 gluedComp.Duration = quantity.Double() * entity.Comp.DurationPerUnit;
+                if (_container.TryGetContainingContainer((target, null, null), out var container) && _hands.IsHolding(container.Owner, target))
+                    PerformGluedEffect((target, gluedComp));
+
                 Dirty(target, gluedComp);
                 return true;
             }
@@ -121,6 +128,16 @@ public sealed partial class GlueSystem : EntitySystem
 
     private void OnHandPickUp(Entity<GluedComponent> entity, ref GotEquippedHandEvent args)
     {
+        PerformGluedEffect(entity);
+    }
+
+    private void OnRefreshNameModifiers(Entity<GluedComponent> entity, ref RefreshNameModifiersEvent args)
+    {
+        args.AddModifier("glued-name-prefix");
+    }
+
+    private void PerformGluedEffect(Entity<GluedComponent> entity)
+    {
         // When predicting dropping a glued item prediction will reinsert the item into the hand when rerolling the state to a previous one.
         // So dropping the item would add UnRemoveableComponent on the client without this guard statement.
         if (_timing.ApplyingState)
@@ -131,10 +148,5 @@ public sealed partial class GlueSystem : EntitySystem
         entity.Comp.Until = _timing.CurTime + entity.Comp.Duration;
         Dirty(entity.Owner, comp);
         Dirty(entity);
-    }
-
-    private void OnRefreshNameModifiers(Entity<GluedComponent> entity, ref RefreshNameModifiersEvent args)
-    {
-        args.AddModifier("glued-name-prefix");
     }
 }

--- a/Content.Shared/Glue/GlueSystem.cs
+++ b/Content.Shared/Glue/GlueSystem.cs
@@ -25,10 +25,10 @@ public sealed partial class GlueSystem : EntitySystem
     [Dependency] private NameModifierSystem _nameMod = default!;
     [Dependency] private OpenableSystem _openable = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
+    [Dependency] private SharedContainerSystem _container = default!;
+    [Dependency] private SharedHandsSystem _hands = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedSolutionContainerSystem _solutionContainer = default!;
-    [Dependency] private SharedHandsSystem _hands = default!;
-    [Dependency] private SharedContainerSystem _container = default!;
 
     public override void Initialize()
     {

--- a/Content.Shared/Glue/GlueSystem.cs
+++ b/Content.Shared/Glue/GlueSystem.cs
@@ -1,10 +1,12 @@
 using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Damage.Components;
 using Content.Shared.Database;
 using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
+using Content.Shared.Inventory;
 using Content.Shared.Item;
 using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Nutrition.EntitySystems;
@@ -33,13 +35,10 @@ public sealed partial class GlueSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<GlueComponent, AfterInteractEvent>(OnInteract, after: new[] { typeof(OpenableSystem) });
-        SubscribeLocalEvent<GluedComponent, ComponentInit>(OnGluedInit);
-        SubscribeLocalEvent<GlueComponent, GetVerbsEvent<UtilityVerb>>(OnUtilityVerb);
-        SubscribeLocalEvent<GluedComponent, GotEquippedHandEvent>(OnHandPickUp);
-        SubscribeLocalEvent<GluedComponent, RefreshNameModifiersEvent>(OnRefreshNameModifiers);
     }
 
     // When glue bottle is used on item it will apply the glued and unremoveable components.
+    // TODO: Move to [SubscribeLocalEvent] once "after:" can be applied.
     private void OnInteract(Entity<GlueComponent> entity, ref AfterInteractEvent args)
     {
         if (args.Handled)
@@ -52,6 +51,7 @@ public sealed partial class GlueSystem : EntitySystem
             args.Handled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnUtilityVerb(Entity<GlueComponent> entity, ref GetVerbsEvent<UtilityVerb> args)
     {
         if (!args.CanInteract || !args.CanAccess || args.Target is not { Valid: true } target ||
@@ -69,6 +69,36 @@ public sealed partial class GlueSystem : EntitySystem
         };
 
         args.Verbs.Add(verb);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnGluedInit(Entity<GluedComponent> entity, ref ComponentInit args)
+    {
+        _nameMod.RefreshNameModifiers(entity.Owner);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnHandPickUp(Entity<GluedComponent> entity, ref GotEquippedHandEvent args)
+    {
+        PerformGluedEffect(entity, args.User);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnRefreshNameModifiers(Entity<GluedComponent> entity, ref RefreshNameModifiersEvent args)
+    {
+        args.AddModifier("glued-name-prefix");
+    }
+
+    [SubscribeLocalEvent]
+    private void OnGluedEffectAttemptEvent(Entity<GluedImmuneComponent> entity, ref GluedEffectAttemptEvent args)
+    {
+        args.Cancelled = true;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnGluedEffectAttemptEvent(Entity<GluedImmuneComponent> entity, ref InventoryRelayedEvent<GluedEffectAttemptEvent> args)
+    {
+        OnGluedEffectAttemptEvent(entity, ref args.Args);
     }
 
     private bool TryGlue(Entity<GlueComponent> entity, EntityUid target, EntityUid actor)
@@ -93,7 +123,7 @@ public sealed partial class GlueSystem : EntitySystem
                 var gluedComp = EnsureComp<GluedComponent>(target);
                 gluedComp.Duration = quantity.Double() * entity.Comp.DurationPerUnit;
                 if (_container.TryGetContainingContainer((target, null, null), out var container) && _hands.IsHolding(container.Owner, target))
-                    PerformGluedEffect((target, gluedComp));
+                    PerformGluedEffect((target, gluedComp), actor);
 
                 Dirty(target, gluedComp);
                 return true;
@@ -121,23 +151,14 @@ public sealed partial class GlueSystem : EntitySystem
         }
     }
 
-    private void OnGluedInit(Entity<GluedComponent> entity, ref ComponentInit args)
+    private void PerformGluedEffect(Entity<GluedComponent> entity, EntityUid user)
     {
-        _nameMod.RefreshNameModifiers(entity.Owner);
-    }
+        // Check if anything on the user cancels it.
+        var attemptEv = new GluedEffectAttemptEvent();
+        RaiseLocalEvent(user, ref attemptEv);
+        if (attemptEv.Cancelled)
+            return;
 
-    private void OnHandPickUp(Entity<GluedComponent> entity, ref GotEquippedHandEvent args)
-    {
-        PerformGluedEffect(entity);
-    }
-
-    private void OnRefreshNameModifiers(Entity<GluedComponent> entity, ref RefreshNameModifiersEvent args)
-    {
-        args.AddModifier("glued-name-prefix");
-    }
-
-    private void PerformGluedEffect(Entity<GluedComponent> entity)
-    {
         // When predicting dropping a glued item prediction will reinsert the item into the hand when rerolling the state to a previous one.
         // So dropping the item would add UnRemoveableComponent on the client without this guard statement.
         if (_timing.ApplyingState)
@@ -149,4 +170,18 @@ public sealed partial class GlueSystem : EntitySystem
         Dirty(entity.Owner, comp);
         Dirty(entity);
     }
+}
+
+/// <summary>
+/// Raised on an entity to determine if it will be affected by a glued item or not.
+/// </summary>
+[ByRefEvent]
+public record struct GluedEffectAttemptEvent() : IInventoryRelayEvent
+{
+    public SlotFlags TargetSlots { get; } = SlotFlags.GLOVES;
+
+    /// <summary>
+    /// If true, prevents the effect from being applied.
+    /// </summary>
+    public bool Cancelled;
 }

--- a/Content.Shared/Glue/GluedImmuneComponent.cs
+++ b/Content.Shared/Glue/GluedImmuneComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Glue;
+
+/// <summary>
+/// This component indicates that an entity ignores the <see cref="GluedComponent"/> on items.
+/// </summary>
+// Careful adding this to player content! It has strong design implications!
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(GlueSystem))]
+public sealed partial class GluedImmuneComponent : Component
+{
+
+}

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -11,10 +11,12 @@ using Content.Shared.Electrocution;
 using Content.Shared.Explosion;
 using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.Flash;
+using Content.Shared.Glue;
 using Content.Shared.Gravity;
 using Content.Shared.IdentityManagement.Components;
 using Content.Shared.Implants;
 using Content.Shared.Inventory.Events;
+using Content.Shared.Lube;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.NameModifier.EntitySystems;
@@ -82,6 +84,8 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, UnwieldAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, IngestionAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshNightVisionEvent>(RefRelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, GluedEffectAttemptEvent>(RefRelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, LubedEffectAttemptEvent>(RefRelayInventoryEvent);
 
         // Eye/vision events
         SubscribeLocalEvent<InventoryComponent, CanSeeAttemptEvent>(RelayInventoryEvent);

--- a/Content.Shared/Lube/LubeSystem.cs
+++ b/Content.Shared/Lube/LubeSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Database;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
@@ -9,6 +10,7 @@ using Content.Shared.Popups;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.Lube;
@@ -21,6 +23,9 @@ public sealed partial class LubeSystem : EntitySystem
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private OpenableSystem _openable = default!;
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private SharedContainerSystem _container = default!;
+    [Dependency] private SharedHandsSystem _hands = default!;
+    [Dependency] private LubedSystem _lubed = default!;
 
     public override void Initialize()
     {
@@ -81,6 +86,9 @@ public sealed partial class LubeSystem : EntitySystem
                 var rand = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(entity));
                 lubed.SlipsLeft = rand.Next(entity.Comp.MinSlips * quantity.Int(), 1 + entity.Comp.MaxSlips * quantity.Int());
                 lubed.SlipStrength = entity.Comp.SlipStrength;
+                if (_container.TryGetContainingContainer((target, null, null), out var container) && _hands.IsHolding(container.Owner, target))
+                    _lubed.PerformLubedEffect((target, lubed), actor, out _);
+
                 Dirty(target, lubed);
                 return true;
             }

--- a/Content.Shared/Lube/LubedImmuneComponent.cs
+++ b/Content.Shared/Lube/LubedImmuneComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Lube;
+
+/// <summary>
+/// This component indicates that an entity ignores the <see cref="LubedComponent"/> on items.
+/// </summary>
+// Careful adding this to player content! It has strong design implications!
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(LubedSystem))]
+public sealed partial class LubedImmuneComponent : Component
+{
+
+}

--- a/Content.Shared/Lube/LubedSystem.cs
+++ b/Content.Shared/Lube/LubedSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Hands;
 using Content.Shared.IdentityManagement;
+using Content.Shared.Inventory;
 using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.Throwing;
@@ -17,35 +18,46 @@ public sealed partial class LubedSystem : EntitySystem
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private ThrowingSystem _throwing = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<LubedComponent, ComponentInit>(OnInit);
-        SubscribeLocalEvent<LubedComponent, BeforeGettingEquippedHandEvent>(OnHandPickUp);
-        SubscribeLocalEvent<LubedComponent, RefreshNameModifiersEvent>(OnRefreshNameModifiers);
-    }
-
+    [SubscribeLocalEvent]
     private void OnInit(Entity<LubedComponent> ent, ref ComponentInit args)
     {
         _nameMod.RefreshNameModifiers(ent.Owner);
     }
 
+    [SubscribeLocalEvent]
     private void OnHandPickUp(Entity<LubedComponent> ent, ref BeforeGettingEquippedHandEvent args)
     {
         PerformLubedEffect(ent, args.User, out var cancelHandPickup);
         args.Cancelled = cancelHandPickup;
     }
 
+    [SubscribeLocalEvent]
     private void OnRefreshNameModifiers(Entity<LubedComponent> ent, ref RefreshNameModifiersEvent args)
     {
         if (ent.Comp.SlipsLeft > 0) // The component is removed deferred, so it might still exist when we refresh.
             args.AddModifier("lubed-name-prefix");
     }
 
+    [SubscribeLocalEvent]
+    private void OnGluedEffectAttemptEvent(Entity<LubedImmuneComponent> entity, ref LubedEffectAttemptEvent args)
+    {
+        args.Cancelled = true;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnGluedEffectAttemptEvent(Entity<LubedImmuneComponent> entity, ref InventoryRelayedEvent<LubedEffectAttemptEvent> args)
+    {
+        OnGluedEffectAttemptEvent(entity, ref args.Args);
+    }
+
     public void PerformLubedEffect(Entity<LubedComponent> ent, EntityUid user, out bool cancelHandPickup)
     {
         cancelHandPickup = false;
+
+        var attemptEv = new LubedEffectAttemptEvent();
+        RaiseLocalEvent(user, ref attemptEv);
+        if (attemptEv.Cancelled)
+            return;
 
         // Throwing is not predicted yet, so we don't want to predict setting the coordinates either, or it will look weird.
         if (_net.IsServer)
@@ -53,7 +65,7 @@ public sealed partial class LubedSystem : EntitySystem
             cancelHandPickup = true;
             _transform.SetCoordinates(ent, Transform(user).Coordinates);
             _transform.AttachToGridOrMap(ent);
-            _throwing.TryThrow(ent, _random.NextVector2(), baseThrowSpeed: ent.Comp.SlipStrength);
+            _throwing.TryThrow(ent, _random.NextVector2(), baseThrowSpeed: ent.Comp.SlipStrength, user: user);
             _popup.PopupEntity(Loc.GetString("lube-slip", ("target", Identity.Entity(ent, EntityManager))), user, user, PopupType.MediumCaution);
         }
 
@@ -65,4 +77,18 @@ public sealed partial class LubedSystem : EntitySystem
             _nameMod.RefreshNameModifiers(ent.Owner);
         }
     }
+}
+
+/// <summary>
+/// Raised on an entity to determine if it will be affected by a lubed item or not.
+/// </summary>
+[ByRefEvent]
+public record struct LubedEffectAttemptEvent() : IInventoryRelayEvent
+{
+    public SlotFlags TargetSlots { get; } = SlotFlags.GLOVES;
+
+    /// <summary>
+    /// If true, prevents the effect from being applied.
+    /// </summary>
+    public bool Cancelled;
 }

--- a/Content.Shared/Lube/LubedSystem.cs
+++ b/Content.Shared/Lube/LubedSystem.cs
@@ -33,12 +33,24 @@ public sealed partial class LubedSystem : EntitySystem
 
     private void OnHandPickUp(Entity<LubedComponent> ent, ref BeforeGettingEquippedHandEvent args)
     {
-        var user = args.User;
+        PerformLubedEffect(ent, args.User, out var cancelHandPickup);
+        args.Cancelled = cancelHandPickup;
+    }
+
+    private void OnRefreshNameModifiers(Entity<LubedComponent> ent, ref RefreshNameModifiersEvent args)
+    {
+        if (ent.Comp.SlipsLeft > 0) // The component is removed deferred, so it might still exist when we refresh.
+            args.AddModifier("lubed-name-prefix");
+    }
+
+    public void PerformLubedEffect(Entity<LubedComponent> ent, EntityUid user, out bool cancelHandPickup)
+    {
+        cancelHandPickup = false;
 
         // Throwing is not predicted yet, so we don't want to predict setting the coordinates either, or it will look weird.
         if (_net.IsServer)
         {
-            args.Cancelled = true;
+            cancelHandPickup = true;
             _transform.SetCoordinates(ent, Transform(user).Coordinates);
             _transform.AttachToGridOrMap(ent);
             _throwing.TryThrow(ent, _random.NextVector2(), baseThrowSpeed: ent.Comp.SlipStrength);
@@ -52,11 +64,5 @@ public sealed partial class LubedSystem : EntitySystem
             RemCompDeferred<LubedComponent>(ent);
             _nameMod.RefreshNameModifiers(ent.Owner);
         }
-    }
-
-    private void OnRefreshNameModifiers(Entity<LubedComponent> ent, ref RefreshNameModifiersEvent args)
-    {
-        if (ent.Comp.SlipsLeft > 0) // The component is removed deferred, so it might still exist when we refresh.
-            args.AddModifier("lubed-name-prefix");
     }
 }

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -111,6 +111,8 @@
   - type: BypassInteractionChecks
   - type: ExplosionResistance
     damageCoefficient: 0
+  - type: GluedImmune
+  - type: LubedImmune
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR makes it so that glue/lube applied to an item in your hand immediately triggers the effect (i.e. gets it stuck/slips it out of your hand). 

Admin ghosts/godmode entities have been given immunity to the glue/lube effects.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

While I won't deny that these allow for some creative strategies (that I've used for several years), it also leads to jank and unfun gameplay.

- Lubed bolas can be thrown to cause effectively a perma-slowdown, since removing them immediately slips them out of your hands. Add glue for extra annoyance. Using jank to bypass this (having two full hands) won't work anymore since #44512 will require a free active hand.
- Glue+lube the nuke disk and put it inside a glue+lube rubbery ducky and put it inside a glue+lube cake. People have started doing this before there's even a sign of nukies.
- Glue catchable tennis/beach/foot balls, throw them at your target - you've now disabled one hand (repeat for both!) without them being able to do much about it. 
- Lube an embeddable and throw it; unless you know the specific jank to get it out safely, trying to remove it will cause it to re-embed, repeating the damage.

Not to mention that the "mechanic" itself is unintuitive and non-communicative. 

Admin ghosts/godmode entities have been given immunity at the request of admins.

## Technical details
<!-- Summary of code changes for easier review. -->

Previously the effect only applied on pick-up, now it checks upon applying the component as well.

Moved the lube/glue effects into their own functions and added a check when the effect is applied to see if the item is in one of the container entity's hands. Lube throwing has an extra parameter to indicate the "thrower", giving them embed immunity.

The check for immunity is done via an inventory relay event. [SubscribeLocalEvent] has been applied to `GlueSystem` and `LubedSystem` while I was at it.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Normal user:
1. Put random item in your hand
2. Apply glue/lube
3. Effect now happens immediately

Aghost/godmode immunity:
1. Aghost
2. Apply glue/lube on an item 
3. Pick up and notice the effect does not apply
4. Repeat with a Urist you have applied Godmode to (using the admin tricks menu)

Inventory relay:
1. Add `GluedImmuneComponent` and `LubedImmuneComponent` to a pair of gloves
2. Apply glue/lube to an item
3. Pick up and notice the effect does not apply

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/0db2b7ee-c2c8-4cde-80c1-6776a7de993b

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Glue and lube now apply their effects immediately when used on a held item.

ADMIN: 
- fix: Admin ghosts and Godmode are now immune to lube/glue effects on items.