### PR TITLE
Unpredict handheld grinder audio

### DIFF
--- a/Content.Shared/Kitchen/EntitySystems/HandheldGrinderSystem.cs
+++ b/Content.Shared/Kitchen/EntitySystems/HandheldGrinderSystem.cs
@@ -68,7 +68,7 @@ public sealed partial class HandheldGrinderSystem : EntitySystem
         };
 
         if (_doAfter.TryStartDoAfter(doAfter))
-            ent.Comp.AudioStream = _audio.PlayPredicted(ent.Comp.Sound, ent, args.User)?.Entity ?? ent.Comp.AudioStream;
+            ent.Comp.AudioStream = _audio.PlayPvs(ent.Comp.Sound, ent)?.Entity ?? ent.Comp.AudioStream;
     }
 
     [SubscribeLocalEvent]

--- a/Content.Shared/Kitchen/EntitySystems/HandheldGrinderSystem.cs
+++ b/Content.Shared/Kitchen/EntitySystems/HandheldGrinderSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Popups;
 using Content.Shared.Stacks;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Kitchen.EntitySystems;
@@ -23,6 +24,7 @@ public sealed partial class HandheldGrinderSystem : EntitySystem
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedPuddleSystem _puddle = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private INetManager _net = default!;
 
     // prevent the infamous UdderSystem debug assert, see https://github.com/space-wizards/space-station-14/pull/35314
     // TODO: find a better solution than copy pasting this into every shared system that caches solution entities
@@ -58,6 +60,11 @@ public sealed partial class HandheldGrinderSystem : EntitySystem
         if (!_solution.ResolveSolution(ent.Owner, ent.Comp.SolutionName, ref ent.Comp.GrinderSolution))
             return;
 
+        ent.Comp.AudioStream = _audio.Stop(ent.Comp.AudioStream);
+
+        if (_net.IsServer) // Cannot correctly cancel predicted audio.
+            ent.Comp.AudioStream = _audio.PlayPvs(ent.Comp.Sound, ent)?.Entity;
+
         var doAfter = new DoAfterArgs(EntityManager, args.User, ent.Comp.DoAfterDuration, new HandheldGrinderDoAfterEvent(), ent, ent, item)
         {
             NeedHand = true,
@@ -67,8 +74,7 @@ public sealed partial class HandheldGrinderSystem : EntitySystem
             BreakOnMove = true
         };
 
-        if (_doAfter.TryStartDoAfter(doAfter))
-            ent.Comp.AudioStream = _audio.PlayPvs(ent.Comp.Sound, ent)?.Entity ?? ent.Comp.AudioStream;
+        _doAfter.TryStartDoAfter(doAfter);
     }
 
     [SubscribeLocalEvent]

--- a/Content.Shared/Kitchen/EntitySystems/HandheldGrinderSystem.cs
+++ b/Content.Shared/Kitchen/EntitySystems/HandheldGrinderSystem.cs
@@ -24,17 +24,9 @@ public sealed partial class HandheldGrinderSystem : EntitySystem
     [Dependency] private SharedPuddleSystem _puddle = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<HandheldGrinderComponent, EntRemovedFromContainerMessage>(OnGrinderRemoved);
-        SubscribeLocalEvent<HandheldGrinderComponent, InteractUsingEvent>(OnInteractUsing);
-        SubscribeLocalEvent<HandheldGrinderComponent, HandheldGrinderDoAfterEvent>(OnHandheldDoAfter);
-    }
-
     // prevent the infamous UdderSystem debug assert, see https://github.com/space-wizards/space-station-14/pull/35314
     // TODO: find a better solution than copy pasting this into every shared system that caches solution entities
+    [SubscribeLocalEvent]
     private void OnGrinderRemoved(Entity<HandheldGrinderComponent> entity, ref EntRemovedFromContainerMessage args)
     {
         // Make sure the removed entity was our contained solution and set it to null
@@ -44,6 +36,7 @@ public sealed partial class HandheldGrinderSystem : EntitySystem
         entity.Comp.GrinderSolution = null;
     }
 
+    [SubscribeLocalEvent]
     private void OnInteractUsing(Entity<HandheldGrinderComponent> ent, ref InteractUsingEvent args)
     {
         if (args.Handled)
@@ -55,7 +48,7 @@ public sealed partial class HandheldGrinderSystem : EntitySystem
 
         if (!CanGrinderBeUsed(ent, item, out var reason))
         {
-            _popup.PopupClient(reason, ent, args.User);
+            _popup.PopupEntity(reason, ent, args.User);
             return;
         }
 
@@ -78,6 +71,7 @@ public sealed partial class HandheldGrinderSystem : EntitySystem
             ent.Comp.AudioStream = _audio.PlayPredicted(ent.Comp.Sound, ent, args.User)?.Entity ?? ent.Comp.AudioStream;
     }
 
+    [SubscribeLocalEvent]
     private void OnHandheldDoAfter(Entity<HandheldGrinderComponent> ent, ref HandheldGrinderDoAfterEvent args)
     {
         ent.Comp.AudioStream = _audio.Stop(ent.Comp.AudioStream);
@@ -90,7 +84,7 @@ public sealed partial class HandheldGrinderSystem : EntitySystem
 
         if (!CanGrinderBeUsed(ent, item, out var reason))
         {
-            _popup.PopupClient(reason, ent, args.User);
+            _popup.PopupEntity(reason, ent, args.User);
             return;
         }
 
@@ -110,7 +104,7 @@ public sealed partial class HandheldGrinderSystem : EntitySystem
         else
             _destructibleSystem.DestroyEntity(item);
 
-        _popup.PopupClient(Loc.GetString(ent.Comp.FinishedPopup, ("item", item)), ent, args.User);
+        _popup.PopupEntity(Loc.GetString(ent.Comp.FinishedPopup, ("item", item)), ent, args.User);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Unpredicted handheld grinder audio. Also modernized the system.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Cancelling predicted audio is fucky, because client spawns a clientside entity, when we try to cancel the audio server and client have different audio entities and shit gets bulldozed and we suffer by hearing KSH KSH KSH KSH KSH KSH KSH KSH forever.

## Technical details
<!-- Summary of code changes for easier review. -->
_net.IsServer, because PlayPvs still somehow played predicted audio.
Replaced subscriptions with the sub attributes.
Self predicting popups.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Spamclick steel onto a mortar and pestle
2. Sound is cancelled every time

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Mortar and pestle & handheld juicer audio will no longer loop endlessly.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
