### PR TITLE
Adds "Free" uplink tab, adds radio implant to it (experimental)

### DIFF
--- a/Resources/Locale/en-US/store/categories.ftl
+++ b/Resources/Locale/en-US/store/categories.ftl
@@ -1,6 +1,7 @@
 # Uplink
 store-category-debug = debug category
 store-category-debug2 = debug category 2
+store-category-free = Free
 store-category-weapons = Weaponry
 store-category-ammo = Ammo
 store-category-explosives = Explosives

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -1,3 +1,28 @@
+# Free
+uplink-radio-implanter-free-name = Radio Implanter
+uplink-radio-implanter-free-desc = Implants a Syndicate radio, allowing covert communication without a headset.
+
+uplink-syndicate-stamp-name = Syndicate Rubber Stamp
+uplink-syndicate-stamp-desc = A rubber stamp for stamping important documents.
+
+uplink-business-card-name = Syndicate Business Card
+uplink-business-card-desc = A business card that you can give to someone to demonstrate your involvement in the syndicate or leave at the crime scene in order to make fun of the detective. You can buy no more than three of them.
+
+uplink-outlaw-hat-name = Outlaw Hat
+uplink-outlaw-hat-desc = A hat that makes you look like you carry a notched pistol, numbered one and nineteen more.
+
+uplink-operative-suit-name = Operative Jumpsuit
+uplink-operative-suit-desc = A suit given to our nuclear operatives with fine fabric to make sure you stand out, no other benefits aside from looking cool.
+
+uplink-operative-skirt-name = Operative Jumpskirt
+uplink-operative-skirt-desc = A skirt given to our nuclear operatives with fine fabric to make sure you stand out, no other benefits aside from looking cool.
+
+uplink-scarf-syndie-red-name = Striped syndicate red scarf
+uplink-scarf-syndie-red-desc = A stylish striped syndicate red scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.
+
+uplink-scarf-syndie-green-name = Striped syndicate green scarf
+uplink-scarf-syndie-green-desc = A stylish striped syndicate green scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.
+
 # Weapons
 uplink-pistol-viper-name = Viper
 uplink-pistol-viper-desc = A small, easily concealable, but somewhat underpowered gun. Retrofitted with a fully automatic receiver. Uses pistol magazines (.35 auto).
@@ -234,7 +259,7 @@ uplink-micro-bomb-implanter-name = Micro Bomb Implanter
 uplink-micro-bomb-implanter-desc = Explode on death or manual activation with this implant. Destroys the body with all equipment.
 
 uplink-radio-implanter-name = Radio Implanter
-uplink-radio-implanter-desc = Implants a Syndicate radio, allowing covert communication without a headset.
+uplink-radio-implanter-desc = Implants a Syndicate radio, allowing covert communication without a headset. One is available under the free tab.
 
 uplink-voice-mask-implanter-name = Identity Mask Implanter
 uplink-voice-mask-implanter-desc = Modifies your vocal cords and facial structure to be able to mimic anyone you could imagine.
@@ -446,14 +471,8 @@ uplink-chameleon-projector-desc = Disappear in plain sight by creating a hologra
 uplink-revolver-cap-gun-name = Cap Gun
 uplink-revolver-cap-gun-desc = Looks almost like the real thing! Ages 8 and up.
 
-uplink-syndicate-stamp-name = Syndicate Rubber Stamp
-uplink-syndicate-stamp-desc = A rubber stamp for stamping important documents.
-
 uplink-cat-ears-name = Cat Ears
 uplink-cat-ears-desc = UwU
-
-uplink-outlaw-hat-name = Outlaw Hat
-uplink-outlaw-hat-desc = A hat that makes you look like you carry a notched pistol, numbered one and nineteen more.
 
 uplink-outlaw-glasses-name = Outlaw Glasses
 uplink-outlaw-glasses-desc = A must for every self-respecting undercover agent.
@@ -467,20 +486,8 @@ uplink-costume-clown-desc = Contains a complete Clown outfit. Includes PDA and s
 uplink-carp-suit-bundle-name = Carp Suit Duffel Bag
 uplink-carp-suit-bundle-desc = Contains a carp suit and some friends to play with.
 
-uplink-operative-suit-name = Operative Jumpsuit
-uplink-operative-suit-desc = A suit given to our nuclear operatives with fine fabric to make sure you stand out, no other benefits aside from looking cool.
-
-uplink-operative-skirt-name = Operative Jumpskirt
-uplink-operative-skirt-desc = A skirt given to our nuclear operatives with fine fabric to make sure you stand out, no other benefits aside from looking cool.
-
 uplink-balloon-name = Syndie Balloon
 uplink-balloon-desc = Handed out to the bravest souls who survived the "atomic twister" ride at Syndieland.
-
-uplink-scarf-syndie-red-name = Striped syndicate red scarf
-uplink-scarf-syndie-red-desc = A stylish striped syndicate red scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.
-
-uplink-scarf-syndie-green-name = Striped syndicate green scarf
-uplink-scarf-syndie-green-desc = A stylish striped syndicate green scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.
 
 uplink-syndicate-pai-name = Syndicate personal ai device
 uplink-syndicate-pai-desc = A Syndicate variant of the pAI with access to the Syndicate radio channel. We do not guarantee their usefulness.
@@ -502,9 +509,6 @@ uplink-cameraBug-desc = A portable device that allows you to view the station's 
 
 uplink-combat-bakery-name = Combat Bakery Kit
 uplink-combat-bakery-desc = A kit of clandestine baked weapons. Contains a baguette sword, a pair of throwing croissants, and a syndicate microwave board for making more. Once the job is done, eat the evidence.
-
-uplink-business-card-name = Syndicate Business Card
-uplink-business-card-desc = A business card that you can give to someone to demonstrate your involvement in the syndicate or leave at the crime scene in order to make fun of the detective. You can buy no more than three of them.
 
 uplink-fake-mindshield-name = Fake Mindshield
 uplink-fake-mindshield-desc = A togglable implant capable of mimicking the same transmissions a real mindshield puts out when on, tricking capable Heads-up displays into thinking you have a mindshield (Nanotrasen brand implanter not provided.)

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -17,6 +17,8 @@
     blacklist:
       tags:
       - NukeOpsUplink
+  - !type:BuyerWhitelistCondition
+    blacklist:
       components:
       - SurplusBundle
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1,4 +1,100 @@
 # TODO: make more categories
+
+#Free
+
+- type: listing
+  id: UplinkRadioImplanterFree
+  name: uplink-radio-implanter-free-name
+  description: uplink-radio-implanter-free-desc
+  icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: synd_label }
+  productEntity: RadioImplanter
+  categories:
+  - UplinkFree
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+      - NukeOpsUplink
+
+- type: listing
+  id: UplinkSyndicateStamp
+  name: uplink-syndicate-stamp-name
+  description: uplink-syndicate-stamp-desc
+  productEntity: RubberStampSyndicate
+  categories:
+  - UplinkFree
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
+  id: UplinkSyndicateBusinessCard
+  name: uplink-business-card-name
+  description: uplink-business-card-desc
+  productEntity: SyndicateBusinessCard
+  categories:
+    - UplinkFree
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 3
+
+- type: listing
+  id: UplinkOutlawHat
+  name: uplink-outlaw-hat-name
+  description: uplink-outlaw-hat-desc
+  productEntity: ClothingHeadHatOutlawHat
+  categories:
+  - UplinkFree
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
+  id: UplinkOperativeSuit
+  name: uplink-operative-suit-name
+  description: uplink-operative-suit-desc
+  productEntity: ClothingUniformJumpsuitOperative
+  categories:
+  - UplinkFree
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
+  id: UplinkOperativeSkirt
+  name: uplink-operative-skirt-name
+  description: uplink-operative-skirt-desc
+  productEntity: ClothingUniformJumpskirtOperative
+  categories:
+  - UplinkFree
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
+  id: UplinkScarfSyndieRed
+  name: uplink-scarf-syndie-red-name
+  description: uplink-scarf-syndie-red-desc
+  productEntity: ClothingNeckScarfStripedSyndieRed
+  categories:
+  - UplinkFree
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
+  id: UplinkScarfSyndieGreen
+  name: uplink-scarf-syndie-green-name
+  description: uplink-scarf-syndie-green-desc
+  productEntity: ClothingNeckScarfStripedSyndieGreen
+  categories:
+    - UplinkFree
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
 # Guns
 
 - type: listing
@@ -1844,17 +1940,6 @@
   - UplinkPointless
 
 - type: listing
-  id: UplinkSyndicateStamp
-  name: uplink-syndicate-stamp-name
-  description: uplink-syndicate-stamp-desc
-  productEntity: RubberStampSyndicate
-  categories:
-  - UplinkPointless
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
   id: UplinkCatEars
   name: uplink-cat-ears-name
   description: uplink-cat-ears-desc
@@ -1868,17 +1953,6 @@
     blacklist:
       components:
       - SurplusBundle
-
-- type: listing
-  id: UplinkOutlawHat
-  name: uplink-outlaw-hat-name
-  description: uplink-outlaw-hat-desc
-  productEntity: ClothingHeadHatOutlawHat
-  categories:
-  - UplinkPointless
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
 
 - type: listing
   id: UplinkOutlawGlasses
@@ -1921,28 +1995,6 @@
   - UplinkPointless
 
 - type: listing
-  id: UplinkOperativeSuit
-  name: uplink-operative-suit-name
-  description: uplink-operative-suit-desc
-  productEntity: ClothingUniformJumpsuitOperative
-  categories:
-  - UplinkPointless
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
-  id: UplinkOperativeSkirt
-  name: uplink-operative-skirt-name
-  description: uplink-operative-skirt-desc
-  productEntity: ClothingUniformJumpskirtOperative
-  categories:
-  - UplinkPointless
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
   id: UplinkBalloon
   name: uplink-balloon-name
   description: uplink-balloon-desc
@@ -1956,39 +2008,6 @@
     blacklist:
       components:
       - SurplusBundle
-
-- type: listing
-  id: UplinkScarfSyndieRed
-  name: uplink-scarf-syndie-red-name
-  description: uplink-scarf-syndie-red-desc
-  productEntity: ClothingNeckScarfStripedSyndieRed
-  categories:
-  - UplinkPointless
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
-  id: UplinkScarfSyndieGreen
-  name: uplink-scarf-syndie-green-name
-  description: uplink-scarf-syndie-green-desc
-  productEntity: ClothingNeckScarfStripedSyndieGreen
-  categories:
-    - UplinkPointless
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
-  id: UplinkSyndicateBusinessCard
-  name: uplink-business-card-name
-  description: uplink-business-card-desc
-  productEntity: SyndicateBusinessCard
-  categories:
-    - UplinkPointless
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 3
 
 - type: listing
   id: UplinkDecoyKit

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -17,6 +17,8 @@
     blacklist:
       tags:
       - NukeOpsUplink
+      components:
+      - SurplusBundle
 
 - type: listing
   id: UplinkSyndicateStamp

--- a/Resources/Prototypes/Store/categories.yml
+++ b/Resources/Prototypes/Store/categories.yml
@@ -35,64 +35,69 @@
 
 #uplink categoires
 - type: storeCategory
+  id: UplinkFree
+  name: store-category-free
+  priority: 0
+
+- type: storeCategory
   id: UplinkWeaponry
   name: store-category-weapons
-  priority: 0
+  priority: 1
 
 - type: storeCategory
   id: UplinkAmmo
   name: store-category-ammo
-  priority: 1
+  priority: 2
 
 - type: storeCategory
   id: UplinkExplosives
   name: store-category-explosives
-  priority: 2
+  priority: 3
 
 - type: storeCategory
   id: UplinkWearables
   name: store-category-wearables
-  priority: 3
+  priority: 4
 
 - type: storeCategory
   id: UplinkChemicals
   name: store-category-chemicals
-  priority: 4
+  priority: 5
 
 - type: storeCategory
   id: UplinkDeception
   name: store-category-deception
-  priority: 5
+  priority: 6
 
 - type: storeCategory
   id: UplinkDisruption
   name: store-category-disruption
-  priority: 6
+  priority: 7
 
 - type: storeCategory
   id: UplinkImplants
   name: store-category-implants
-  priority: 7
+  priority: 8
 
 - type: storeCategory
   id: UplinkAllies
   name: store-category-allies
-  priority: 8
+  priority: 9
 
 - type: storeCategory
   id: UplinkJob
   name: store-category-job
-  priority: 9
+  priority: 10
 
 - type: storeCategory
   id: UplinkPointless
   name: store-category-pointless
-  priority: 10
+  priority: 11
 
 - type: storeCategory
   id: UplinkObjective
   name: store-category-objective
-  priority: 11
+  priority: 12
 
 #nukie delivery
 

--- a/Resources/Prototypes/Store/presets.yml
+++ b/Resources/Prototypes/Store/presets.yml
@@ -5,6 +5,7 @@
   - type: Store
     name: store-preset-name-uplink
     categories:
+    - UplinkFree
     - UplinkWeaponry
     - UplinkAmmo
     - UplinkExplosives


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a free tab to the uplink, organized some .ftl and such accordingly, added the radio implant to it as an experimental change. Implanter tab purchase marked to indicate you can grab one for free (purchase limit 1, also blacklisted from surplus.)

## Why / Balance
Traitor rounds are really swingy, mostly in the direction of greenshift. I think a lot of this is psychology. People feel anxious and hunted, codewords are sometimes never used or never responded to, lower-experience players don't have anyone to consult. Going loud while solo is also a skill few people have. Giving everyone access to the syndicate channel is far from a perfect solution but I think it gives an opportunity to test how traitor rounds play out with more coordination and hopefully make them less boring. This was absolutely possible before at only 2TC but that's a prisoner's dilemma kind of situation. I have seen a better solution to this proposed where traitors are in premade teams based on sponsor but this could be a good way to test it/stopgap.

Concerns:
This invalidates codewords - largely yes but I don't think they're doing the job right now.
Newer players will get caught with the implant and instantly compromise traitor comms - there are solutions to this but none of them elegant. I think an OK solution would be them breaking when pulled.
Unified traitors will demolish the station - this is hard to say for certain. I think a lot of this is server culture and hinges on a fairly small set of players who have the skills to pull this off. I think these people already know how to find each other. Worth testing.

## Technical details
Pretty much exclusively moving things around in the ftl and yml files. Tried to keep things organized. Free category was moved to the top, some people might not like that if there's nothing of value in it. The free tab listings seem to do whatever they want due to having no price to sort by and do not follow the order of the yml. I don't know what to do about that but the radio implant is listing #2 every time I boot up the test server so works for me.

## Test plan
Uplink shows modified description for normal radio implant listing, free tab present, free tab contains 1 radio implant for purchase. Nukie uplink does not contain this.

## Media
<img width="1536" height="613" alt="image" src="https://github.com/user-attachments/assets/8d5998fc-fe62-42cc-8199-5f3fe4a0f354" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The uplink now has a "Free" category.
- tweak: EXPERIMENTAL: Traitors can purchase one radio implant in the free tab. 

