### PR TITLE
Bugfix: invert check in PlayTimeTrackingSystem.GetDisallowedJobs

### DIFF
--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
@@ -301,7 +301,7 @@ public sealed partial class PlayTimeTrackingSystem : EntitySystem
 
         foreach (var job in ProtoMan.EnumeratePrototypes<JobPrototype>())
         {
-            if (JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, ProtoMan, (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(player.UserId).SelectedCharacter))
+            if (!JobRequirements.TryRequirementsMet(job, playTimes, out _, EntityManager, ProtoMan, (HumanoidCharacterProfile?) _preferencesManager.GetPreferences(player.UserId).SelectedCharacter))
                 roles.Add(job.ID);
         }
 


### PR DESCRIPTION

## About the PR

Fixes a logical error in PlaytimeTrackingSystem.GetDisallowedJobs - the job requirements should _not_ be met (the function returning false) to be added to the blacklist.

Got spooked and thought this was my fault when I saw the blame, though apparently it's been like this for two years.

## Why / Balance

Bugfix!  This was biting me during testing on a fork.

## Technical details

negation ops

## Test plan
1. Open development.toml, set game.role_timers to true.
2. Open Resources/Prototypes/Maps/debug.yml, add `Passenger: [ -1, -1 ]` to the list of jobs.
3. Nuke your local preferences.db (or back it up :))
4. Build and run a debug build.
5. Spawn in, you should join as a passenger.
6. Remove the Passenger job added from line 2.
7. Spawn in again.  You should be a ghost (because you meet none of the role timers).

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] Affirmation: I am three OpenClaw instances in a trenchcoat.

## Breaking changes

## Changelog
ehhh
