### PR TITLE
ConfirmButton: state machine consistency, OnConfirming action

### DIFF
--- a/Content.Client/UserInterface/Controls/ConfirmButton.cs
+++ b/Content.Client/UserInterface/Controls/ConfirmButton.cs
@@ -22,6 +22,7 @@ public sealed partial class ConfirmButton : Button
 
     private TimeSpan? _nextReset;
     private TimeSpan? _nextCooldown;
+    private bool _isConfirming;
     private string? _confirmationText;
     private string? _text;
 
@@ -29,6 +30,11 @@ public sealed partial class ConfirmButton : Button
     /// Fired when the button was pressed and confirmed
     /// </summary>
     public new event Action<ButtonEventArgs>? OnPressed;
+
+    /// <summary>
+    /// Fired when the button has started to confirm and is awaiting a second button press.
+    /// </summary>
+    public event Action<ButtonEventArgs>? OnConfirming;
 
     /// <inheritdoc cref="Button.Text"/>
     /// <remarks>
@@ -42,6 +48,20 @@ public sealed partial class ConfirmButton : Button
         {
             _text = value;
             base.Text = IsConfirming ? _confirmationText : value;
+        }
+    }
+
+    /// <inheritdoc cref="Button.Disabled"/>
+    /// <remarks>
+    /// Overrides the confirming state of the button when set.
+    /// </remarks>
+    public new bool Disabled
+    {
+        get => base.Disabled;
+        set
+        {
+            IsConfirming = false;
+            base.Disabled = value;
         }
     }
 
@@ -67,8 +87,36 @@ public sealed partial class ConfirmButton : Button
     [ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan CooldownTime { get; set; } = TimeSpan.FromSeconds(.5);
 
+    /// <summary>
+    /// A property to get or change whether the button is confirming (awaiting a second press within a time limit) or not
+    /// </summary>
     [ViewVariables]
-    public bool IsConfirming = false;
+    public bool IsConfirming
+    {
+        get => _isConfirming;
+        set
+        {
+            // If we have a change in state, update the text and redraw the controls.
+            if (_isConfirming != value)
+            {
+                _isConfirming = value;
+                base.Text = IsConfirming ? Text : ConfirmationText;
+                DrawModeChanged();
+
+                // Set the timer when changing the confirmation status.
+                if (!value)
+                {
+                    _nextReset = null;
+                    _nextCooldown = null;
+                }
+                else
+                {
+                    _nextCooldown = _gameTiming.CurTime + CooldownTime;
+                    _nextReset = _gameTiming.CurTime + ResetTime;
+                }
+            }
+        }
+    }
 
     public ConfirmButton()
     {
@@ -82,8 +130,6 @@ public sealed partial class ConfirmButton : Button
         if (IsConfirming && _gameTiming.CurTime > _nextReset)
         {
             IsConfirming = false;
-            base.Text = Text;
-            DrawModeChanged();
         }
 
         if (Disabled && _gameTiming.CurTime > _nextCooldown)
@@ -126,17 +172,15 @@ public sealed partial class ConfirmButton : Button
         switch (IsConfirming)
         {
             case false:
-                _nextCooldown  = _gameTiming.CurTime + CooldownTime;
-                _nextReset = _gameTiming.CurTime + ResetTime;
                 Disabled = true;
+                OnConfirming?.Invoke(buttonEvent);
                 break;
             case true:
                 OnPressed?.Invoke(buttonEvent);
                 break;
         }
 
-        base.Text = IsConfirming ? Text : ConfirmationText;
-
+        // NOTE: this handles setting the text and timers.
         IsConfirming = !IsConfirming;
     }
 }

--- a/Content.Client/UserInterface/Controls/ConfirmButton.cs
+++ b/Content.Client/UserInterface/Controls/ConfirmButton.cs
@@ -53,22 +53,23 @@ public sealed partial class ConfirmButton : Button
         set
         {
             _text = value;
-            if (!IsConfirming)
-                base.Text = value;
+            UpdateText();
         }
     }
 
-    /// <inheritdoc cref="Button.Disabled"/>
+    /// <inheritdoc cref="BaseButton.Disabled"/>
     /// <remarks>
     /// Overrides the confirming state of the button when set.
+    /// Intended for public use, should not be used inside the class due to IsConfirming side-effects.
     /// </remarks>
     public new bool Disabled
     {
         get => base.Disabled;
         set
         {
-            IsConfirming = false;
-            base.Disabled = value;
+            // Force out of confirming status (may change base.Disabled), then write your new disabled value.
+            SetIsConfirming(false);
+            SetDisabled(value);
         }
     }
 
@@ -82,8 +83,7 @@ public sealed partial class ConfirmButton : Button
         set
         {
             _confirmationText = value;
-            if (IsConfirming)
-                base.Text = value;
+            UpdateText();
         }
     }
 
@@ -108,29 +108,8 @@ public sealed partial class ConfirmButton : Button
         get => _isConfirming;
         set
         {
-            // If we have a change in state, update the text and redraw the controls.
             if (_isConfirming != value)
-            {
-                _isConfirming = value;
-                base.Text = value ? ConfirmationText : Text;
-                DrawModeChanged();
-
-                // Set the timer when changing the confirmation status.
-                if (!value)
-                {
-                    // Revert disabled state if left to transition back.
-                    if (Disabled && _nextReset != null)
-                        base.Disabled = false; // Must set the base, leave IsConfirming intact
-                    _nextReset = null;
-                    _nextCooldown = null;
-                }
-                else
-                {
-                    base.Disabled = true; // Must set the base, leave IsConfirming intact
-                    _nextCooldown = _gameTiming.CurTime + CooldownTime;
-                    _nextReset = _gameTiming.CurTime + ResetTime;
-                }
-            }
+                SetIsConfirming(value);
         }
     }
 
@@ -147,9 +126,9 @@ public sealed partial class ConfirmButton : Button
             return;
 
         if (_gameTiming.CurTime > _nextReset)
-            IsConfirming = false;
+            SetIsConfirming(false);
         else if (Disabled && _gameTiming.CurTime > _nextCooldown)
-            base.Disabled = false; // Must set the base, leave IsConfirming intact
+            SetDisabled(false);
     }
 
     protected override void DrawModeChanged()
@@ -173,10 +152,11 @@ public sealed partial class ConfirmButton : Button
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-            return;
         }
-
-        base.DrawModeChanged();
+        else
+        {
+            base.DrawModeChanged();
+        }
     }
 
     private void HandleOnPressed(ButtonEventArgs buttonEvent)
@@ -185,9 +165,8 @@ public sealed partial class ConfirmButton : Button
         if (IsConfirming && _nextCooldown > _gameTiming.CurTime)
             return;
 
-        // Update state before invoking our events.
-        // NOTE: this sets the text, timers, and disables the button appropriately
-        IsConfirming = !IsConfirming;
+        // Update the state machine before invoking our events.
+        SetIsConfirming(!IsConfirming);
 
         switch (IsConfirming)
         {
@@ -197,6 +176,51 @@ public sealed partial class ConfirmButton : Button
             case false:
                 OnPressed?.Invoke(buttonEvent);
                 break;
+        }
+    }
+
+    /// <summary>
+    /// Updates the text shown on the button depending on whether the button is confirming or not.
+    /// </summary>
+    private void UpdateText()
+    {
+        base.Text = IsConfirming ? ConfirmationText : Text;
+    }
+
+    /// <summary>
+    /// Internal setter logi
+    /// </summary>
+    private void SetDisabled(bool value)
+    {
+        base.Disabled = value;
+    }
+
+    /// <summary>
+    /// Internal setter logic for <see cref="IsConfirming"/>
+    /// Sets the text, the timers, and the disabled state.
+    /// </summary>
+    private void SetIsConfirming(bool value)
+    {
+        _isConfirming = value;
+
+        // Update button visuals.
+        UpdateText();
+        DrawModeChanged();
+
+        if (value)
+        {
+            // Start our timers, disable button until cooldown.
+            SetDisabled(true);
+            _nextCooldown = _gameTiming.CurTime + CooldownTime;
+            _nextReset = _gameTiming.CurTime + ResetTime;
+        }
+        else
+        {
+            // Clear timers, ensure button is enabled if it was disabled before (previous SetIsConfirming(true) call => valid reset timer)
+            if (Disabled && _nextReset != null)
+                SetDisabled(false);
+            _nextReset = null;
+            _nextCooldown = null;
         }
     }
 }

--- a/Content.Client/UserInterface/Controls/ConfirmButton.cs
+++ b/Content.Client/UserInterface/Controls/ConfirmButton.cs
@@ -47,7 +47,8 @@ public sealed partial class ConfirmButton : Button
         set
         {
             _text = value;
-            base.Text = IsConfirming ? _confirmationText : value;
+            if (!IsConfirming)
+                base.Text = value;
         }
     }
 
@@ -75,8 +76,8 @@ public sealed partial class ConfirmButton : Button
         set
         {
             _confirmationText = value;
-            if (_isConfirming)
-                base.Text = _confirmationText;
+            if (IsConfirming)
+                base.Text = value;
         }
     }
 
@@ -105,7 +106,7 @@ public sealed partial class ConfirmButton : Button
             if (_isConfirming != value)
             {
                 _isConfirming = value;
-                base.Text = IsConfirming ? ConfirmationText : Text;
+                base.Text = value ? ConfirmationText : Text;
                 DrawModeChanged();
 
                 // Set the timer when changing the confirmation status.

--- a/Content.Client/UserInterface/Controls/ConfirmButton.cs
+++ b/Content.Client/UserInterface/Controls/ConfirmButton.cs
@@ -72,7 +72,12 @@ public sealed partial class ConfirmButton : Button
     public string ConfirmationText
     {
         get => _confirmationText ?? Loc.GetString("generic-confirm");
-        set => _confirmationText = value;
+        set
+        {
+            _confirmationText = value;
+            if (_isConfirming)
+                base.Text = _confirmationText;
+        }
     }
 
     /// <summary>
@@ -100,7 +105,7 @@ public sealed partial class ConfirmButton : Button
             if (_isConfirming != value)
             {
                 _isConfirming = value;
-                base.Text = IsConfirming ? Text : ConfirmationText;
+                base.Text = IsConfirming ? ConfirmationText : Text;
                 DrawModeChanged();
 
                 // Set the timer when changing the confirmation status.
@@ -111,6 +116,7 @@ public sealed partial class ConfirmButton : Button
                 }
                 else
                 {
+                    base.Disabled = true; // Must set the base, leave IsConfirming intact
                     _nextCooldown = _gameTiming.CurTime + CooldownTime;
                     _nextReset = _gameTiming.CurTime + ResetTime;
                 }
@@ -133,7 +139,7 @@ public sealed partial class ConfirmButton : Button
         }
 
         if (Disabled && _gameTiming.CurTime > _nextCooldown)
-            Disabled = false;
+            base.Disabled = false; // Must set the base, leave IsConfirming intact
     }
 
     protected override void DrawModeChanged()
@@ -169,18 +175,18 @@ public sealed partial class ConfirmButton : Button
         if (IsConfirming && _nextCooldown > _gameTiming.CurTime)
             return;
 
+        // Update state before invoking our events.
+        // NOTE: this sets the text, timers, and disables the button appropriately
+        IsConfirming = !IsConfirming;
+
         switch (IsConfirming)
         {
-            case false:
-                Disabled = true;
+            case true:
                 OnConfirming?.Invoke(buttonEvent);
                 break;
-            case true:
+            case false:
                 OnPressed?.Invoke(buttonEvent);
                 break;
         }
-
-        // NOTE: this handles setting the text and timers.
-        IsConfirming = !IsConfirming;
     }
 }

--- a/Content.Client/UserInterface/Controls/ConfirmButton.cs
+++ b/Content.Client/UserInterface/Controls/ConfirmButton.cs
@@ -118,7 +118,8 @@ public sealed partial class ConfirmButton : Button
                 // Set the timer when changing the confirmation status.
                 if (!value)
                 {
-                    if (base.Disabled && _nextReset != null)
+                    // Revert disabled state if left to transition back.
+                    if (Disabled && _nextReset != null)
                         base.Disabled = false; // Must set the base, leave IsConfirming intact
                     _nextReset = null;
                     _nextCooldown = null;

--- a/Content.Client/UserInterface/Controls/ConfirmButton.cs
+++ b/Content.Client/UserInterface/Controls/ConfirmButton.cs
@@ -118,7 +118,8 @@ public sealed partial class ConfirmButton : Button
                 // Set the timer when changing the confirmation status.
                 if (!value)
                 {
-                    base.Disabled = _nextReset != null;
+                    if (base.Disabled && _nextReset != null)
+                        base.Disabled = false; // Must set the base, leave IsConfirming intact
                     _nextReset = null;
                     _nextCooldown = null;
                 }

--- a/Content.Client/UserInterface/Controls/ConfirmButton.cs
+++ b/Content.Client/UserInterface/Controls/ConfirmButton.cs
@@ -20,7 +20,13 @@ public sealed partial class ConfirmButton : Button
 
     public const string ConfirmPrefix = "confirm-";
 
+    /// <summary>
+    /// The time when the button will revert from confirming if left unpressed.
+    /// </summary>
     private TimeSpan? _nextReset;
+    /// <summary>
+    /// The time when the button should re-enable itself (to avoid debouncing).
+    /// </summary>
     private TimeSpan? _nextCooldown;
     private bool _isConfirming;
     private string? _confirmationText;
@@ -112,6 +118,7 @@ public sealed partial class ConfirmButton : Button
                 // Set the timer when changing the confirmation status.
                 if (!value)
                 {
+                    base.Disabled = _nextReset != null;
                     _nextReset = null;
                     _nextCooldown = null;
                 }
@@ -134,12 +141,12 @@ public sealed partial class ConfirmButton : Button
 
     protected override void FrameUpdate(FrameEventArgs args)
     {
-        if (IsConfirming && _gameTiming.CurTime > _nextReset)
-        {
-            IsConfirming = false;
-        }
+        if (!IsConfirming)
+            return;
 
-        if (Disabled && _gameTiming.CurTime > _nextCooldown)
+        if (_gameTiming.CurTime > _nextReset)
+            IsConfirming = false;
+        else if (Disabled && _gameTiming.CurTime > _nextCooldown)
             base.Disabled = false; // Must set the base, leave IsConfirming intact
     }
 


### PR DESCRIPTION
## About the PR

Fixes a few inconsistencies in the ConfirmButton.  Supercedes #43010 (a fine fix but not the root of the problem).

Adds a new OnConfirming event that is called when the button is first pressed, but before a second click fires the OnPressed event.

## Why / Balance

Bad state transitions in ConfirmButton.  Disabled, Text, ConfirmText and IsConfirming all had odd transitions leading to potentially inconsistent states.  At the moment, anything set through the ConfirmButton's API should result in a consistent state.

A call to Disabled (setting it true or false) now explicitly takes the button out of the IsConfirming state.

## Technical details

The majority of the transition logic was moved into the IsConfirming property.  This now sets the text, the timers, and updates the disabled state of the button.

Added a new _isConfirming backing field for the IsConfirming property to use.

The FrameUpdate loop was changed to only work when IsConfirming is true.

## Test plan

Nothing in the repo as-is really uses these features of the ConfirmButton (which is sad, it's a nice control!)  Instead, I've created a small test bench to test these changes.

1. Check out the [2026-07-10-confirmed-test-bench](https://github.com/space-wizards/space-station-14/compare/master...whatston3:2026-07-10-confirmed-test-bench) branch from my repo, build it, run in debug.
2. Spawn a confirmulator.
3. Open the confirmulator.  You have controls to set the number of gronks you have, and buttons to spend those gronks if you have enough.
4. Each of the purchase gronks buttons should be mutually exclusive with each other (this uses the OnConfirming action).
5. The first of the three buttons on the bottom disables the purchase buttons (calling .Disable = true) or re-enables them.
6. The other two set the text or confirmation text of the buttons.
7. Play around with the interface.  The following things should be true:
8. The purchase buttons should never wrongfully set themselves disabled or reenabled when the confirm timeout elapses, it should only be driven by the number of gronks and the enabled button.
9. Every text set should result in the buttons in the appropriate state being updated immediately.
10. Only one purchase button should ever be confirming at a given time.

## Media

The computer mentioned in the test plan shown in action.

https://github.com/user-attachments/assets/b2189018-81c9-4021-9b18-87e1607c4b8a

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

The ConfirmButton.Disabled property, if set, now cancels the button's pending confirmation.

## Changelog
wrote up a whole damn test bench window that dies with this, like tears in the rain
a tragedy