### PR TITLE
Fix some missing localization warnings

### DIFF
--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
@@ -161,7 +161,7 @@ public sealed partial class PlayerTab : Control
                 $"{info.CharacterName} " +
                 $"{info.IdentityName} " +
                 $"{info.StartingJob} " +
-                $"{Loc.GetString(info.Subtype ?? string.Empty)} " +
+                $"{(info.Subtype is not null ? Loc.GetString(info.Subtype) : string.Empty)} " +
                 $"{(_proto.TryIndex(info.RoleProto, out var proto) ? Loc.GetString(proto.Name) : string.Empty)}"))
             .ToList());
     }

--- a/Content.IntegrationTests/Tests/Labels/LabelPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Labels/LabelPrototypeTest.cs
@@ -1,0 +1,28 @@
+using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Utility;
+using Content.Shared.Labels.Components;
+
+namespace Content.IntegrationTests.Tests.Labels;
+
+[TestFixture]
+public sealed class LabelPrototypeTest : GameTest
+{
+    private static string[] _entitiesWithLabel = GameDataScrounger.EntitiesWithComponent("Label");
+
+    [Test]
+    [TestOf(typeof(LabelComponent))]
+    [TestCaseSource(nameof(_entitiesWithLabel))]
+    [Description("Ensures entity prototypes do not set LabelComponent.CurrentLabel directly.")]
+    public async Task CurrentLabelNotSetInPrototype(string protoKey)
+    {
+        var pair = Pair;
+        var server = pair.Server;
+        var protoMan = server.ProtoMan;
+
+        var proto = protoMan.Index(protoKey);
+        var comp = (LabelComponent)proto.Components["Label"].Component;
+
+        Assert.That(comp.CurrentLabel, Is.Null.Or.Empty,
+            $"Prototype {proto.ID} sets LabelComponent.CurrentLabel directly. Use LabelComponent.LocalizedLabel instead.");
+    }
+}

--- a/Content.IntegrationTests/Tests/Labels/LabelPrototypeTest.cs
+++ b/Content.IntegrationTests/Tests/Labels/LabelPrototypeTest.cs
@@ -4,7 +4,6 @@ using Content.Shared.Labels.Components;
 
 namespace Content.IntegrationTests.Tests.Labels;
 
-[TestFixture]
 public sealed class LabelPrototypeTest : GameTest
 {
     private static string[] _entitiesWithLabel = GameDataScrounger.EntitiesWithComponent("Label");

--- a/Content.Shared/Labels/Components/LabelComponent.cs
+++ b/Content.Shared/Labels/Components/LabelComponent.cs
@@ -11,11 +11,18 @@ namespace Content.Shared.Labels.Components;
 public sealed partial class LabelComponent : Component
 {
     /// <summary>
-    /// Current text on the label. If set before map init, during map init this string will be localized.
-    /// This permits localized preset labels with fallback to the text written on the label.
+    /// Current text on the label.
+    /// Do not use this in entity prototypes - use <see cref="LocalizedLabel"/> instead.
     /// </summary>
     [DataField, AutoNetworkedField]
     public string? CurrentLabel { get; set; }
+
+    /// <summary>
+    /// Localization ID used to set <see cref="CurrentLabel"/> on map init.
+    /// Use this in entity prototypes.
+    /// </summary>
+    [DataField]
+    public LocId? LocalizedLabel { get; set; }
 
     /// <summary>
     /// Should the label show up in the examine menu?

--- a/Content.Shared/Labels/EntitySystems/LabelSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/LabelSystem.cs
@@ -36,9 +36,9 @@ public sealed partial class LabelSystem : EntitySystem
 
     private void OnLabelCompMapInit(Entity<LabelComponent> ent, ref MapInitEvent args)
     {
-        if (!string.IsNullOrEmpty(ent.Comp.CurrentLabel))
+        if (!string.IsNullOrEmpty(ent.Comp.CurrentLabel) && Loc.TryGetString(ent.Comp.CurrentLabel, out var localized))
         {
-            ent.Comp.CurrentLabel = Loc.GetString(ent.Comp.CurrentLabel);
+            ent.Comp.CurrentLabel = localized;
             Dirty(ent);
         }
 

--- a/Content.Shared/Labels/EntitySystems/LabelSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/LabelSystem.cs
@@ -36,9 +36,9 @@ public sealed partial class LabelSystem : EntitySystem
 
     private void OnLabelCompMapInit(Entity<LabelComponent> ent, ref MapInitEvent args)
     {
-        if (!string.IsNullOrEmpty(ent.Comp.CurrentLabel) && Loc.TryGetString(ent.Comp.CurrentLabel, out var localized))
+        if (ent.Comp.LocalizedLabel is { } locId)
         {
-            ent.Comp.CurrentLabel = localized;
+            ent.Comp.CurrentLabel = Loc.GetString(locId);
             Dirty(ent);
         }
 

--- a/Resources/Locale/en-US/janitorial/spray.ftl
+++ b/Resources/Locale/en-US/janitorial/spray.ftl
@@ -1,0 +1,1 @@
+spray-bottle-label-space-cleaner = space cleaner

--- a/Resources/Locale/en-US/medical/pills.ftl
+++ b/Resources/Locale/en-US/medical/pills.ftl
@@ -1,0 +1,11 @@
+pill-label-dexalin-20u = dexalin 20u
+pill-label-dylovene-20u = dylovene 20u
+pill-label-hyronalin-20u = hyronalin 20u
+pill-label-potassium-iodide-20u = potassium iodide 20u
+pill-label-iron-20u = iron 20u
+pill-label-copper-20u = copper 20u
+pill-label-kelotane-20u = kelotane 20u
+pill-label-dermaline-20u = dermaline 20u
+pill-label-tricordrazine-20u = tricordrazine 20u
+pill-label-bicaridine-20u = bicaridine 20u
+pill-label-charcoal-20u = charcoal 20u

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -40,7 +40,7 @@
     - state: internals
     - state: nitrogentank
   - type: Label
-    currentLabel: reagent-name-nitrogen
+    localizedLabel: reagent-name-nitrogen
 
 - type: entity
   parent: BoxCardboard
@@ -84,7 +84,7 @@
     - state: internals
     - state: nitrogentank
   - type: Label
-    currentLabel: reagent-name-nitrogen
+    localizedLabel: reagent-name-nitrogen
 
 - type: entity
 
@@ -129,7 +129,7 @@
     - state: internals
     - state: nitrogentank
   - type: Label
-    currentLabel: reagent-name-nitrogen
+    localizedLabel: reagent-name-nitrogen
 
 - type: entity
 
@@ -174,7 +174,7 @@
     - state: internals
     - state: nitrogentank
   - type: Label
-    currentLabel: reagent-name-nitrogen
+    localizedLabel: reagent-name-nitrogen
 
 - type: entity
   parent: BoxCardboard
@@ -220,7 +220,7 @@
         - id: FoodSnackNutribrick
         - id: DrinkWaterBottleFull
   - type: Label
-    currentLabel: reagent-name-nitrogen
+    localizedLabel: reagent-name-nitrogen
 
 - type: entity
   parent: BoxSurvival
@@ -258,7 +258,7 @@
     - state: internals
     - state: nitrogentank
   - type: Label
-    currentLabel: reagent-name-nitrogen
+    localizedLabel: reagent-name-nitrogen
 
 - type: entity
   parent: BoxSurvival
@@ -316,7 +316,7 @@
     - state: internals
     - state: nitrogentank
   - type: Label
-    currentLabel: reagent-name-nitrogen
+    localizedLabel: reagent-name-nitrogen
 
 
 - type: entity
@@ -354,4 +354,4 @@
     - state: internals
     - state: nitrogentank
   - type: Label
-    currentLabel: reagent-name-nitrogen
+    localizedLabel: reagent-name-nitrogen

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks-cartons.yml
@@ -275,7 +275,7 @@
       - ReagentId: JuiceLime
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-juice-lime
+    localizedLabel: reagent-name-juice-lime
   - type: Sprite
     sprite: Objects/Consumable/Drinks/limejuice.rsi
 
@@ -291,7 +291,7 @@
       - ReagentId: JuiceOrange
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-juice-orange
+    localizedLabel: reagent-name-juice-orange
   - type: Sprite
     sprite: Objects/Consumable/Drinks/orangejuice.rsi
 
@@ -307,6 +307,6 @@
       - ReagentId: Cream
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-cream
+    localizedLabel: reagent-name-cream
   - type: Sprite
     sprite: Objects/Consumable/Drinks/cream.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles_glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles_glass.yml
@@ -90,7 +90,7 @@
   description: One sip of this and you just know you're gonna have a good time.
   components:
   - type: Label
-    currentLabel: reagent-name-absinthe
+    localizedLabel: reagent-name-absinthe
   - type: Sprite
     sprite: Objects/Consumable/Drinks/absinthebottle.rsi
 
@@ -112,7 +112,7 @@
   description: A fruity, exceptionally azure drink. Does not allow the imbiber to use the fifth magic.
   components:
   - type: Label
-    currentLabel: reagent-name-blue-curacao
+    localizedLabel: reagent-name-blue-curacao
   - type: Sprite
     sprite: Objects/Consumable/Drinks/alco-bottle.rsi
     layers:
@@ -146,7 +146,7 @@
       - ReagentId: Nothing
         Quantity: 120
   - type: Label
-    currentLabel: reagent-name-nothing
+    localizedLabel: reagent-name-nothing
   - type: Sprite
     sprite: Objects/Consumable/Drinks/bottleofnothing.rsi
 
@@ -162,7 +162,7 @@
       - ReagentId: Champagne
         Quantity: 120
   - type: Label
-    currentLabel: reagent-name-champagne
+    localizedLabel: reagent-name-champagne
   - type: Sprite
     sprite: Objects/Consumable/Drinks/champagnebottle.rsi
   - type: Openable
@@ -177,7 +177,7 @@
   description: A sweet and strongly alcoholic drink, made after numerous distillations and years of maturing. You might as well not scream 'SHITCURITY' this time.
   components:
   - type: Label
-    currentLabel: reagent-name-cognac
+    localizedLabel: reagent-name-cognac
   - type: Sprite
     sprite: Objects/Consumable/Drinks/cognacbottle.rsi
 
@@ -204,7 +204,7 @@
       - ReagentId: Grenadine
         Quantity: 120
   - type: Label
-    currentLabel: reagent-name-grenadine
+    localizedLabel: reagent-name-grenadine
   - type: Sprite
     sprite: Objects/Consumable/Drinks/grenadinebottle.rsi
     layers:
@@ -222,7 +222,7 @@
   description: A bottle of high quality gin, produced in the New London Space Station.
   components:
   - type: Label
-    currentLabel: reagent-name-gin
+    localizedLabel: reagent-name-gin
   - type: Sprite
     sprite: Objects/Consumable/Drinks/ginbottle.rsi
 
@@ -244,7 +244,7 @@
   description: 100 proof cinnamon schnapps, made for alcoholic teen girls on spring break.
   components:
   - type: Label
-    currentLabel: reagent-name-gildlager
+    localizedLabel: reagent-name-gildlager
   - type: Sprite
     sprite: Objects/Consumable/Drinks/gildlagerbottle.rsi
 
@@ -266,7 +266,7 @@
   description: The great taste of coffee with none of the benifits.
   components:
   - type: Label
-    currentLabel: reagent-name-coffeeliqueur
+    localizedLabel: reagent-name-coffeeliqueur
   - type: Sprite
     sprite: Objects/Consumable/Drinks/coffeeliqueurbottle.rsi
 
@@ -293,7 +293,7 @@
       - ReagentId: MelonLiquor
         Quantity: 120
   - type: Label
-    currentLabel: reagent-name-melon-liquor
+    localizedLabel: reagent-name-melon-liquor
   - type: Sprite
     sprite: Objects/Consumable/Drinks/alco-bottle.rsi
     layers:
@@ -311,7 +311,7 @@
   description: Silver laced tequila, served in space night clubs across the galaxy.
   components:
   - type: Label
-    currentLabel: reagent-name-patron
+    localizedLabel: reagent-name-patron
   - type: Sprite
     sprite: Objects/Consumable/Drinks/patronbottle.rsi
 
@@ -363,7 +363,7 @@
   description: This isn't just rum, oh no. It's practically GRIFF in a bottle.
   components:
   - type: Label
-    currentLabel: reagent-name-rum
+    localizedLabel: reagent-name-rum
   - type: Sprite
     sprite: Objects/Consumable/Drinks/rumbottle.rsi
 
@@ -385,7 +385,7 @@
   description: Made from premium petroleum distillates, pure thalidomide and other fine quality ingredients!
   components:
   - type: Label
-    currentLabel: reagent-name-tequila
+    localizedLabel: reagent-name-tequila
   - type: Sprite
     sprite: Objects/Consumable/Drinks/tequillabottle.rsi
 
@@ -407,7 +407,7 @@
   description: Sweet, sweet dryness!
   components:
   - type: Label
-    currentLabel: reagent-name-vermouth
+    localizedLabel: reagent-name-vermouth
   - type: Sprite
     sprite: Objects/Consumable/Drinks/vermouthbottle.rsi
 
@@ -429,7 +429,7 @@
   description: Aah, vodka. Prime choice of drink AND fuel by Russians worldwide.
   components:
   - type: Label
-    currentLabel: reagent-name-vodka
+    localizedLabel: reagent-name-vodka
   - type: Sprite
     sprite: Objects/Consumable/Drinks/vodkabottle.rsi
 
@@ -451,7 +451,7 @@
   description: A premium single-malt whiskey, gently matured inside the tunnels of a nuclear shelter. TUNNEL WHISKEY RULES.
   components:
   - type: Label
-    currentLabel: reagent-name-whiskey
+    localizedLabel: reagent-name-whiskey
   - type: Sprite
     sprite: Objects/Consumable/Drinks/whiskeybottle.rsi
 
@@ -473,7 +473,7 @@
   description: A faint aura of unease and asspainery surrounds the bottle.
   components:
   - type: Label
-    currentLabel: reagent-name-wine
+    localizedLabel: reagent-name-wine
   - type: Sprite
     sprite: Objects/Consumable/Drinks/winebottle.rsi
   - type: Tag
@@ -540,7 +540,7 @@
       - ReagentId: Beer
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-beer
+    localizedLabel: reagent-name-beer
   - type: Sprite
     sprite: Objects/Consumable/Drinks/beer.rsi
   - type: Openable
@@ -564,7 +564,7 @@
       - ReagentId: Ale
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-ale
+    localizedLabel: reagent-name-ale
   - type: Sprite
     sprite: Objects/Consumable/Drinks/alebottle.rsi
   - type: Openable
@@ -582,7 +582,7 @@
   description: An alcoholic beverage made from malted grains, hops, yeast, and water.
   components:
   - type: Label
-    currentLabel: reagent-name-beer
+    localizedLabel: reagent-name-beer
   - type: Sprite
     sprite: Objects/Consumable/Drinks/beer.rsi
   - type: Openable
@@ -611,7 +611,7 @@
   description: A true dorf's drink of choice.
   components:
   - type: Label
-    currentLabel: reagent-name-ale
+    localizedLabel: reagent-name-ale
   - type: Sprite
     sprite: Objects/Consumable/Drinks/alebottle.rsi
   - type: Openable
@@ -642,6 +642,6 @@
       - ReagentId: Sake
         Quantity: 60
   - type: Label
-    currentLabel: reagent-name-sake
+    localizedLabel: reagent-name-sake
   - type: Sprite
     sprite: Objects/Consumable/Drinks/sakebottle.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles_plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles_plastic.yml
@@ -61,7 +61,7 @@
   - type: Sprite
     sprite: Objects/Consumable/Drinks/waterbottle.rsi
   - type: Label
-    currentLabel: reagent-name-water
+    localizedLabel: reagent-name-water
 
 # Large Plastic Bottles
 
@@ -77,7 +77,7 @@
       - ReagentId: Cola
         Quantity: 120
   - type: Label
-    currentLabel: reagent-name-cola
+    localizedLabel: reagent-name-cola
   - type: Sprite
     sprite: Objects/Consumable/Drinks/colabottle.rsi
 
@@ -93,7 +93,7 @@
       - ReagentId: SpaceMountainWind
         Quantity: 120
   - type: Label
-    currentLabel: reagent-name-space-mountain-wind
+    localizedLabel: reagent-name-space-mountain-wind
   - type: Sprite
     sprite: Objects/Consumable/Drinks/space_mountain_wind_bottle.rsi
 
@@ -109,7 +109,7 @@
       - ReagentId: SpaceUp
         Quantity: 120
   - type: Label
-    currentLabel: reagent-name-space-up
+    localizedLabel: reagent-name-space-up
   - type: Sprite
     sprite: Objects/Consumable/Drinks/space-up_bottle.rsi
 
@@ -127,7 +127,7 @@
   - type: Sprite
     sprite: Objects/Consumable/Drinks/sodawater-bottle.rsi
   - type: Label
-    currentLabel: reagent-name-soda-water
+    localizedLabel: reagent-name-soda-water
 
 - type: entity
   parent: [DrinkVisualsAllFilled, DrinkBottlePlasticBaseFull]
@@ -143,7 +143,7 @@
   - type: Sprite
     sprite: Objects/Consumable/Drinks/tonic-bottle.rsi
   - type: Label
-    currentLabel: reagent-name-tonic-water
+    localizedLabel: reagent-name-tonic-water
 
 # Large
 
@@ -160,7 +160,7 @@
       - ReagentId: Sugar
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-sugar
+    localizedLabel: reagent-name-sugar
   # TODO new sprite
 
 - type: entity
@@ -175,7 +175,7 @@
       - ReagentId: LemonLime
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-lemon-lime
+    localizedLabel: reagent-name-lemon-lime
   # TODO new sprite
 
 - type: entity
@@ -190,7 +190,7 @@
       - ReagentId: Mead
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-mead
+    localizedLabel: reagent-name-mead
   # TODO new sprite
 
 - type: entity
@@ -205,7 +205,7 @@
       - ReagentId: Ice
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-ice
+    localizedLabel: reagent-name-ice
   # TODO new sprite
 
 - type: entity
@@ -220,7 +220,7 @@
       - ReagentId: CoconutWater
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-coconut-water
+    localizedLabel: reagent-name-coconut-water
   # TODO new sprite
 
 - type: entity
@@ -235,7 +235,7 @@
       - ReagentId: Coffee
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-coffee
+    localizedLabel: reagent-name-coffee
   # TODO new sprite
 
 - type: entity
@@ -250,7 +250,7 @@
       - ReagentId: Tea
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-tea
+    localizedLabel: reagent-name-tea
   # TODO new sprite
 
 - type: entity
@@ -265,7 +265,7 @@
       - ReagentId: GreenTea
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-green-tea
+    localizedLabel: reagent-name-green-tea
   # TODO new sprite
 
 - type: entity
@@ -280,7 +280,7 @@
       - ReagentId: IcedTea
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-iced-tea
+    localizedLabel: reagent-name-iced-tea
   # TODO new sprite
 
 - type: entity
@@ -295,7 +295,7 @@
       - ReagentId: DrGibb
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-dr-gibb
+    localizedLabel: reagent-name-dr-gibb
   # TODO new sprite
 
 - type: entity
@@ -310,7 +310,7 @@
       - ReagentId: RootBeer
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-root-beer
+    localizedLabel: reagent-name-root-beer
   # TODO new sprite
 
 - type: entity
@@ -325,7 +325,7 @@
       - ReagentId: JuiceWatermelon
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-juice-watermelon
+    localizedLabel: reagent-name-juice-watermelon
   # TODO new sprite
 
 - type: entity
@@ -340,5 +340,5 @@
       - ReagentId: EnergyDrink
         Quantity: 240
   - type: Label
-    currentLabel: reagent-name-energy-drink
+    localizedLabel: reagent-name-energy-drink
   # TODO new sprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemical-containers.yml
@@ -26,7 +26,7 @@
   suffix: punct & tranex
   components:
   - type: Label
-    currentLabel: reagent-name-puncturase-tranexamic
+    localizedLabel: reagent-name-puncturase-tranexamic
   - type: Solution
     solution:
       reagents:
@@ -41,7 +41,7 @@
   suffix: pyra & derma
   components:
   - type: Label
-    currentLabel: reagent-name-pyrazine-dermaline
+    localizedLabel: reagent-name-pyrazine-dermaline
   - type: Solution
     solution:
       reagents:
@@ -56,7 +56,7 @@
   suffix: dex+ & saline
   components:
   - type: Label
-    currentLabel: reagent-name-dexalin-plus-saline
+    localizedLabel: reagent-name-dexalin-plus-saline
   - type: Solution
     solution:
       reagents:
@@ -71,7 +71,7 @@
   suffix: tricordrazine
   components:
   - type: Label
-    currentLabel: reagent-name-tricordrazine
+    localizedLabel: reagent-name-tricordrazine
   - type: Solution
     solution:
       reagents:
@@ -84,7 +84,7 @@
   suffix: blood
   components:
   - type: Label
-    currentLabel: reagent-name-blood
+    localizedLabel: reagent-name-blood
   - type: Solution
     solution:
       reagents:
@@ -97,7 +97,7 @@
   suffix: water
   components:
   - type: Label
-    currentLabel: reagent-name-water
+    localizedLabel: reagent-name-water
   - type: Solution
     solution:
       reagents:
@@ -111,7 +111,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-carbon
+    localizedLabel: reagent-name-carbon
   - type: Solution
     solution:
       reagents:
@@ -125,7 +125,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-iodine
+    localizedLabel: reagent-name-iodine
   - type: Solution
     solution:
       reagents:
@@ -139,7 +139,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-fluorine
+    localizedLabel: reagent-name-fluorine
   - type: Solution
     solution:
       reagents:
@@ -153,7 +153,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-chlorine
+    localizedLabel: reagent-name-chlorine
   - type: Solution
     solution:
       reagents:
@@ -167,7 +167,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-aluminium
+    localizedLabel: reagent-name-aluminium
   - type: Solution
     solution:
       reagents:
@@ -181,7 +181,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-phosphorus
+    localizedLabel: reagent-name-phosphorus
   - type: Solution
     solution:
       reagents:
@@ -195,7 +195,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-sulfur
+    localizedLabel: reagent-name-sulfur
   - type: Solution
     solution:
       reagents:
@@ -209,7 +209,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-silicon
+    localizedLabel: reagent-name-silicon
   - type: Solution
     solution:
       reagents:
@@ -223,7 +223,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-hydrogen
+    localizedLabel: reagent-name-hydrogen
   - type: Solution
     solution:
       reagents:
@@ -237,7 +237,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-lithium
+    localizedLabel: reagent-name-lithium
   - type: Solution
     solution:
       reagents:
@@ -251,7 +251,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-sodium
+    localizedLabel: reagent-name-sodium
   - type: Solution
     solution:
       reagents:
@@ -265,7 +265,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-potassium
+    localizedLabel: reagent-name-potassium
   - type: Solution
     solution:
       reagents:
@@ -279,7 +279,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-radium
+    localizedLabel: reagent-name-radium
   - type: Solution
     solution:
       reagents:
@@ -293,7 +293,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-iron
+    localizedLabel: reagent-name-iron
   - type: Solution
     solution:
       reagents:
@@ -307,7 +307,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-copper
+    localizedLabel: reagent-name-copper
   - type: Solution
     solution:
       reagents:
@@ -321,7 +321,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-gold
+    localizedLabel: reagent-name-gold
   - type: Solution
     solution:
       reagents:
@@ -335,7 +335,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-mercury
+    localizedLabel: reagent-name-mercury
   - type: Solution
     solution:
       reagents:
@@ -349,7 +349,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-silver
+    localizedLabel: reagent-name-silver
   - type: Solution
     solution:
       reagents:
@@ -363,7 +363,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-ethanol
+    localizedLabel: reagent-name-ethanol
   - type: Solution
     solution:
       reagents:
@@ -377,7 +377,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-sugar
+    localizedLabel: reagent-name-sugar
   - type: Solution
     solution:
       reagents:
@@ -391,7 +391,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-nitrogen
+    localizedLabel: reagent-name-nitrogen
   - type: Solution
     solution:
       reagents:
@@ -405,7 +405,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-oxygen
+    localizedLabel: reagent-name-oxygen
   - type: Solution
     solution:
       reagents:
@@ -419,7 +419,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-plant-b-gone
+    localizedLabel: reagent-name-plant-b-gone
   - type: Solution
     solution:
       reagents:
@@ -433,7 +433,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-welding-fuel
+    localizedLabel: reagent-name-welding-fuel
   - type: Solution
     solution:
       reagents:
@@ -447,7 +447,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-bicaridine
+    localizedLabel: reagent-name-bicaridine
   - type: Solution
     solution:
       reagents:
@@ -461,7 +461,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-puncturase
+    localizedLabel: reagent-name-puncturase
   - type: Solution
     solution:
       reagents:
@@ -475,7 +475,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-dermaline
+    localizedLabel: reagent-name-dermaline
   - type: Solution
     solution:
       reagents:
@@ -489,7 +489,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-dylovene
+    localizedLabel: reagent-name-dylovene
   - type: Solution
     solution:
       reagents:
@@ -503,7 +503,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-tranexamic-acid
+    localizedLabel: reagent-name-tranexamic-acid
   - type: Solution
     solution:
       reagents:
@@ -517,7 +517,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-hyronalin
+    localizedLabel: reagent-name-hyronalin
   - type: Solution
     solution:
       reagents:
@@ -531,7 +531,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-saline
+    localizedLabel: reagent-name-saline
   - type: Solution
     solution:
       reagents:
@@ -545,7 +545,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
-    currentLabel: reagent-name-dexalin-plus
+    localizedLabel: reagent-name-dexalin-plus
   - type: Solution
     solution:
       reagents:

--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-bottles.yml
@@ -157,7 +157,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-aloxadone
+    localizedLabel: reagent-name-aloxadone
   - type: Solution
     solution:
       reagents:
@@ -170,7 +170,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-ambuzol
+    localizedLabel: reagent-name-ambuzol
   - type: Solution
     solution:
       reagents:
@@ -183,7 +183,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-ambuzol-plus
+    localizedLabel: reagent-name-ambuzol-plus
   - type: Solution
     solution:
       reagents:
@@ -196,7 +196,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-arithrazine
+    localizedLabel: reagent-name-arithrazine
   - type: Solution
     solution:
       reagents:
@@ -209,7 +209,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-barozine
+    localizedLabel: reagent-name-barozine
   - type: Solution
     solution:
       reagents:
@@ -222,7 +222,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-bicaridine
+    localizedLabel: reagent-name-bicaridine
   - type: Solution
     solution:
       reagents:
@@ -235,7 +235,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-bruizine
+    localizedLabel: reagent-name-bruizine
   - type: Solution
     solution:
       reagents:
@@ -248,7 +248,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-cognizine
+    localizedLabel: reagent-name-cognizine
   - type: Solution
     solution:
       reagents:
@@ -261,7 +261,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-cryoxadone
+    localizedLabel: reagent-name-cryoxadone
   - type: Solution
     solution:
       reagents:
@@ -274,7 +274,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-cryptobiolin
+    localizedLabel: reagent-name-cryptobiolin
   - type: Solution
     solution:
       reagents:
@@ -287,7 +287,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-dermaline
+    localizedLabel: reagent-name-dermaline
   - type: Solution
     solution:
       reagents:
@@ -300,7 +300,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-dexalin
+    localizedLabel: reagent-name-dexalin
   - type: Solution
     solution:
       reagents:
@@ -313,7 +313,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-dexalin-plus
+    localizedLabel: reagent-name-dexalin-plus
   - type: Solution
     solution:
       reagents:
@@ -326,7 +326,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-diphenhydramine
+    localizedLabel: reagent-name-diphenhydramine
   - type: Solution
     solution:
       reagents:
@@ -339,7 +339,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-diphenylmethylamine
+    localizedLabel: reagent-name-diphenylmethylamine
   - type: Solution
     solution:
       reagents:
@@ -352,7 +352,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-doxarubixadone
+    localizedLabel: reagent-name-doxarubixadone
   - type: Solution
     solution:
       reagents:
@@ -365,7 +365,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-dylovene
+    localizedLabel: reagent-name-dylovene
   - type: Solution
     solution:
       reagents:
@@ -378,7 +378,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-epinephrine
+    localizedLabel: reagent-name-epinephrine
   - type: Solution
     solution:
       reagents:
@@ -391,7 +391,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-ethyloxyephedrine
+    localizedLabel: reagent-name-ethyloxyephedrine
   - type: Solution
     solution:
       reagents:
@@ -404,7 +404,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-ethylredoxrazine
+    localizedLabel: reagent-name-ethylredoxrazine
   - type: Solution
     solution:
       reagents:
@@ -417,7 +417,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-haloperidol
+    localizedLabel: reagent-name-haloperidol
   - type: Solution
     solution:
       reagents:
@@ -430,7 +430,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-holywater
+    localizedLabel: reagent-name-holywater
   - type: Solution
     solution:
       reagents:
@@ -443,7 +443,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-hyronalin
+    localizedLabel: reagent-name-hyronalin
   - type: Solution
     solution:
       reagents:
@@ -456,7 +456,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-inaprovaline
+    localizedLabel: reagent-name-inaprovaline
   - type: Solution
     solution:
       reagents:
@@ -469,7 +469,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-insuzine
+    localizedLabel: reagent-name-insuzine
   - type: Solution
     solution:
       reagents:
@@ -482,7 +482,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-ipecac
+    localizedLabel: reagent-name-ipecac
   - type: Solution
     solution:
       reagents:
@@ -495,7 +495,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-kelotane
+    localizedLabel: reagent-name-kelotane
   - type: Solution
     solution:
       reagents:
@@ -508,7 +508,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-lacerinol
+    localizedLabel: reagent-name-lacerinol
   - type: Solution
     solution:
       reagents:
@@ -521,7 +521,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-leporazine
+    localizedLabel: reagent-name-leporazine
   - type: Solution
     solution:
       reagents:
@@ -534,7 +534,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-lipozine
+    localizedLabel: reagent-name-lipozine
   - type: Solution
     solution:
       reagents:
@@ -547,7 +547,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-mannitol
+    localizedLabel: reagent-name-mannitol
   - type: Solution
     solution:
       reagents:
@@ -560,7 +560,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-oculine
+    localizedLabel: reagent-name-oculine
   - type: Solution
     solution:
       reagents:
@@ -573,7 +573,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-omnizine
+    localizedLabel: reagent-name-omnizine
   - type: Solution
     solution:
       reagents:
@@ -586,7 +586,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-opporozidone
+    localizedLabel: reagent-name-opporozidone
   - type: Solution
     solution:
       reagents:
@@ -599,7 +599,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-phalanximine
+    localizedLabel: reagent-name-phalanximine
   - type: Solution
     solution:
       reagents:
@@ -612,7 +612,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-polypyrylium-oligomers
+    localizedLabel: reagent-name-polypyrylium-oligomers
   - type: Solution
     solution:
       reagents:
@@ -625,7 +625,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-potassium-iodide
+    localizedLabel: reagent-name-potassium-iodide
   - type: Solution
     solution:
       reagents:
@@ -638,7 +638,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-psicodine
+    localizedLabel: reagent-name-psicodine
   - type: Solution
     solution:
       reagents:
@@ -651,7 +651,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-pulped-banana-peel
+    localizedLabel: reagent-name-pulped-banana-peel
   - type: Solution
     solution:
       reagents:
@@ -664,7 +664,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-puncturase
+    localizedLabel: reagent-name-puncturase
   - type: Solution
     solution:
       reagents:
@@ -677,7 +677,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-pyrazine
+    localizedLabel: reagent-name-pyrazine
   - type: Solution
     solution:
       reagents:
@@ -690,7 +690,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-saline
+    localizedLabel: reagent-name-saline
   - type: Solution
     solution:
       reagents:
@@ -703,7 +703,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-siderlac
+    localizedLabel: reagent-name-siderlac
   - type: Solution
     solution:
       reagents:
@@ -716,7 +716,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-sigynate
+    localizedLabel: reagent-name-sigynate
   - type: Solution
     solution:
       reagents:
@@ -729,7 +729,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-stellibinin
+    localizedLabel: reagent-name-stellibinin
   - type: Solution
     solution:
       reagents:
@@ -742,7 +742,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-synaptizine
+    localizedLabel: reagent-name-synaptizine
   - type: Solution
     solution:
       reagents:
@@ -755,7 +755,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-tranexamic-acid
+    localizedLabel: reagent-name-tranexamic-acid
   - type: Solution
     solution:
       reagents:
@@ -768,7 +768,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-tricordrazine
+    localizedLabel: reagent-name-tricordrazine
   - type: Solution
     solution:
       reagents:
@@ -781,7 +781,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-ultravasculine
+    localizedLabel: reagent-name-ultravasculine
   - type: Solution
     solution:
       reagents:
@@ -794,7 +794,7 @@
   suffix: charcoal
   components:
   - type: Label
-    currentLabel: reagent-name-charcoal
+    localizedLabel: reagent-name-charcoal
   - type: Solution
     solution:
       reagents:
@@ -809,7 +809,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-robust-harvest
+    localizedLabel: reagent-name-robust-harvest
   - type: Solution
     solution:
       reagents:
@@ -822,7 +822,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-e-z-nutrient
+    localizedLabel: reagent-name-e-z-nutrient
   - type: Solution
     solution:
       reagents:
@@ -835,7 +835,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-left4-zed
+    localizedLabel: reagent-name-left4-zed
   - type: Solution
     solution:
       reagents:
@@ -848,7 +848,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-unstable-mutagen
+    localizedLabel: reagent-name-unstable-mutagen
   - type: Solution
     solution:
       reagents:
@@ -861,7 +861,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-nocturine
+    localizedLabel: reagent-name-nocturine
   - type: Solution
     solution:
       reagents:
@@ -874,7 +874,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-ephedrine
+    localizedLabel: reagent-name-ephedrine
   - type: Solution
     solution:
       reagents:
@@ -887,7 +887,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-pax
+    localizedLabel: reagent-name-pax
   - type: Solution
     solution:
       reagents:
@@ -900,7 +900,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-mute-toxin
+    localizedLabel: reagent-name-mute-toxin
   - type: Solution
     solution:
       reagents:
@@ -913,7 +913,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-lead
+    localizedLabel: reagent-name-lead
   - type: Solution
     solution:
       reagents:
@@ -926,7 +926,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-toxin
+    localizedLabel: reagent-name-toxin
   - type: Solution
     solution:
       reagents:
@@ -939,7 +939,7 @@
   suffix: laughter
   components:
   - type: Label
-    currentLabel: reagent-name-laughter
+    localizedLabel: reagent-name-laughter
   - type: Solution
     solution:
       reagents:
@@ -953,7 +953,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-aluminium
+    localizedLabel: reagent-name-aluminium
   - type: Solution
     solution:
       reagents:
@@ -966,7 +966,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-carbon
+    localizedLabel: reagent-name-carbon
   - type: Solution
     solution:
       reagents:
@@ -979,7 +979,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-chlorine
+    localizedLabel: reagent-name-chlorine
   - type: Solution
     solution:
       reagents:
@@ -992,7 +992,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-copper
+    localizedLabel: reagent-name-copper
   - type: Solution
     solution:
       reagents:
@@ -1005,7 +1005,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-ethanol
+    localizedLabel: reagent-name-ethanol
   - type: Solution
     solution:
       reagents:
@@ -1018,7 +1018,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-fluorine
+    localizedLabel: reagent-name-fluorine
   - type: Solution
     solution:
       reagents:
@@ -1031,7 +1031,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-hydrogen
+    localizedLabel: reagent-name-hydrogen
   - type: Solution
     solution:
       reagents:
@@ -1044,7 +1044,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-iodine
+    localizedLabel: reagent-name-iodine
   - type: Solution
     solution:
       reagents:
@@ -1057,7 +1057,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-iron
+    localizedLabel: reagent-name-iron
   - type: Solution
     solution:
       reagents:
@@ -1070,7 +1070,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-lithium
+    localizedLabel: reagent-name-lithium
   - type: Solution
     solution:
       reagents:
@@ -1083,7 +1083,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-mercury
+    localizedLabel: reagent-name-mercury
   - type: Solution
     solution:
       reagents:
@@ -1096,7 +1096,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-nitrogen
+    localizedLabel: reagent-name-nitrogen
   - type: Solution
     solution:
       reagents:
@@ -1109,7 +1109,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-oxygen
+    localizedLabel: reagent-name-oxygen
   - type: Solution
     solution:
       reagents:
@@ -1122,7 +1122,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-phosphorus
+    localizedLabel: reagent-name-phosphorus
   - type: Solution
     solution:
       reagents:
@@ -1135,7 +1135,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-potassium
+    localizedLabel: reagent-name-potassium
   - type: Solution
     solution:
       reagents:
@@ -1148,7 +1148,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-radium
+    localizedLabel: reagent-name-radium
   - type: Solution
     solution:
       reagents:
@@ -1161,7 +1161,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-silicon
+    localizedLabel: reagent-name-silicon
   - type: Solution
     solution:
       reagents:
@@ -1174,7 +1174,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-sodium
+    localizedLabel: reagent-name-sodium
   - type: Solution
     solution:
       reagents:
@@ -1187,7 +1187,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-sugar
+    localizedLabel: reagent-name-sugar
   - type: Solution
     solution:
       reagents:
@@ -1200,7 +1200,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-name-sulfur
+    localizedLabel: reagent-name-sulfur
   - type: Solution
     solution:
       reagents:

--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-vials.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-vials.yml
@@ -97,7 +97,7 @@
   suffix: vestine
   components:
   - type: Label
-    currentLabel: reagent-name-vestine
+    localizedLabel: reagent-name-vestine
   - type: Solution
     solution:
       reagents:
@@ -113,7 +113,7 @@
   suffix: radium
   components:
   - type: Label
-    currentLabel: reagent-name-radium
+    localizedLabel: reagent-name-radium
   - type: Solution
     solution:
       reagents:
@@ -128,7 +128,7 @@
   suffix: chlorine
   components:
   - type: Label
-    currentLabel: reagent-name-chlorine
+    localizedLabel: reagent-name-chlorine
   - type: Solution
     solution:
       reagents:
@@ -143,7 +143,7 @@
   suffix: plasma
   components:
   - type: Label
-    currentLabel: reagent-name-plasma
+    localizedLabel: reagent-name-plasma
   - type: Solution
     solution:
       reagents:

--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry.yml
@@ -183,7 +183,7 @@
   id: CryoxadoneBeakerSmall
   components:
   - type: Label
-    currentLabel: reagent-name-cryoxadone
+    localizedLabel: reagent-name-cryoxadone
   - type: Solution
     solution:
       reagents:
@@ -196,7 +196,7 @@
   suffix: arithrazine
   components:
   - type: Label
-    currentLabel: reagent-name-arithrazine
+    localizedLabel: reagent-name-arithrazine
   - type: Solution
     solution:
       reagents:
@@ -209,7 +209,7 @@
   suffix: sigynate
   components:
   - type: Label
-    currentLabel: reagent-name-sigynate
+    localizedLabel: reagent-name-sigynate
   - type: Solution
     solution:
       reagents:
@@ -222,7 +222,7 @@
   suffix: phalanximine
   components:
   - type: Label
-    currentLabel: reagent-name-phalanximine
+    localizedLabel: reagent-name-phalanximine
   - type: Solution
     solution:
       reagents:
@@ -235,7 +235,7 @@
   suffix: diphenhydramine
   components:
   - type: Label
-    currentLabel: reagent-name-diphenhydramine
+    localizedLabel: reagent-name-diphenhydramine
   - type: Solution
     solution:
       reagents:
@@ -248,7 +248,7 @@
   suffix: bruizine
   components:
   - type: Label
-    currentLabel: reagent-name-bruizine
+    localizedLabel: reagent-name-bruizine
   - type: Solution
     solution:
       reagents:
@@ -261,7 +261,7 @@
   suffix: lacerinol
   components:
   - type: Label
-    currentLabel: reagent-name-lacerinol
+    localizedLabel: reagent-name-lacerinol
   - type: Solution
     solution:
       reagents:

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -102,7 +102,7 @@
       - ReagentId: SpaceCleaner
         Quantity: 60
   - type: Label
-    localizedLabel: space cleaner
+    localizedLabel: spray-bottle-label-space-cleaner
   - type: Tag
     tags:
       - Spray
@@ -119,7 +119,7 @@
       - ReagentId: SpaceCleaner
         Quantity: 120
   - type: Label
-    localizedLabel: space cleaner
+    localizedLabel: spray-bottle-label-space-cleaner
 
 - type: entity
   parent: [SolutionNormal, SprayBottle]

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -102,7 +102,7 @@
       - ReagentId: SpaceCleaner
         Quantity: 60
   - type: Label
-    currentLabel: space cleaner
+    localizedLabel: space cleaner
   - type: Tag
     tags:
       - Spray
@@ -119,7 +119,7 @@
       - ReagentId: SpaceCleaner
         Quantity: 120
   - type: Label
-    currentLabel: space cleaner
+    localizedLabel: space cleaner
 
 - type: entity
   parent: [SolutionNormal, SprayBottle]

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -405,7 +405,7 @@
   - type: Sprite
     state: pill16
   - type: Label
-    currentLabel: dexalin 20u
+    localizedLabel: dexalin 20u
   - type: Solution
     solution:
       reagents:
@@ -419,7 +419,7 @@
   suffix: Dexalin 20u, 7
   components:
   - type: Label
-    currentLabel: dexalin 20u
+    localizedLabel: dexalin 20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -437,7 +437,7 @@
   - type: Sprite
     state: pill10
   - type: Label
-    currentLabel: dylovene 20u
+    localizedLabel: dylovene 20u
   - type: Solution
     solution:
       reagents:
@@ -451,7 +451,7 @@
   suffix: Dylovene 20u, 5
   components:
   - type: Label
-    currentLabel: dylovene 20u
+    localizedLabel: dylovene 20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -469,7 +469,7 @@
   - type: Sprite
     state: pill17
   - type: Label
-    currentLabel: hyronalin 20u
+    localizedLabel: hyronalin 20u
   - type: Solution
     solution:
       reagents:
@@ -483,7 +483,7 @@
   suffix: Hyronalin 20u, 5
   components:
   - type: Label
-    currentLabel: hyronalin 20u
+    localizedLabel: hyronalin 20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -501,7 +501,7 @@
   - type: Sprite
     state: pill9
   - type: Label
-    currentLabel: potassium iodide 20u
+    localizedLabel: potassium iodide 20u
   - type: Solution
     solution:
       reagents:
@@ -515,7 +515,7 @@
   suffix: Potassium iodide 20u, 5
   components:
   - type: Label
-    currentLabel: potassium iodide 20u
+    localizedLabel: potassium iodide 20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -533,7 +533,7 @@
   - type: Sprite
     state: pill14
   - type: Label
-    currentLabel: iron 20u
+    localizedLabel: iron 20u
   - type: Solution
     solution:
       reagents:
@@ -551,7 +551,7 @@
   - type: Sprite
     state: pill13
   - type: Label
-    currentLabel: copper 20u
+    localizedLabel: copper 20u
   - type: Solution
     solution:
       reagents:
@@ -565,7 +565,7 @@
   suffix: Iron 20u, 5
   components:
   - type: Label
-    currentLabel: iron 20u
+    localizedLabel: iron 20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -579,7 +579,7 @@
   suffix: Copper 20u, 5
   components:
   - type: Label
-    currentLabel: copper 20u
+    localizedLabel: copper 20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -597,7 +597,7 @@
   - type: Sprite
     state: pill4
   - type: Label
-    currentLabel: kelotane 20u
+    localizedLabel: kelotane 20u
   - type: Solution
     solution:
       reagents:
@@ -611,7 +611,7 @@
   suffix: Kelotane 20u, 5
   components:
   - type: Label
-    currentLabel: kelotane 20u
+    localizedLabel: kelotane 20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -629,7 +629,7 @@
   - type: Sprite
     state: pill8
   - type: Label
-    currentLabel: dermaline 20u
+    localizedLabel: dermaline 20u
   - type: Solution
     solution:
       reagents:
@@ -643,7 +643,7 @@
   suffix: Dermaline 20u, 5
   components:
   - type: Label
-    currentLabel: dermaline 20u
+    localizedLabel: dermaline 20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -672,7 +672,7 @@
   - type: Sprite
     state: pill3
   - type: Label
-    currentLabel: tricordrazine 20u
+    localizedLabel: tricordrazine 20u
   - type: Solution
     solution:
       reagents:
@@ -686,7 +686,7 @@
   suffix: Tricordrazine 20u, 5
   components:
   - type: Label
-    currentLabel: tricordrazine 20u
+    localizedLabel: tricordrazine 20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -704,7 +704,7 @@
   - type: Sprite
     state: pill5
   - type: Label
-    currentLabel: bicaridine 20u
+    localizedLabel: bicaridine 20u
   - type: Solution
     solution:
       reagents:
@@ -718,7 +718,7 @@
   suffix: Bicaridine 20u, 5
   components:
   - type: Label
-    currentLabel: bicaridine 20u
+    localizedLabel: bicaridine 20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -736,7 +736,7 @@
   - type: Sprite
     state: pill21
   - type: Label
-    currentLabel: charcoal 20u
+    localizedLabel: charcoal 20u
   - type: Solution
     solution:
       reagents:
@@ -750,7 +750,7 @@
   suffix: Charcoal 20u, 3
   components:
   - type: Label
-    currentLabel: charcoal 20u
+    localizedLabel: charcoal 20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -839,7 +839,7 @@
   id: SyringeEphedrine
   components:
   - type: Label
-    currentLabel: reagent-name-ephedrine
+    localizedLabel: reagent-name-ephedrine
   - type: Solution
     solution:
       reagents:
@@ -852,7 +852,7 @@
   id: SyringeInaprovaline
   components:
   - type: Label
-    currentLabel: reagent-name-inaprovaline
+    localizedLabel: reagent-name-inaprovaline
   - type: Solution
     solution:
       reagents:
@@ -865,7 +865,7 @@
   id: SyringeTranexamicAcid
   components:
   - type: Label
-    currentLabel: reagent-name-tranexamic-acid
+    localizedLabel: reagent-name-tranexamic-acid
   - type: Solution
     solution:
       reagents:
@@ -878,7 +878,7 @@
   id: SyringeBicaridine
   components:
   - type: Label
-    currentLabel: reagent-name-bicaridine
+    localizedLabel: reagent-name-bicaridine
   - type: Solution
     solution:
       reagents:
@@ -891,7 +891,7 @@
   id: SyringeDermaline
   components:
   - type: Label
-    currentLabel: reagent-name-dermaline
+    localizedLabel: reagent-name-dermaline
   - type: Solution
     solution:
       reagents:
@@ -904,7 +904,7 @@
   id: SyringeHyronalin
   components:
   - type: Label
-    currentLabel: reagent-name-hyronalin
+    localizedLabel: reagent-name-hyronalin
   - type: Solution
     solution:
       reagents:
@@ -917,7 +917,7 @@
   id: SyringeIpecac
   components:
   - type: Label
-    currentLabel: reagent-name-ipecac
+    localizedLabel: reagent-name-ipecac
   - type: Solution
     solution:
       reagents:
@@ -930,7 +930,7 @@
   id: SyringeAmbuzol
   components:
   - type: Label
-    currentLabel: reagent-name-ambuzol
+    localizedLabel: reagent-name-ambuzol
   - type: Solution
     solution:
       reagents:
@@ -943,7 +943,7 @@
   id: SyringeSigynate
   components:
   - type: Label
-    currentLabel: reagent-name-sigynate
+    localizedLabel: reagent-name-sigynate
   - type: Solution
     solution:
       reagents:
@@ -956,7 +956,7 @@
   id: SyringeEthylredoxrazine
   components:
   - type: Label
-    currentLabel: reagent-name-ethylredoxrazine
+    localizedLabel: reagent-name-ethylredoxrazine
   - type: Solution
     solution:
       reagents:
@@ -969,7 +969,7 @@
   id: SyringePhalanximine
   components:
   - type: Label
-    currentLabel: reagent-name-phalanximine
+    localizedLabel: reagent-name-phalanximine
   - type: Solution
     solution:
       reagents:
@@ -982,7 +982,7 @@
   id: SyringeSaline
   components:
   - type: Label
-    currentLabel: reagent-name-saline
+    localizedLabel: reagent-name-saline
   - type: Solution
     solution:
       reagents:
@@ -996,7 +996,7 @@
   id: SyringeRomerol
   components:
   - type: Label
-    currentLabel: reagent-name-romerol
+    localizedLabel: reagent-name-romerol
   - type: Solution
     solution:
       reagents:
@@ -1009,7 +1009,7 @@
   id: SyringeStimulants
   components:
   - type: Label
-    currentLabel: reagent-name-stimulants
+    localizedLabel: reagent-name-stimulants
   - type: Solution
     solution:
       reagents:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -405,7 +405,7 @@
   - type: Sprite
     state: pill16
   - type: Label
-    localizedLabel: dexalin 20u
+    localizedLabel: pill-label-dexalin-20u
   - type: Solution
     solution:
       reagents:
@@ -419,7 +419,7 @@
   suffix: Dexalin 20u, 7
   components:
   - type: Label
-    localizedLabel: dexalin 20u
+    localizedLabel: pill-label-dexalin-20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -437,7 +437,7 @@
   - type: Sprite
     state: pill10
   - type: Label
-    localizedLabel: dylovene 20u
+    localizedLabel: pill-label-dylovene-20u
   - type: Solution
     solution:
       reagents:
@@ -451,7 +451,7 @@
   suffix: Dylovene 20u, 5
   components:
   - type: Label
-    localizedLabel: dylovene 20u
+    localizedLabel: pill-label-dylovene-20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -469,7 +469,7 @@
   - type: Sprite
     state: pill17
   - type: Label
-    localizedLabel: hyronalin 20u
+    localizedLabel: pill-label-hyronalin-20u
   - type: Solution
     solution:
       reagents:
@@ -483,7 +483,7 @@
   suffix: Hyronalin 20u, 5
   components:
   - type: Label
-    localizedLabel: hyronalin 20u
+    localizedLabel: pill-label-hyronalin-20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -501,7 +501,7 @@
   - type: Sprite
     state: pill9
   - type: Label
-    localizedLabel: potassium iodide 20u
+    localizedLabel: pill-label-potassium-iodide-20u
   - type: Solution
     solution:
       reagents:
@@ -515,7 +515,7 @@
   suffix: Potassium iodide 20u, 5
   components:
   - type: Label
-    localizedLabel: potassium iodide 20u
+    localizedLabel: pill-label-potassium-iodide-20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -533,7 +533,7 @@
   - type: Sprite
     state: pill14
   - type: Label
-    localizedLabel: iron 20u
+    localizedLabel: pill-label-iron-20u
   - type: Solution
     solution:
       reagents:
@@ -551,7 +551,7 @@
   - type: Sprite
     state: pill13
   - type: Label
-    localizedLabel: copper 20u
+    localizedLabel: pill-label-copper-20u
   - type: Solution
     solution:
       reagents:
@@ -565,7 +565,7 @@
   suffix: Iron 20u, 5
   components:
   - type: Label
-    localizedLabel: iron 20u
+    localizedLabel: pill-label-iron-20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -579,7 +579,7 @@
   suffix: Copper 20u, 5
   components:
   - type: Label
-    localizedLabel: copper 20u
+    localizedLabel: pill-label-copper-20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -597,7 +597,7 @@
   - type: Sprite
     state: pill4
   - type: Label
-    localizedLabel: kelotane 20u
+    localizedLabel: pill-label-kelotane-20u
   - type: Solution
     solution:
       reagents:
@@ -611,7 +611,7 @@
   suffix: Kelotane 20u, 5
   components:
   - type: Label
-    localizedLabel: kelotane 20u
+    localizedLabel: pill-label-kelotane-20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -629,7 +629,7 @@
   - type: Sprite
     state: pill8
   - type: Label
-    localizedLabel: dermaline 20u
+    localizedLabel: pill-label-dermaline-20u
   - type: Solution
     solution:
       reagents:
@@ -643,7 +643,7 @@
   suffix: Dermaline 20u, 5
   components:
   - type: Label
-    localizedLabel: dermaline 20u
+    localizedLabel: pill-label-dermaline-20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -672,7 +672,7 @@
   - type: Sprite
     state: pill3
   - type: Label
-    localizedLabel: tricordrazine 20u
+    localizedLabel: pill-label-tricordrazine-20u
   - type: Solution
     solution:
       reagents:
@@ -686,7 +686,7 @@
   suffix: Tricordrazine 20u, 5
   components:
   - type: Label
-    localizedLabel: tricordrazine 20u
+    localizedLabel: pill-label-tricordrazine-20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -704,7 +704,7 @@
   - type: Sprite
     state: pill5
   - type: Label
-    localizedLabel: bicaridine 20u
+    localizedLabel: pill-label-bicaridine-20u
   - type: Solution
     solution:
       reagents:
@@ -718,7 +718,7 @@
   suffix: Bicaridine 20u, 5
   components:
   - type: Label
-    localizedLabel: bicaridine 20u
+    localizedLabel: pill-label-bicaridine-20u
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -736,7 +736,7 @@
   - type: Sprite
     state: pill21
   - type: Label
-    localizedLabel: charcoal 20u
+    localizedLabel: pill-label-charcoal-20u
   - type: Solution
     solution:
       reagents:
@@ -750,7 +750,7 @@
   suffix: Charcoal 20u, 3
   components:
   - type: Label
-    localizedLabel: charcoal 20u
+    localizedLabel: pill-label-charcoal-20u
   - type: EntityTableContainerFill
     containers:
       storagebase:

--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -187,7 +187,7 @@
   suffix: Tools
   components:
   - type: Label
-    currentLabel: holopad-general-tools
+    localizedLabel: holopad-general-tools
 
 - type: entity
   parent: Holopad
@@ -195,7 +195,7 @@
   suffix: Cryosleep
   components:
   - type: Label
-    currentLabel: holopad-general-cryosleep
+    localizedLabel: holopad-general-cryosleep
 
 - type: entity
   parent: Holopad
@@ -203,7 +203,7 @@
   suffix: Theater
   components:
   - type: Label
-    currentLabel: holopad-general-theater
+    localizedLabel: holopad-general-theater
 
 - type: entity
   parent: Holopad
@@ -211,7 +211,7 @@
   suffix: Disposals
   components:
   - type: Label
-    currentLabel: holopad-general-disposals
+    localizedLabel: holopad-general-disposals
 
 - type: entity
   parent: Holopad
@@ -219,7 +219,7 @@
   suffix: EVA Storage
   components:
   - type: Label
-    currentLabel: holopad-general-eva
+    localizedLabel: holopad-general-eva
 
 - type: entity
   parent: Holopad
@@ -227,7 +227,7 @@
   suffix: Lounge
   components:
   - type: Label
-    currentLabel: holopad-general-lounge
+    localizedLabel: holopad-general-lounge
 
 - type: entity
   parent: Holopad
@@ -235,7 +235,7 @@
   suffix: Arcade
   components:
   - type: Label
-    currentLabel: holopad-general-arcade
+    localizedLabel: holopad-general-arcade
 
 - type: entity
   parent: Holopad
@@ -243,7 +243,7 @@
   suffix: Evac
   components:
   - type: Label
-    currentLabel: holopad-general-evac
+    localizedLabel: holopad-general-evac
 
 - type: entity
   parent: Holopad
@@ -251,7 +251,7 @@
   suffix: Arrivals
   components:
   - type: Label
-    currentLabel: holopad-general-arrivals
+    localizedLabel: holopad-general-arrivals
 
 # Command
 - type: entity
@@ -260,7 +260,7 @@
   suffix: Bridge
   components:
   - type: Label
-    currentLabel: holopad-command-bridge
+    localizedLabel: holopad-command-bridge
 
 - type: entity
   parent: Holopad
@@ -268,7 +268,7 @@
   suffix: Vault
   components:
   - type: Label
-    currentLabel: holopad-command-vault
+    localizedLabel: holopad-command-vault
 
 - type: entity
   parent: Holopad
@@ -276,7 +276,7 @@
   suffix: Bridge Hallway
   components:
   - type: Label
-    currentLabel: holopad-command-bridge-hallway
+    localizedLabel: holopad-command-bridge-hallway
 
 - type: entity
   parent: Holopad
@@ -284,7 +284,7 @@
   suffix: Command Meeting
   components:
   - type: Label
-    currentLabel: holopad-command-meeting-room
+    localizedLabel: holopad-command-meeting-room
 
 - type: entity
   parent: Holopad
@@ -292,7 +292,7 @@
   suffix: Command Lounge
   components:
   - type: Label
-    currentLabel: holopad-command-lounge
+    localizedLabel: holopad-command-lounge
 
 - type: entity
   parent: Holopad
@@ -300,7 +300,7 @@
   suffix: Captain
   components:
   - type: Label
-    currentLabel: holopad-command-captain
+    localizedLabel: holopad-command-captain
 
 - type: entity
   parent: Holopad
@@ -308,7 +308,7 @@
   suffix: HoP
   components:
   - type: Label
-    currentLabel: holopad-command-hop
+    localizedLabel: holopad-command-hop
 
 - type: entity
   parent: Holopad
@@ -316,7 +316,7 @@
   suffix: CMO
   components:
   - type: Label
-    currentLabel: holopad-command-cmo
+    localizedLabel: holopad-command-cmo
 
 - type: entity
   parent: Holopad
@@ -324,7 +324,7 @@
   suffix: QM
   components:
   - type: Label
-    currentLabel: holopad-command-qm
+    localizedLabel: holopad-command-qm
 
 - type: entity
   parent: Holopad
@@ -332,7 +332,7 @@
   suffix: CE
   components:
   - type: Label
-    currentLabel: holopad-command-ce
+    localizedLabel: holopad-command-ce
 
 - type: entity
   parent: Holopad
@@ -340,7 +340,7 @@
   suffix: RD
   components:
   - type: Label
-    currentLabel: holopad-command-rd
+    localizedLabel: holopad-command-rd
 
 - type: entity
   parent: Holopad
@@ -348,7 +348,7 @@
   suffix: HoS
   components:
   - type: Label
-    currentLabel: holopad-command-hos
+    localizedLabel: holopad-command-hos
 
 # Science
 - type: entity
@@ -357,7 +357,7 @@
   suffix: Anomaly
   components:
   - type: Label
-    currentLabel: holopad-science-anomaly
+    localizedLabel: holopad-science-anomaly
 
 - type: entity
   parent: Holopad
@@ -365,7 +365,7 @@
   suffix: Artifact
   components:
   - type: Label
-    currentLabel: holopad-science-artifact
+    localizedLabel: holopad-science-artifact
 
 - type: entity
   parent: Holopad
@@ -373,7 +373,7 @@
   suffix: Artifact North
   components:
   - type: Label
-    currentLabel: holopad-science-artifact-north
+    localizedLabel: holopad-science-artifact-north
 
 - type: entity
   parent: Holopad
@@ -381,7 +381,7 @@
   suffix: Artifact South
   components:
   - type: Label
-    currentLabel: holopad-science-artifact-south
+    localizedLabel: holopad-science-artifact-south
 
 - type: entity
   parent: Holopad
@@ -389,7 +389,7 @@
   suffix: Robotics
   components:
   - type: Label
-    currentLabel: holopad-science-robotics
+    localizedLabel: holopad-science-robotics
 
 - type: entity
   parent: Holopad
@@ -397,7 +397,7 @@
   suffix: R&D
   components:
   - type: Label
-    currentLabel: holopad-science-rnd
+    localizedLabel: holopad-science-rnd
 
 - type: entity
   parent: Holopad
@@ -405,7 +405,7 @@
   suffix: Sci Front
   components:
   - type: Label
-    currentLabel: holopad-science-front
+    localizedLabel: holopad-science-front
 
 - type: entity
   parent: Holopad
@@ -413,7 +413,7 @@
   suffix: Sci Breakroom
   components:
   - type: Label
-    currentLabel: holopad-science-breakroom
+    localizedLabel: holopad-science-breakroom
 
 # Medical
 - type: entity
@@ -422,7 +422,7 @@
   suffix: Medbay
   components:
   - type: Label
-    currentLabel: holopad-medical-medbay
+    localizedLabel: holopad-medical-medbay
 
 - type: entity
   parent: Holopad
@@ -430,7 +430,7 @@
   suffix: Chemistry
   components:
   - type: Label
-    currentLabel: holopad-medical-chemistry
+    localizedLabel: holopad-medical-chemistry
 
 - type: entity
   parent: Holopad
@@ -438,7 +438,7 @@
   suffix: Cryopods
   components:
   - type: Label
-    currentLabel: holopad-medical-cryopods
+    localizedLabel: holopad-medical-cryopods
 
 - type: entity
   parent: Holopad
@@ -446,7 +446,7 @@
   suffix: Morgue
   components:
   - type: Label
-    currentLabel: holopad-medical-morgue
+    localizedLabel: holopad-medical-morgue
 
 - type: entity
   parent: Holopad
@@ -454,7 +454,7 @@
   suffix: Surgery
   components:
   - type: Label
-    currentLabel: holopad-medical-surgery
+    localizedLabel: holopad-medical-surgery
 
 - type: entity
   parent: Holopad
@@ -462,7 +462,7 @@
   suffix: Paramedic
   components:
   - type: Label
-    currentLabel: holopad-medical-paramedic
+    localizedLabel: holopad-medical-paramedic
 
 - type: entity
   parent: Holopad
@@ -470,7 +470,7 @@
   suffix: Virology
   components:
   - type: Label
-    currentLabel: holopad-medical-virology
+    localizedLabel: holopad-medical-virology
 
 - type: entity
   parent: Holopad
@@ -478,7 +478,7 @@
   suffix: Med Front
   components:
   - type: Label
-    currentLabel: holopad-medical-front
+    localizedLabel: holopad-medical-front
 
 - type: entity
   parent: Holopad
@@ -486,7 +486,7 @@
   suffix: Med Breakroom
   components:
   - type: Label
-    currentLabel: holopad-medical-breakroom
+    localizedLabel: holopad-medical-breakroom
 
 - type: entity
   parent: Holopad
@@ -494,7 +494,7 @@
   suffix: Med Clinic
   components:
   - type: Label
-    currentLabel: holopad-medical-clinic
+    localizedLabel: holopad-medical-clinic
 
 # Cargo
 - type: entity
@@ -503,7 +503,7 @@
   suffix: Cargo Front
   components:
   - type: Label
-    currentLabel: holopad-cargo-front
+    localizedLabel: holopad-cargo-front
 
 - type: entity
   parent: Holopad
@@ -511,7 +511,7 @@
   suffix: Cargo Bay
   components:
   - type: Label
-    currentLabel: holopad-cargo-bay
+    localizedLabel: holopad-cargo-bay
 
 - type: entity
   parent: Holopad
@@ -519,7 +519,7 @@
   suffix: Salvage Bay
   components:
   - type: Label
-    currentLabel: holopad-cargo-salvage-bay
+    localizedLabel: holopad-cargo-salvage-bay
 
 - type: entity
   parent: Holopad
@@ -527,7 +527,7 @@
   suffix: Cargo Breakroom
   components:
   - type: Label
-    currentLabel: holopad-cargo-breakroom
+    localizedLabel: holopad-cargo-breakroom
 
 - type: entity
   parent: Holopad
@@ -535,7 +535,7 @@
   suffix: Cargo Mailroom
   components:
   - type: Label
-    currentLabel: holopad-cargo-mailroom
+    localizedLabel: holopad-cargo-mailroom
 
 # Engineering
 - type: entity
@@ -544,7 +544,7 @@
   suffix: Atmos Front
   components:
   - type: Label
-    currentLabel: holopad-engineering-atmos-front
+    localizedLabel: holopad-engineering-atmos-front
 
 - type: entity
   parent: Holopad
@@ -552,7 +552,7 @@
   suffix: Atmos Main
   components:
   - type: Label
-    currentLabel: holopad-engineering-atmos-main
+    localizedLabel: holopad-engineering-atmos-main
 
 - type: entity
   parent: Holopad
@@ -560,7 +560,7 @@
   suffix: TEG
   components:
   - type: Label
-    currentLabel: holopad-engineering-atmos-teg
+    localizedLabel: holopad-engineering-atmos-teg
 
 - type: entity
   parent: Holopad
@@ -568,7 +568,7 @@
   suffix: Engi Storage
   components:
   - type: Label
-    currentLabel: holopad-engineering-storage
+    localizedLabel: holopad-engineering-storage
 
 - type: entity
   parent: Holopad
@@ -576,7 +576,7 @@
   suffix: Engi Breakroom
   components:
   - type: Label
-    currentLabel: holopad-engineering-breakroom
+    localizedLabel: holopad-engineering-breakroom
 
 - type: entity
   parent: Holopad
@@ -584,7 +584,7 @@
   suffix: Engi Front
   components:
   - type: Label
-    currentLabel: holopad-engineering-front
+    localizedLabel: holopad-engineering-front
 
 - type: entity
   parent: Holopad
@@ -592,7 +592,7 @@
   suffix: Telecoms
   components:
   - type: Label
-    currentLabel: holopad-engineering-telecoms
+    localizedLabel: holopad-engineering-telecoms
 
 - type: entity
   parent: Holopad
@@ -600,7 +600,7 @@
   suffix: Tech Vault
   components:
   - type: Label
-    currentLabel: holopad-engineering-tech-vault
+    localizedLabel: holopad-engineering-tech-vault
 
 - type: entity
   parent: Holopad
@@ -608,7 +608,7 @@
   suffix: AME
   components:
   - type: Label
-    currentLabel: holopad-engineering-ame
+    localizedLabel: holopad-engineering-ame
 
 - type: entity
   parent: Holopad
@@ -616,7 +616,7 @@
   suffix: Power
   components:
   - type: Label
-    currentLabel: holopad-engineering-power
+    localizedLabel: holopad-engineering-power
 
 - type: entity
   parent: Holopad
@@ -624,7 +624,7 @@
   suffix: Engi Main
   components:
   - type: Label
-    currentLabel: holopad-engineering-main
+    localizedLabel: holopad-engineering-main
 
 # Security
 - type: entity
@@ -633,7 +633,7 @@
   suffix: Sec Front
   components:
   - type: Label
-    currentLabel: holopad-security-front
+    localizedLabel: holopad-security-front
 
 - type: entity
   parent: Holopad
@@ -641,7 +641,7 @@
   suffix: Brig
   components:
   - type: Label
-    currentLabel: holopad-security-brig
+    localizedLabel: holopad-security-brig
 
 - type: entity
   parent: Holopad
@@ -649,7 +649,7 @@
   suffix: Warden
   components:
   - type: Label
-    currentLabel: holopad-security-warden
+    localizedLabel: holopad-security-warden
 
 - type: entity
   parent: Holopad
@@ -657,7 +657,7 @@
   suffix: Interrogation
   components:
   - type: Label
-    currentLabel: holopad-security-interrogation
+    localizedLabel: holopad-security-interrogation
 
 - type: entity
   parent: Holopad
@@ -665,7 +665,7 @@
   suffix: Sec Breakroom
   components:
   - type: Label
-    currentLabel: holopad-security-breakroom
+    localizedLabel: holopad-security-breakroom
 
 - type: entity
   parent: Holopad
@@ -673,7 +673,7 @@
   suffix: Detective
   components:
   - type: Label
-    currentLabel: holopad-security-detective
+    localizedLabel: holopad-security-detective
 
 - type: entity
   parent: Holopad
@@ -681,7 +681,7 @@
   suffix: Perma
   components:
   - type: Label
-    currentLabel: holopad-security-perma
+    localizedLabel: holopad-security-perma
 
 - type: entity
   parent: Holopad
@@ -689,7 +689,7 @@
   suffix: Courtroom
   components:
   - type: Label
-    currentLabel: holopad-security-courtroom
+    localizedLabel: holopad-security-courtroom
 
 - type: entity
   parent: Holopad
@@ -697,7 +697,7 @@
   suffix: Lawyer
   components:
   - type: Label
-    currentLabel: holopad-security-lawyer
+    localizedLabel: holopad-security-lawyer
 
 - type: entity
   parent: Holopad
@@ -705,7 +705,7 @@
   suffix: Armory
   components:
   - type: Label
-    currentLabel: holopad-security-armory
+    localizedLabel: holopad-security-armory
 
 - type: entity
   parent: Holopad
@@ -713,7 +713,7 @@
   suffix: Sec Locker Room
   components:
   - type: Label
-    currentLabel: holopad-security-locker-room
+    localizedLabel: holopad-security-locker-room
 
 - type: entity
   parent: Holopad
@@ -721,7 +721,7 @@
   suffix: Brig Med
   components:
   - type: Label
-    currentLabel: holopad-security-brig-med
+    localizedLabel: holopad-security-brig-med
 
 - type: entity
   parent: Holopad
@@ -729,7 +729,7 @@
   suffix: Sec Evac Checkpoint
   components:
   - type: Label
-    currentLabel: holopad-security-evac-checkpoint
+    localizedLabel: holopad-security-evac-checkpoint
 
 - type: entity
   parent: Holopad
@@ -737,7 +737,7 @@
   suffix: Sec Arrivals Checkpoint
   components:
   - type: Label
-    currentLabel: holopad-security-arrivals-checkpoint
+    localizedLabel: holopad-security-arrivals-checkpoint
 
 # Service
 - type: entity
@@ -746,7 +746,7 @@
   suffix: Janitor
   components:
   - type: Label
-    currentLabel: holopad-service-janitor
+    localizedLabel: holopad-service-janitor
 
 - type: entity
   parent: Holopad
@@ -754,7 +754,7 @@
   suffix: Bar
   components:
   - type: Label
-    currentLabel: holopad-service-bar
+    localizedLabel: holopad-service-bar
 
 - type: entity
   parent: Holopad
@@ -762,7 +762,7 @@
   suffix: Kitchen
   components:
   - type: Label
-    currentLabel: holopad-service-kitchen
+    localizedLabel: holopad-service-kitchen
 
 - type: entity
   parent: Holopad
@@ -770,7 +770,7 @@
   suffix: Botany
   components:
   - type: Label
-    currentLabel: holopad-service-botany
+    localizedLabel: holopad-service-botany
 
 - type: entity
   parent: Holopad
@@ -778,7 +778,7 @@
   suffix: Chapel
   components:
   - type: Label
-    currentLabel: holopad-service-chapel
+    localizedLabel: holopad-service-chapel
 
 - type: entity
   parent: Holopad
@@ -786,7 +786,7 @@
   suffix: Library
   components:
   - type: Label
-    currentLabel: holopad-service-library
+    localizedLabel: holopad-service-library
 
 - type: entity
   parent: Holopad
@@ -794,7 +794,7 @@
   suffix: Game Room
   components:
   - type: Label
-    currentLabel: holopad-service-gameroom
+    localizedLabel: holopad-service-gameroom
 
 - type: entity
   parent: Holopad
@@ -802,7 +802,7 @@
   suffix: Newsroom
   components:
   - type: Label
-    currentLabel: holopad-service-newsroom
+    localizedLabel: holopad-service-newsroom
 
 - type: entity
   parent: Holopad
@@ -810,7 +810,7 @@
   suffix: Zookeeper
   components:
   - type: Label
-    currentLabel: holopad-service-zookeeper
+    localizedLabel: holopad-service-zookeeper
 
 - type: entity
   parent: Holopad
@@ -818,7 +818,7 @@
   suffix: Boxer
   components:
   - type: Label
-    currentLabel: holopad-service-boxer
+    localizedLabel: holopad-service-boxer
 
 - type: entity
   parent: Holopad
@@ -826,7 +826,7 @@
   suffix: Clown
   components:
   - type: Label
-    currentLabel: holopad-service-clown
+    localizedLabel: holopad-service-clown
 
 - type: entity
   parent: Holopad
@@ -834,7 +834,7 @@
   suffix: Musician
   components:
   - type: Label
-    currentLabel: holopad-service-musician
+    localizedLabel: holopad-service-musician
 
 - type: entity
   parent: Holopad
@@ -842,7 +842,7 @@
   suffix: Mime
   components:
   - type: Label
-    currentLabel: holopad-service-mime
+    localizedLabel: holopad-service-mime
 
 # AI
 - type: entity
@@ -851,7 +851,7 @@
   suffix: AI Core
   components:
   - type: Label
-    currentLabel: holopad-ai-core
+    localizedLabel: holopad-ai-core
 
 - type: entity
   parent: Holopad
@@ -859,7 +859,7 @@
   suffix: AI Main
   components:
   - type: Label
-    currentLabel: holopad-ai-main
+    localizedLabel: holopad-ai-main
 
 - type: entity
   parent: Holopad
@@ -867,7 +867,7 @@
   suffix: AI Upload
   components:
   - type: Label
-    currentLabel: holopad-ai-upload
+    localizedLabel: holopad-ai-upload
 
 - type: entity
   parent: Holopad
@@ -875,7 +875,7 @@
   suffix: AI Backup Power
   components:
   - type: Label
-    currentLabel: holopad-ai-backup-power
+    localizedLabel: holopad-ai-backup-power
 
 - type: entity
   parent: Holopad
@@ -883,7 +883,7 @@
   suffix: AI Entrance
   components:
   - type: Label
-    currentLabel: holopad-ai-entrance
+    localizedLabel: holopad-ai-entrance
 
 - type: entity
   parent: Holopad
@@ -891,7 +891,7 @@
   suffix: AI Chute
   components:
   - type: Label
-    currentLabel: holopad-ai-chute
+    localizedLabel: holopad-ai-chute
 
 # Long Range
 - type: entity
@@ -900,7 +900,7 @@
   suffix: ATS
   components:
   - type: Label
-    currentLabel: holopad-cargo-ats
+    localizedLabel: holopad-cargo-ats
 
 - type: entity
   parent: HolopadLongRange
@@ -908,7 +908,7 @@
   suffix: Station Bridge
   components:
   - type: Label
-    currentLabel: holopad-station-bridge
+    localizedLabel: holopad-station-bridge
 
 - type: entity
   parent: HolopadLongRange
@@ -916,7 +916,7 @@
   suffix: Station Cargo Bay
   components:
   - type: Label
-    currentLabel: holopad-station-cargo-bay
+    localizedLabel: holopad-station-cargo-bay
 
 - type: entity
   parent: HolopadLongRange
@@ -924,7 +924,7 @@
   suffix: Cargo Shuttle
   components:
   - type: Label
-    currentLabel: holopad-cargo-shuttle
+    localizedLabel: holopad-cargo-shuttle
 
 - type: entity
   parent: HolopadLongRange
@@ -932,7 +932,7 @@
   suffix: Evac Shuttle
   components:
   - type: Label
-    currentLabel: holopad-centcomm-evac
+    localizedLabel: holopad-centcomm-evac
 
 
 # Map Specific
@@ -943,4 +943,4 @@
   suffix: Clown/Mime
   components:
   - type: Label
-    currentLabel: holopad-service-clown-mime
+    localizedLabel: holopad-service-clown-mime

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/gas_pipe_sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/gas_pipe_sensor.yml
@@ -65,7 +65,7 @@
   suffix: Distribution
   components:
   - type: Label
-    currentLabel: gas-pipe-sensor-distribution-loop
+    localizedLabel: gas-pipe-sensor-distribution-loop
   - type: AtmosPipeLayers
     alternativePrototypes:
       Primary: GasPipeSensorDistribution
@@ -78,7 +78,7 @@
   suffix: Waste
   components:
   - type: Label
-    currentLabel: gas-pipe-sensor-waste-loop
+    localizedLabel: gas-pipe-sensor-waste-loop
   - type: AtmosPipeLayers
     alternativePrototypes:
       Primary: GasPipeSensorWaste
@@ -91,7 +91,7 @@
   suffix: Mixed air
   components:
   - type: Label
-    currentLabel: gas-pipe-sensor-mixed-air
+    localizedLabel: gas-pipe-sensor-mixed-air
   - type: AtmosPipeLayers
     alternativePrototypes:
       Primary: GasPipeSensorMixedAir
@@ -104,7 +104,7 @@
   suffix: TEG hot
   components:
   - type: Label
-    currentLabel: gas-pipe-sensor-teg-hot-loop
+    localizedLabel: gas-pipe-sensor-teg-hot-loop
   - type: AtmosPipeLayers
     alternativePrototypes:
       Primary: GasPipeSensorTEGHot
@@ -117,7 +117,7 @@
   suffix: TEG cold
   components:
   - type: Label
-    currentLabel: gas-pipe-sensor-teg-cold-loop
+    localizedLabel: gas-pipe-sensor-teg-cold-loop
   - type: AtmosPipeLayers
     alternativePrototypes:
       Primary: GasPipeSensorTEGCold


### PR DESCRIPTION
## About the PR
`PlayerTab.xaml.cs`:
No longer passes an empty string as the message ID if `info.Subtype` is null.

`LabelSystem.cs`:
A new `LabelComponent.LocalizedLabel` field that sets `LabelComponent.CurrentLabel` on map init.
Entity prototypes should no longer use `LabelComponent.CurrentLabel`.

## Test plan
`PlayerTab.xaml.cs`:
- Open the admin players tab.
- Check the console.

`LabelSystem.cs`:
- Spawn any item with a label (like pills).
- Check the console.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
LabelComponent.CurrentLabel can no longer be used in entity prototypes. Use LabelComponent.LocalizedLabel instead.