### PR TITLE
Entity Effect dispatch benchmark

### DIFF
--- a/Content.Benchmarks/EffectDispatchBenchmark.cs
+++ b/Content.Benchmarks/EffectDispatchBenchmark.cs
@@ -1,0 +1,196 @@
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Content.IntegrationTests;
+using Content.IntegrationTests.Pair;
+using Content.Shared.EntityEffects;
+using Robust.Shared;
+using Robust.Shared.Analyzers;
+using Robust.Shared.GameObjects;
+
+namespace Content.Benchmarks;
+
+/// <summary>
+/// Benchmark comparing EntityEffect dispatch strategies.
+/// Old: event bus SubscribeLocalEvent + RaiseLocalEvent
+/// New: static Dictionary{{Type, IEntityEffectHandler}} + direct interface call
+/// </summary>
+[Virtual]
+public partial class EffectDispatchBenchmark
+{
+    private TestPair _pair = default!;
+    private BenchSystem _sys = default!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        ProgramShared.PathOffset = "../../../../";
+        PoolManager.Startup(typeof(BenchSystem).Assembly);
+        _pair = PoolManager.GetServerClient(testContext: new ExternalTestContext("Benchmark", StreamWriter.Null)).GetAwaiter().GetResult();
+
+        var entMan = _pair.Server.EntMan;
+        _sys = entMan.System<BenchSystem>();
+
+        _pair.Server.WaitPost(() =>
+        {
+            var hitUid = entMan.Spawn();
+            entMan.AddComponent<DummyComponent>(hitUid);
+            _sys.HitTarget = new(hitUid, entMan.GetComponent<TransformComponent>(hitUid));
+
+            var missUid = entMan.Spawn();
+            _sys.MissTarget = new(missUid, entMan.GetComponent<TransformComponent>(missUid));
+
+        })
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _pair.DisposeAsync();
+        PoolManager.Shutdown();
+    }
+
+    [Benchmark(Baseline = true)]
+    public int EventBusDispatch_Hit()
+    {
+        return _sys.RaiseViaEventBusHit();
+    }
+
+    [Benchmark]
+    public int EventBusDispatch_Miss()
+    {
+        return _sys.RaiseViaEventBusMiss();
+    }
+
+    [Benchmark]
+    public int CurrentImplementation_Hit()
+    {
+        return _sys.RaiseViaCurrentImplementation();
+    }
+
+    [Benchmark]
+    public int CurrentImplementation_Miss()
+    {
+        return _sys.RaiseViaCurrentImplementationMiss();
+    }
+
+    [Benchmark]
+    public int CSharpEventDispatch_Hit()
+    {
+        return _sys.RaiseViaCSharpEventHit();
+    }
+
+    [Benchmark]
+    public int CSharpEventDispatch_Miss()
+    {
+        return _sys.RaiseViaCSharpEventHit();
+    }
+
+    public sealed partial class BenchSystem : EntitySystem
+    {
+        private SharedEntityEffectsSystem _effectsSystem = default!;
+
+        public Entity<TransformComponent> HitTarget;
+        public Entity<TransformComponent> MissTarget;
+
+        private EntityEffect _effect = new TestEffect();
+
+        private int _counter;
+
+        public delegate void EffectHandler(EntityUid uid);
+
+        public event EffectHandler OnEffect;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            SubscribeLocalEvent<DummyComponent, TestEffectEvent>(OnEventBus);
+
+            OnEffect += OnCSharpEvent;
+
+            _effectsSystem = EntityManager.System<SharedEntityEffectsSystem>();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void OnEventBus(Entity<DummyComponent> entity, ref TestEffectEvent args)
+        {
+            _counter++;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void OnCSharpEvent(EntityUid uid)
+        {
+            TryComp<DummyComponent>(uid, out _);
+            _counter++;
+        }
+
+        public int RaiseViaEventBusHit()
+        {
+            _counter = 0;
+            var ev = new TestEffectEvent();
+            RaiseLocalEvent(HitTarget.Owner, ref ev);
+            return _counter;
+        }
+
+        public int RaiseViaEventBusMiss()
+        {
+            _counter = 0;
+            var ev = new TestEffectEvent();
+            RaiseLocalEvent(MissTarget.Owner, ref ev);
+            return _counter;
+        }
+
+        public int RaiseViaCurrentImplementation()
+        {
+            _counter = 0;
+            _effectsSystem.ApplyEffect(HitTarget, _effect);
+            return _counter;
+        }
+
+        public int RaiseViaCurrentImplementationMiss()
+        {
+            _counter = 0;
+            _effectsSystem.ApplyEffect(MissTarget, _effect);
+            return _counter;
+        }
+
+        public int RaiseViaCSharpEventHit()
+        {
+            _counter = 0;
+            OnEffect?.Invoke(HitTarget.Owner);
+            return _counter;
+        }
+
+        public int RaiseViaCSharpEventMiss()
+        {
+            _counter = 0;
+            OnEffect?.Invoke(MissTarget.Owner);
+            return _counter;
+        }
+    }
+
+    [ByRefEvent]
+    public struct TestEffectEvent
+    {
+    }
+
+    public sealed partial class TestEffectSystem : EntityEffectSystem<DummyComponent, TestEffect>
+    {
+        protected override void Effect(Entity<DummyComponent> entity, ref EntityEffectEvent<TestEffect> args)
+        {
+        }
+    }
+    public sealed partial class TestEffect : EntityEffectBase<TestEffect>
+    {
+
+    }
+
+    [RegisterComponent]
+    public sealed partial class DummyComponent : Component
+    {
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a benchmark for Entity Effect dispatch, partially taken from #44345

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Benchmarking things is good and we are trying to speed up entityeffects/conditions. Having a benchmark will help

## Technical details
<!-- Summary of code changes for easier review. -->
Has a run for current implementation hit and miss, c sharp events, and using plain event bus. Code is fairly straightforward.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Run the EffectDispatchBenchmark benchmark

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
| Method                     | Mean      | Error     | StdDev    | Ratio | RatioSD |
|--------------------------- |----------:|----------:|----------:|------:|--------:|
| EventBusDispatch_Hit       | 45.289 ns | 1.3581 ns | 3.8527 ns |  1.01 |    0.12 |                                                                                                                                                                                                                                
| EventBusDispatch_Miss      | 24.067 ns | 0.5046 ns | 1.3024 ns |  0.53 |    0.05 |
| CurrentImplementation_Hit  | 57.515 ns | 1.1739 ns | 2.3979 ns |  1.28 |    0.11 |
| CurrentImplementation_Miss | 35.133 ns | 0.6743 ns | 0.6622 ns |  0.78 |    0.06 |
| CSharpEventDispatch_Hit    |  5.295 ns | 0.0200 ns | 0.0167 ns |  0.12 |    0.01 |
| CSharpEventDispatch_Miss   |  5.561 ns | 0.0686 ns | 0.0573 ns |  0.12 |    0.01 |


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
