### PR TITLE
Remove Comp.Owner from CableAnchorStateChangedEvent

### DIFF
--- a/Content.Server/Power/Components/CableComponent.cs
+++ b/Content.Server/Power/Components/CableComponent.cs
@@ -1,10 +1,8 @@
 using Content.Server.Power.EntitySystems;
 using Content.Shared.Power;
 using Content.Shared.Tools;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
-using System.Diagnostics.Tracing;
 using Content.Shared.Tools.Systems;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Power.Components;
 
@@ -28,10 +26,10 @@ public sealed partial class CableComponent : Component
     ///     Checked by <see cref="CablePlacerComponent"/> to determine if there is
     ///     already a cable of a type on a tile.
     /// </summary>
-    [DataField("cableType")]
+    [DataField]
     public CableType CableType = CableType.HighVoltage;
 
-    [DataField("cuttingDelay")]
+    [DataField]
     public float CuttingDelay = 1f;
 }
 
@@ -41,18 +39,17 @@ public sealed partial class CableComponent : Component
 [ByRefEvent]
 public readonly struct CableAnchorStateChangedEvent
 {
-    public readonly TransformComponent Transform;
-    public EntityUid Entity => Transform.Owner;
-    public bool Anchored => Transform.Anchored;
+    public readonly Entity<CableComponent, TransformComponent> Cable;
+    public bool Anchored => Cable.Comp2.Anchored;
 
     /// <summary>
     ///     If true, the entity is being detached to null-space
     /// </summary>
     public readonly bool Detaching;
 
-    public CableAnchorStateChangedEvent(TransformComponent transform, bool detaching = false)
+    public CableAnchorStateChangedEvent(Entity<CableComponent, TransformComponent> cable, bool detaching = false)
     {
+        Cable = cable;
         Detaching = detaching;
-        Transform = transform;
     }
 }

--- a/Content.Server/Power/Components/CableComponent.cs
+++ b/Content.Server/Power/Components/CableComponent.cs
@@ -39,15 +39,15 @@ public sealed partial class CableComponent : Component
 [ByRefEvent]
 public readonly struct CableAnchorStateChangedEvent
 {
-    public readonly Entity<CableComponent, TransformComponent> Cable;
-    public bool Anchored => Cable.Comp2.Anchored;
+    public readonly Entity<TransformComponent> Cable;
+    public bool Anchored => Cable.Comp.Anchored;
 
     /// <summary>
     ///     If true, the entity is being detached to null-space
     /// </summary>
     public readonly bool Detaching;
 
-    public CableAnchorStateChangedEvent(Entity<CableComponent, TransformComponent> cable, bool detaching = false)
+    public CableAnchorStateChangedEvent(Entity<TransformComponent> cable, bool detaching = false)
     {
         Cable = cable;
         Detaching = detaching;

--- a/Content.Server/Power/EntitySystems/CableSystem.cs
+++ b/Content.Server/Power/EntitySystems/CableSystem.cs
@@ -47,7 +47,7 @@ public sealed partial class CableSystem : EntitySystem
             return;
 
         var xform = Transform(uid);
-        var ev = new CableAnchorStateChangedEvent(xform);
+        var ev = new CableAnchorStateChangedEvent((uid, cable, xform));
         RaiseLocalEvent(uid, ref ev);
 
         if (_electrocutionSystem.TryDoElectrifiedAct(uid, args.User))
@@ -61,7 +61,7 @@ public sealed partial class CableSystem : EntitySystem
 
     private void OnAnchorChanged(EntityUid uid, CableComponent cable, ref AnchorStateChangedEvent args)
     {
-        var ev = new CableAnchorStateChangedEvent(args.Transform, args.Detaching);
+        var ev = new CableAnchorStateChangedEvent((uid, cable, args.Transform), args.Detaching);
         RaiseLocalEvent(uid, ref ev);
 
         if (args.Anchored)

--- a/Content.Server/Power/EntitySystems/CableSystem.cs
+++ b/Content.Server/Power/EntitySystems/CableSystem.cs
@@ -47,7 +47,7 @@ public sealed partial class CableSystem : EntitySystem
             return;
 
         var xform = Transform(uid);
-        var ev = new CableAnchorStateChangedEvent((uid, cable, xform));
+        var ev = new CableAnchorStateChangedEvent((uid, xform));
         RaiseLocalEvent(uid, ref ev);
 
         if (_electrocutionSystem.TryDoElectrifiedAct(uid, args.User))
@@ -61,7 +61,7 @@ public sealed partial class CableSystem : EntitySystem
 
     private void OnAnchorChanged(EntityUid uid, CableComponent cable, ref AnchorStateChangedEvent args)
     {
-        var ev = new CableAnchorStateChangedEvent((uid, cable, args.Transform), args.Detaching);
+        var ev = new CableAnchorStateChangedEvent((uid, args.Transform), args.Detaching);
         RaiseLocalEvent(uid, ref ev);
 
         if (args.Anchored)

--- a/Content.Server/Power/EntitySystems/PowerMonitoringConsoleSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerMonitoringConsoleSystem.cs
@@ -152,7 +152,7 @@ internal sealed partial class PowerMonitoringConsoleSystem : SharedPowerMonitori
 
     public void OnCableAnchorStateChanged(EntityUid uid, CableComponent component, CableAnchorStateChangedEvent args)
     {
-        var xform = args.Cable.Comp2;
+        var xform = args.Cable.Comp;
 
         if (xform.GridUid == null || !TryComp<MapGridComponent>(xform.GridUid, out var grid))
             return;

--- a/Content.Server/Power/EntitySystems/PowerMonitoringConsoleSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerMonitoringConsoleSystem.cs
@@ -152,7 +152,7 @@ internal sealed partial class PowerMonitoringConsoleSystem : SharedPowerMonitori
 
     public void OnCableAnchorStateChanged(EntityUid uid, CableComponent component, CableAnchorStateChangedEvent args)
     {
-        var xform = args.Transform;
+        var xform = args.Cable.Comp2;
 
         if (xform.GridUid == null || !TryComp<MapGridComponent>(xform.GridUid, out var grid))
             return;


### PR DESCRIPTION
## About the PR
Title.

## Why / Balance
`Comp.Owner` is obsolete.

## Test plan
Cut the cable.
-> the cable is correctly disconnected.

Remove the tile under the cable using RCD.
-> the cable is correctly disconnected.

Open the power monitoring console.
Cut the cable.
-> the changes are correctly displayed.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
`CableAnchorStateChangedEvent` constructor signature has been changed from `(TransformComponent, bool)` to `(Entity<TransformComponent>, bool)`.