### PR TITLE
Admin playertab can now filter for roles

### DIFF
--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
@@ -9,6 +9,7 @@ using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.XAML;
 using Robust.Shared.Configuration;
+using Robust.Shared.Prototypes;
 using static Content.Client.Administration.UI.Tabs.PlayerTab.PlayerTabHeader;
 using static Robust.Client.UserInterface.Controls.BaseButton;
 
@@ -20,6 +21,7 @@ public sealed partial class PlayerTab : Control
     [Dependency] private IEntityManager _entManager = default!;
     [Dependency] private IConfigurationManager _config = default!;
     [Dependency] private IPlayerManager _playerMan = default!;
+    [Dependency] private IPrototypeManager _proto = default!;
 
     private const string ArrowUp = "↑";
     private const string ArrowDown = "↓";
@@ -155,7 +157,12 @@ public sealed partial class PlayerTab : Control
         UpdateHeaderSymbols();
 
         SearchList.PopulateList(sortedPlayers.Select(info => new PlayerListData(info,
-                $"{info.Username} {info.CharacterName} {info.IdentityName} {info.StartingJob}"))
+                $"{info.Username} " +
+                $"{info.CharacterName} " +
+                $"{info.IdentityName} " +
+                $"{info.StartingJob} " +
+                $"{Loc.GetString(info.Subtype ?? string.Empty)} " +
+                $"{(_proto.TryIndex(info.RoleProto, out var proto) ? Loc.GetString(proto.Name) : string.Empty)}"))
             .ToList());
     }
 


### PR DESCRIPTION
## About the PR
Admin playertab can now filter the player list for roles and role subtypes (Crew Aligned, Team Antagonist, Zombie, etc)
Both new categories use localization

## Why / Balance
QOL, feature was requested

## Technical details
The playerinfo's role and subtype are now also added to the "search string". This required for IPrototypeManager to be added as a dependency, because the playerinfo available only contains the protoID of the role, it must be indexed to get the name's locId. 

## Test plan
Launch client
Press F7
Try filtering to previous categories: username, character name, username, "Captain" job, 
Try filtering for "Crew Aligned" role
Turn character into Zombie via right-click Antag menu
Try filtering for "Zombie" subtype

## Media
https://github.com/user-attachments/assets/025ca554-6682-4102-90ab-cea75986322a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl: Errant
ADMIN:
- tweak: The F7 playertab's filter now also works with role (Crew Aligned, Team Antagonist etc) and role subtype (Traitor, Zombie etc).
