### PR TITLE
Bugfix: Try targeted edge first in ConstructionSystem.HandleNode

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -140,6 +140,7 @@ namespace Content.Server.Construction
                 {
                     construction.EdgeIndex = edgeIndex;
                 }
+                return;
             }
 
             // If we're not on the same edge as we were before, that means handling that edge changed the node.

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -129,28 +129,23 @@ namespace Content.Server.Construction
         /// <summary>
         /// Handling a successful edge traversal. Ensures the entity's node index, edge index, and pathfinding information are correct.
         /// </summary>
+        /// <remarks>
+        /// Only a True result may modify the state.
+        /// In the case of DoAfter, it's only allowed to modify the waiting flag and the current edge index.
+        /// In the case of validated, it should NEVER modify the state at all.
+        /// </remarks>
         private void ProcessSuccessfulEdgeResult(HandleResult result, int edgeIndex, ConstructionGraphNode node, EntityUid uid, ConstructionComponent construction)
         {
-            // Only a True result may modify the state.
-            // In the case of DoAfter, it's only allowed to modify the waiting flag and the current edge index.
-            // In the case of validated, it should NEVER modify the state at all.
-            if (result is not HandleResult.True)
+            if (result == HandleResult.DoAfter)
             {
-                if (result is HandleResult.DoAfter)
-                {
-                    construction.EdgeIndex = edgeIndex;
-                }
-
-                return;
+                construction.EdgeIndex = edgeIndex;
             }
-
-            // If we're not on the same edge as we were before, that means handling that edge changed the node.
-            if (construction.Node != node.Name)
-                return;
-
-            // If we're still in the same node, that means we entered the edge and it's still not done.
-            construction.EdgeIndex = edgeIndex;
-            UpdatePathfinding(uid, construction);
+            else if (result == HandleResult.True && construction.Node == node.Name)
+            {
+                // If we're still in the same node, that means we entered the edge and it's still not done.
+                construction.EdgeIndex = edgeIndex;
+                UpdatePathfinding(uid, construction);
+            }
         }
 
         /// <summary>

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -130,9 +130,9 @@ namespace Content.Server.Construction
         /// Handling a successful edge traversal. Ensures the entity's node index, edge index, and pathfinding information are correct.
         /// </summary>
         /// <remarks>
-        /// Only a True result may modify the state.
+        /// Only a True result can may modify the pathfinding state.
         /// In the case of DoAfter, it's only allowed to modify the waiting flag and the current edge index.
-        /// In the case of validated, it should NEVER modify the state at all.
+        /// In the case of Validated/False, the state should not be changed.
         /// </remarks>
         private void ProcessSuccessfulEdgeResult(HandleResult result, int edgeIndex, ConstructionGraphNode node, EntityUid uid, ConstructionComponent construction)
         {

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -130,7 +130,7 @@ namespace Content.Server.Construction
         /// Handling a successful edge traversal. Ensures the entity's node index, edge index, and pathfinding information are correct.
         /// </summary>
         /// <remarks>
-        /// Only a True result can may modify the pathfinding state.
+        /// Only a True result may modify the pathfinding state.
         /// In the case of DoAfter, it's only allowed to modify the waiting flag and the current edge index.
         /// In the case of Validated/False, the state should not be changed.
         /// </remarks>

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -140,6 +140,7 @@ namespace Content.Server.Construction
                 {
                     construction.EdgeIndex = edgeIndex;
                 }
+
                 return;
             }
 

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Reflection.Metadata;
 using Content.Server.Administration.Logs;
 using Content.Server.Construction.Components;
 using Content.Server.Temperature.Components;
@@ -12,7 +11,6 @@ using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Prying.Systems;
 using Content.Shared.Radio.EntitySystems;
-using Content.Shared.Stacks;
 using Content.Shared.Temperature;
 using Content.Shared.Temperature.Components;
 using Content.Shared.Tools.Systems;

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -111,6 +111,10 @@ namespace Content.Server.Construction
             // edges' first steps. If any of them accepts the interaction, we stop iterating and enter that edge.
             for (var i = 0; i < node.Edges.Count; i++)
             {
+                // Don't retry the same edge.
+                if (i == construction.TargetEdgeIndex)
+                    continue;
+
                 var edge = node.Edges[i];
                 if (HandleEdge(uid, ev, edge, validation, construction) is var result and not HandleResult.False)
                 {

--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Reflection.Metadata;
 using Content.Server.Administration.Logs;
 using Content.Server.Construction.Components;
 using Content.Server.Temperature.Components;
@@ -96,6 +97,18 @@ namespace Content.Server.Construction
             // Let's make extra sure this is zero...
             construction.StepIndex = 0;
 
+            // First, if we have a target edge, try that.
+            if (construction.TargetEdgeIndex is { } targetEdge
+                && targetEdge >= 0
+                && targetEdge < node.Edges.Count)
+            {
+                if (HandleEdge(uid, ev, node.Edges[targetEdge], validation, construction) is var result and not HandleResult.False)
+                {
+                    ProcessSuccessfulEdgeResult(result, targetEdge, node, uid, construction);
+                    return result;
+                }
+            }
+
             // When we handle a node, we're essentially testing the current event interaction against all of this node's
             // edges' first steps. If any of them accepts the interaction, we stop iterating and enter that edge.
             for (var i = 0; i < node.Edges.Count; i++)
@@ -103,32 +116,37 @@ namespace Content.Server.Construction
                 var edge = node.Edges[i];
                 if (HandleEdge(uid, ev, edge, validation, construction) is var result and not HandleResult.False)
                 {
-                    // Only a True result may modify the state.
-                    // In the case of DoAfter, it's only allowed to modify the waiting flag and the current edge index.
-                    // In the case of validated, it should NEVER modify the state at all.
-                    if (result is not HandleResult.True)
-                    {
-                        if (result is HandleResult.DoAfter)
-                        {
-                            construction.EdgeIndex = i;
-                        }
-
-                        return result;
-                    }
-
-                    // If we're not on the same edge as we were before, that means handling that edge changed the node.
-                    if (construction.Node != node.Name)
-                        return result;
-
-                    // If we're still in the same node, that means we entered the edge and it's still not done.
-                    construction.EdgeIndex = i;
-                    UpdatePathfinding(uid, construction);
-
+                    ProcessSuccessfulEdgeResult(result, i, node, uid, construction);
                     return result;
                 }
             }
 
             return HandleResult.False;
+        }
+
+        /// <summary>
+        /// Handling a successful edge traversal. Ensures the entity's node index, edge index, and pathfinding information are correct.
+        /// </summary>
+        private void ProcessSuccessfulEdgeResult(HandleResult result, int edgeIndex, ConstructionGraphNode node, EntityUid uid, ConstructionComponent construction)
+        {
+            // Only a True result may modify the state.
+            // In the case of DoAfter, it's only allowed to modify the waiting flag and the current edge index.
+            // In the case of validated, it should NEVER modify the state at all.
+            if (result is not HandleResult.True)
+            {
+                if (result is HandleResult.DoAfter)
+                {
+                    construction.EdgeIndex = edgeIndex;
+                }
+            }
+
+            // If we're not on the same edge as we were before, that means handling that edge changed the node.
+            if (construction.Node != node.Name)
+                return;
+
+            // If we're still in the same node, that means we entered the edge and it's still not done.
+            construction.EdgeIndex = edgeIndex;
+            UpdatePathfinding(uid, construction);
         }
 
         /// <summary>


### PR DESCRIPTION
## About the PR

Attempts to handle the target edge first in ConstructionSystem.HandleNode.  Fixes cases where a given interaction matches multiple edges.

## Why / Balance

When handling a construction graph, your pathfinding should define target edges based on your nodes.  Those should be respected if they exist!

Without this, #43495 is effectively blocked as-is.

Fixes a bug encountered in #43495 where a node (girder), having two edges that could be matched by an interaction (applying some number of rods), would try the edges in the order they were defined, ignorant of the user's desired node.

## Technical details
Moved the majority of the HandleEdge bookkeeping into a function since otherwise it'd be repeated.

## Test plan
Apply the patch from #43495 onto this PR [Patch available here](https://patch-diff.githubusercontent.com/raw/space-wizards/space-station-14/pull/43495.patch)

Try to build the diagonal mining wall.  It should work!

## Media
    
</details>

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
nope