### PR TITLE
filter gases with 0 moles from admin logs

### DIFF
--- a/Content.Shared/Atmos/Piping/Unary/Systems/SharedGasCanisterSystem.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Systems/SharedGasCanisterSystem.cs
@@ -114,7 +114,8 @@ public abstract partial class SharedGasCanisterSystem : GasMaxPressureSystem<Gas
 
         for (var i = 0; i < containedGasArray.Length; i++)
         {
-            containedGasDict.Add((Gas)i, entity.Comp.Air[i]);
+            if (entity.Comp.Air.GetMoles(i) > 0f)
+                containedGasDict.Add((Gas)i, entity.Comp.Air[i]);
         }
 
         AdminLogger.Add(LogType.CanisterValve, impact, $"{ToPrettyString(args.Actor):player} set the valve on {ToPrettyString(entity):canister} to {args.Valve:valveState} while it contained [{string.Join(", ", containedGasDict)}]");


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made it so that when someone releases the valve on a canister, it only lists gases that are present in the mixture instead of all of them.

## Why / Balance
This cluttered admin logs and made it difficult to search for. Now, if you see evac fill up with tritium and you see a canister, you can just search "tritium" and get to what you need to see faster.

## Technical details
One liner that filters any zero-mole gas in a mixture.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Checkout master
2. spawn an oxygen canister
3. spawn a tritium canister
4. open the valve on the oxygen canister
5. open the valve on the tritium canister
6. open admin logs and search "tritium"
7.  see both canisters and who opened the valve on them

1. checkout this branch
2. spawn an oxygen canister
3. spawn a tritium canister
4. open the valve on the oxygen canister
5. open the valve on the tritium canister
6. open admin logs and search "tritium"
7. see only the trit canister and who opened the valve on it

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:
<img width="2100" height="95" alt="image" src="https://github.com/user-attachments/assets/5154a424-b740-488c-ae0c-92b445af83cf" />


After:
<img width="1510" height="102" alt="image" src="https://github.com/user-attachments/assets/32bed0de-eb83-4b1b-94de-a02b7e15e40f" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: Canister valve logs now only show gases that were present in the canister mixture.