### PR TITLE
Fix/nukeops mindshield leak

### DIFF
--- a/Content.Client/Store/Ui/StoreBoundUserInterface.cs
+++ b/Content.Client/Store/Ui/StoreBoundUserInterface.cs
@@ -24,6 +24,7 @@ public sealed class StoreBoundUserInterface : BoundUserInterface
     public StoreBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
         _storeSystem = EntMan.System<StoreSystem>();
+        _prototypeManager = IoCManager.Resolve<IPrototypeManager>();
     }
 
     protected override void Open()

--- a/Content.Client/Store/Ui/StoreBoundUserInterface.cs
+++ b/Content.Client/Store/Ui/StoreBoundUserInterface.cs
@@ -31,8 +31,6 @@ public sealed class StoreBoundUserInterface : BoundUserInterface
         base.Open();
 
         _menu = this.CreateWindow<StoreMenu>();
-        if (_storeSystem.TryGetStore(Owner, out var store))
-            _menu.Title = Loc.GetString(store.Value.Comp.Name);
 
         _menu.OnListingButtonPressed += (_, listing) =>
         {
@@ -75,6 +73,9 @@ public sealed class StoreBoundUserInterface : BoundUserInterface
                 UpdateListingsWithSearchFilter();
                 _menu?.SetFooterVisibility(msg.ShowFooter);
                 _menu?.UpdateRefund(msg.AllowRefund);
+
+                if (_menu != null)
+                    _menu.Title = Loc.GetString(msg.Name);
                 break;
         }
     }

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -39,6 +39,9 @@ using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
+using Content.Shared.Antag;
+using Robust.Shared.Player;
+using Robust.Shared.GameStates;
 using System.Data;
 using System.Linq;
 using System.Text;
@@ -94,6 +97,10 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
 
         SubscribeLocalEvent<NukeopsRuleComponent, AfterAntagEntitySelectedEvent>(OnAfterAntagEntSelected);
         SubscribeLocalEvent<NukeopsRuleComponent, RuleLoadedGridsEvent>(OnRuleLoadedGrids);
+
+        SubscribeLocalEvent<NukeOperativeComponent, ComponentGetStateAttemptEvent>(OnNukeOpsGetStateAttempt);
+        SubscribeLocalEvent<NukeOperativeComponent, ComponentStartup>(DirtyNukeOps);
+        SubscribeLocalEvent<ShowAntagIconsComponent, ComponentStartup>(DirtyNukeOps);
     }
 
     protected override void Started(EntityUid uid,
@@ -703,6 +710,34 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
         // Fallback to ID
         if (_idCard.TryFindIdCard(carrier, out var idCard))
             job = idCard.Comp.LocalizedJobTitle ?? job;
+    }
+
+    private void OnNukeOpsGetStateAttempt(EntityUid uid, NukeOperativeComponent comp, ref ComponentGetStateAttemptEvent args)
+    {
+        args.Cancelled = !CanGetState(args.Player);
+    }
+
+    private bool CanGetState(ICommonSession? player)
+    {
+        if (player?.AttachedEntity is not {} user)
+            return true;
+
+        if (HasComp<NukeOperativeComponent>(user))
+            return true;
+
+        if (HasComp<ShowAntagIconsComponent>(user))
+            return true;
+
+        return false;
+    }
+
+    private void DirtyNukeOps<T>(EntityUid someUid, T someComp, ComponentStartup ev)
+    {
+        var query = EntityQueryEnumerator<NukeOperativeComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            Dirty(uid, comp);
+        }
     }
 }
 

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -260,7 +260,7 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
                 var handled = false;
                 foreach (var cond in nukeops.WinConditions)
                 {
-                    if (cond.ToString().ToLower() == "NukeExplodedOnCorrectStation") // If this is true, then the nuke destroyed the station! It's likely everyone is very dead so keeping the round going is pointless.
+                    if (cond == WinCondition.NukeExplodedOnCorrectStation) // If this is true, then the nuke destroyed the station! It's likely everyone is very dead so keeping the round going is pointless.
                     {
                         _roundEndSystem.EndRound(); // end the round!
                         handled = true;

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -101,7 +101,6 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
 
         SubscribeLocalEvent<NukeOperativeComponent, ComponentGetStateAttemptEvent>(OnNukeOpsGetStateAttempt);
         SubscribeLocalEvent<NukeOperativeComponent, ComponentStartup>(DirtyNukeOps);
-        SubscribeLocalEvent<ShowAntagIconsComponent, ComponentStartup>(DirtyNukeOps);
     }
 
     protected override void Started(EntityUid uid,
@@ -736,13 +735,6 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
     {
         var nukeQuery = EntityQueryEnumerator<NukeOperativeComponent>();
         while (nukeQuery.MoveNext(out var uid, out var comp))
-        {
-            Dirty(uid, comp);
-        }
-
-        // also re-sync mindshield state since ShowAntagIconsComponent affects its visibility too
-        var mindshieldQuery = EntityQueryEnumerator<MindShieldComponent>();
-        while (mindshieldQuery.MoveNext(out var uid, out var comp))
         {
             Dirty(uid, comp);
         }

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -42,6 +42,7 @@ using Robust.Shared.Utility;
 using Content.Shared.Antag;
 using Robust.Shared.Player;
 using Robust.Shared.GameStates;
+using Content.Shared.Mindshield.Components;
 using System.Data;
 using System.Linq;
 using System.Text;
@@ -733,8 +734,15 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
 
     private void DirtyNukeOps<T>(EntityUid someUid, T someComp, ComponentStartup ev)
     {
-        var query = EntityQueryEnumerator<NukeOperativeComponent>();
-        while (query.MoveNext(out var uid, out var comp))
+        var nukeQuery = EntityQueryEnumerator<NukeOperativeComponent>();
+        while (nukeQuery.MoveNext(out var uid, out var comp))
+        {
+            Dirty(uid, comp);
+        }
+
+        // also re-sync mindshield state since ShowAntagIconsComponent affects its visibility too
+        var mindshieldQuery = EntityQueryEnumerator<MindShieldComponent>();
+        while (mindshieldQuery.MoveNext(out var uid, out var comp))
         {
             Dirty(uid, comp);
         }

--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -9,6 +9,10 @@ using Content.Shared.Revolutionary;
 using Content.Shared.Revolutionary.Components;
 using Content.Shared.Roles.Components;
 using Robust.Shared.Containers;
+using Content.Shared.Antag;
+using Content.Shared.Overlays;
+using Robust.Shared.Player;
+using Robust.Shared.GameStates;
 
 namespace Content.Server.Mindshield;
 
@@ -30,6 +34,9 @@ public sealed partial class MindShieldSystem : EntitySystem
         SubscribeLocalEvent<MindShieldImplantComponent, ImplantImplantedEvent>(OnImplantImplanted);
         SubscribeLocalEvent<MindShieldImplantComponent, ImplantRemovedEvent>(OnImplantRemoved);
         SubscribeLocalEvent<MindShieldComponent, AttemptConvertRevolutionaryEvent>(OnAttemptConvert);
+        SubscribeLocalEvent<MindShieldComponent, ComponentGetStateAttemptEvent>(OnMindShieldGetStateAttempt);
+        SubscribeLocalEvent<ShowMindShieldIconsComponent, ComponentStartup>(DirtyMindShieldComps);
+        SubscribeLocalEvent<ShowAntagIconsComponent, ComponentStartup>(DirtyMindShieldComps);
     }
 
     private void OnImplantImplanted(Entity<MindShieldImplantComponent> ent, ref ImplantImplantedEvent ev)
@@ -65,6 +72,37 @@ public sealed partial class MindShieldSystem : EntitySystem
     private void OnAttemptConvert(Entity<MindShieldComponent> ent, ref AttemptConvertRevolutionaryEvent args)
     {
         args.Cancelled = true;
+    }
+
+    private void OnMindShieldGetStateAttempt(EntityUid uid, MindShieldComponent comp, ref ComponentGetStateAttemptEvent args)
+    {
+        args.Cancelled = !CanGetState(uid, args.Player);
+    }
+
+    private bool CanGetState(EntityUid target, ICommonSession? player)
+    {
+        if (player?.AttachedEntity is not {} user)
+            return true;
+
+        if (user == target)
+            return true;
+
+        if (HasComp<ShowAntagIconsComponent>(user))
+            return true;
+
+        if (HasComp<ShowMindShieldIconsComponent>(user))
+            return true;
+
+        return false;
+    }
+
+    private void DirtyMindShieldComps<T>(EntityUid someUid, T someComp, ComponentStartup ev)
+    {
+        var query = EntityQueryEnumerator<MindShieldComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            Dirty(uid, comp);
+        }
     }
 }
 

--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -36,6 +36,9 @@ public sealed partial class MindShieldSystem : EntitySystem
         SubscribeLocalEvent<MindShieldComponent, AttemptConvertRevolutionaryEvent>(OnAttemptConvert);
         SubscribeLocalEvent<MindShieldComponent, ComponentGetStateAttemptEvent>(OnMindShieldGetStateAttempt);
         SubscribeLocalEvent<ShowMindShieldIconsComponent, ComponentStartup>(DirtyMindShieldComps);
+        // Also dirty when ShowAntagIconsComponent is gained (e.g. admin/ghost mid-round)
+        // so the new observer sees existing mindshield icons immediately.
+        SubscribeLocalEvent<ShowAntagIconsComponent, ComponentStartup>(DirtyMindShieldComps);
     }
 
     private void OnImplantImplanted(Entity<MindShieldImplantComponent> ent, ref ImplantImplantedEvent ev)

--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -36,7 +36,6 @@ public sealed partial class MindShieldSystem : EntitySystem
         SubscribeLocalEvent<MindShieldComponent, AttemptConvertRevolutionaryEvent>(OnAttemptConvert);
         SubscribeLocalEvent<MindShieldComponent, ComponentGetStateAttemptEvent>(OnMindShieldGetStateAttempt);
         SubscribeLocalEvent<ShowMindShieldIconsComponent, ComponentStartup>(DirtyMindShieldComps);
-        SubscribeLocalEvent<ShowAntagIconsComponent, ComponentStartup>(DirtyMindShieldComps);
     }
 
     private void OnImplantImplanted(Entity<MindShieldImplantComponent> ent, ref ImplantImplantedEvent ev)

--- a/Content.Shared/Mindshield/Components/MindShieldComponent.cs
+++ b/Content.Shared/Mindshield/Components/MindShieldComponent.cs
@@ -13,4 +13,6 @@ public sealed partial class MindShieldComponent : Component
 {
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public ProtoId<SecurityIconPrototype> MindShieldStatusIcon = "MindShieldIcon";
+
+    public override bool SessionSpecific => true;
 }

--- a/Content.Shared/NukeOps/NukeOperativeComponent.cs
+++ b/Content.Shared/NukeOps/NukeOperativeComponent.cs
@@ -19,4 +19,6 @@ public sealed partial class NukeOperativeComponent : Component
     /// </summary>
     [DataField("syndStatusIcon", customTypeSerializer: typeof(PrototypeIdSerializer<FactionIconPrototype>))]
     public string SyndStatusIcon = "SyndicateFaction";
+
+    public override bool SessionSpecific => true;
 }

--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mindshield.Components;
+using Content.Shared.NukeOps;
 using Content.Shared.Popups;
 using Content.Shared.Revolutionary.Components;
 using Content.Shared.Stunnable;
@@ -97,6 +98,18 @@ public abstract partial class SharedRevolutionarySystem : EntitySystem
 
         var headRevComps = AllEntityQuery<HeadRevolutionaryComponent>();
         while (headRevComps.MoveNext(out var uid, out var comp))
+        {
+            Dirty(uid, comp);
+        }
+
+        var nukeOpsComps = AllEntityQuery<NukeOperativeComponent>();
+        while (nukeOpsComps.MoveNext(out var uid, out var comp))
+        {
+            Dirty(uid, comp);
+        }
+
+        var mindShieldComps = AllEntityQuery<MindShieldComponent>();
+        while (mindShieldComps.MoveNext(out var uid, out var comp))
         {
             Dirty(uid, comp);
         }

--- a/Content.Shared/Store/Components/StoreComponent.cs
+++ b/Content.Shared/Store/Components/StoreComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Store.Components;
 /// This component manages a store which players can use to purchase different listings
 /// through the ui. The currency, listings, and categories are defined in yaml.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent]
 public sealed partial class StoreComponent : Component
 {
     [DataField]

--- a/Content.Shared/Store/SharedStoreSystem.UI.cs
+++ b/Content.Shared/Store/SharedStoreSystem.UI.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Shared.FixedPoint;
 using Content.Shared.PDA.Ringer;
 using Content.Shared.Store.Components;
@@ -81,7 +81,7 @@ public abstract partial class SharedStoreSystem
         // only tell operatives to lock their uplink if it can be locked
         var showFooter = HasComp<RingerUplinkComponent>(store);
 
-        var state = new StoreUpdateState(component.LastAvailableListings, allCurrency, showFooter, component.RefundAllowed);
+        var state = new StoreUpdateState(component.LastAvailableListings, allCurrency, showFooter, component.RefundAllowed, component.Name);
         UpdateRemoteStores(store, state);
         UI.SetUiState(store, StoreUiKey.Key, state);
     }

--- a/Content.Shared/Store/StoreUi.cs
+++ b/Content.Shared/Store/StoreUi.cs
@@ -21,12 +21,15 @@ public sealed class StoreUpdateState : BoundUserInterfaceState
 
     public readonly bool AllowRefund;
 
-    public StoreUpdateState(HashSet<ListingDataWithCostModifiers> listings, Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> balance, bool showFooter, bool allowRefund)
+    public readonly string Name;
+
+    public StoreUpdateState(HashSet<ListingDataWithCostModifiers> listings, Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2> balance, bool showFooter, bool allowRefund, string name)
     {
         Listings = listings;
         Balance = balance;
         ShowFooter = showFooter;
         AllowRefund = allowRefund;
+        Name = name;
     }
 }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Clients were receiving component state for NukeOperativeComponent and MindShieldComponent even when they had no reason to know about it fixed that

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Cheats could potentially read net state to detect nukeops and mindshielded players. Now only the antag themselves and players with ShowAntagIconsComponent/ShowMindShieldIconsComponent get that data.

## Technical details
<!-- Summary of code changes for easier review. -->
- Added SessionSpecific = true to NukeOperativeComponent and MindShieldComponent
- Added ComponentGetStateAttemptEvent handlers on server to gate state visibility
- Moved all dirty on ShowAntagIconsComponent added logic into SharedRevolutionarySystem.DirtyRevComps to avoid duplicate event subscriptions
- Removed [NetworkedComponent] from StoreComponent
- Passed store Name into StoreUpdateState

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Run local server + 2 clients
2. Give client 1 NukeOperative component via admin tools
3. On client 2 (no special components)  open entity inspector  nukeop state should not be visible
4. Give client 2 ShowAntagIcons  now it should be visible
5. Open a syndicate uplink and confirm the store still works

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
No visual changes.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer's discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: nukeop and mindshield component state is no longer sent to clients that shouldn't know about it
