### PR TITLE
Add functionality to select players when opening admin log UI

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
@@ -17,7 +17,7 @@
                 <Control HorizontalExpand="True" MinWidth="5" />
                 <Button Visible="True" Name="PopOut" Access="Public" Text="{Loc 'admin-logs-pop-out'}" StyleClasses="OpenBoth" HorizontalAlignment="Left" />
                 <Control HorizontalExpand="True" />
-                <Button Visible="False" Name="Bans" Text="{Loc 'admin-player-actions-bans'}" StyleClasses="OpenRight" />
+                <Button Visible="False" Name="PlayerLogs" Text="{Loc 'admin-player-actions-logs'}" StyleClasses="OpenRight" />
                 <Button Visible="False" Access="Public" Name="Notes" Text="{Loc 'admin-player-actions-notes'}" StyleClasses="OpenBoth" />
                 <controls:ConfirmButton Visible="False" Name="Kick" Text="{Loc 'admin-player-actions-kick'}" ConfirmationText="{Loc 'admin-player-actions-confirm'}" StyleClasses="OpenBoth" />
                 <Button Visible="False" Name="Ban" Text="{Loc 'admin-player-actions-ban'}" StyleClasses="OpenBoth" />

--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -156,11 +156,10 @@ namespace Content.Client.Administration.UI.Bwoink
                 return bch.LastMessage.CompareTo(ach.LastMessage);
             };
 
-
-            Bans.OnPressed += _ =>
+            PlayerLogs.OnPressed += _ =>
             {
                 if (_currentPlayer is not null)
-                    _console.ExecuteCommand($"banlist \"{_currentPlayer.SessionId}\"");
+                    _console.ExecuteCommand($"adminlogs \"{_currentPlayer.SessionId}\"");
             };
 
             Notes.OnPressed += _ =>
@@ -228,8 +227,8 @@ namespace Content.Client.Administration.UI.Bwoink
         {
             var disabled = _currentPlayer == null;
 
-            Bans.Visible = _adminManager.HasFlag(AdminFlags.Ban);
-            Bans.Disabled = !Bans.Visible || disabled;
+            PlayerLogs.Visible = _adminManager.HasFlag(AdminFlags.Logs);
+            PlayerLogs.Disabled = !PlayerLogs.Visible || disabled;
 
             Notes.Visible = _adminManager.HasFlag(AdminFlags.ViewNotes);
             Notes.Disabled = !Notes.Visible || disabled;

--- a/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsControl.xaml.cs
@@ -63,6 +63,8 @@ public sealed partial class AdminLogsControl : Control
 
     public HashSet<LogImpact> SelectedImpacts { get; } = new();
 
+    private bool firstTimeOpened = true;
+
     public void SetCurrentRound(int round)
     {
         CurrentRound = round;
@@ -179,6 +181,22 @@ public sealed partial class AdminLogsControl : Control
             }
 
             player.Pressed = false;
+        }
+
+        UpdateLogs();
+    }
+
+    public void SelectPlayers(List<Guid> players)
+    {
+        SelectedPlayers.Clear();
+        SelectedPlayers.UnionWith(players);
+
+        foreach (var control in PlayersContainer.Children)
+        {
+            if (control is not AdminLogPlayerButton player)
+                continue;
+
+            player.Pressed = SelectedPlayers.Contains(player.Id);
         }
 
         UpdateLogs();
@@ -420,15 +438,13 @@ public sealed partial class AdminLogsControl : Control
     public void SetPlayers(Dictionary<Guid, string> players)
     {
         var buttons = new SortedSet<AdminLogPlayerButton>(_adminLogPlayerButtonComparer);
-        var allSelected = true;
+        // we retrieve everything if we open this window for the first time and the selected player list is empty
+        var allSelected = firstTimeOpened && SelectedPlayers.Count == 0;
 
         foreach (var control in PlayersContainer.Children.ToArray())
         {
             if (control is not AdminLogPlayerButton player)
                 continue;
-
-            if (!SelectedPlayers.Contains(player.Id))
-                allSelected = false;
 
             if (!players.Remove(player.Id))
                 continue;
@@ -457,6 +473,8 @@ public sealed partial class AdminLogsControl : Control
         foreach (var player in buttons)
         {
             PlayersContainer.AddChild(player);
+
+            player.Pressed = SelectedPlayers.Contains(player.Id);
         }
 
         UpdateLogs();

--- a/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
+++ b/Content.Client/Administration/UI/Logs/AdminLogsEui.cs
@@ -232,6 +232,11 @@ public sealed partial class AdminLogsEui : BaseEui
                 if (setLogFilter.Search != null)
                     LogsControl.LogSearch.SetText(setLogFilter.Search);
 
+                if (setLogFilter.Players != null)
+                {
+                    LogsControl.SelectPlayers(setLogFilter.Players);
+                }
+
                 if (setLogFilter.Types != null)
                     LogsControl.SetTypesSelection(setLogFilter.Types, setLogFilter.InvertTypes);
 

--- a/Content.Server/Administration/Commands/OpenAdminLogsCommand.cs
+++ b/Content.Server/Administration/Commands/OpenAdminLogsCommand.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using Content.Server.Administration.Logs;
-using Content.Server.EUI;
 using Content.Shared.Administration;
 using Robust.Server.Player;
 using Robust.Shared.Console;
@@ -10,9 +9,9 @@ namespace Content.Server.Administration.Commands;
 [AdminCommand(AdminFlags.Logs)]
 public sealed partial class OpenAdminLogsCommand : LocalizedEntityCommands
 {
-    [Dependency] private EuiManager _euiManager = default!;
     [Dependency] private IAdminLogManager _adminLogManager = default!;
     [Dependency] private IPlayerLocator _locator = default!;
+    [Dependency] private IPlayerManager _players = default!;
 
     public override string Command => Cmd;
     public const string Cmd = "adminlogs";
@@ -37,7 +36,7 @@ public sealed partial class OpenAdminLogsCommand : LocalizedEntityCommands
 
                 if (dbGuid == null)
                 {
-                    shell.WriteError(Loc.GetString("cmd-adminnotes-wrong-target", ("user", args[0])));
+                    shell.WriteError(Loc.GetString("cmd-admin-logs-wrong-target", ("user", args[0])));
                     return;
                 }
 
@@ -52,8 +51,7 @@ public sealed partial class OpenAdminLogsCommand : LocalizedEntityCommands
         if (args.Length != 1)
             return CompletionResult.Empty;
 
-        var playerMgr = IoCManager.Resolve<IPlayerManager>();
-        var options = playerMgr.Sessions.Select(c => c.Name).OrderBy(c => c).ToArray();
+        var options = _players.Sessions.Select(c => c.Name).OrderBy(c => c).ToArray();
         return CompletionResult.FromHintOptions(options, Loc.GetString("cmd-admin-logs-hint"));
     }
 }

--- a/Content.Server/Administration/Commands/OpenAdminLogsCommand.cs
+++ b/Content.Server/Administration/Commands/OpenAdminLogsCommand.cs
@@ -1,6 +1,8 @@
-﻿using Content.Server.Administration.Logs;
+﻿using System.Linq;
+using Content.Server.Administration.Logs;
 using Content.Server.EUI;
 using Content.Shared.Administration;
+using Robust.Server.Player;
 using Robust.Shared.Console;
 
 namespace Content.Server.Administration.Commands;
@@ -9,19 +11,49 @@ namespace Content.Server.Administration.Commands;
 public sealed partial class OpenAdminLogsCommand : LocalizedEntityCommands
 {
     [Dependency] private EuiManager _euiManager = default!;
+    [Dependency] private IAdminLogManager _adminLogManager = default!;
+    [Dependency] private IPlayerLocator _locator = default!;
 
     public override string Command => Cmd;
     public const string Cmd = "adminlogs";
 
-    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    public override async void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        if (shell.Player is not { } player)
+        if (shell.Player is not { } admin)
         {
             shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
             return;
         }
 
-        var ui = new AdminLogsEui();
-        _euiManager.OpenEui(ui, player);
+        Guid? player = null;
+
+        switch (args.Length)
+        {
+            case 1 when Guid.TryParse(args[0], out var playerGuid):
+                player = playerGuid;
+                break;
+            case 1:
+                var dbGuid = await _locator.LookupIdByNameAsync(args[0]);
+
+                if (dbGuid == null)
+                {
+                    shell.WriteError(Loc.GetString("cmd-adminnotes-wrong-target", ("user", args[0])));
+                    return;
+                }
+
+                player = dbGuid.UserId;
+                break;
+        }
+        _adminLogManager.OpenEui(admin, targetPlayer: player);
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 1)
+            return CompletionResult.Empty;
+
+        var playerMgr = IoCManager.Resolve<IPlayerManager>();
+        var options = playerMgr.Sessions.Select(c => c.Name).OrderBy(c => c).ToArray();
+        return CompletionResult.FromHintOptions(options, Loc.GetString("cmd-admin-logs-hint"));
     }
 }

--- a/Content.Server/Administration/Logs/AdminLogManager.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Administration.Systems;
 using Content.Server.Database;
+using Content.Server.EUI;
 using Content.Server.GameTicking;
 using Content.Shared.Administration.Logs;
 using Content.Shared.CCVar;
@@ -29,6 +30,7 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
 {
     [Dependency] private IConfigurationManager _configuration = default!;
     [Dependency] private ILogManager _logManager = default!;
+    [Dependency] private EuiManager _euis = default!;
     [Dependency] private IServerDbManager _db = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IDynamicTypeFactory _typeFactory = default!;
@@ -632,5 +634,17 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
     public Task<int> CountLogs(int round)
     {
         return _db.CountAdminLogs(round);
+    }
+
+    public void OpenEui(ICommonSession admin, string? search = null, Guid? targetPlayer = null)
+    {
+        var ui = new AdminLogsEui();
+        _euis.OpenEui(ui, admin);
+
+        List<Guid>? userList = null;
+        if (targetPlayer is not null)
+            userList = [targetPlayer.Value];
+
+        ui.SetLogFilter(search, userList);
     }
 }

--- a/Content.Server/Administration/Logs/AdminLogsEui.cs
+++ b/Content.Server/Administration/Logs/AdminLogsEui.cs
@@ -142,10 +142,11 @@ public sealed partial class AdminLogsEui : BaseEui
         }
     }
 
-    public void SetLogFilter(string? search = null, bool invertTypes = false, HashSet<LogType>? types = null)
+    public void SetLogFilter(string? search = null, List<Guid>? players = null, bool invertTypes = false, HashSet<LogType>? types = null)
     {
         var message = new SetLogFilter(
             search,
+            players,
             invertTypes,
             types);
 

--- a/Content.Server/Administration/Logs/IAdminLogManager.cs
+++ b/Content.Server/Administration/Logs/IAdminLogManager.cs
@@ -3,6 +3,8 @@ using System.Threading.Tasks;
 using Content.Server.Database;
 using Content.Server.GameTicking;
 using Content.Shared.Administration.Logs;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
 
 namespace Content.Server.Administration.Logs;
 
@@ -24,4 +26,5 @@ public interface IAdminLogManager : ISharedAdminLogManager
     IAsyncEnumerable<JsonDocument> CurrentRoundJson(LogFilter? filter = null);
     Task<Round> CurrentRound();
     Task<int> CountLogs(int round);
+    void OpenEui(ICommonSession admin, string? search = null, Guid? targetPlayer = null);
 }

--- a/Content.Server/Administration/Systems/AdminQuickInfoSystem.cs
+++ b/Content.Server/Administration/Systems/AdminQuickInfoSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.Administration.Managers;
+using Content.Server.Mind;
 using Content.Shared.Administration;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
@@ -17,6 +18,7 @@ namespace Content.Server.Administration.Systems;
 public sealed partial class AdminQuickInfoSystem : EntitySystem
 {
     [Dependency] private IAdminManager _adminManager = null!;
+    [Dependency] private MindSystem _mind = null!;
 
     public override void Initialize()
     {
@@ -41,9 +43,9 @@ public sealed partial class AdminQuickInfoSystem : EntitySystem
                 NetUserId? lastPlayer = null;
 
                 // Check the last mind that was attached to the entity and get its userid.
-                if (TryComp<MindContainerComponent>(ent, out var comp) && TryComp<MindComponent>(comp.LastMind, out var mindComp))
+                if (_mind.TryGetLastMind(ent.Value, out var lastMind))
                 {
-                    lastPlayer = mindComp.UserId;
+                    lastPlayer = lastMind.Value.Comp.UserId;
                 }
                 var metadata = MetaData(ent.Value);
                 return new QuickInfoShared.SingleEntityInfo(e, true, metadata.EntityName, metadata.EntityPrototype?.ID, lastPlayer);

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -247,25 +247,18 @@ namespace Content.Server.Administration.Systems
 
                 // Player Admin Logs. this is distinct from entity logs above as it will get the logs of the _player_
                 // that last owned the mind of the entity you are right-clicking on. words.
-                // this also means we need to get a mind manually because _mindSystem.TryGetMind checks if
-                // MindComponent.HasMind is true. But is false if a component has a mind, but it was transferred or
-                // something, which happens when someone suicides or whatever. Stinky!
-                if (TryComp<MindContainerComponent>(args.Target, out var mindContainer) && mindContainer.LastMind != null)
+                if (_mindSystem.TryGetLastMindOwner(args.Target, out var lastOwner))
                 {
-                    if (TryComp<MindComponent>(mindContainer.LastMind, out var lastMind) &&
-                        lastMind.OriginalOwnerUserId != null)
+                    args.Verbs.Add(new Verb()
                     {
-                        args.Verbs.Add(new Verb()
+                        Priority = -3,
+                        Text = Loc.GetString("admin-verbs-admin-logs-player"),
+                        Category = VerbCategory.Admin,
+                        Act = () =>
                         {
-                            Priority = -3,
-                            Text = Loc.GetString("admin-verbs-admin-logs-player"),
-                            Category = VerbCategory.Admin,
-                            Act = () =>
-                            {
-                                _adminLogs.OpenEui(player, targetPlayer: lastMind.OriginalOwnerUserId);
-                            },
-                        });
-                    }
+                            _adminLogs.OpenEui(player, targetPlayer: lastOwner);
+                        },
+                    });
                 }
 
                 // Freeze

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -48,6 +48,7 @@ namespace Content.Server.Administration.Systems
     {
         [Dependency] private IConGroupController _groupController = default!;
         [Dependency] private IConsoleHost _console = default!;
+        [Dependency] private IAdminLogManager _adminLogs = default!;
         [Dependency] private IAdminManager _adminManager = default!;
         [Dependency] private IGameTiming _gameTiming = default!;
         [Dependency] private SharedMapSystem _map = default!;
@@ -259,7 +260,10 @@ namespace Content.Server.Administration.Systems
                             Priority = -3,
                             Text = Loc.GetString("admin-verbs-admin-logs-player"),
                             Category = VerbCategory.Admin,
-                            Act = () => _console.RemoteExecuteCommand(player, $"adminlogs {lastMind.OriginalOwnerUserId}"),
+                            Act = () =>
+                            {
+                                _adminLogs.OpenEui(player, targetPlayer: lastMind.OriginalOwnerUserId);
+                            },
                         });
                     }
                 }

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -106,6 +106,8 @@ namespace Content.Server.Administration.Systems
                 mark.Impact = LogImpact.Low;
                 args.Verbs.Add(mark);
 
+                var hasMind = _mindSystem.TryGetMind(args.Target, out var mindId, out var mindComp);
+
                 if (TryComp(args.Target, out ActorComponent? targetActor))
                 {
                     // AdminHelp
@@ -152,7 +154,7 @@ namespace Content.Server.Administration.Systems
                             var profile = _gameTicker.GetPlayerProfile(targetActor.PlayerSession);
                             var mobUid = _spawning.SpawnPlayerMob(coords.Value, null, profile, stationUid);
 
-                            if (_mindSystem.TryGetMind(args.Target, out var mindId, out var mindComp))
+                            if (hasMind)
                                 _mindSystem.TransferTo(mindId, mobUid, true, mind: mindComp);
 
                         },
@@ -201,7 +203,7 @@ namespace Content.Server.Administration.Systems
                     });
                 }
 
-                if (_mindSystem.TryGetMind(args.Target, out var mindId, out var mindComp) && mindComp.UserId != null)
+                if (hasMind && mindComp?.UserId != null)
                 {
                     // Erase
                     args.Verbs.Add(new Verb
@@ -297,7 +299,7 @@ namespace Content.Server.Administration.Systems
                 }
 
 
-                // Admin Logs
+                // Entity Admin Logs
                 if (_adminManager.HasAdminFlag(player, AdminFlags.Logs))
                 {
                     Verb logsVerbEntity = new()
@@ -314,6 +316,19 @@ namespace Content.Server.Administration.Systems
                         Impact = LogImpact.Low
                     };
                     args.Verbs.Add(logsVerbEntity);
+                }
+
+                // Player Admin Logs. this is distinct from entity logs above as it will get the logs of the _player_
+                // that last owned the mind of the entity you are right-clicking on. words.
+                if (hasMind && mindComp?.OriginalOwnerUserId != null)
+                {
+                    args.Verbs.Add(new Verb()
+                    {
+                        Priority = -3,
+                        Text = Loc.GetString("admin-verbs-admin-logs-player"),
+                        Category = VerbCategory.Admin,
+                        Act = () => _console.RemoteExecuteCommand(player, $"adminlogs {mindComp.OriginalOwnerUserId}"),
+                    });
                 }
 
                 // TeleportTo

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -36,6 +36,7 @@ using Robust.Shared.Toolshed;
 using Robust.Shared.Utility;
 using System.Linq;
 using Content.Shared.Chemistry.Components;
+using Content.Shared.Mind;
 using static Content.Shared.Configurable.ConfigurationComponent;
 
 namespace Content.Server.Administration.Systems
@@ -106,8 +107,6 @@ namespace Content.Server.Administration.Systems
                 mark.Impact = LogImpact.Low;
                 args.Verbs.Add(mark);
 
-                var hasMind = _mindSystem.TryGetMind(args.Target, out var mindId, out var mindComp);
-
                 if (TryComp(args.Target, out ActorComponent? targetActor))
                 {
                     // AdminHelp
@@ -154,7 +153,7 @@ namespace Content.Server.Administration.Systems
                             var profile = _gameTicker.GetPlayerProfile(targetActor.PlayerSession);
                             var mobUid = _spawning.SpawnPlayerMob(coords.Value, null, profile, stationUid);
 
-                            if (hasMind)
+                            if (_mindSystem.TryGetMind(args.Target, out var mindId, out var mindComp))
                                 _mindSystem.TransferTo(mindId, mobUid, true, mind: mindComp);
 
                         },
@@ -203,7 +202,7 @@ namespace Content.Server.Administration.Systems
                     });
                 }
 
-                if (hasMind && mindComp?.UserId != null)
+                if (_mindSystem.TryGetMind(args.Target, out var mindId, out var mindComp) && mindComp.UserId != null)
                 {
                     // Erase
                     args.Verbs.Add(new Verb
@@ -243,6 +242,26 @@ namespace Content.Server.Administration.Systems
                         Category = VerbCategory.Debug,
                         Act = () => _console.RemoteExecuteCommand(player, $"vv {GetNetEntity(mindId)}"),
                     });
+                }
+
+                // Player Admin Logs. this is distinct from entity logs above as it will get the logs of the _player_
+                // that last owned the mind of the entity you are right-clicking on. words.
+                // this also means we need to get a mind manually because _mindSystem.TryGetMind checks if
+                // MindComponent.HasMind is true. But is false if a component has a mind, but it was transferred or
+                // something, which happens when someone suicides or whatever. Stinky!
+                if (TryComp<MindContainerComponent>(args.Target, out var mindContainer) && mindContainer.LastMind != null)
+                {
+                    if (TryComp<MindComponent>(mindContainer.LastMind, out var lastMind) &&
+                        lastMind.OriginalOwnerUserId != null)
+                    {
+                        args.Verbs.Add(new Verb()
+                        {
+                            Priority = -3,
+                            Text = Loc.GetString("admin-verbs-admin-logs-player"),
+                            Category = VerbCategory.Admin,
+                            Act = () => _console.RemoteExecuteCommand(player, $"adminlogs {lastMind.OriginalOwnerUserId}"),
+                        });
+                    }
                 }
 
                 // Freeze
@@ -299,7 +318,7 @@ namespace Content.Server.Administration.Systems
                 }
 
 
-                // Entity Admin Logs
+                // Admin Logs
                 if (_adminManager.HasAdminFlag(player, AdminFlags.Logs))
                 {
                     Verb logsVerbEntity = new()
@@ -316,19 +335,6 @@ namespace Content.Server.Administration.Systems
                         Impact = LogImpact.Low
                     };
                     args.Verbs.Add(logsVerbEntity);
-                }
-
-                // Player Admin Logs. this is distinct from entity logs above as it will get the logs of the _player_
-                // that last owned the mind of the entity you are right-clicking on. words.
-                if (hasMind && mindComp?.OriginalOwnerUserId != null)
-                {
-                    args.Verbs.Add(new Verb()
-                    {
-                        Priority = -3,
-                        Text = Loc.GetString("admin-verbs-admin-logs-player"),
-                        Category = VerbCategory.Admin,
-                        Act = () => _console.RemoteExecuteCommand(player, $"adminlogs {mindComp.OriginalOwnerUserId}"),
-                    });
                 }
 
                 // TeleportTo

--- a/Content.Shared/Administration/Logs/AdminLogsEuiState.cs
+++ b/Content.Shared/Administration/Logs/AdminLogsEuiState.cs
@@ -28,14 +28,16 @@ public static class AdminLogsEuiMsg
     [Serializable, NetSerializable]
     public sealed class SetLogFilter : EuiMessageBase
     {
-        public SetLogFilter(string? search = null, bool invertTypes = false, HashSet<LogType>? types = null)
+        public SetLogFilter(string? search = null, List<Guid>? players = null, bool invertTypes = false, HashSet<LogType>? types = null)
         {
             Search = search;
+            Players = players;
             InvertTypes = invertTypes;
             Types = types;
         }
 
         public string? Search { get; set; }
+        public List<Guid>? Players { get; set; }
         public bool InvertTypes { get; set; }
         public HashSet<LogType>? Types { get; set; }
     }

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -569,8 +569,7 @@ public abstract partial class SharedMindSystem : EntitySystem
     /// <returns>true if a last mind was found, false if not</returns>
     public bool TryGetLastMind(
         Entity<MindContainerComponent?> entity,
-        [NotNullWhen(true)] out Entity<MindComponent>? lastMind
-    )
+        [NotNullWhen(true)] out Entity<MindComponent>? lastMind)
     {
         lastMind = null;
 

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -585,7 +585,7 @@ public abstract partial class SharedMindSystem : EntitySystem
 
         lastMind = new Entity<MindComponent>(entity.Comp.LastMind.Value, lastMindComp);
 
-        return false;
+        return true;
     }
 
     /// <summary>

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -560,6 +560,59 @@ public abstract partial class SharedMindSystem : EntitySystem
     }
 
     /// <summary>
+    /// Try to get the last mind that was associated with the given entity. This is distinct from TryGetMind as it does
+    /// not require an active mind to be associated with an entity (e.g. dead players after ghosting or taking a ghost
+    /// role)
+    /// </summary>
+    /// <param name="entity">Entity to find the last mind for</param>
+    /// <param name="lastMind">Output mind entity with <see cref="MindComponent"/>. null if function returns false</param>
+    /// <returns>true if a last mind was found, false if not</returns>
+    public bool TryGetLastMind(
+        Entity<MindContainerComponent?> entity,
+        [NotNullWhen(true)] out Entity<MindComponent>? lastMind
+    )
+    {
+        lastMind = null;
+
+        if (!Resolve(entity.Owner, ref entity.Comp, logMissing: false))
+            return false;
+
+        if (entity.Comp.LastMind == null)
+            return false;
+
+        if (!TryComp<MindComponent>(entity.Comp.LastMind.Value, out var lastMindComp))
+            return false;
+
+        lastMind = new Entity<MindComponent>(entity.Comp.LastMind.Value, lastMindComp);
+
+        return false;
+    }
+
+    /// <summary>
+    /// Try to get the original owner <see cref="NetUserId"/> of the last mind associated with a given entity
+    /// </summary>
+    /// <param name="entity"><see cref="EntityUid"/> to get the last mind owner from</param>
+    /// <param name="lastOwner"><see cref="NetUserId"/> of the last mind owner. null if function returns false</param>
+    /// <returns>true if a mind was found and the last owner is not null, false if not</returns>
+    public bool TryGetLastMindOwner(
+        Entity<MindContainerComponent?> entity,
+        [NotNullWhen(true)] out NetUserId? lastOwner
+    )
+    {
+        lastOwner = null;
+
+        if (!TryGetLastMind(entity, out var lastMind))
+            return false;
+
+        if (lastMind.Value.Comp.OriginalOwnerUserId == null)
+            return false;
+
+        lastOwner = lastMind.Value.Comp.OriginalOwnerUserId;
+
+        return true;
+    }
+
+    /// <summary>
     /// Sets the Mind's UserId, Session, and updates the player's PlayerData. This should have no direct effect on the
     /// entity that any mind is connected to, except as a side effect of the fact that it may change a player's
     /// attached entity. E.g., ghosts get deleted.

--- a/Resources/Locale/en-US/administration/admin-verbs.ftl
+++ b/Resources/Locale/en-US/administration/admin-verbs.ftl
@@ -4,6 +4,7 @@ edit-solutions-verb-get-data-text = Edit Solutions
 explode-verb-get-data-text = Explode
 ahelp-verb-get-data-text = Message
 admin-verbs-admin-logs-entity = Entity Logs
+admin-verbs-admin-logs-player = Player Logs
 admin-verbs-teleport-to = Teleport To
 admin-verbs-teleport-here = Teleport Here
 admin-verbs-freeze = Freeze

--- a/Resources/Locale/en-US/administration/commands/adminlogs.ftl
+++ b/Resources/Locale/en-US/administration/commands/adminlogs.ftl
@@ -1,0 +1,1 @@
+cmd-admin-logs-hint = Username

--- a/Resources/Locale/en-US/administration/commands/adminlogs.ftl
+++ b/Resources/Locale/en-US/administration/commands/adminlogs.ftl
@@ -1,1 +1,2 @@
 cmd-admin-logs-hint = Username
+cmd-admin-logs-wrong-target = Unable to find user '{$user}'.

--- a/Resources/Locale/en-US/administration/ui/actions.ftl
+++ b/Resources/Locale/en-US/administration/ui/actions.ftl
@@ -1,5 +1,5 @@
 admin-player-actions-reason = Reason
-admin-player-actions-bans = Ban List
+admin-player-actions-logs = Player logs
 admin-player-actions-notes = Notes
 admin-player-actions-kick = Kick
 admin-player-actions-ban = Ban


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Several changes to admin logs:

- Adminlogs command now takes a player username as an argument and autocompletes
- Admin logs can now immediately filter by player instead of only by entity
- Replaced the ban list button in the ahelp menu with a player logs button which opens logs for that specific player
- Added an admin verb on entities with a `LastMind` in a `MindContainerComponent` and an `OriginalOwnerUserId` that opens logs for the last player to occupy the entity
- Admin logs player selection is now remembered when changing rounds

## Why / Balance
As admin I regularly wanted to check the logs of some player who died, ghosted, then took pun pun or whatever, but doing so required opening the entity logs of that player and removing the entity uid text, then searching for the player or just opening a new admin log window and selecting the player, which were both annoying things to do.

This adds a shortcut to just go straight to the player logs from the ahelp menu or through the admin verb.

## Technical details
I'll say right out of the gate that I copied a lot of functionality from where it already existed:

- I moved the logic for opening an admin log EUI into the admin log manager, which is similar to how it is done in the adminnotes manager/EUI and makes it so you can use the manager's method to open the UI
- I added autocomplete by almost 1 to 1 copying the functionality from the adminnotes autocomplete, except I removed the manual usage of `IoCManager.Resolve` for the admin log manager and moved it to a field.
- I tweaked the logic in the admin log EUI:
  - It now only selects all players by default if you are opening the UI for the first time and the selected players are empty
  - Added a selectplayers function that is used when opening the UI with a selection of players

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. checkout master
2. start server and 2 clients
3. connect to server with both clients
4. on one client, right-click some player entity
5. use the "entity logs" admin verb by right clicking on the entity
6. weep
7. open the ahelp menu
8. look at the ban list option
9. weep again
10. checkout this PR
2. start server and 2 clients
3. connect to server with both clients
4. on one client, right-click some player entity
5. observe both "entity logs" and "player logs"
6. rejoice
7. open the ahelp menu
8. look at the player logs button
9. rejoice again
10. play around with controlling different entities and still using the player log admin verb on previous entities you have controlled
11. rejoice even more

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Ahelp window button, consistent admin logs selection, admin verbs, player logs verb after suicide/takeover:

https://github.com/user-attachments/assets/9bcf4936-7a55-46dd-a024-a1091e5af2a7

Command autocompletion:

https://github.com/user-attachments/assets/f81e0d50-a823-4efe-8db3-89db3d3572cc




## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

`SetLogFilter` in `AdminLogsEui` now takes a `List<Guid>` as a second argument to filter by players.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Crude Oil
ADMIN:
- add: Admin logs command autocompletes on players
- add: Admins now have a "player logs" verb that opens admin logs with that player selected
- add: Added "player logs" button to the ahelp window
- remove: Removed "ban list" button from the ahelp window
- tweak: Player selection in admin logs remains consistent when selecting different rounds
