### PR TITLE
Update SlowOnDamageSystem.cs

### DIFF
--- a/Content.Shared/Damage/Systems/SlowOnDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/SlowOnDamageSystem.cs
@@ -78,7 +78,7 @@ public sealed partial class SlowOnDamageSystem : EntitySystem
 
     private void OnExamined(Entity<ClothingSlowOnDamageModifierComponent> ent, ref ExaminedEvent args)
     {
-        var msg = Loc.GetString("slow-on-damage-modifier-examine", ("mod", (1 - ent.Comp.Modifier) * 100));
+        var msg = Loc.GetString("slow-on-damage-modifier-examine", ("mod", ent.Comp.Modifier * 100));
         args.PushMarkup(msg);
     }
 


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed the inversion on "slow-on-damage-modifier-examine"
So 0.25 is actually 25% and 0.75 is 75% and etc.

## Why / Balance
If an item were to have 0.25 (25%) reduction it would say "Slowness from injuries is reduced by 75%" and vice versa which is simply incorrect.

## Technical details
One line change in a .cs file

## Test plan
A bit of a pain in the ass, you'll need to spawn in something with the component and a modifier other than 0.5 so you can tell it's no longer inverted. There are currently no objects that fit this criteria.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
If this breaks anything I'd be fascinated to know how it did so.

## Changelog