### PR TITLE
Fix hand labeler removing non-existent labels

### DIFF
--- a/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
@@ -7,7 +7,6 @@ using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
-using Robust.Shared.Network;
 
 namespace Content.Shared.Labels.EntitySystems;
 
@@ -17,7 +16,6 @@ public abstract partial class SharedHandLabelerSystem : EntitySystem
     [Dependency] private SharedPopupSystem _popupSystem = default!;
     [Dependency] private LabelSystem _labelSystem = default!;
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
-    [Dependency] private INetManager _netManager = default!;
     [Dependency] private EntityWhitelistSystem _whitelistSystem = default!;
 
     public override void Initialize()
@@ -67,10 +65,9 @@ public abstract partial class SharedHandLabelerSystem : EntitySystem
             return;
         }
 
-        if (_netManager.IsServer)
-            _labelSystem.Label(target, ent.Comp.AssignedLabel);
+        _labelSystem.Label(target, ent.Comp.AssignedLabel);
 
-        _popupSystem.PopupClient(Loc.GetString("hand-labeler-successfully-applied"), user, user);
+        _popupSystem.PopupEntity(Loc.GetString("hand-labeler-successfully-applied"), user, user);
 
         // Log labeling
         _adminLogger.Add(LogType.Action, LogImpact.Low,
@@ -79,10 +76,12 @@ public abstract partial class SharedHandLabelerSystem : EntitySystem
 
     private void RemoveLabelFrom(EntityUid uid, EntityUid user, EntityUid target)
     {
-        if (_netManager.IsServer)
-            _labelSystem.Label(target, null);
+        if (!_labelSystem.HasLabel(target))
+            return;
 
-        _popupSystem.PopupClient(Loc.GetString("hand-labeler-successfully-removed"), user, user);
+        _labelSystem.Label(target, null);
+
+        _popupSystem.PopupEntity(Loc.GetString("hand-labeler-successfully-removed"), user, user);
 
         // Log labeling
         _adminLogger.Add(LogType.Action, LogImpact.Low,


### PR DESCRIPTION
## About the PR
Fixes hand labeler showing "Removed label successfully" even when there is no label to remove.

## Why / Balance
Bugfix

## Test plan
See the media.

## Media

https://github.com/user-attachments/assets/7d1fd59d-8e17-48b1-914c-c5645a0a805b

https://github.com/user-attachments/assets/be75f4f4-dc65-4a12-9b00-d74e161d370d

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl: B_Kirill
- fix: Fixed hand labeler showing "Removed label successfully" when there was no label to remove.
