### PR TITLE
Shields Rework

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -16,8 +16,6 @@ public sealed partial class BlockingSystem
     private void InitializeUser()
     {
         SubscribeLocalEvent<BlockingUserComponent, DamageModifyEvent>(OnUserDamageModified);
-        SubscribeLocalEvent<BlockingComponent, DamageModifyEvent>(OnDamageModified);
-
         SubscribeLocalEvent<BlockingUserComponent, EntParentChangedMessage>(OnParentChanged);
         SubscribeLocalEvent<BlockingUserComponent, ContainerGettingInsertedAttemptEvent>(OnInsertAttempt);
         SubscribeLocalEvent<BlockingUserComponent, AnchorStateChangedEvent>(OnAnchorChanged);
@@ -42,51 +40,37 @@ public sealed partial class BlockingSystem
         UserStopBlocking(uid, component);
     }
 
-    private void OnUserDamageModified(EntityUid uid, BlockingUserComponent component, DamageModifyEvent args)
+    private void OnUserDamageModified(Entity<BlockingUserComponent> entity, ref DamageModifyEvent args)
     {
-        if (component.BlockingItem is not { } item || !TryComp<BlockingComponent>(item, out var blocking))
+        if (entity.Comp.BlockingItem is not { } item || !_blockQuery.TryComp(item, out var blocking))
             return;
 
         if (args.Damage.GetTotal() <= 0)
             return;
 
-        // A shield should only block damage it can itself absorb. To determine that we need the Damageable component on it.
-        if (!TryComp<DamageableComponent>(item, out var dmgComp))
-            return;
-
         var blockFraction = blocking.IsBlocking ? blocking.ActiveBlockFraction : blocking.PassiveBlockFraction;
-        var modifier = blocking.IsBlocking ? blocking.ActiveBlockDamageModifier : blocking.PassiveBlockDamageModifer;
         blockFraction = Math.Clamp(blockFraction, 0, 1);
-        _damageable.TryChangeDamage((item, dmgComp), blockFraction * args.OriginalDamage);
 
-        var modify = new DamageModifierSet();
-        foreach (var key in modifier.Coefficients.Keys.Concat(modifier.FlatReduction.Keys))
-        {
-            modify.Coefficients.TryAdd(key, 1 - blockFraction);
-        }
-
-        args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage, modify);
-
-        if (blocking.IsBlocking && !args.Damage.Equals(args.OriginalDamage))
-        {
-            _audio.PlayPvs(blocking.BlockSound, uid);
-        }
-    }
-
-    private void OnDamageModified(EntityUid uid, BlockingComponent component, DamageModifyEvent args)
-    {
-        var modifier = component.IsBlocking ? component.ActiveBlockDamageModifier : component.PassiveBlockDamageModifer;
-        if (modifier == null)
-        {
+        // This is how much damage the shield is attempting to block
+        var split = args.OriginalDamage * blockFraction;
+        var damage = _damageable.ChangeDamage(item, split);
+        if (!damage.AnyPositive())
             return;
-        }
 
-        args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage, modifier);
+        // Of the damage that went through, reduce by the appropriate blocking modifiers.
+        var modifier = GetBlockingModifier((item, blocking));
+        var blowthrough = DamageSpecifier.ApplyModifierSet(damage, modifier);
+
+        args.Damage *= 1f - blockFraction;
+        args.Damage += blowthrough;
+
+        if (blocking.IsBlocking && damage.AnyPositive())
+            _audio.PlayPvs(blocking.BlockSound, entity);
     }
 
     private void OnEntityTerminating(EntityUid uid, BlockingUserComponent component, ref EntityTerminatingEvent args)
     {
-        if (!TryComp<BlockingComponent>(component.BlockingItem, out var blockingComponent))
+        if (!_blockQuery.TryComp(component.BlockingItem, out var blockingComponent))
             return;
 
         StopBlockingHelper(component.BlockingItem.Value, blockingComponent, uid);

--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -1,7 +1,5 @@
-using System.Linq;
 using Content.Shared.Blocking.Components;
 using Content.Shared.Damage;
-using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;

--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared.Blocking.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;

--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -54,12 +54,10 @@ public sealed partial class BlockingSystem
         // This is how much damage the shield is attempting to block
         var split = args.OriginalDamage * blockFraction;
         var damage = _damageable.ChangeDamage(item, split);
-        if (!damage.AnyPositive())
-            return;
 
         // Of the damage that went through, reduce by the appropriate blocking modifiers.
         var modifier = GetBlockingModifier((item, blocking));
-        var blowthrough = DamageSpecifier.ApplyModifierSet(damage, modifier);
+        var blowthrough = DamageSpecifier.ApplyModifierSet(split, modifier);
 
         args.Damage *= 1f - blockFraction;
         args.Damage += blowthrough;

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -35,9 +35,9 @@ public sealed partial class BlockingSystem : EntitySystem
     [Dependency] private TurfSystem _turf = default!;
 
     [Dependency] private EntityQuery<BlockingComponent> _blockQuery = default!;
+    [Dependency] private EntityQuery<BlockingUserComponent> _userQuery = default!;
     [Dependency] private EntityQuery<HandsComponent> _handQuery = default!;
     [Dependency] private EntityQuery<MobStateComponent> _mobQuery = default!;
-    [Dependency] private EntityQuery<BlockingUserComponent> _userQuery = default!;
 
     public override void Initialize()
     {
@@ -191,13 +191,13 @@ public sealed partial class BlockingSystem : EntitySystem
             return false;
         }
         _actionsSystem.SetToggled(component.BlockingToggleActionEntity, true);
-        _popupSystem.PopupPredicted(msgUser, msgOther, user, user);
+        _popupSystem.PopupEntity(msgUser, msgOther, user, user);
 
         if (TryComp<PhysicsComponent>(user, out var physicsComponent))
         {
             _fixtureSystem.TryCreateFixture(user,
                 component.Shape,
-                BlockingComponent.BlockFixtureID,
+                BlockingComponent.BlockFixtureId,
                 hard: true,
                 collisionLayer: (int)CollisionGroup.WallLayer,
                 body: physicsComponent);
@@ -212,13 +212,13 @@ public sealed partial class BlockingSystem : EntitySystem
     private void CantBlockError(EntityUid user)
     {
         var msgError = Loc.GetString("action-popup-blocking-user-cant-block");
-        _popupSystem.PopupClient(msgError, user, user);
+        _popupSystem.PopupEntity(msgError, user, user);
     }
 
     private void TooCloseError(EntityUid user)
     {
         var msgError = Loc.GetString("action-popup-blocking-user-too-close");
-        _popupSystem.PopupClient(msgError, user, user);
+        _popupSystem.PopupEntity(msgError, user, user);
     }
 
     /// <summary>
@@ -250,9 +250,9 @@ public sealed partial class BlockingSystem : EntitySystem
                 _transformSystem.Unanchor(user, xform, false);
 
             _actionsSystem.SetToggled(component.BlockingToggleActionEntity, false);
-            _fixtureSystem.DestroyFixture(user, BlockingComponent.BlockFixtureID, body: physicsComponent);
+            _fixtureSystem.DestroyFixture(user, BlockingComponent.BlockFixtureId, body: physicsComponent);
             _physics.SetBodyType(user, blockingUserComponent.OriginalBodyType, body: physicsComponent);
-            _popupSystem.PopupPredicted(msgUser, msgOther, user, user);
+            _popupSystem.PopupEntity(msgUser, msgOther, user, user);
         }
 
         component.IsBlocking = false;
@@ -291,13 +291,18 @@ public sealed partial class BlockingSystem : EntitySystem
         component.User = null;
     }
 
+    private DamageModifierSet GetBlockingModifier(Entity<BlockingComponent> entity)
+    {
+        return entity.Comp.IsBlocking ? entity.Comp.ActiveBlockModifier ?? entity.Comp.PassiveBlockModifier : entity.Comp.PassiveBlockModifier;
+    }
+
     private void OnVerbExamine(EntityUid uid, BlockingComponent component, GetVerbsEvent<ExamineVerb> args)
     {
         if (!args.CanInteract || !args.CanAccess)
             return;
 
         var fraction = component.IsBlocking ? component.ActiveBlockFraction : component.PassiveBlockFraction;
-        var modifier = component.IsBlocking ? component.ActiveBlockDamageModifier : component.PassiveBlockDamageModifer;
+        var modifier = GetBlockingModifier((uid, component));
 
         var msg = new FormattedMessage();
         msg.AddMarkupOrThrow(Loc.GetString("blocking-fraction", ("value", MathF.Round(fraction * 100, 1))));

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Content.Shared.Actions;
+using Content.Shared.Blocking.Components;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.Hands;

--- a/Content.Shared/Blocking/Components/BlockingComponent.cs
+++ b/Content.Shared/Blocking/Components/BlockingComponent.cs
@@ -3,9 +3,8 @@ using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
-namespace Content.Shared.Blocking;
+namespace Content.Shared.Blocking.Components;
 
 /// <summary>
 /// This component goes on an item that you want to use to block

--- a/Content.Shared/Blocking/Components/BlockingComponent.cs
+++ b/Content.Shared/Blocking/Components/BlockingComponent.cs
@@ -20,37 +20,45 @@ public sealed partial class BlockingComponent : Component
     /// <summary>
     /// The entity that's blocking
     /// </summary>
-    [DataField, AutoNetworkedField] public EntityUid? User;
+    [DataField, AutoNetworkedField]
+    public EntityUid? User;
 
     /// <summary>
     /// Is it currently blocking?
     /// </summary>
-    [DataField, AutoNetworkedField] public bool IsBlocking;
+    [DataField, AutoNetworkedField]
+    public bool IsBlocking;
 
     /// <summary>
     /// The shape of the blocking fixture that will be dynamically spawned
     /// </summary>
-    [DataField] public IPhysShape Shape = new PhysShapeCircle(0.5f);
+    [DataField]
+    public IPhysShape Shape = new PhysShapeCircle(0.5f);
 
     /// <summary>
     /// The damage modifer to use while passively blocking
     /// </summary>
-    [DataField(required: true)] public DamageModifierSet PassiveBlockModifier = default!;
+    [DataField(required: true)]
+    public DamageModifierSet PassiveBlockModifier = default!;
 
     /// <summary>
     /// Optional damage modifier to use while actively blocking.
     /// If this is null, shield will use the PassiveBlockModifier instead.
     /// </summary>
-    [DataField] public DamageModifierSet? ActiveBlockModifier;
+    [DataField]
+    public DamageModifierSet? ActiveBlockModifier;
 
-    [DataField] public EntProtoId BlockingToggleAction = "ActionToggleBlock";
+    [DataField]
+    public EntProtoId BlockingToggleAction = "ActionToggleBlock";
 
-    [DataField, AutoNetworkedField] public EntityUid? BlockingToggleActionEntity;
+    [DataField, AutoNetworkedField]
+    public EntityUid? BlockingToggleActionEntity;
 
     /// <summary>
     /// The sound to be played when you get hit while actively blocking
     /// </summary>
-    [DataField] public SoundSpecifier BlockSound =
+    [DataField]
+    public SoundSpecifier BlockSound =
         new SoundPathSpecifier("/Audio/Weapons/block_metal1.ogg")
         {
             Params = AudioParams.Default.WithVariation(0.25f)
@@ -60,11 +68,13 @@ public sealed partial class BlockingComponent : Component
     /// Fraction of original damage shield will take instead of user
     /// when not blocking
     /// </summary>
-    [DataField] public float PassiveBlockFraction = 0.5f;
+    [DataField]
+    public float PassiveBlockFraction = 0.5f;
 
     /// <summary>
     /// Fraction of original damage shield will take instead of user
     /// when blocking
     /// </summary>
-    [DataField] public float ActiveBlockFraction = 1.0f;
+    [DataField]
+    public float ActiveBlockFraction = 1.0f;
 }

--- a/Content.Shared/Blocking/Components/BlockingComponent.cs
+++ b/Content.Shared/Blocking/Components/BlockingComponent.cs
@@ -13,45 +13,39 @@ namespace Content.Shared.Blocking.Components;
 public sealed partial class BlockingComponent : Component
 {
     /// <summary>
+    /// The ID for the fixture that's dynamically created when blocking
+    /// </summary>
+    public const string BlockFixtureId = "blocking-active";
+
+    /// <summary>
     /// The entity that's blocking
     /// </summary>
-    [DataField, AutoNetworkedField]
-    public EntityUid? User;
+    [DataField, AutoNetworkedField] public EntityUid? User;
 
     /// <summary>
     /// Is it currently blocking?
     /// </summary>
-    [DataField, AutoNetworkedField]
-    public bool IsBlocking;
-
-    /// <summary>
-    /// The ID for the fixture that's dynamically created when blocking
-    /// </summary>
-    public const string BlockFixtureID = "blocking-active";
+    [DataField, AutoNetworkedField] public bool IsBlocking;
 
     /// <summary>
     /// The shape of the blocking fixture that will be dynamically spawned
     /// </summary>
-    [DataField]
-    public IPhysShape Shape = new PhysShapeCircle(0.5f);
+    [DataField] public IPhysShape Shape = new PhysShapeCircle(0.5f);
 
     /// <summary>
     /// The damage modifer to use while passively blocking
     /// </summary>
-    [DataField("passiveBlockModifier", required: true)]
-    public DamageModifierSet PassiveBlockDamageModifer = default!;
+    [DataField(required: true)] public DamageModifierSet PassiveBlockModifier = default!;
 
     /// <summary>
-    /// The damage modifier to use while actively blocking.
+    /// Optional damage modifier to use while actively blocking.
+    /// If this is null, shield will use the PassiveBlockModifier instead.
     /// </summary>
-    [DataField("activeBlockModifier", required: true)]
-    public DamageModifierSet ActiveBlockDamageModifier = default!;
+    [DataField] public DamageModifierSet? ActiveBlockModifier;
 
-    [DataField]
-    public EntProtoId BlockingToggleAction = "ActionToggleBlock";
+    [DataField] public EntProtoId BlockingToggleAction = "ActionToggleBlock";
 
-    [DataField, AutoNetworkedField]
-    public EntityUid? BlockingToggleActionEntity;
+    [DataField, AutoNetworkedField] public EntityUid? BlockingToggleActionEntity;
 
     /// <summary>
     /// The sound to be played when you get hit while actively blocking
@@ -66,13 +60,11 @@ public sealed partial class BlockingComponent : Component
     /// Fraction of original damage shield will take instead of user
     /// when not blocking
     /// </summary>
-    [DataField]
-    public float PassiveBlockFraction = 0.5f;
+    [DataField] public float PassiveBlockFraction = 0.5f;
 
     /// <summary>
     /// Fraction of original damage shield will take instead of user
     /// when blocking
     /// </summary>
-    [DataField]
-    public float ActiveBlockFraction = 1.0f;
+    [DataField] public float ActiveBlockFraction = 1.0f;
 }

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -243,6 +243,7 @@
       passiveBlockModifier:
         flatReductions:
           Blunt: 5
+          Piercing: 1 # Scar told me to.
     - type: Construction
       graph: WebObjects
       node: shield

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -33,7 +33,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 100 #This is probably enough damage before it breaks
+          damage: 125 #This is probably enough damage before it breaks
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
@@ -158,7 +158,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 50 #Weaker shield
+          damage: 75 #Weaker shield
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
@@ -197,7 +197,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 10 #Very very weak shield
+          damage: 25 #Very very weak shield
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
@@ -228,7 +228,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 50
+          damage: 75
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
@@ -408,7 +408,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 100
+          damage: 125
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -19,17 +19,11 @@
           Slash: 0.9
           Piercing: 0.9
           Heat: 0.9
-      activeBlockModifier:
-        coefficients:
-          Blunt: 0.8
-          Slash: 0.8
-          Piercing: 0.8
-          Heat: 0.8
         flatReductions:
-          Blunt: 1
-          Slash: 1
-          Piercing: 1
-          Heat: 1
+          Blunt: 10
+          Slash: 10
+          Piercing: 10
+          Heat: 10
     - type: Damageable
     - type: Injurable
       damageContainer: Shield
@@ -88,15 +82,13 @@
     - type: Blocking
       passiveBlockModifier:
         coefficients:
-          Blunt: 0.7
-          Slash: 0.7
-      activeBlockModifier:
-        coefficients:
-          Blunt: 0.5
-          Slash: 0.5
+          Blunt: 0.8
+          Slash: 0.8
         flatReductions:
-          Blunt: 1
-          Slash: 1
+          Blunt: 15
+          Slash: 15
+          Piercing: 5
+          Heat: 5
 
 - type: entity
   name: laser shield
@@ -111,12 +103,13 @@
     - type: Blocking
       passiveBlockModifier:
         coefficients:
-          Heat: 0.7
-      activeBlockModifier:
-        coefficients:
-          Heat: 0.5
+          Slash: 0.9
+          Heat: 0.8
         flatReductions:
-          Heat: 1
+          Blunt: 5
+          Slash: 10
+          Piercing: 5
+          Heat: 20
 
 - type: entity
   name: ballistic shield
@@ -131,12 +124,13 @@
     - type: Blocking
       passiveBlockModifier:
         coefficients:
-          Piercing: 0.7
-      activeBlockModifier:
-        coefficients:
-          Piercing: 0.5
+          Blunt: 0.9
+          Piercing: 0.8
         flatReductions:
-          Piercing: 1
+          Blunt: 10
+          Slash: 5
+          Piercing: 20
+          Heat: 5
 
 #Craftable shields
 
@@ -152,21 +146,11 @@
       heldPrefix: buckler
     - type: Blocking
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.95
-          Slash: 0.95
-          Piercing: 0.95
-          Heat: 2
-      activeBlockModifier:
-        coefficients:
-          Blunt: 0.85
-          Slash: 0.85
-          Piercing: 0.85
-          Heat: 2
         flatReductions:
-          Blunt: 1
-          Slash: 1
-          Piercing: 1
+          Blunt: 5
+          Slash: 5
+          Piercing: 5
+          Heat: 5
     - type: Construction
       graph: WoodenBuckler
       node: woodenBuckler
@@ -174,7 +158,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 30 #Weaker shield
+          damage: 50 #Weaker shield
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
@@ -201,19 +185,11 @@
       heldPrefix: cardshield
     - type: Blocking
       passiveBlockModifier:
-        coefficients:
-          Blunt: 1
-          Slash: 2
-          Piercing: 0.6
-          Heat: 3
-      activeBlockModifier:
-        coefficients:
-          Blunt: 0.9
-          Slash: 1.8
-          Piercing: 0.5
-          Heat: 2.5
         flatReductions:
-          Blunt: 0.5
+          Blunt: 1
+          Slash: 1
+          Piercing: 1
+          Heat: 1
     - type: Construction
       graph: CardShield
       node: cardShield
@@ -245,24 +221,6 @@
       state: makeshift-icon
     - type: Item
       heldPrefix: metal
-    - type: Blocking
-      passiveBlockModifier:
-        coefficients:
-          Blunt: 0.95
-          Slash: 0.95
-          Piercing: 0.95
-          Heat: 0.9
-      activeBlockModifier:
-        coefficients:
-          Blunt: 0.85
-          Slash: 0.85
-          Piercing: 0.85
-          Heat: 0.8
-        flatReductions:
-          Blunt: 0.5
-          Slash: 0.5
-          Piercing: 0.5
-          Heat: 1
     - type: Construction
       graph: MakeshiftShield
       node: makeshiftShield
@@ -270,7 +228,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 20 #Very weak shield
+          damage: 50
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
@@ -297,19 +255,8 @@
       heldPrefix: icon
     - type: Blocking
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.95
-          Slash: 0.95
-          Piercing: 0.95
-      activeBlockModifier:
-        coefficients:
-          Blunt: 0.85
-          Slash: 0.85
-          Piercing: 0.85
         flatReductions:
-          Blunt: 0.5
-          Slash: 0.5
-          Piercing: 0.5
+          Blunt: 5
     - type: Construction
       graph: WebObjects
       node: shield
@@ -317,7 +264,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 20
+          damage: 50
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
@@ -342,23 +289,6 @@
       state: ratvarian-icon
     - type: Item
       heldPrefix: ratvarian
-    - type: Blocking
-      passiveBlockModifier:
-        coefficients:
-          Blunt: 0.8
-          Slash: 0.8
-          Piercing: 0.8
-          Heat: 1.5
-      activeBlockModifier:
-        coefficients:
-          Blunt: 0.7
-          Slash: 0.7
-          Piercing: 0.7
-          Heat: 1.5
-        flatReductions:
-          Blunt: 1
-          Slash: 1
-          Piercing: 1
       #Have it break into brass when clock cult is in
 
 - type: entity
@@ -378,25 +308,19 @@
     - type: Blocking #Mirror shield reflects heat/laser, but is relatively weak to everything else.
       passiveBlockModifier:
         coefficients:
-          Blunt: 1.2
-          Slash: 1.2
-          Piercing: 1.2
-          Heat: .7
-      activeBlockModifier:
-        coefficients:
-          Blunt: 1.2
-          Slash: 1.2
-          Piercing: 1.2
-          Heat: .6
+          Heat: 0.1
         flatReductions:
-          Heat: 1
+          Blunt: 5
+          Slash: 10
+          Piercing: 5
+          Heat: 25
       blockSound: !type:SoundPathSpecifier
         path: /Audio/Effects/glass_step.ogg
     - type: Destructible
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 40
+          damage: 50
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
@@ -467,19 +391,13 @@
     - type: Blocking
       passiveBlockModifier:
         coefficients:
-          Blunt: 1.0
-          Slash: 0.9
-          Piercing: 0.85
-          Heat: 0.6
-      activeBlockModifier:
-        coefficients:
-          Blunt: 1.2
-          Slash: 0.85
-          Piercing: 0.5
-          Heat: 0.4
+          Piercing: 0.9
+          Heat: 0.1
         flatReductions:
-          Heat: 1
-          Piercing: 1
+          Blunt: 5
+          Piercing: 10
+          Slash: 5
+          Heat: 25
     - type: Appearance
     - type: Damageable
     - type: Injurable
@@ -561,24 +479,5 @@
         right:
           - state: inhand-right-shield
     - type: Appearance
-    - type: Destructible
-      thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 70
-        behaviors:
-        - !type:DoActsBehavior
-          acts: [ "Destruction" ]
-        - !type:PlaySoundBehavior
-          sound:
-            collection: MetalGlassBreak
-        - !type:SpawnEntitiesBehavior
-          spawn:
-            SheetSteel:
-              min: 1
-              max: 1
-            SheetGlass:
-              min: 2
-              max: 2
     - type: StaticPrice
       price: 150

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -14,11 +14,6 @@
       heldPrefix: riot
     - type: Blocking
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.9
-          Slash: 0.9
-          Piercing: 0.9
-          Heat: 0.9
         flatReductions:
           Blunt: 10
           Slash: 10
@@ -81,9 +76,6 @@
       price: 90
     - type: Blocking
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.8
-          Slash: 0.8
         flatReductions:
           Blunt: 15
           Slash: 15
@@ -102,9 +94,6 @@
       heldPrefix: riot_laser
     - type: Blocking
       passiveBlockModifier:
-        coefficients:
-          Slash: 0.9
-          Heat: 0.8
         flatReductions:
           Blunt: 5
           Slash: 10
@@ -123,9 +112,6 @@
       heldPrefix: riot_bullet
     - type: Blocking
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.9
-          Piercing: 0.8
         flatReductions:
           Blunt: 10
           Slash: 5
@@ -308,7 +294,7 @@
     - type: Blocking #Mirror shield reflects heat/laser, but is relatively weak to everything else.
       passiveBlockModifier:
         coefficients:
-          Heat: 0.1
+          Heat: 0.5
         flatReductions:
           Blunt: 5
           Slash: 10
@@ -391,8 +377,7 @@
     - type: Blocking
       passiveBlockModifier:
         coefficients:
-          Piercing: 0.9
-          Heat: 0.1
+          Heat: 0.5
         flatReductions:
           Blunt: 5
           Piercing: 10


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Reworked Shields! This needed to be done post explosions no longer ignoring armor since it allowed for some funny jank lets just say. 
This was also needed as a lot of the shield values are, weird to say the least.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I needed to prevent being able to parry the nuke with a cardboard shield, which meant I needed to implemented shields having a max damage they could block before breaking. The least jank way to do this was to use the already existing datafields properly. 
Before they just reduced the amount of damage each shield took, which is a wasteful way of slightly increasing a shield's HP. 

As such, I changed it so the damage modifiers are applied to the damage incoming to the person using the shield, and act as the maximum damage a shield can block. This means shields now have varying levels of protection for a variety of circumstances based on what they're being hit with, rather than either blocking all (50%) the damage or none of it. 

To compensate for the lost of shield durability, I increased the health of most shields by 25% which is about the amount of additional health the e-shield would need to compensate for its resistance losses against bullets. I increased the health of a lot of the other less used shields by a bunch as well because they were extremely flimsy to the point of the being complete jokes. 

This also means that big damage sources are better against shields which is cool and neat, but rarely matters from testing. Perhaps in the future it will matter more but as of now it's something downstreams will likely get a kick out of. 

## Technical details
<!-- Summary of code changes for easier review. -->
- Changes to the execution flow of BlockingSystem.User to allow for a more logical flow of how damage is applied to shields, and blocked by shields
- Removed a DamageModifySubscription from BlockingComponent that was no longer needed. 
- Cleaned up BlockingComponent
- YAML changes to compensate for the changes to code logic. 

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`ActiveBlockDamageModifier` and `PassiveBlockDamageModifier` have been renamed to `ActiveBlockModifier` and `PassiveBlockModifier` respectively.
`ActiveBlockModifier` and `PassiveBlockModifier` now block incoming damage to the user, and not to the shield. Adjust your YAML accordingly.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Shields are now more effective at blocking specific damage types.
- tweak: Many lesser used shields have had their health increased, but are now worse at blocking damage.