### PR TITLE
Increase rapid connection limit for dev

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -61,5 +61,5 @@ pg_username = "postgres"
 pg_password = "postgres"
 
 [net]
-max_rapid_connections = 13
-max_ip_connections = 13
+max_rapid_connections = 413
+max_ip_connections = 413

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -62,3 +62,4 @@ pg_password = "postgres"
 
 [net]
 max_rapid_connections = 13
+max_ip_connections = 13

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -59,3 +59,6 @@ pg_port = 5432
 pg_database = "ss14"
 pg_username = "postgres"
 pg_password = "postgres"
+
+[net]
+max_rapid_connections = 12

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -61,4 +61,4 @@ pg_username = "postgres"
 pg_password = "postgres"
 
 [net]
-max_rapid_connections = 12
+max_rapid_connections = 13


### PR DESCRIPTION
## About the PR
Increase the connection limit for the dev build, so you can launch up to 12 clients without triggering the DOS protection

## Why / Balance
Dev convenience when needing several clients for testing. It is probably a lot more common for someone to be testing with more than 3 clients, than it is for someone to test anything related to the DOS protection limits. So the default configuration should be catering to the former

## Technical details
Just a cvar change for the dev build, no impact on live servers

## Test plan

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
