### PR TITLE
Fix smart fridge UI mispredicts items count

### DIFF
--- a/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
+++ b/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
@@ -99,6 +99,9 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
 
     private void OnItemRemoved(Entity<SmartFridgeComponent> ent, ref EntRemovedFromContainerMessage args)
     {
+        if (_timing.ApplyingState)
+            return;
+
         var key = new SmartFridgeEntry(Identity.Name(args.Entity, EntityManager));
 
         if (ent.Comp.ContainedEntries.TryGetValue(key, out var contained))
@@ -122,9 +125,6 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
 
     private void OnDispenseItem(Entity<SmartFridgeComponent> ent, ref SmartFridgeDispenseItemMessage args)
     {
-        if (!_timing.IsFirstTimePredicted)
-            return;
-
         if (!Allowed(ent, args.Actor))
             return;
 

--- a/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
+++ b/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
@@ -99,7 +99,7 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
 
     private void OnItemRemoved(Entity<SmartFridgeComponent> ent, ref EntRemovedFromContainerMessage args)
     {
-        if (_timing.ApplyingState)
+        if (args.Container.ID != ent.Comp.Container  || _timing.ApplyingState)
             return;
 
         var key = new SmartFridgeEntry(Identity.Name(args.Entity, EntityManager));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Annoying bug when you have to click random fruit in fridge container to get all correct count, visual, sound of procedure.
Bug happens when player leaves PVS of smartfridge container and system deletes all entities in container to 0. When player come back he will see all items in container sets to 0. When clicked prediction works and set correct count with wrong visual and sound effect.

## Why / Balance
Annoying bug when you have to click random fruit in fridge container to get all correct count, visual, sound of procedure.
Closes: #44247
Draft PR from @sudobeans: #44248

## Technical details
Added _timing.ApplyingState in EntRemovedFromContainerMessage event handler.

## Test plan
1. Spawn SmartFridge
2. Set some fruits in SmartFridge
3. Walk some distance to trigger PVS event
4. Come back to smart fridge and see UI.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Smart Fridge UI could show empty items when it is not

