### PR TITLE
Fix recent grappling hook code review comments

### DIFF
--- a/Content.Shared/Weapons/Misc/GrapplingProjectileEmbedComponent.cs
+++ b/Content.Shared/Weapons/Misc/GrapplingProjectileEmbedComponent.cs
@@ -5,12 +5,12 @@ namespace Content.Shared.Weapons.Misc;
 /// <summary>
 /// Component used to track that an object has a grappling projectile embeded into it, to ensure joint relays between grid and entities are properly updated.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class GrapplingProjectileEmbedComponent : Component
 {
     /// <summary>
     /// The projectiles embedded in this entity.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public List<EntityUid> GrapplingProjectiles = new();
 }

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -311,39 +311,21 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
                 var grapplerOffsetB = _transform.GetRelativePosition(Transform(joint.BodyBUid), grapplerUidB);
                 var grapplerBodyB = Comp<PhysicsComponent>(grapplerUidB);
 
-                // Handle edge-cases where the mass is zero (e.g. station anchor). Treat that as infinite weight.
-                float massFactor;
-                if (grapplerBodyA.Mass == 0f && grapplerBodyB.Mass != 0f)
-                {
-                    massFactor = 1f;
-                }
-                else if (grapplerBodyA.Mass != 0f && grapplerBodyB.Mass == 0f)
-                {
-                    massFactor = 0f;
-                }
-                else if (grapplerBodyA.Mass == 0f && grapplerBodyB.Mass == 0f)
-                {
-                    massFactor = 0.5f;
-                }
-                else
-                {
-                    // This assumes the bodies can move freely.
-                    // It would be nice if any resisting force applied to the grid (e.g. if stuck on something and can't move closer) would transfer to the main entity.
-                    massFactor = grapplerBodyA.Mass / (grapplerBodyA.Mass + grapplerBodyB.Mass);
-                }
-
                 // Note that this way of calculating the impulse does not take into account objects being stuck on things, e.g. a movable grapple point stuck behind a wall.
                 // Ideally the contraction of the joint itself should take this into account, but alas, this works for now.
 
-                var massFactorA = (1 - massFactor);
-                if (grapplerBodyA.Mass < BaseWeightMass) // To prevent small things go zoomies
+                var massFactorA = 1f;
+                var massFactorB = 1f;
+
+                // To prevent small things go zoomies
+                // Technically doesn't preserve momentum but it's either this or things start being yeeted at light speed.
+                if (grapplerBodyA.Mass < BaseWeightMass)
                     massFactorA *= grapplerBodyA.Mass / BaseWeightMass;
 
-                _physics.ApplyLinearImpulse(grapplerUidA, -targetDirection * massFactorA * grappling.ReelForce * frameTime, grapplerOffsetA, body: grapplerBodyA);
-
-                var massFactorB = massFactor;
-                if (grapplerBodyB.Mass < BaseWeightMass) // To prevent small things go zoomies
+                if (grapplerBodyB.Mass < BaseWeightMass)
                     massFactorB *= grapplerBodyB.Mass / BaseWeightMass;
+
+                _physics.ApplyLinearImpulse(grapplerUidA, -targetDirection * massFactorA * grappling.ReelForce * frameTime, grapplerOffsetA, body: grapplerBodyA);
 
                 _physics.ApplyLinearImpulse(grapplerUidB, targetDirection * massFactorB * grappling.ReelForce * frameTime, grapplerOffsetB, body: grapplerBodyB);
             }

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -50,8 +50,6 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
     {
         base.Initialize();
 
-        SubscribeAllEvent<RequestGrapplingReelMessage>(OnGrapplingReel);
-
         // TODO: After step trigger refactor, dropping a grappling gun should manually try and activate step triggers it's suppressing.
         UpdatesBefore.Add(typeof(SharedJointSystem)); // We want to run before joints are solved
     }
@@ -134,11 +132,8 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         if (args.Handled || !args.Complex)
             return;
 
-        if (Timing.IsFirstTimePredicted)
-            _audio.PlayPredicted(entity.Comp.CycleSound, entity.Owner, args.User);
-
+        _audio.PlayPredicted(entity.Comp.CycleSound, entity.Owner, args.User);
         Ungrapple((entity), false, args.User);
-
         args.Handled = true;
     }
 
@@ -148,6 +143,7 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         SetReeling(entity, false, args.User);
     }
 
+    [EventSubscription]
     private void OnGrapplingReel(RequestGrapplingReelMessage msg, EntitySessionEventArgs args)
     {
         if (args.SenderSession.AttachedEntity is not { } player)
@@ -277,9 +273,13 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
                 // Checks if the entity is "tied" to the grid it is on via extra-gravity technology (e.g. magboots). If so, for the purposes of reeling it counts as if you're weighing the same as the grid.
                 bool attachedToGrid;
 
+                // If the entities being targetted are on the same grid. If they are, the grid itself should not be affected with any pushing, to avoid becoming a "grappling hook-powered shuttle".
+                var sameGrid = false;
+
                 if (_transform.GetGrid(joint.BodyAUid) == _transform.GetGrid(joint.BodyBUid))
                 {
                     attachedToGrid = false;
+                    sameGrid = true;
                 }
                 else
                 {
@@ -324,7 +324,8 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
                 if (grapplerBodyB.Mass < BaseWeightMass)
                     massFactorB *= grapplerBodyB.Mass / BaseWeightMass;
 
-                _physics.ApplyLinearImpulse(grapplerUidA, -targetDirection * massFactorA * grappling.ReelForce * frameTime, grapplerOffsetA, body: grapplerBodyA);
+                if (sameGrid && physicalHook != _transform.GetGrid(joint.BodyAUid))
+                    _physics.ApplyLinearImpulse(grapplerUidA, -targetDirection * massFactorA * grappling.ReelForce * frameTime, grapplerOffsetA, body: grapplerBodyA);
 
                 _physics.ApplyLinearImpulse(grapplerUidB, targetDirection * massFactorB * grappling.ReelForce * frameTime, grapplerOffsetB, body: grapplerBodyB);
             }

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -48,31 +48,23 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<GrapplingProjectileComponent, JointRemovedEvent>(OnGrappleJointRemoved);
-        SubscribeLocalEvent<GrapplingProjectileComponent, ComponentShutdown>(OnGrappleProjectileShutdown);
-        SubscribeLocalEvent<GrapplingProjectileComponent, ProjectileEmbedEvent>(OnGrappleCollide);
-
-        SubscribeLocalEvent<GrapplingGunComponent, GunShotEvent>(OnGrapplingShot);
-        SubscribeLocalEvent<GrapplingGunComponent, ActivateInWorldEvent>(OnGunActivate);
-        SubscribeLocalEvent<GrapplingGunComponent, HandDeselectedEvent>(OnGrapplingDeselected);
+        base.Initialize();
 
         SubscribeAllEvent<RequestGrapplingReelMessage>(OnGrapplingReel);
-        SubscribeLocalEvent<CanWeightlessMoveEvent>(OnWeightlessMove);
 
         // TODO: After step trigger refactor, dropping a grappling gun should manually try and activate step triggers it's suppressing.
-
-        SubscribeLocalEvent<GrapplingProjectileEmbedComponent, AnchorStateChangedEvent>(OnAnchorStateChanged);
-
         UpdatesBefore.Add(typeof(SharedJointSystem)); // We want to run before joints are solved
-        base.Initialize();
+
     }
 
-    private void OnGrappleJointRemoved(EntityUid uid, GrapplingProjectileComponent component, JointRemovedEvent args)
+    [SubscribeLocalEvent]
+    private void OnGrappleJointRemoved(Entity<GrapplingProjectileComponent> entity, ref JointRemovedEvent args)
     {
         if (_netManager.IsServer)
-            QueueDel(uid);
+            QueueDel(entity);
     }
 
+    [SubscribeLocalEvent]
     private void OnGrappleProjectileShutdown(Entity<GrapplingProjectileComponent> ent, ref ComponentShutdown args)
     {
         if (!TryComp<EmbeddableProjectileComponent>(ent, out var embedComp) || embedComp.EmbeddedIntoUid == null)
@@ -84,9 +76,10 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         grapplingEmbedComp.GrapplingProjectiles.Remove(ent);
     }
 
+    [SubscribeLocalEvent]
     private void OnGrappleCollide(EntityUid uid, GrapplingProjectileComponent component, ref ProjectileEmbedEvent args)
     {
-        if (!Timing.IsFirstTimePredicted || !args.Weapon.HasValue || !TryComp<GrapplingGunComponent>(args.Weapon, out var grapple))
+        if (!args.Weapon.HasValue || !TryComp<GrapplingGunComponent>(args.Weapon, out var grapple))
             return;
 
         var grapplePos = _transform.GetWorldPosition(args.Weapon.Value);
@@ -114,7 +107,8 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         _joints.RefreshRelay(args.Weapon.Value, jointCompGrapple);
     }
 
-    private void OnGrapplingShot(EntityUid uid, GrapplingGunComponent component, ref GunShotEvent args)
+    [SubscribeLocalEvent]
+    private void OnGrapplingShot(Entity<GrapplingGunComponent> entity, ref GunShotEvent args)
     {
         foreach (var (shotUid, _) in args.Ammo)
         {
@@ -123,32 +117,36 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
 
             //todo: this doesn't actually support multigrapple
             // At least show the visuals.
-            component.Projectile = shotUid.Value;
-            DirtyField(uid, component, nameof(GrapplingGunComponent.Projectile));
+            entity.Comp.Projectile = shotUid.Value;
+            DirtyField(entity.AsNullable(), nameof(GrapplingGunComponent.Projectile));
             var visuals = EnsureComp<JointVisualsComponent>(shotUid.Value);
-            visuals.Sprite = component.RopeSprite;
-            visuals.Target = uid;
+            visuals.Sprite = entity.Comp.RopeSprite;
+            visuals.Target = entity.Owner;
             Dirty(shotUid.Value, visuals);
         }
 
-        TryComp<AppearanceComponent>(uid, out var appearance);
-        _appearance.SetData(uid, SharedTetherGunSystem.TetherVisualsStatus.Key, false, appearance);
+        if (TryComp<AppearanceComponent>(entity.Owner, out var appearance))
+            _appearance.SetData(entity.Owner, SharedTetherGunSystem.TetherVisualsStatus.Key, false, appearance);
     }
 
-    private void OnGunActivate(EntityUid uid, GrapplingGunComponent component, ActivateInWorldEvent args)
+    [SubscribeLocalEvent]
+    private void OnGunActivate(Entity<GrapplingGunComponent> entity, ref ActivateInWorldEvent args)
     {
-        if (!Timing.IsFirstTimePredicted || args.Handled || !args.Complex)
+        if (args.Handled || !args.Complex)
             return;
 
-        _audio.PlayPredicted(component.CycleSound, uid, args.User);
-        Ungrapple((uid, component), false, args.User);
+        if (Timing.IsFirstTimePredicted)
+            _audio.PlayPredicted(entity.Comp.CycleSound, entity.Owner, args.User);
+
+        Ungrapple((entity), false, args.User);
 
         args.Handled = true;
     }
 
-    private void OnGrapplingDeselected(EntityUid uid, GrapplingGunComponent component, HandDeselectedEvent args)
+    [SubscribeLocalEvent]
+    private void OnGrapplingDeselected(Entity<GrapplingGunComponent> entity, ref HandDeselectedEvent args)
     {
-        SetReeling(uid, component, false, args.User);
+        SetReeling(entity, false, args.User);
     }
 
     private void OnGrapplingReel(RequestGrapplingReelMessage msg, EntitySessionEventArgs args)
@@ -169,9 +167,10 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
             return;
         }
 
-        SetReeling(activeItem.Value, grappling, msg.Reeling, player);
+        SetReeling((activeItem.Value, grappling), msg.Reeling, player);
     }
 
+    [SubscribeLocalEvent]
     private void OnWeightlessMove(ref CanWeightlessMoveEvent ev)
     {
         if (ev.CanMove || !TryComp<JointRelayTargetComponent>(ev.Uid, out var relayComp))
@@ -187,6 +186,7 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnAnchorStateChanged(Entity<GrapplingProjectileEmbedComponent> entity, ref AnchorStateChangedEvent args)
     {
         foreach (var hook in entity.Comp.GrapplingProjectiles)
@@ -199,65 +199,6 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
 
             RefreshJointRelay(entity);
         }
-    }
-
-    /// <summary>
-    /// Ungrapples the grappling hook, destroying the hook and severing the joint
-    /// </summary>
-    /// <param name="grapple">Entity for the grappling gun</param>
-    /// <param name="isBreak">Whether to play the sound for the rope breaking</param>
-    /// <param name="user">The user responsible for the ungrapple. Optional</param>
-    public void Ungrapple(Entity<GrapplingGunComponent> grapple, bool isBreak, EntityUid? user = null)
-    {
-        if (!Timing.IsFirstTimePredicted || grapple.Comp.Projectile is not { } projectile)
-            return;
-
-        if (isBreak)
-        {
-            if (user != null)
-                _audio.PlayPredicted(grapple.Comp.BreakSound, grapple.Owner, user);
-            else if (_netManager.IsServer) // This feels... hacky.
-                _audio.PlayPvs(grapple.Comp.BreakSound, grapple.Owner);
-        }
-
-        _appearance.SetData(grapple.Owner, SharedTetherGunSystem.TetherVisualsStatus.Key, true);
-
-        if (_netManager.IsServer)
-            QueueDel(projectile);
-
-        SetReeling(grapple.Owner, grapple.Comp, false, user);
-        grapple.Comp.Projectile = null;
-        DirtyField(grapple.Owner, grapple.Comp, nameof(GrapplingGunComponent.Projectile));
-        _gun.ChangeBasicEntityAmmoCount(grapple.Owner, 1);
-    }
-
-    private void SetReeling(EntityUid uid, GrapplingGunComponent component, bool value, EntityUid? user)
-    {
-        if (TryComp<JointComponent>(uid, out var jointComp) &&
-            jointComp.GetJoints.TryGetValue(GrapplingJoint, out var joint) &&
-            joint is DistanceJoint distance)
-        {
-            if (distance.MaxLength <= distance.MinLength + component.RopeFullyReeledMargin)
-                value = false;
-        }
-
-        if (component.Reeling == value)
-            return;
-
-        if (value)
-        {
-            // We null-coalesce here because playing the sound again will cause it to become eternally stuck playing
-            component.Stream ??= _audio.PlayPredicted(component.ReelSound, uid, user)?.Entity;
-        }
-        else if (!value && component.Stream.HasValue && Timing.IsFirstTimePredicted)
-        {
-            // The IsFirstTimePredicted check is important here because otherwise component.Stream will be set to null from an early cancellation if this isn't FirstTimePredicted
-            component.Stream = _audio.Stop(component.Stream);
-        }
-
-        component.Reeling = value;
-
-        DirtyField(uid, component, nameof(GrapplingGunComponent.Reeling));
     }
 
     public override void UpdateBeforeSolve(bool prediction, float frameTime)
@@ -330,7 +271,7 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
 
             if (ropeLength <= distance.MinLength + grappling.RopeFullyReeledMargin)
             {
-                SetReeling(uid, grappling, false, null);
+                SetReeling((uid, grappling), false, null);
             }
             else if (ropeLength >= distance.MaxLength - grappling.RopeMargin)
             {
@@ -398,7 +339,7 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
                 if (grapplerBodyA.Mass < BaseWeightMass) // To prevent small things go zoomies
                     massFactorA *= grapplerBodyA.Mass / BaseWeightMass;
 
-                _physics.ApplyLinearImpulse(grapplerUidA, targetDirection * massFactorA * grappling.ReelForce * frameTime * -1, grapplerOffsetA, body: grapplerBodyA);
+                _physics.ApplyLinearImpulse(grapplerUidA, -targetDirection * massFactorA * grappling.ReelForce * frameTime, grapplerOffsetA, body: grapplerBodyA);
 
                 var massFactorB = massFactor;
                 if (grapplerBodyB.Mass < BaseWeightMass) // To prevent small things go zoomies
@@ -409,6 +350,65 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
 
             Dirty(uid, jointComp);
         }
+    }
+
+    /// <summary>
+    /// Ungrapples the grappling hook, destroying the hook and severing the joint
+    /// </summary>
+    /// <param name="grapple">Entity for the grappling gun</param>
+    /// <param name="isBreak">Whether to play the sound for the rope breaking</param>
+    /// <param name="user">The user responsible for the ungrapple. Optional</param>
+    public void Ungrapple(Entity<GrapplingGunComponent> grapple, bool isBreak, EntityUid? user = null)
+    {
+        if (grapple.Comp.Projectile is not { } projectile)
+            return;
+
+        if (isBreak && Timing.IsFirstTimePredicted)
+        {
+            if (user != null)
+                _audio.PlayPredicted(grapple.Comp.BreakSound, grapple.Owner, user);
+            else if (_netManager.IsServer) // This feels... hacky.
+                _audio.PlayPvs(grapple.Comp.BreakSound, grapple.Owner);
+        }
+
+        _appearance.SetData(grapple.Owner, SharedTetherGunSystem.TetherVisualsStatus.Key, true);
+
+        if (_netManager.IsServer)
+            QueueDel(projectile);
+
+        SetReeling(grapple, false, user);
+        grapple.Comp.Projectile = null;
+        DirtyField(grapple.Owner, grapple.Comp, nameof(GrapplingGunComponent.Projectile));
+        _gun.ChangeBasicEntityAmmoCount(grapple.Owner, 1);
+    }
+
+    private void SetReeling(Entity<GrapplingGunComponent> entity, bool value, EntityUid? user)
+    {
+        if (TryComp<JointComponent>(entity.Owner, out var jointComp) &&
+            jointComp.GetJoints.TryGetValue(GrapplingJoint, out var joint) &&
+            joint is DistanceJoint distance)
+        {
+            if (distance.MaxLength <= distance.MinLength + entity.Comp.RopeFullyReeledMargin)
+                value = false;
+        }
+
+        if (entity.Comp.Reeling == value)
+            return;
+
+        if (value)
+        {
+            // We null-coalesce here because playing the sound again will cause it to become eternally stuck playing
+            entity.Comp.Stream ??= _audio.PlayPredicted(entity.Comp.ReelSound, entity.Owner, user)?.Entity;
+        }
+        else if (!value && entity.Comp.Stream.HasValue && Timing.IsFirstTimePredicted)
+        {
+            // The IsFirstTimePredicted check is important here because otherwise component.Stream will be set to null from an early cancellation if this isn't FirstTimePredicted
+            entity.Comp.Stream = _audio.Stop(entity.Comp.Stream);
+        }
+
+        entity.Comp.Reeling = value;
+
+        DirtyField(entity.AsNullable(), nameof(GrapplingGunComponent.Reeling));
     }
 
     /// <summary>
@@ -457,10 +457,15 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         }
     }
 
-
+    /// <summary>
+    /// Client to server message to begin/end reeling in the grapplign hook.
+    /// </summary>
     [Serializable, NetSerializable]
     protected sealed class RequestGrapplingReelMessage : EntityEventArgs
     {
+        /// <summary>
+        /// Whether the client wants to reel in or stop reeling.
+        /// </summary>
         public bool Reeling;
 
         public RequestGrapplingReelMessage(bool reeling)

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -54,7 +54,6 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
 
         // TODO: After step trigger refactor, dropping a grappling gun should manually try and activate step triggers it's suppressing.
         UpdatesBefore.Add(typeof(SharedJointSystem)); // We want to run before joints are solved
-
     }
 
     [SubscribeLocalEvent]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixes review comments left after #43746 got merged.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This should not really change any behaviors in gameplay, other than perhaps some minor differences in how grids interact.

## Technical details
<!-- Summary of code changes for easier review. -->

1. Networked `GrapplingProjectileEmbedComponent.GrapplingProjectiles`
2. Moved all events subscriptions in `SharedGrapplingGunSystem` into using `[SubscribeLocalEvent]`.
3. Changed methods to use `Entity<T>`
4. Moved `Timing.IsFirstTimePredicted` into only dealing with audio
5. Reordered methods in the class
6. Mass calculation has been simplified because it didn't need to be as complicated as it was. That being said, it does not fully address the concern about preservation of momentum. Low-mass objects can't have the same inertia applied as high-mass objects because that would yeet them into the stratosphere. If there's a solution here I'm not seeing, do let me know.
7. Added a `sameGrid` check that, if true, prevents applying impulse to a grid if you're standing on it. Prevents grappling hook-powered shuttles. Thanks Baldman!

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Go into dev, get a grappling hook and walk out into the space area
2. Play around with spawning grids; loose girders and mail carts can be used as hookable non-grid entities

Feel free to change the density of `BaseSpeciesMob`'s fixture (must be done in the prototype, does not update if edited in the component) to see how it works with low-density entities. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Behavior should be the same as before

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Grappling hooks no longer move grids if both the hook and user are on the same grid.