### PR TITLE
fix: bug where enabling auto chat highlights would overwrite existing custom highlights

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -34,6 +34,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
     private string? _highlightsColor;
 
     private bool _autoFillHighlightsEnabled;
+    private string _autoHighlights = "";
 
     /// <summary>
     ///     The boolean that keeps track of the 'OnCharacterUpdated' event, whenever it's a player attaching or opening the character info panel.
@@ -44,7 +45,14 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
 
     private void InitializeHighlights()
     {
-        _config.OnValueChanged(CCVars.ChatAutoFillHighlights, (value) => { _autoFillHighlightsEnabled = value; }, true);
+        _config.OnValueChanged(CCVars.ChatAutoFillHighlights, (value) =>
+        {
+            _autoFillHighlightsEnabled = value;
+            if (value)
+                UpdateAutoFillHighlights();
+            else
+                ReloadHighlights();
+        }, true);
 
         _config.OnValueChanged(CCVars.ChatHighlightsColor, (value) => { _highlightsColor = value; }, true);
 
@@ -77,7 +85,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         // If auto highlights are enabled generate a request for new character info
         // that will be used to determine the highlights.
         _charInfoIsAttach = true;
-        _characterInfo.RequestCharacterInfo();
+        _characterInfo?.RequestCharacterInfo();
     }
 
     public void UpdateHighlights(string newHighlights, bool firstLoad = false)
@@ -89,11 +97,26 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         _config.SetCVar(CCVars.ChatHighlights, newHighlights);
         _config.SaveToFile();
 
+        ReloadHighlights();
+        HighlightsUpdated?.Invoke(newHighlights);
+    }
+
+    public void ReloadHighlights()
+    {
         _highlights.Clear();
+
+        var combined = _config.GetCVar(CCVars.ChatHighlights);
+        if (_autoFillHighlightsEnabled && !string.IsNullOrEmpty(_autoHighlights))
+        {
+            if (string.IsNullOrEmpty(combined))
+                combined = _autoHighlights;
+            else
+                combined += "\n" + _autoHighlights;
+        }
 
         // We first subdivide the highlights based on newlines to prevent replacing
         // a valid "\n" tag and adding it to the final regex.
-        var splittedHighlights = newHighlights.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var splittedHighlights = combined.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         for (var i = 0; i < splittedHighlights.Length; i++)
         {
@@ -160,8 +183,8 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         if (_loc.TryGetString($"highlights-{jobKey}", out var jobMatches))
             newHighlights += '\n' + jobMatches.Replace(", ", "\n");
 
-        UpdateHighlights(newHighlights);
-        HighlightsUpdated?.Invoke(newHighlights);
+        _autoHighlights = newHighlights;
+        ReloadHighlights();
         _charInfoIsAttach = false;
     }
 }

--- a/Content.IntegrationTests/Tests/Chat/ChatHighlightTest.cs
+++ b/Content.IntegrationTests/Tests/Chat/ChatHighlightTest.cs
@@ -1,181 +1,158 @@
-using System;
+#nullable enable
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using Content.Client.CharacterInfo;
 using Content.Client.UserInterface.Systems.Chat;
+using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Shared.CCVar;
 using NUnit.Framework;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
 
-namespace Content.IntegrationTests.Tests.Chat
+namespace Content.IntegrationTests.Tests.Chat;
+
+public sealed class ChatHighlightTest : GameTest
 {
-    [TestFixture]
-    public sealed class ChatHighlightTest
+    [SidedDependency(Side.Client)] private readonly IConfigurationManager _configManager = null!;
+    [SidedDependency(Side.Client)] private readonly IUserInterfaceManager _uiManager = null!;
+
+    [Test]
+    [RunOnSide(Side.Client)]
+    public async Task TestCustomHighlightsPreserved()
     {
-        [Test]
-        public async Task TestCustomHighlightsPreserved()
-        {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings
-            {
-                Connected = true,
-            });
+        var chatController = _uiManager.GetUIController<ChatUIController>();
 
-            var client = pair.Client;
-            var configManager = client.ResolveDependency<IConfigurationManager>();
-            var uiManager = client.ResolveDependency<IUserInterfaceManager>();
+        // 1. Enable auto-fill highlights
+        _configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
 
-            await client.WaitPost(() =>
-            {
-                var chatController = uiManager.GetUIController<ChatUIController>();
+        // 2. Set custom highlights
+        var customHighlights = "ling\nrev";
+        chatController.UpdateHighlights(customHighlights);
 
-                // 1. Enable auto-fill highlights
-                configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
+        // Verify they are saved
+        Assert.That(_configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
 
-                // 2. Set custom highlights
-                var customHighlights = "ling\nrev";
-                chatController.UpdateHighlights(customHighlights);
+        // 3. Simulate character update
+        var characterData = new CharacterInfoSystem.CharacterData(
+            default,
+            "Captain",
+            new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
+            null,
+            "John Doe"
+        );
 
-                // Verify they are saved
-                Assert.That(configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
+        var method = chatController.GetType().GetMethod(
+            "OnCharacterUpdated",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
 
-                // 3. Simulate character update
-                var characterData = new CharacterInfoSystem.CharacterData(
-                    default,
-                    "Captain",
-                    new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
-                    null,
-                    "John Doe"
-                );
+        Assert.That(method, Is.Not.Null);
 
-                var method = chatController.GetType().GetMethod(
-                    "OnCharacterUpdated",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
+        // Set internal state to allow character update processing
+        var attachField = chatController.GetType().GetField(
+            "_charInfoIsAttach",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        Assert.That(attachField, Is.Not.Null);
+        attachField.SetValue(chatController, true);
 
-                Assert.That(method, Is.Not.Null);
+        // Invoke update
+        method.Invoke(chatController, new object[] { characterData });
 
-                // Set internal state to allow character update processing
-                var attachField = chatController.GetType().GetField(
-                    "_charInfoIsAttach",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
-                Assert.That(attachField, Is.Not.Null);
-                attachField.SetValue(chatController, true);
+        // 4. Assertions:
+        // - Custom highlights in config must remain unchanged
+        Assert.That(_configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
 
-                // Invoke update
-                method.Invoke(chatController, new object[] { characterData });
+        // - Internal active regex highlights must contain both custom & auto-filled highlights
+        var highlightsField = chatController.GetType().GetField(
+            "_highlights",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        Assert.That(highlightsField, Is.Not.Null);
+        var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
 
-                // 4. Assertions:
-                // - Custom highlights in config must remain unchanged
-                Assert.That(configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
+        // Check that custom and auto highlights are loaded
+        // Custom:
+        Assert.That(activeHighlights, Contains.Item("ling"));
+        Assert.That(activeHighlights, Contains.Item("rev"));
+        // Auto:
+        Assert.That(activeHighlights, Contains.Item("Captain"));
+        Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)")); // "Cap" becomes regex-escaped and word-bounded
 
-                // - Internal active regex highlights must contain both custom & auto-filled highlights
-                var highlightsField = chatController.GetType().GetField(
-                    "_highlights",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
-                Assert.That(highlightsField, Is.Not.Null);
-                var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+        // 5. Disable auto-fill highlights and verify auto-filled highlights are removed
+        _configManager.SetCVar(CCVars.ChatAutoFillHighlights, false);
 
-                // Check that custom and auto highlights are loaded
-                // Custom:
-                Assert.That(activeHighlights, Contains.Item("ling"));
-                Assert.That(activeHighlights, Contains.Item("rev"));
-                // Auto:
-                Assert.That(activeHighlights, Contains.Item("Captain"));
-                Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)")); // "Cap" becomes regex-escaped and word-bounded
+        activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+        Assert.That(activeHighlights, Contains.Item("ling"));
+        Assert.That(activeHighlights, Contains.Item("rev"));
+        Assert.That(activeHighlights, Is.Not.Contains("Captain"));
+    }
 
-                // 5. Disable auto-fill highlights and verify auto-filled highlights are removed
-                configManager.SetCVar(CCVars.ChatAutoFillHighlights, false);
+    [Test]
+    [RunOnSide(Side.Client)]
+    public async Task TestEnablingAutoFillPreservesCustomHighlights()
+    {
+        var chatController = _uiManager.GetUIController<ChatUIController>();
 
-                activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
-                Assert.That(activeHighlights, Contains.Item("ling"));
-                Assert.That(activeHighlights, Contains.Item("rev"));
-                Assert.That(activeHighlights, Is.Not.Contains("Captain"));
-            });
+        // 1. Start with auto-fill disabled
+        _configManager.SetCVar(CCVars.ChatAutoFillHighlights, false);
 
-            await pair.CleanReturnAsync();
-        }
+        // 2. Set custom highlights
+        var customHighlights = "ling\nrev";
+        chatController.UpdateHighlights(customHighlights);
 
-        [Test]
-        public async Task TestEnablingAutoFillPreservesCustomHighlights()
-        {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings
-            {
-                Connected = true,
-            });
+        // Verify active matches are ONLY custom highlights
+        var highlightsField = chatController.GetType().GetField(
+            "_highlights",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        Assert.That(highlightsField, Is.Not.Null);
+        var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
 
-            var client = pair.Client;
-            var configManager = client.ResolveDependency<IConfigurationManager>();
-            var uiManager = client.ResolveDependency<IUserInterfaceManager>();
+        Assert.That(activeHighlights, Contains.Item("ling"));
+        Assert.That(activeHighlights, Contains.Item("rev"));
+        Assert.That(activeHighlights.Count, Is.EqualTo(2));
 
-            await client.WaitPost(() =>
-            {
-                var chatController = uiManager.GetUIController<ChatUIController>();
+        // 3. Enable auto-fill highlights
+        _configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
 
-                // 1. Start with auto-fill disabled
-                configManager.SetCVar(CCVars.ChatAutoFillHighlights, false);
+        // 4. Simulate character update (spawning into round)
+        var characterData = new CharacterInfoSystem.CharacterData(
+            default,
+            "Captain",
+            new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
+            null,
+            "John Doe"
+        );
 
-                // 2. Set custom highlights
-                var customHighlights = "ling\nrev";
-                chatController.UpdateHighlights(customHighlights);
+        var method = chatController.GetType().GetMethod(
+            "OnCharacterUpdated",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
 
-                // Verify active matches are ONLY custom highlights
-                var highlightsField = chatController.GetType().GetField(
-                    "_highlights",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
-                Assert.That(highlightsField, Is.Not.Null);
-                var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+        Assert.That(method, Is.Not.Null);
 
-                Assert.That(activeHighlights, Contains.Item("ling"));
-                Assert.That(activeHighlights, Contains.Item("rev"));
-                Assert.That(activeHighlights.Count, Is.EqualTo(2));
+        var attachField = chatController.GetType().GetField(
+            "_charInfoIsAttach",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        Assert.That(attachField, Is.Not.Null);
+        attachField.SetValue(chatController, true);
 
-                // 3. Enable auto-fill highlights
-                configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
+        // Invoke character update
+        method.Invoke(chatController, new object[] { characterData });
 
-                // 4. Simulate character update (spawning into round)
-                var characterData = new CharacterInfoSystem.CharacterData(
-                    default,
-                    "Captain",
-                    new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
-                    null,
-                    "John Doe"
-                );
+        // 5. Assertions:
+        // - Config highlights MUST NOT be wiped and remain as custom highlights
+        Assert.That(_configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
 
-                var method = chatController.GetType().GetMethod(
-                    "OnCharacterUpdated",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
-
-                Assert.That(method, Is.Not.Null);
-
-                var attachField = chatController.GetType().GetField(
-                    "_charInfoIsAttach",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
-                Assert.That(attachField, Is.Not.Null);
-                attachField.SetValue(chatController, true);
-
-                // Invoke character update
-                method.Invoke(chatController, new object[] { characterData });
-
-                // 5. Assertions:
-                // - Config highlights MUST NOT be wiped and remain as custom highlights
-                Assert.That(configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
-
-                // - Active highlights list must now merge both custom and auto-filled ones
-                activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
-                Assert.That(activeHighlights, Contains.Item("ling"));
-                Assert.That(activeHighlights, Contains.Item("rev"));
-                Assert.That(activeHighlights, Contains.Item("Captain"));
-                Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)"));
-            });
-
-            await pair.CleanReturnAsync();
-        }
+        // - Active highlights list must now merge both custom and auto-filled ones
+        activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+        Assert.That(activeHighlights, Contains.Item("ling"));
+        Assert.That(activeHighlights, Contains.Item("rev"));
+        Assert.That(activeHighlights, Contains.Item("Captain"));
+        Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)"));
     }
 }

--- a/Content.IntegrationTests/Tests/Chat/ChatHighlightTest.cs
+++ b/Content.IntegrationTests/Tests/Chat/ChatHighlightTest.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Content.Client.CharacterInfo;
+using Content.Client.UserInterface.Systems.Chat;
+using Content.Shared.CCVar;
+using NUnit.Framework;
+using Robust.Client.UserInterface;
+using Robust.Shared.Configuration;
+
+namespace Content.IntegrationTests.Tests.Chat
+{
+    [TestFixture]
+    public sealed class ChatHighlightTest
+    {
+        [Test]
+        public async Task TestCustomHighlightsPreserved()
+        {
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings
+            {
+                Connected = true,
+            });
+
+            var client = pair.Client;
+            var configManager = client.ResolveDependency<IConfigurationManager>();
+            var uiManager = client.ResolveDependency<IUserInterfaceManager>();
+
+            await client.WaitPost(() =>
+            {
+                var chatController = uiManager.GetUIController<ChatUIController>();
+
+                // 1. Enable auto-fill highlights
+                configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
+
+                // 2. Set custom highlights
+                var customHighlights = "ling\nrev";
+                chatController.UpdateHighlights(customHighlights);
+
+                // Verify they are saved
+                Assert.That(configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
+
+                // 3. Simulate character update
+                var characterData = new CharacterInfoSystem.CharacterData(
+                    default,
+                    "Captain",
+                    new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
+                    null,
+                    "John Doe"
+                );
+
+                var method = chatController.GetType().GetMethod(
+                    "OnCharacterUpdated",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+
+                Assert.That(method, Is.Not.Null);
+
+                // Set internal state to allow character update processing
+                var attachField = chatController.GetType().GetField(
+                    "_charInfoIsAttach",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+                Assert.That(attachField, Is.Not.Null);
+                attachField.SetValue(chatController, true);
+
+                // Invoke update
+                method.Invoke(chatController, new object[] { characterData });
+
+                // 4. Assertions:
+                // - Custom highlights in config must remain unchanged
+                Assert.That(configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
+
+                // - Internal active regex highlights must contain both custom & auto-filled highlights
+                var highlightsField = chatController.GetType().GetField(
+                    "_highlights",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+                Assert.That(highlightsField, Is.Not.Null);
+                var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+
+                // Check that custom and auto highlights are loaded
+                // Custom:
+                Assert.That(activeHighlights, Contains.Item("ling"));
+                Assert.That(activeHighlights, Contains.Item("rev"));
+                // Auto:
+                Assert.That(activeHighlights, Contains.Item("Captain"));
+                Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)")); // "Cap" becomes regex-escaped and word-bounded
+
+                // 5. Disable auto-fill highlights and verify auto-filled highlights are removed
+                configManager.SetCVar(CCVars.ChatAutoFillHighlights, false);
+
+                activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+                Assert.That(activeHighlights, Contains.Item("ling"));
+                Assert.That(activeHighlights, Contains.Item("rev"));
+                Assert.That(activeHighlights, Is.Not.Contains("Captain"));
+            });
+
+            await pair.CleanReturnAsync();
+        }
+
+        [Test]
+        public async Task TestEnablingAutoFillPreservesCustomHighlights()
+        {
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings
+            {
+                Connected = true,
+            });
+
+            var client = pair.Client;
+            var configManager = client.ResolveDependency<IConfigurationManager>();
+            var uiManager = client.ResolveDependency<IUserInterfaceManager>();
+
+            await client.WaitPost(() =>
+            {
+                var chatController = uiManager.GetUIController<ChatUIController>();
+
+                // 1. Start with auto-fill disabled
+                configManager.SetCVar(CCVars.ChatAutoFillHighlights, false);
+
+                // 2. Set custom highlights
+                var customHighlights = "ling\nrev";
+                chatController.UpdateHighlights(customHighlights);
+
+                // Verify active matches are ONLY custom highlights
+                var highlightsField = chatController.GetType().GetField(
+                    "_highlights",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+                Assert.That(highlightsField, Is.Not.Null);
+                var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+
+                Assert.That(activeHighlights, Contains.Item("ling"));
+                Assert.That(activeHighlights, Contains.Item("rev"));
+                Assert.That(activeHighlights.Count, Is.EqualTo(2));
+
+                // 3. Enable auto-fill highlights
+                configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
+
+                // 4. Simulate character update (spawning into round)
+                var characterData = new CharacterInfoSystem.CharacterData(
+                    default,
+                    "Captain",
+                    new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
+                    null,
+                    "John Doe"
+                );
+
+                var method = chatController.GetType().GetMethod(
+                    "OnCharacterUpdated",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+
+                Assert.That(method, Is.Not.Null);
+
+                var attachField = chatController.GetType().GetField(
+                    "_charInfoIsAttach",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+                Assert.That(attachField, Is.Not.Null);
+                attachField.SetValue(chatController, true);
+
+                // Invoke character update
+                method.Invoke(chatController, new object[] { characterData });
+
+                // 5. Assertions:
+                // - Config highlights MUST NOT be wiped and remain as custom highlights
+                Assert.That(configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
+
+                // - Active highlights list must now merge both custom and auto-filled ones
+                activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+                Assert.That(activeHighlights, Contains.Item("ling"));
+                Assert.That(activeHighlights, Contains.Item("rev"));
+                Assert.That(activeHighlights, Contains.Item("Captain"));
+                Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)"));
+            });
+
+            await pair.CleanReturnAsync();
+        }
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

I see that chatcode is under restriction, I imagine this counts? However this is a bug fix for an optional feature, which is preventing people from using it (see https://github.com/ss14Starlight/space-station-14/pull/5125#issuecomment-4956601404)

> Chatcode - PRs involving chatcode or adding/changing formatting functionality are at risk of being closed due to impacting refactoring chatcode. Ask @SlamBamActionman or @Fildrance if you intend to work in this area.

Is this okay @SlamBamActionman / @Fildrance ?

## About the PR
<!-- What did you change? -->
Previously, with this option enabled, it would save the auto highlights to disk, overwriting any custom highlights the user had set up.

Now the auto highlights are stored in memory (as they are different round to round) and will not overwrite the custom highlights on disk.

This should have no impact on people who don't use auto-highlights (a large majority of the playerbase, since it's tucked away in accessibility settings)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It harms people trying out this feature as a once-off, or downstream servers from enabling it as default (as it would wipe players current custom filters)

## Technical details
<!-- Summary of code changes for easier review. -->
Adds `private string _autoHighlights = "";` to store the generated auto highlights in memory. Previously, this system would generate newHighlights (if _charInfoIsAttach is true, which is only set by enabling the auto highlight settings), and call UpdateHighlights(newHighlights);
```cs
    private void OnCharacterUpdated(CharacterData data)
    {
        // If _charInfoIsAttach is false then the opening of the character panel was the one
        // to generate the event, dismiss it.
        if (!_charInfoIsAttach)
            return;

        var (_, job, _, _, entityName) = data;

        // Mark this entity's name as our character name for the "UpdateHighlights" function.
        var newHighlights = "@" + entityName;

        // Subdivide the character's name based on spaces or hyphens so that every word gets highlighted.
        if (newHighlights.Count(c => (c == ' ' || c == '-')) == 1)
            newHighlights = newHighlights.Replace("-", "\n@").Replace(" ", "\n@");

        // If the character has a name with more than one hyphen assume it is a lizard name and extract the first and
        // last name eg. "Eats-The-Food" -> "@Eats" "@Food"
        if (newHighlights.Count(c => c == '-') > 1)
            newHighlights = newHighlights.Split('-')[0] + "\n@" + newHighlights.Split('-')[^1];

        // Convert the job title to kebab-case and use it as a key for the loc file.
        var jobKey = job.Replace(' ', '-').ToLower();

        if (_loc.TryGetString($"highlights-{jobKey}", out var jobMatches))
            newHighlights += '\n' + jobMatches.Replace(", ", "\n");

        UpdateHighlights(newHighlights);
        HighlightsUpdated?.Invoke(newHighlights);
        _charInfoIsAttach = false;
    }
```

The first thing UpdateHighlights does is save the passed highlights to file, overwriting any existing highlights
```cs
    public void UpdateHighlights(string newHighlights, bool firstLoad = false)
    {
        // Do nothing if the provided highlights are the same as the old ones and it is not the first time.
        if (!firstLoad && _config.GetCVar(CCVars.ChatHighlights).Equals(newHighlights, StringComparison.CurrentCultureIgnoreCase))
            return;

        _config.SetCVar(CCVars.ChatHighlights, newHighlights);
        _config.SaveToFile();
        ...
```

This seems like a bug, as auto generated highlights differ round-to-round, character-to-character and are generated on the fly anyway each time. So there's no benefit to persisting them, and the downside is overwriting existing custom user highlights.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Go to accessibility settings and make sure the auto-chat highlights is disabled
2. Open the chat highlights settings and add some custom highlights.
3. Spawn into the game as the default character.
4. Go back to accessibility settings and turn "Auto-fill Chat Highlights" on.
5. Open the chat highlights settings box again.
6. The bug is that your custom highlights are now completely gone, replaced by your character's name and job words.

I have also added two tests (TestEnablingAutoFillPreservesCustomHighlights and TestCustomHighlightsPreserved) which failed pre-fix (tests run against master) and now pass:


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
UpdateHighlights no longer persists the optional auto-highlights to disk, instead storing just a player's custom ones and keeping the auto-generated ones in memory.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
fix: Fix enabling auto chat highlights wiping your current custom chat highlights.
