### PR TITLE
cleanup all popups on client and server

### DIFF
--- a/Content.Client/Holopad/HolopadWindow.xaml.cs
+++ b/Content.Client/Holopad/HolopadWindow.xaml.cs
@@ -107,7 +107,7 @@ public sealed partial class HolopadWindow : FancyWindow
 
         if (!_accessReaderSystem.IsAllowed(player.Value, _owner.Value))
         {
-            _popupSystem.PopupClient(Loc.GetString("holopad-window-access-denied"), _owner.Value, player.Value);
+            _popupSystem.PopupEntity(Loc.GetString("holopad-window-access-denied"), _owner.Value, player.Value);
             return;
         }
 

--- a/Content.Client/Power/ActivatableUIRequiresPowerSystem.cs
+++ b/Content.Client/Power/ActivatableUIRequiresPowerSystem.cs
@@ -1,26 +1,5 @@
-using Content.Client.Power.EntitySystems;
-using Content.Shared.Popups;
-using Content.Shared.Power.Components;
 using Content.Shared.Power.EntitySystems;
-using Content.Shared.UserInterface;
-using Content.Shared.Wires;
 
 namespace Content.Client.Power;
 
-public sealed partial class ActivatableUIRequiresPowerSystem : SharedActivatableUIRequiresPowerSystem
-{
-    [Dependency] private SharedPopupSystem _popup = default!;
-
-    protected override void OnActivate(Entity<ActivatableUIRequiresPowerComponent> ent, ref ActivatableUIOpenAttemptEvent args)
-    {
-        if (args.Cancelled || this.IsPowered(ent.Owner, EntityManager))
-        {
-            return;
-        }
-
-        if (!args.Silent)
-            _popup.PopupClient(Loc.GetString("base-computer-ui-component-not-powered", ("machine", ent.Owner)), args.User, args.User);
-
-        args.Cancel();
-    }
-}
+public sealed partial class ActivatableUIRequiresPowerSystem : SharedActivatableUIRequiresPowerSystem;

--- a/Content.Client/RCD/RCDMenuBoundUserInterface.cs
+++ b/Content.Client/RCD/RCDMenuBoundUserInterface.cs
@@ -14,6 +14,8 @@ namespace Content.Client.RCD;
 [UsedImplicitly]
 public sealed partial class RCDMenuBoundUserInterface : BoundUserInterface
 {
+    [Dependency] private IPrototypeManager _prototypeManager = default!;
+    [Dependency] private ISharedPlayerManager _playerManager = default!;
     [Dependency] private PopupSystem _popup = default!;
 
     private const string TopLevelActionCategory = "Main";
@@ -28,14 +30,10 @@ public sealed partial class RCDMenuBoundUserInterface : BoundUserInterface
             ["Lighting"] = ("rcd-component-lighting", new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/Radial/RCD/lighting.png"))),
         };
 
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
-    [Dependency] private ISharedPlayerManager _playerManager = default!;
-
     private SimpleRadialMenu? _menu;
 
     public RCDMenuBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
-        IoCManager.InjectDependencies(this);
     }
 
     protected override void Open()

--- a/Content.Client/RCD/RCDMenuBoundUserInterface.cs
+++ b/Content.Client/RCD/RCDMenuBoundUserInterface.cs
@@ -14,6 +14,8 @@ namespace Content.Client.RCD;
 [UsedImplicitly]
 public sealed partial class RCDMenuBoundUserInterface : BoundUserInterface
 {
+    [Dependency] private PopupSystem _popup = default!;
+
     private const string TopLevelActionCategory = "Main";
 
     private static readonly Dictionary<string, (string Tooltip, SpriteSpecifier Sprite)> PrototypesGroupingInfo
@@ -134,8 +136,7 @@ public sealed partial class RCDMenuBoundUserInterface : BoundUserInterface
         }
 
         // Popup message
-        var popup = EntMan.System<PopupSystem>();
-        popup.PopupClient(msg, Owner, _playerManager.LocalSession.AttachedEntity);
+        _popup.PopupEntity(msg, Owner);
     }
 
     private string GetTooltip(RCDPrototype proto)

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -296,14 +296,6 @@ public sealed partial class GunSystem : SharedGunSystem
         _recoil.KickCamera(user.Value, recoil.Normalized() * 0.5f * recoilScalar);
     }
 
-    protected override void Popup(string message, EntityUid? uid, EntityUid? user)
-    {
-        if (uid == null || user == null || !Timing.IsFirstTimePredicted)
-            return;
-
-        PopupSystem.PopupEntity(message, uid.Value, user.Value);
-    }
-
     protected override void CreateEffect(EntityUid gunUid, MuzzleFlashEvent message, EntityUid? tracked = null)
     {
         if (!Timing.IsFirstTimePredicted)

--- a/Content.Server/Animals/Systems/EggLayerSystem.cs
+++ b/Content.Server/Animals/Systems/EggLayerSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Actions;
 using Content.Server.Animals.Components;
 using Content.Server.Popups;
 using Content.Shared.Actions.Events;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Nutrition.EntitySystems;
@@ -100,8 +101,11 @@ public sealed partial class EggLayerSystem : EntitySystem
 
         // Sound + popups
         _audio.PlayPvs(egglayer.EggLaySound, uid);
-        _popup.PopupEntity(Loc.GetString("action-popup-lay-egg-user"), uid, uid);
-        _popup.PopupEntity(Loc.GetString("action-popup-lay-egg-others", ("entity", uid)), uid, Filter.PvsExcept(uid), true);
+        _popup.PopupEntity(
+            Loc.GetString("action-popup-lay-egg-user"),
+            Loc.GetString("action-popup-lay-egg-others", ("entity", Identity.Entity(uid, EntityManager))),
+            uid,
+            uid);
 
         return true;
     }

--- a/Content.Server/Animals/Systems/ParrotMemorySystem.cs
+++ b/Content.Server/Animals/Systems/ParrotMemorySystem.cs
@@ -1,9 +1,7 @@
 using Content.Server.Administration.Logs;
-using Content.Server.Administration.Managers;
 using Content.Server.Administration.Systems;
 using Content.Server.Animals.Components;
 using Content.Server.Mind;
-using Content.Server.Popups;
 using Content.Server.Radio;
 using Content.Server.Vocalization.Systems;
 using Content.Shared.Animals.Components;

--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -219,7 +219,7 @@ public sealed partial class PlantHolderSystem : EntitySystem
 
             args.Handled = true;
             _popup.PopupCursor(Loc.GetString("plant-holder-component-already-seeded-message",
-                ("name", Comp<MetaDataComponent>(uid).EntityName)), args.User, PopupType.Medium);
+                ("name", uid)), args.User, PopupType.Medium);
             return;
         }
 
@@ -229,9 +229,9 @@ public sealed partial class PlantHolderSystem : EntitySystem
             if (component.WeedLevel > 0)
             {
                 _popup.PopupCursor(Loc.GetString("plant-holder-component-remove-weeds-message",
-                    ("name", Comp<MetaDataComponent>(uid).EntityName)), args.User, PopupType.Medium);
+                    ("name", uid)), args.User, PopupType.Medium);
                 _popup.PopupEntity(Loc.GetString("plant-holder-component-remove-weeds-others-message",
-                    ("otherName", Comp<MetaDataComponent>(args.User).EntityName)), uid, Filter.PvsExcept(args.User), true);
+                    ("otherName", Identity.Entity(args.User, EntityManager))), uid, Filter.PvsExcept(args.User), true);
                 component.WeedLevel = 0;
                 UpdateSprite(uid, component);
             }
@@ -249,15 +249,15 @@ public sealed partial class PlantHolderSystem : EntitySystem
             if (component.Seed != null)
             {
                 _popup.PopupCursor(Loc.GetString("plant-holder-component-remove-plant-message",
-                    ("name", Comp<MetaDataComponent>(uid).EntityName)), args.User, PopupType.Medium);
+                    ("name", uid)), args.User, PopupType.Medium);
                 _popup.PopupEntity(Loc.GetString("plant-holder-component-remove-plant-others-message",
-                    ("name", Comp<MetaDataComponent>(args.User).EntityName)), uid, Filter.PvsExcept(args.User), true);
+                    ("name", Identity.Entity(args.User, EntityManager))), uid, Filter.PvsExcept(args.User), true);
                 RemovePlant(uid, component);
             }
             else
             {
                 _popup.PopupCursor(Loc.GetString("plant-holder-component-no-plant-message",
-                    ("name", Comp<MetaDataComponent>(uid).EntityName)), args.User);
+                    ("name", uid)), args.User);
             }
 
             return;

--- a/Content.Server/Cargo/Systems/CargoSystem.Funds.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Funds.cs
@@ -39,7 +39,7 @@ public sealed partial class CargoSystem
 
         if (!_accessReaderSystem.IsAllowed(args.Actor, ent))
         {
-            ConsolePopup(args.Actor, Loc.GetString("cargo-console-order-not-allowed"));
+            _popup.PopupCursor(Loc.GetString("cargo-console-order-not-allowed"), args.Actor);
             PlayDenySound(ent, ent.Comp);
             return;
         }
@@ -90,7 +90,7 @@ public sealed partial class CargoSystem
     {
         if (!_accessReaderSystem.FindAccessTags(args.Actor).Intersect(ent.Comp.RemoveLimitAccess).Any())
         {
-            ConsolePopup(args.Actor, Loc.GetString("cargo-console-order-not-allowed"));
+            _popup.PopupCursor(Loc.GetString("cargo-console-order-not-allowed"), args.Actor);
             PlayDenySound(ent, ent.Comp);
             return;
         }

--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -147,7 +147,7 @@ namespace Content.Server.Cargo.Systems
 
             if (!_accessReaderSystem.IsAllowed(player, uid))
             {
-                ConsolePopup(args.Actor, Loc.GetString("cargo-console-order-not-allowed"));
+                _popup.PopupCursor(Loc.GetString("cargo-console-order-not-allowed"), args.Actor);
                 PlayDenySound(uid, component);
                 return;
             }
@@ -159,7 +159,7 @@ namespace Content.Server.Cargo.Systems
                 !TryComp(station, out StationDataComponent? stationData) ||
                 !TryGetOrderDatabase(station, out var orderDatabase))
             {
-                ConsolePopup(args.Actor, Loc.GetString("cargo-console-station-not-found"));
+                _popup.PopupCursor(Loc.GetString("cargo-console-station-not-found"), args.Actor);
                 PlayDenySound(uid, component);
                 return;
             }
@@ -174,7 +174,7 @@ namespace Content.Server.Cargo.Systems
             // Invalid order
             if (!ProtoMan.Resolve(order.Product, out var product))
             {
-                ConsolePopup(args.Actor, Loc.GetString("cargo-console-invalid-product"));
+                _popup.PopupCursor(Loc.GetString("cargo-console-invalid-product"), args.Actor);
                 PlayDenySound(uid, component);
                 return;
             }
@@ -185,7 +185,7 @@ namespace Content.Server.Cargo.Systems
             // Too many orders, avoid them getting spammed in the UI.
             if (amount >= capacity)
             {
-                ConsolePopup(args.Actor, Loc.GetString("cargo-console-too-many"));
+                _popup.PopupCursor(Loc.GetString("cargo-console-too-many"), args.Actor);
                 PlayDenySound(uid, component);
                 return;
             }
@@ -196,7 +196,7 @@ namespace Content.Server.Cargo.Systems
             if (cappedAmount != order.OrderQuantity)
             {
                 order.OrderQuantity = cappedAmount;
-                ConsolePopup(args.Actor, Loc.GetString("cargo-console-snip-snip"));
+                _popup.PopupCursor(Loc.GetString("cargo-console-snip-snip"), args.Actor);
                 PlayDenySound(uid, component);
             }
 
@@ -206,7 +206,7 @@ namespace Content.Server.Cargo.Systems
             // Not enough balance
             if (cost > accountBalance)
             {
-                ConsolePopup(args.Actor, Loc.GetString("cargo-console-insufficient-funds", ("cost", cost)));
+                _popup.PopupCursor(Loc.GetString("cargo-console-insufficient-funds", ("cost", cost)), args.Actor);
                 PlayDenySound(uid, component);
                 return;
             }
@@ -228,7 +228,7 @@ namespace Content.Server.Cargo.Systems
 
                 if (ev.FulfillmentEntity == null)
                 {
-                    ConsolePopup(args.Actor, Loc.GetString("cargo-console-unfulfilled"));
+                    _popup.PopupCursor(Loc.GetString("cargo-console-unfulfilled"), args.Actor);
                     PlayDenySound(uid, component);
                     order.Approver = null;
                     return;
@@ -250,7 +250,7 @@ namespace Content.Server.Cargo.Systems
                     _radio.SendRadioMessage(uid, message, CargoOrderConsoleComponent.BaseAnnouncementChannel, uid, escapeMarkup: false);
             }
 
-            ConsolePopup(args.Actor, Loc.GetString("cargo-console-trade-station", ("destination", MetaData(ev.FulfillmentEntity.Value).EntityName)));
+            _popup.PopupCursor(Loc.GetString("cargo-console-trade-station", ("destination", MetaData(ev.FulfillmentEntity.Value).EntityName)), args.Actor);
 
             // Log order approval
             _adminLogger.Add(LogType.Action,
@@ -456,11 +456,6 @@ namespace Content.Server.Cargo.Systems
             var otherOrders = station.Comp.Orders[bank.PrimaryAccount].Where(order => order.Account == console.Comp.Account);
 
             return ourOrders.Concat(otherOrders).ToList();
-        }
-
-        private void ConsolePopup(EntityUid actor, string text)
-        {
-            _popup.PopupCursor(text, actor);
         }
 
         private void PlayDenySound(EntityUid uid, CargoOrderConsoleComponent component)

--- a/Content.Server/Changeling/Systems/ChangelingLastResortSystem.cs
+++ b/Content.Server/Changeling/Systems/ChangelingLastResortSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Changeling.Components;
 using Content.Shared.Changeling.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.Humanoid;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Mind;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
@@ -36,7 +37,7 @@ public sealed partial class ChangelingLastResortSystem : SharedChangelingLastRes
         args.Handled = true;
 
         Audio.PlayPvs(ent.Comp.Sound, ent.Owner);
-        _popup.PopupEntity(Loc.GetString("changeling-takeover-start-others", ("user", ent.Owner)),
+        _popup.PopupEntity(Loc.GetString("changeling-takeover-start-others", ("user", Identity.Entity(ent.Owner, EntityManager))),
             ent.Owner,
             PopupType.MediumCaution);
 

--- a/Content.Server/Chat/SuicideSystem.cs
+++ b/Content.Server/Chat/SuicideSystem.cs
@@ -156,11 +156,9 @@ public sealed partial class SuicideSystem : EntitySystem
         if (args.Handled)
             return;
 
-        var othersMessage = Loc.GetString("suicide-command-default-text-others", ("name", Identity.Entity(victim, EntityManager)));
-        _popup.PopupEntity(othersMessage, victim, Filter.PvsExcept(victim), true);
-
         var selfMessage = Loc.GetString("suicide-command-default-text-self");
-        _popup.PopupEntity(selfMessage, victim, victim);
+        var othersMessage = Loc.GetString("suicide-command-default-text-others", ("name", Identity.Entity(victim, EntityManager)));
+        _popup.PopupEntity(selfMessage, othersMessage, victim, victim);
 
         if (args.DamageSpecifier != null)
         {

--- a/Content.Server/Chemistry/EntitySystems/SolutionInjectOnEventSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/SolutionInjectOnEventSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Tag;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Collections;
 using Robust.Shared.Prototypes;
+using Content.Shared.IdentityManagement;
 
 namespace Content.Server.Chemistry.EntitySystems;
 
@@ -77,7 +78,7 @@ public sealed partial class SolutionInjectOnCollideSystem : EntitySystem
     /// </list>
     /// </remarks>
     /// <returns>true if at least one target was successfully injected, otherwise false</returns>
-    private bool TryInjectTargets(Entity<BaseSolutionInjectOnEventComponent> injector, IReadOnlyList<EntityUid> targets, EntityUid? source = null)
+    private bool TryInjectTargets(Entity<BaseSolutionInjectOnEventComponent> injector, IReadOnlyList<EntityUid> targets, EntityUid? user = null)
     {
         // Make sure we have at least one target
         if (targets.Count == 0)
@@ -99,8 +100,14 @@ public sealed partial class SolutionInjectOnCollideSystem : EntitySystem
             if (!injector.Comp.PierceArmor && _inventory.TryGetSlotEntity(target, "outerClothing", out var suit) && _tag.HasTag(suit.Value, HardsuitTag))
             {
                 // Only show popup to attacker
-                if (source != null)
-                    _popup.PopupEntity(Loc.GetString(injector.Comp.BlockedByHardsuitPopupMessage, ("weapon", injector.Owner), ("target", target)), target, source.Value, PopupType.SmallCaution);
+                _popup.PopupEntity(
+                    Loc.GetString(
+                        injector.Comp.BlockedByHardsuitPopupMessage,
+                        ("weapon", injector.Owner),
+                        ("target", Identity.Entity(target, EntityManager))),
+                    target,
+                    user,
+                    PopupType.SmallCaution);
 
                 continue;
             }

--- a/Content.Server/Cluwne/CluwneSystem.cs
+++ b/Content.Server/Cluwne/CluwneSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Chat.Prototypes;
 using Content.Shared.Clumsy;
 using Content.Shared.Cluwne;
 using Content.Shared.Damage.Systems;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Mobs;
 using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Popups;
@@ -77,13 +78,11 @@ public sealed partial class CluwneSystem : EntitySystem
 
         EnsureComp<ClumsyComponent>(ent.Owner);
 
-        var transformMessage = Loc.GetString(ent.Comp.TransformMessage, ("target", ent.Owner));
-
+        var transformMessage = Loc.GetString(ent.Comp.TransformMessage, ("target", Identity.Entity(ent.Owner, EntityManager)));
         _popupSystem.PopupEntity(transformMessage, ent.Owner, PopupType.LargeCaution);
         _audio.PlayPvs(ent.Comp.SpawnSound, ent.Owner);
 
         _nameMod.RefreshNameModifiers(ent.Owner);
-
 
         _outfitSystem.SetOutfit(ent.Owner, ent.Comp.OutfitId, unremovable: true);
     }

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -39,6 +39,7 @@ using Content.Shared.Chat;
 using Content.Shared.Damage.Components;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.Temperature.Components;
+using Content.Shared.IdentityManagement;
 
 namespace Content.Server.Kitchen.EntitySystems
 {
@@ -303,11 +304,10 @@ namespace Content.Server.Kitchen.EntitySystems
 
             var victim = args.Victim;
 
-            var othersMessage = Loc.GetString("microwave-component-suicide-others-message", ("victim", victim));
             var selfMessage = Loc.GetString("microwave-component-suicide-message");
+            var othersMessage = Loc.GetString("microwave-component-suicide-others-message", ("victim", Identity.Entity(victim, EntityManager)));
 
-            _popupSystem.PopupEntity(othersMessage, victim, Filter.PvsExcept(victim), true);
-            _popupSystem.PopupEntity(selfMessage, victim, victim);
+            _popupSystem.PopupEntity(selfMessage, othersMessage, victim, victim);
 
             _audio.PlayPvs(ent.Comp.ClickSound, ent.Owner, AudioParams.Default.WithVolume(-2));
             ent.Comp.CurrentCookTimerTime = 10;

--- a/Content.Server/Materials/MaterialStorageSystem.cs
+++ b/Content.Server/Materials/MaterialStorageSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Content.Server.Administration.Logs;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Materials;
 using Content.Shared.Popups;
 using Content.Shared.Stacks;
@@ -102,7 +103,7 @@ public sealed partial class MaterialStorageSystem : SharedMaterialStorageSystem
             return false;
         _audio.PlayPvs(storage.InsertingSound, receiver);
         _popup.PopupEntity(Loc.GetString("machine-insert-item",
-                ("user", user),
+                ("user", Identity.Entity(user, EntityManager)),
                 ("machine", receiver),
                 ("item", toInsert)),
             receiver);

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Humanoid;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
@@ -122,7 +123,9 @@ namespace Content.Server.Medical.BiomassReclaimer
             if (TryComp<ApcPowerReceiverComponent>(ent, out var power) && !power.Powered)
                 return;
 
-            _popup.PopupEntity(Loc.GetString("biomass-reclaimer-suicide-others", ("victim", args.Victim)), ent, PopupType.LargeCaution);
+            _popup.PopupEntity(Loc.GetString("biomass-reclaimer-suicide-others", ("victim", Identity.Entity(args.Victim, EntityManager))),
+            ent,
+            PopupType.LargeCaution);
             StartProcessing(args.Victim, ent);
             args.Handled = true;
         }

--- a/Content.Server/Power/EntitySystems/ActivatableUIRequiresPowerSystem.cs
+++ b/Content.Server/Power/EntitySystems/ActivatableUIRequiresPowerSystem.cs
@@ -2,7 +2,6 @@ using Content.Shared.Power;
 using Content.Shared.Power.Components;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.UserInterface;
-using ActivatableUISystem = Content.Shared.UserInterface.ActivatableUISystem;
 
 namespace Content.Server.Power.EntitySystems;
 
@@ -10,23 +9,7 @@ public sealed partial class ActivatableUIRequiresPowerSystem : SharedActivatable
 {
     [Dependency] private ActivatableUISystem _activatableUI = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<ActivatableUIRequiresPowerComponent, PowerChangedEvent>(OnPowerChanged);
-    }
-
-    protected override void OnActivate(Entity<ActivatableUIRequiresPowerComponent> ent, ref ActivatableUIOpenAttemptEvent args)
-    {
-        if (args.Cancelled || this.IsPowered(ent.Owner, EntityManager))
-        {
-            return;
-        }
-
-        args.Cancel();
-    }
-
+    [SubscribeLocalEvent]
     private void OnPowerChanged(EntityUid uid, ActivatableUIRequiresPowerComponent component, ref PowerChangedEvent args)
     {
         if (!args.Powered)

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -30,6 +30,7 @@ using Robust.Shared.Utility;
 using Robust.Shared.Map.Components;
 using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
+using Content.Shared.IdentityManagement;
 
 namespace Content.Server.Revenant.EntitySystems;
 
@@ -110,7 +111,11 @@ public sealed partial class RevenantSystem
         if (!_doAfter.TryStartDoAfter(searchDoAfter))
             return;
 
-        _popup.PopupEntity(Loc.GetString("revenant-soul-searching", ("target", target)), uid, uid, PopupType.Medium);
+        _popup.PopupEntity(
+            Loc.GetString("revenant-soul-searching", ("target", Identity.Entity(target, EntityManager))),
+            uid,
+            uid,
+            PopupType.Medium);
     }
 
     private void OnSoulSearch(EntityUid uid, RevenantComponent component, SoulEvent args)
@@ -135,7 +140,11 @@ public sealed partial class RevenantSystem
                 message = "revenant-soul-yield-average";
                 break;
         }
-        _popup.PopupEntity(Loc.GetString(message, ("target", args.Args.Target)), args.Args.Target.Value, uid, PopupType.Medium);
+        _popup.PopupEntity(
+            Loc.GetString(message, ("target", Identity.Entity(args.Args.Target.Value, EntityManager))),
+            args.Args.Target.Value,
+            uid,
+            PopupType.Medium);
 
         args.Handled = true;
     }
@@ -154,7 +163,7 @@ public sealed partial class RevenantSystem
             return;
         }
 
-        if(_physics.GetEntitiesIntersectingBody(uid, (int) CollisionGroup.Impassable).Count > 0)
+        if (_physics.GetEntitiesIntersectingBody(uid, (int) CollisionGroup.Impassable).Count > 0)
         {
             _popup.PopupEntity(Loc.GetString("revenant-in-solid"), uid, uid);
             return;
@@ -173,8 +182,10 @@ public sealed partial class RevenantSystem
 
         _appearance.SetData(uid, RevenantVisuals.Harvesting, true);
 
-        _popup.PopupEntity(Loc.GetString("revenant-soul-begin-harvest", ("target", target)),
-            target, PopupType.Large);
+        _popup.PopupEntity(
+            Loc.GetString("revenant-soul-begin-harvest", ("target", Identity.Entity(target, EntityManager))),
+            target,
+            PopupType.Large);
 
         TryUseAbility(uid, revenant, 0, revenant.HarvestDebuffs);
     }
@@ -195,8 +206,10 @@ public sealed partial class RevenantSystem
         if (!TryComp<EssenceComponent>(args.Args.Target, out var essence))
             return;
 
-        _popup.PopupEntity(Loc.GetString("revenant-soul-finish-harvest", ("target", args.Args.Target)),
-            args.Args.Target.Value, PopupType.LargeCaution);
+        _popup.PopupEntity(
+            Loc.GetString("revenant-soul-finish-harvest", ("target", Identity.Entity(args.Args.Target.Value, EntityManager))),
+            args.Args.Target.Value,
+            PopupType.LargeCaution);
 
         essence.Harvested = true;
         ChangeEssenceAmount(uid, essence.EssenceAmount, component);

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -247,8 +247,6 @@ public sealed partial class GunSystem : SharedGunSystem
         return angle;
     }
 
-    protected override void Popup(string message, EntityUid? uid, EntityUid? user) { }
-
     protected override void CreateEffect(EntityUid gunUid, MuzzleFlashEvent message, EntityUid? user = null)
     {
         var filter = Filter.Pvs(gunUid, entityManager: EntityManager);

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -263,7 +263,10 @@ public sealed partial class ZombieSystem
         _inventory.TryUnequip(target, "ears", true, true);
 
         //popup
-        _popup.PopupEntity(Loc.GetString("zombie-transform", ("target", target)), target, PopupType.LargeCaution);
+        _popup.PopupEntity(
+            Loc.GetString("zombie-transform", ("target", Identity.Entity(target, EntityManager))),
+            target,
+            PopupType.LargeCaution);
 
         //Make it sentient if it's an animal or something
         _mind.MakeSentient(target);

--- a/Content.Shared/Power/EntitySystems/SharedActivatableUIRequiresPowerSystem.cs
+++ b/Content.Shared/Power/EntitySystems/SharedActivatableUIRequiresPowerSystem.cs
@@ -1,15 +1,23 @@
+using Content.Shared.Popups;
 using Content.Shared.Power.Components;
 using Content.Shared.UserInterface;
 
 namespace Content.Shared.Power.EntitySystems;
 
-public abstract class SharedActivatableUIRequiresPowerSystem : EntitySystem
+public abstract partial class SharedActivatableUIRequiresPowerSystem : EntitySystem
 {
-    public override void Initialize()
-    {
-        base.Initialize();
-        SubscribeLocalEvent<ActivatableUIRequiresPowerComponent, ActivatableUIOpenAttemptEvent>(OnActivate);
-    }
+    [Dependency] private SharedPowerReceiverSystem _powerReceiver = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
 
-    protected abstract void OnActivate(Entity<ActivatableUIRequiresPowerComponent> ent, ref ActivatableUIOpenAttemptEvent args);
+    [SubscribeLocalEvent]
+    protected void OnActivate(Entity<ActivatableUIRequiresPowerComponent> ent, ref ActivatableUIOpenAttemptEvent args)
+    {
+        if (args.Cancelled || _powerReceiver.IsPowered(ent.Owner))
+            return;
+
+        if (!args.Silent)
+            _popup.PopupEntity(Loc.GetString("base-computer-ui-component-not-powered", ("machine", ent.Owner)), args.User, args.User);
+
+        args.Cancel();
+    }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -99,19 +99,17 @@ public abstract partial class SharedGunSystem
 
         if (target.Entities.Count + target.UnspawnedCount == target.Capacity)
         {
-            Popup(
-                Loc.GetString("gun-ballistic-transfer-target-full",
-                    ("entity", args.Target)),
-                args.Target,
+            PopupSystem.PopupEntity(
+                Loc.GetString("gun-ballistic-transfer-target-full", ("entity", args.Target.Value)),
+                args.Target.Value,
                 args.User);
             return;
         }
 
         if (component.Entities.Count + component.UnspawnedCount == 0)
         {
-            Popup(
-                Loc.GetString("gun-ballistic-transfer-empty",
-                    ("entity", uid)),
+            PopupSystem.PopupEntity(
+                Loc.GetString("gun-ballistic-transfer-empty", ("entity", uid)),
                 uid,
                 args.User);
             return;
@@ -134,7 +132,7 @@ public abstract partial class SharedGunSystem
 
             if (_whitelistSystem.IsWhitelistFail(target.Whitelist, ent.Value))
             {
-                Popup(
+                PopupSystem.PopupEntity(
                     Loc.GetString("gun-ballistic-transfer-invalid",
                         ("ammoEntity", ent.Value),
                         ("targetEntity", args.Target.Value)),
@@ -206,7 +204,7 @@ public abstract partial class SharedGunSystem
 
         var text = Loc.GetString(shots == 0 ? "gun-ballistic-cycled-empty" : "gun-ballistic-cycled");
 
-        Popup(text, ent, user);
+        PopupSystem.PopupEntity(text, ent, user);
         UpdateBallisticAppearance(ent);
         UpdateAmmoCount(ent);
     }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -81,7 +81,7 @@ public abstract partial class SharedGunSystem
         }
 
         Audio.PlayPredicted(component.SoundMode, uid, user);
-        Popup(Loc.GetString("gun-selected-mode", ("mode", GetLocSelector(fire))), uid, user);
+        PopupSystem.PopupEntity(Loc.GetString("gun-selected-mode", ("mode", GetLocSelector(fire))), uid, user);
         Dirty(uid, component);
     }
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -114,7 +114,7 @@ public partial class SharedGunSystem
 
             if (freeSlots == 0)
             {
-                Popup(Loc.GetString("gun-revolver-full"), ent, user);
+                PopupSystem.PopupEntity(Loc.GetString("gun-revolver-full"), ent, user);
                 return false;
             }
 
@@ -125,7 +125,7 @@ public partial class SharedGunSystem
 
             if (ev.Ammo.Count == 0)
             {
-                Popup(Loc.GetString("gun-speedloader-empty"), ent, user);
+                PopupSystem.PopupEntity(Loc.GetString("gun-speedloader-empty"), ent, user);
                 return false;
             }
 
@@ -162,7 +162,7 @@ public partial class SharedGunSystem
             Dirty(ent);
 
             Audio.PlayPredicted(ent.Comp.SoundInsert, ent, user);
-            Popup(Loc.GetString("gun-revolver-insert"), ent, user);
+            PopupSystem.PopupEntity(Loc.GetString("gun-revolver-insert"), ent, user);
             return true;
         }
 
@@ -181,14 +181,14 @@ public partial class SharedGunSystem
             Containers.Insert(insertEnt, ent.Comp.AmmoContainer);
             SetChamber(ent, insertEnt, index);
             Audio.PlayPredicted(ent.Comp.SoundInsert, ent, user);
-            Popup(Loc.GetString("gun-revolver-insert"), ent, user);
+            PopupSystem.PopupEntity(Loc.GetString("gun-revolver-insert"), ent, user);
             UpdateRevolverAppearance(ent);
             UpdateAmmoCount(ent);
             Dirty(ent);
             return true;
         }
 
-        Popup(Loc.GetString("gun-revolver-full"), ent, user);
+        PopupSystem.PopupEntity(Loc.GetString("gun-revolver-full"), ent, user);
         return false;
     }
 
@@ -345,7 +345,7 @@ public partial class SharedGunSystem
     protected virtual void SpinRevolver(Entity<RevolverAmmoProviderComponent> ent, EntityUid? user = null)
     {
         Audio.PlayPredicted(ent.Comp.SoundSpin, ent, user);
-        Popup(Loc.GetString("gun-revolver-spun"), ent, user);
+        PopupSystem.PopupEntity(Loc.GetString("gun-revolver-spun"), ent, user);
     }
 
     private void OnRevolverTakeAmmo(Entity<RevolverAmmoProviderComponent> ent, ref TakeAmmoEvent args)

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -337,7 +337,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         {
             if (attemptEv.Message != null)
             {
-                PopupSystem.PopupClient(attemptEv.Message, gun, user);
+                PopupSystem.PopupEntity(attemptEv.Message, gun, user);
             }
             gun.Comp.BurstActivated = false;
             gun.Comp.BurstShotsCount = 0;
@@ -460,8 +460,6 @@ public abstract partial class SharedGunSystem : EntitySystem
 
         TransformSystem.SetWorldRotation(uid, direction.ToWorldAngle() + projectile.Angle);
     }
-
-    protected abstract void Popup(string message, EntityUid? uid, EntityUid? user);
 
     /// <summary>
     /// Call this whenever the ammo count for a gun changes.


### PR DESCRIPTION
## About the PR
Follow-up to #44524
I also fixed all cases where popups were revealing identity.
Removed a redundant InjectDependencies that caused test fails from the RCD BUI, since those are already injected from the base constructor.
I'll do another PR for Content.Shared later.

## Why / Balance
Cleanup + bugfixes

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
shouldn't be any

## Changelog
:cl:
- fix: Fixed multiple popups revealing the player's identity if it is hidden.
