### PR TITLE
Bugfix: status icons and health bar respect sprite offset

### DIFF
--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -107,7 +107,7 @@ public sealed class EntityHealthBarOverlay : Overlay
             var yOffset = bounds.Height * EyeManager.PixelsPerMeter / 2 - 3f;
             var widthOfMob = bounds.Width * EyeManager.PixelsPerMeter;
 
-            var position = new Vector2(-widthOfMob / EyeManager.PixelsPerMeter / 2, yOffset / EyeManager.PixelsPerMeter);
+            var position = new Vector2(sprite.Offset.X - widthOfMob / EyeManager.PixelsPerMeter / 2, sprite.Offset.Y + yOffset / EyeManager.PixelsPerMeter);
             var color = GetProgressColor(deathProgress.ratio, deathProgress.inCrit);
 
             // Hardcoded width of the progress bar because it doesn't match the texture.

--- a/Content.Client/StatusIcon/StatusIconOverlay.cs
+++ b/Content.Client/StatusIcon/StatusIconOverlay.cs
@@ -95,8 +95,8 @@ public sealed partial class StatusIconOverlay : Overlay
                         accOffsetL += texture.Height;
                         countL++;
                     }
-                    yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float)(accOffsetL - proto.Offset) / EyeManager.PixelsPerMeter;
-                    xOffset = -(bounds.Width + sprite.Offset.X) / 2f + (float)proto.OffsetHorizontal / EyeManager.PixelsPerMeter;
+                    yOffset = sprite.Offset.Y + bounds.Height / 2f - (float)(accOffsetL - proto.Offset) / EyeManager.PixelsPerMeter;
+                    xOffset = sprite.Offset.X - bounds.Width / 2f + (float)proto.OffsetHorizontal / EyeManager.PixelsPerMeter;
 
                 }
                 else
@@ -108,8 +108,8 @@ public sealed partial class StatusIconOverlay : Overlay
                         accOffsetR += texture.Height;
                         countR++;
                     }
-                    yOffset = (bounds.Height + sprite.Offset.Y) / 2f - (float)(accOffsetR - proto.Offset) / EyeManager.PixelsPerMeter;
-                    xOffset = (bounds.Width + sprite.Offset.X) / 2f - (float)(texture.Width - proto.OffsetHorizontal) / EyeManager.PixelsPerMeter;
+                    yOffset = sprite.Offset.Y + bounds.Height / 2f - (float)(accOffsetR - proto.Offset) / EyeManager.PixelsPerMeter;
+                    xOffset = sprite.Offset.X + bounds.Width / 2f - (float)(texture.Width - proto.OffsetHorizontal) / EyeManager.PixelsPerMeter;
 
                 }
 


### PR DESCRIPTION
## About the PR

Fixes the position of status icons so that the sprite offset is always added completely.
Adds the sprite's offset to the position of the health bar.

The icons now track the position of the sprite itself when jittering instead of bouncing around.  This is particularly egregious with large sprite offsets.

## Why / Balance

Bugfix.

Noticed this here: #44596

Apparently it's been like this for three years.  Three years.

## Technical details

arithmetic ops

Offset is always added in its entirety - that is the relative position of the sprite, and positions you in the center of the sprite's bounding box.  Width and height should be halved, because that will place you at the corners of that box.

## Test plan
Spawn Urist.
Spawn another Urist for yourself.
Spawn an omni hud, put it on.
The status icons for the Urist should be placed well - SSD to the left, job icon to the right (the two placement cases).
Spawn a jet injector, fill it with Ethyloxyephedrine, and inject the Urist.
Look at him go.  The icons should track the Urist.
Spawn a third Urist.
Edit the Urist's SpriteComponent's offset through VV, set the value to large values (several meters apart).  The status icon and health bar should track the Urist as it moves around.

## Media

The test plan is followed in both videos, the top shows the current status on master, the bottom with the PR as it stands.

Before:

https://github.com/user-attachments/assets/b57c6b29-e930-41cd-89a8-ecad65ede5c7

After:

https://github.com/user-attachments/assets/1b916b46-75b4-4e00-9b88-2caf1cdd0f01

The whole HUD shimmies.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
ehhhhhhhhh