### PR TITLE
Generic metabolizer types

### DIFF
--- a/Resources/Locale/en-US/metabolism/metabolizer-types.ftl
+++ b/Resources/Locale/en-US/metabolism/metabolizer-types.ftl
@@ -1,11 +1,26 @@
-metabolizer-type-animal = Animal
-metabolizer-type-bloodsucker = Bloodsucker
-metabolizer-type-dragon = Dragon
 metabolizer-type-human = Human
 metabolizer-type-slime = Slime
 metabolizer-type-vox = Vox
-metabolizer-type-rat = Rat
 metabolizer-type-plant = Plant
 metabolizer-type-dwarf = Dwarf
 metabolizer-type-moth = Moth
 metabolizer-type-arachnid = Arachnid
+
+metabolizer-type-oxygen-breathing = Oxygen breathing
+metabolizer-type-nitrogen-breathing = Nitrogen breathing
+metabolizer-type-co2-breathing = CO2 breathing
+metabolizer-type-oxygen-toxic = Toxicated by oxygen
+metabolizer-type-ammonia-immune = Ammonia immune
+
+metabolizer-type-fuel-drinker = Digesting fuel
+metabolizer-type-blood-drinker = Digesting blood
+metabolizer-type-bloodsucker = Bloodsucker
+metabolizer-type-theobromine-intolerant = Theobromine intolerant
+metabolizer-type-trash-eater = Digesting trash
+
+metabolizer-type-weh-immune = Weh immune
+metabolizer-type-animal = Animal
+
+# dis shit idk how to name it
+metabolizer-type-copper-blood = Restoring blood with copper
+metabolizer-type-iron-blood = Restoring blood with iron

--- a/Resources/Prototypes/Body/Animals/animal.yml
+++ b/Resources/Prototypes/Body/Animals/animal.yml
@@ -3,7 +3,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Animal ]
+    metabolizerTypes: [ OxygenBreathing, IronRestoresBlood, Animal, TheobromineIntolerant ]
 
 - type: entity
   parent: OrganBaseOrganic

--- a/Resources/Prototypes/Body/Animals/bloodsucker.yml
+++ b/Resources/Prototypes/Body/Animals/bloodsucker.yml
@@ -4,7 +4,7 @@
   suffix: bloodsucker
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Bloodsucker ]
+    metabolizerTypes: [ OxygenBreathing, IronRestoresBlood, Bloodsucker ]
 
 - type: entity
   id: OrganBloodsuckerStomach

--- a/Resources/Prototypes/Body/Animals/rat.yml
+++ b/Resources/Prototypes/Body/Animals/rat.yml
@@ -4,7 +4,7 @@
   suffix: Rat
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Rat ]
+    metabolizerTypes: [ OxygenBreathing, IronRestoresBlood, BloodDrinker, AmmoniaImmune ]
 
 - type: entity
   id: BaseMobRat

--- a/Resources/Prototypes/Body/Species/arachnid.yml
+++ b/Resources/Prototypes/Body/Species/arachnid.yml
@@ -151,7 +151,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Arachnid ]
+    metabolizerTypes: [ OxygenBreathing, CopperRestoresBlood, Arachnid ]
 
 - type: entity
   parent: OrganArachnid

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -179,7 +179,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Plant ]
+    metabolizerTypes: [ OxygenBreathing, CO2Breathing, Plant ]
 
 - type: entity
   parent: OrganDiona

--- a/Resources/Prototypes/Body/Species/dwarf.yml
+++ b/Resources/Prototypes/Body/Species/dwarf.yml
@@ -174,7 +174,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Dwarf ]
+    metabolizerTypes: [ OxygenBreathing, IronRestoresBlood, Dwarf ]
 
 - type: entity
   parent: [ OrganHumanTorso, OrganDwarfAppearance ]

--- a/Resources/Prototypes/Body/Species/human.yml
+++ b/Resources/Prototypes/Body/Species/human.yml
@@ -109,7 +109,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Human ]
+    metabolizerTypes: [ OxygenBreathing, IronRestoresBlood, Human ]
 
 - type: entity
   parent: OrganHuman

--- a/Resources/Prototypes/Body/Species/moth.yml
+++ b/Resources/Prototypes/Body/Species/moth.yml
@@ -207,7 +207,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Moth ]
+    metabolizerTypes: [ OxygenBreathing, IronRestoresBlood, Moth ]
 
 - type: entity
   parent: OrganMoth

--- a/Resources/Prototypes/Body/Species/reptilian.yml
+++ b/Resources/Prototypes/Body/Species/reptilian.yml
@@ -179,7 +179,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Animal ]
+    metabolizerTypes: [ OxygenBreathing, IronRestoresBlood, Animal, TheobromineIntolerant ]
 
 - type: entity
   parent: OrganReptilian

--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -182,7 +182,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Slime ]
+    metabolizerTypes: [ NitrogenBreathing, Slime ]
 
 - type: entity
   parent: OrganSlimePerson
@@ -257,7 +257,7 @@
   - type: Stomach
   - type: Metabolizer
     maxReagents: 6
-    metabolizerTypes: [ Slime ]
+    metabolizerTypes: [ NitrogenBreathing, Slime ]
     stages: [ Digestion, Bloodstream, Metabolites ]
 
 - type: entity

--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -265,7 +265,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Vox ]
+    metabolizerTypes: [ NitrogenBreathing, OxygenToxicated, IronRestoresBlood, Vox, TrashEater, FuelDrinker ]
 
 - type: entity
   parent: OrganVox

--- a/Resources/Prototypes/Body/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Body/Species/vulpkanin.yml
@@ -220,7 +220,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Animal ]
+    metabolizerTypes: [ OxygenBreathing, IronRestoresBlood, Animal, TheobromineIntolerant ]
 
 - type: entity
   parent: OrganVulpkanin

--- a/Resources/Prototypes/Chemistry/MetabolizerTypes/breathing.yml
+++ b/Resources/Prototypes/Chemistry/MetabolizerTypes/breathing.yml
@@ -1,0 +1,19 @@
+- type: metabolizerType
+  id: OxygenBreathing
+  name: metabolizer-type-oxygen-breathing
+
+- type: metabolizerType
+  id: NitrogenBreathing
+  name: metabolizer-type-nitrogen-breathing
+
+- type: metabolizerType
+  id: CO2Breathing
+  name: metabolizer-type-co2-breathing
+
+- type: metabolizerType
+  id: OxygenToxicated
+  name: metabolizer-type-oxygen-toxic
+
+- type: metabolizerType
+  id: AmmoniaImmune
+  name: metabolizer-type-ammonia-immune

--- a/Resources/Prototypes/Chemistry/MetabolizerTypes/digestion.yml
+++ b/Resources/Prototypes/Chemistry/MetabolizerTypes/digestion.yml
@@ -1,0 +1,19 @@
+- type: metabolizerType
+  id: FuelDrinker
+  name: metabolizer-type-fuel-drinker
+
+- type: metabolizerType
+  id: BloodDrinker
+  name: metabolizer-type-blood-drinker
+
+- type: metabolizerType
+  id: Bloodsucker
+  name: metabolizer-type-bloodsucker
+
+- type: metabolizerType
+  id: TheobromineIntolerant
+  name: metabolizer-type-theobromine-intolerant
+
+- type: metabolizerType
+  id: TrashEater
+  name: metabolizer-type-trash-eater

--- a/Resources/Prototypes/Chemistry/MetabolizerTypes/medical.yml
+++ b/Resources/Prototypes/Chemistry/MetabolizerTypes/medical.yml
@@ -4,4 +4,4 @@
 
 - type: metabolizerType
   id: IronRestoresBlood
-  name: metabolizer-type-copper-blood
+  name: metabolizer-type-iron-blood

--- a/Resources/Prototypes/Chemistry/MetabolizerTypes/medical.yml
+++ b/Resources/Prototypes/Chemistry/MetabolizerTypes/medical.yml
@@ -1,0 +1,7 @@
+- type: metabolizerType
+  id: CopperRestoresBlood
+  name: metabolizer-type-copper-blood
+
+- type: metabolizerType
+  id: IronRestoresBlood
+  name: metabolizer-type-copper-blood

--- a/Resources/Prototypes/Chemistry/MetabolizerTypes/misc.yml
+++ b/Resources/Prototypes/Chemistry/MetabolizerTypes/misc.yml
@@ -1,0 +1,7 @@
+- type: metabolizerType
+  id: WehImmune
+  name: metabolizer-type-weh-immune
+
+- type: metabolizerType
+  id: Animal
+  name: metabolizer-type-animal

--- a/Resources/Prototypes/Chemistry/MetabolizerTypes/species.yml
+++ b/Resources/Prototypes/Chemistry/MetabolizerTypes/species.yml
@@ -2,18 +2,6 @@
 # you'll likely have to tag its metabolizers with something other than Human.
 
 - type: metabolizerType
-  id: Animal
-  name: metabolizer-type-animal
-
-- type: metabolizerType
-  id: Bloodsucker
-  name: metabolizer-type-bloodsucker
-
-- type: metabolizerType
-  id: Dragon
-  name: metabolizer-type-dragon
-
-- type: metabolizerType
   id: Human
   name: metabolizer-type-human
 
@@ -24,10 +12,6 @@
 - type: metabolizerType
   id: Vox
   name: metabolizer-type-vox
-
-- type: metabolizerType
-  id: Rat
-  name: metabolizer-type-rat
 
 - type: metabolizerType
   id: Plant

--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -89,7 +89,7 @@
     - type: Metabolizer
       solutionOnBody: false
       updateInterval: 0.25
-      metabolizerTypes: [ Dragon ]
+      metabolizerTypes: [ OxygenBreathing, AmmoniaImmune, IronRestoresBlood ]
       stages: [ Digestion, Bloodstream ]
     - type: ToolRefinable
       refineResult:

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -112,7 +112,7 @@
   - type: Metabolizer
     solutionOnBody: false
     updateInterval: 0.25
-    metabolizerTypes: [ Dragon ]
+    metabolizerTypes: [ OxygenBreathing, AmmoniaImmune, IronRestoresBlood, Animal ]
     stages: [ Digestion, Bloodstream ]
   - type: ToolRefinable
     refineResult:

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -25,6 +25,11 @@
           - !type:MetabolizerTypeCondition
             type: [ Human ]
             inverted: true
+      - !type:SatiateThirst
+        factor: 1.0
+        conditions:
+          - !type:MetabolizerTypeCondition
+            type: [ BloodDrinker, Bloodsucker ]
       - !type:EvenHealthChange
         conditions:
         - !type:MetabolizerTypeCondition

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -223,7 +223,7 @@
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Rat ]
+          type: [ AmmoniaImmune ]
           inverted: true
         - !type:ReagentCondition
           reagent: Ammonia
@@ -237,7 +237,7 @@
         probability: 0.12
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Rat, Vox ]
+          type: [ AmmoniaImmune, Vox ]
           inverted: true
         - !type:ReagentCondition
           reagent: Ammonia
@@ -254,7 +254,7 @@
       - !type:EvenHealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Rat ]
+          type: [ AmmoniaImmune ]
         - !type:ReagentCondition
           reagent: Ammonia
           min: 1
@@ -267,7 +267,7 @@
         amount: 1
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Rat ]
+          type: [ AmmoniaImmune ]
         - !type:ReagentCondition
           reagent: Ammonia
           min: 1

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -64,7 +64,7 @@
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid ]
+          type: [ CopperRestoresBlood ]
           inverted: true
         damage:
           types:
@@ -72,7 +72,7 @@
       - !type:ModifyBloodLevel
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid ]
+          type: [ CopperRestoresBlood ]
         amount: 0.4
 
 - type: reagent
@@ -152,14 +152,14 @@
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid ]
+          type: [ IronRestoresBlood ]
         damage:
           types:
             Poison: 0.1
       - !type:ModifyBloodLevel
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid ]
+          type: [ IronRestoresBlood ]
           inverted: true
         amount: 0.4
 

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -348,7 +348,7 @@
         prototype: ArtifactLizard # Does the same thing as the original YML I made for this reagent.
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [Animal]
+          type: [WehImmune]
           inverted: true
         - !type:ReagentCondition
           reagent: JuiceThatMakesYouWeh
@@ -383,7 +383,7 @@
         prototype: ArtifactLizard
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Animal ]
+          type: [ WehImmune ]
           inverted: true
         - !type:ReagentCondition
           reagent: JuiceThatMakesYouHew

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -16,12 +16,12 @@
       - !type:Oxygenate
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Human, Animal, Rat, Plant ]
+          type: [ OxygenBreathing ]
       # Convert Oxygen into CO2.
       - !type:ModifyLungGas
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Vox ]
+          type: [ OxygenToxicated ]
           inverted: true
         ratios:
           CarbonDioxide: 1.0
@@ -29,7 +29,7 @@
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Vox ]
+          type: [ OxygenToxicated ]
         ignoreResistances: true
         damage:
           types:
@@ -39,7 +39,7 @@
         minScale: 1
         conditions:
           - !type:MetabolizerTypeCondition
-            type: [ Vox ]
+            type: [ OxygenToxicated ]
         clear: true
         time: 5
     Respiration:
@@ -47,12 +47,12 @@
       - !type:Oxygenate
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Human, Animal, Rat, Plant, Arachnid, Moth ]
+          type: [ OxygenBreathing ]
       # Convert Oxygen into CO2.
       - !type:ModifyLungGas
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Vox ]
+          type: [ OxygenToxicated ]
           inverted: true
         ratios:
           CarbonDioxide: 1.0
@@ -60,7 +60,7 @@
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Vox ]
+          type: [ OxygenToxicated ]
         ignoreResistances: true
         damage:
           types:
@@ -70,7 +70,7 @@
         minScale: 0.5
         conditions:
           - !type:MetabolizerTypeCondition
-            type: [ Vox ]
+            type: [ OxygenToxicated ]
         clear: true
         time: 5
 
@@ -170,7 +170,7 @@
       - !type:Oxygenate
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Plant ]
+          type: [ CO2Breathing ]
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
@@ -184,7 +184,7 @@
       - !type:Oxygenate
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Plant ]
+          type: [ CO2Breathing ]
           inverted: true
         factor: -4
     Respiration:
@@ -192,7 +192,7 @@
       - !type:Oxygenate
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Plant ]
+          type: [ CO2Breathing ]
       - !type:HealthChange
         minScale: 0.5
         conditions:
@@ -209,7 +209,7 @@
       - !type:Oxygenate # carbon dioxide displaces oxygen from the bloodstream, causing asphyxiation
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Plant ]
+          type: [ CO2Breathing ]
           inverted: true
         factor: -4
       # We need a metabolism effect on reagent removal
@@ -237,7 +237,7 @@
       - !type:Oxygenate
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Vox, Slime ]
+          type: [ NitrogenBreathing ]
       # Converts Nitrogen into Ammonia
       - !type:ModifyLungGas
         conditions:

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -171,11 +171,11 @@
         factor: 1
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [Vox]
+          type: [FuelDrinker]
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [Vox]
+          type: [FuelDrinker]
           inverted: true
         damage:
           types:

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -412,7 +412,7 @@
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [Animal] # Applying damage to the mobs with lower metabolism capabilities
+          type: [TheobromineIntolerant] # Applying damage to the mobs with lower metabolism capabilities
         damage:
           types:
             Poison: 0.4
@@ -420,7 +420,7 @@
         probability: 0.04 #Scaled for time, not metabolismrate.
         conditions:
           - !type:MetabolizerTypeCondition
-            type: [Animal]
+            type: [TheobromineIntolerant]
 
 - type: reagent
   id: Amatoxin
@@ -761,7 +761,7 @@
         factor: 1
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [Vox]
+          type: [TrashEater]
 
 - type: reagent
   id: Hemorrhinol


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR adds a bunch of new metabolizer types that would allow to create new metabolizer organs for mobs or species without digging through reagent prototypes (e.g. manual entering your new single metabolizer type to oxygen metabolisms)

This is reimplementation of #35195

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I personally find it very annoying to not be able to use some generic metabolizer types in order to create a unique metabolisms for the mob

## Technical details
<!-- Summary of code changes for easier review. -->
Prototype work, several changes in reagents and metabolizer organs. Really simple PR

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Play as mobs with different metabolisms. Everything should work the same from the player perspective.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
none

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Species metabolizer types are no longer responsible for breathing and digestion. You should use generic and non-generic metabolizer types in organs as lists.
E.g.
```yml
- type: entity
  id: OrganVoxMetabolizer
  abstract: true
  components:
  - type: Metabolizer
    metabolizerTypes: [ NitrogenBreathing, OxygenToxicated, IronRestoresBlood, Vox, TrashEater, FuelDrinker ]
```

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl
