### PR TITLE
Removal of Liquid/Supercooled Gas Canisters from Cargo Requests

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -19,16 +19,6 @@
   group: market
 
 - type: cargoProduct
-  id: AtmosphericsLiquidOxygen
-  icon:
-    sprite: Structures/Storage/canister.rsi
-    state: blue
-  product: LiquidOxygenCanister
-  cost: 1000
-  category: cargoproduct-category-name-atmospherics
-  group: market
-
-- type: cargoProduct
   id: AtmosphericsNitrogen
   icon:
     sprite: Structures/Storage/canister.rsi
@@ -39,32 +29,12 @@
   group: market
 
 - type: cargoProduct
-  id: AtmosphericsLiquidNitrogen
-  icon:
-    sprite: Structures/Storage/canister.rsi
-    state: red
-  product: LiquidNitrogenCanister
-  cost: 1000
-  category: cargoproduct-category-name-atmospherics
-  group: market
-
-- type: cargoProduct
   id: AtmosphericsCarbonDioxide
   icon:
     sprite: Structures/Storage/canister.rsi
     state: black
   product: CarbonDioxideCanister
   cost: 670 # even though it's poisonous, it comes locked and only damages you slowly even with high amounts (tested)
-  category: cargoproduct-category-name-atmospherics
-  group: market
-
-- type: cargoProduct
-  id: AtmosphericsLiquidCarbonDioxide
-  icon:
-    sprite: Structures/Storage/canister.rsi
-    state: black
-  product: LiquidCarbonDioxideCanister
-  cost: 1800 # much less deadly than the plasma can (this has been tested) even though this is cold+poison
   category: cargoproduct-category-name-atmospherics
   group: market
 


### PR DESCRIPTION
## About the PR
Removes all versions of liquid/supercooled gas canisters including:
- Oxygen
- Nitrogen
- Carbon Dioxide

This PR does not remove these items from being spawn-able in game for admin and possible future uses of loot spawns.

## Why / Balance
Giving a super quick way to purchase in most cases, liquid nitrogen without interacting with Atmospherics seems to be unintended. This should incentivize interacting as crew with atmospherics more especially at the start of shifts rather than purchasing it from Cargo. 

## Technical details
Removes three prototypes from cargo_atmospherics.yml

## Test plan
Launched into Development Environment.
Confirmed liquid canisters were still spawn-able.
Confirmed that liquid canisters were no longer purchasable from Cargo Request.

## Media
<img width="997" height="600" alt="image" src="https://github.com/user-attachments/assets/60370c2c-52af-4b08-bcb0-cc39c55d55f0" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- remove: Removed liquid gas canisters from being purchased by Cargo.