### PR TITLE
Replace `string` with `ProtoId<ReagentPrototype>` in a few places

### DIFF
--- a/Content.Client/Guidebook/Controls/GuideReagentReaction.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuideReagentReaction.xaml.cs
@@ -113,7 +113,7 @@ public sealed partial class GuideReagentReaction : BoxContainer, ISearchableCont
         SetMixingCategory(categories, null, sysMan);
     }
 
-    private void SetReagents(List<ReagentQuantity> reagents, ref Container container, IPrototypeManager protoMan, bool addLinks = true)
+    private static void SetReagents(List<ReagentQuantity> reagents, ref Container container, IPrototypeManager protoMan, bool addLinks = true)
     {
         var amounts = new Dictionary<ProtoId<ReagentPrototype>, FixedPoint2>();
         foreach (var (reagent, quantity) in reagents)
@@ -123,8 +123,8 @@ public sealed partial class GuideReagentReaction : BoxContainer, ISearchableCont
         SetReagents(amounts, ref container, protoMan, addLinks);
     }
 
-    private void SetReagents(
-        Dictionary<ProtoId<ReagentPrototype>, ReactantPrototype> reactants,
+    private static void SetReagents(
+        Dictionary<ProtoId<ReagentPrototype>, ReactantInfo> reactants,
         ref Container container,
         IPrototypeManager protoMan,
         bool addLinks = true)

--- a/Content.Client/Guidebook/Controls/GuideReagentReaction.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuideReagentReaction.xaml.cs
@@ -36,7 +36,7 @@ public sealed partial class GuideReagentReaction : BoxContainer, ISearchableCont
         Container container = ReactantsContainer;
         SetReagents(prototype.Reactants, ref container, protoMan);
         Container productContainer = ProductsContainer;
-        var products = new Dictionary<string, FixedPoint2>(prototype.Products);
+        var products = new Dictionary<ProtoId<ReagentPrototype>, FixedPoint2>(prototype.Products);
         foreach (var (reagent, reactantProto) in prototype.Reactants)
         {
             if (reactantProto.Catalyst)
@@ -101,11 +101,11 @@ public sealed partial class GuideReagentReaction : BoxContainer, ISearchableCont
         ReactantsContainer.Visible = true;
         ReactantsContainer.AddChild(label);
 
-        if (prototype.Reagent != null)
+        if (prototype.Reagent is {} reagent)
         {
-            var quantity = new Dictionary<string, FixedPoint2>
+            var quantity = new Dictionary<ProtoId<ReagentPrototype>, FixedPoint2>
             {
-                { prototype.Reagent, FixedPoint2.New(0.21f) }
+                { reagent, FixedPoint2.New(0.21f) }
             };
             Container productContainer = ProductsContainer;
             SetReagents(quantity, ref productContainer, protoMan, false);
@@ -115,7 +115,7 @@ public sealed partial class GuideReagentReaction : BoxContainer, ISearchableCont
 
     private void SetReagents(List<ReagentQuantity> reagents, ref Container container, IPrototypeManager protoMan, bool addLinks = true)
     {
-        var amounts = new Dictionary<string, FixedPoint2>();
+        var amounts = new Dictionary<ProtoId<ReagentPrototype>, FixedPoint2>();
         foreach (var (reagent, quantity) in reagents)
         {
             amounts.Add(reagent.Prototype, quantity);
@@ -124,12 +124,12 @@ public sealed partial class GuideReagentReaction : BoxContainer, ISearchableCont
     }
 
     private void SetReagents(
-        Dictionary<string, ReactantPrototype> reactants,
+        Dictionary<ProtoId<ReagentPrototype>, ReactantPrototype> reactants,
         ref Container container,
         IPrototypeManager protoMan,
         bool addLinks = true)
     {
-        var amounts = new Dictionary<string, FixedPoint2>();
+        var amounts = new Dictionary<ProtoId<ReagentPrototype>, FixedPoint2>();
         foreach (var (reagent, reactantPrototype) in reactants)
         {
             amounts.Add(reagent, reactantPrototype.Amount);
@@ -137,22 +137,7 @@ public sealed partial class GuideReagentReaction : BoxContainer, ISearchableCont
         SetReagents(amounts, ref container, protoMan, addLinks);
     }
 
-    [PublicAPI]
-    private void SetReagents(
-        Dictionary<ProtoId<MixingCategoryPrototype>, ReactantPrototype> reactants,
-        ref Container container,
-        IPrototypeManager protoMan,
-        bool addLinks = true)
-    {
-        var amounts = new Dictionary<string, FixedPoint2>();
-        foreach (var (reagent, reactantPrototype) in reactants)
-        {
-            amounts.Add(reagent, reactantPrototype.Amount);
-        }
-        SetReagents(amounts, ref container, protoMan, addLinks);
-    }
-
-    private void SetReagents(Dictionary<string, FixedPoint2> reagents, ref Container container, IPrototypeManager protoMan, bool addLinks = true)
+    private static void SetReagents(Dictionary<ProtoId<ReagentPrototype>, FixedPoint2> reagents, ref Container container, IPrototypeManager protoMan, bool addLinks = true)
     {
         foreach (var (product, amount) in reagents.OrderByDescending(p => p.Value))
         {

--- a/Content.Server/GuideGenerator/ReagentEntry.cs
+++ b/Content.Server/GuideGenerator/ReagentEntry.cs
@@ -55,10 +55,10 @@ public sealed class ReactionEntry
     public string Name { get; }
 
     [JsonPropertyName("reactants")]
-    public Dictionary<string, ReactantEntry> Reactants { get; }
+    public Dictionary<ProtoId<ReagentPrototype>, ReactantEntry> Reactants { get; }
 
     [JsonPropertyName("products")]
-    public Dictionary<string, float> Products { get; }
+    public Dictionary<ProtoId<ReagentPrototype>, float> Products { get; }
 
     [JsonPropertyName("effects")]
     public List<EntityEffect> Effects { get; }

--- a/Content.Shared/Chemistry/Reaction/ChemicalReactionSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/ChemicalReactionSystem.cs
@@ -11,7 +11,6 @@ using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
-
 namespace Content.Shared.Chemistry.Reaction
 {
     public sealed partial class ChemicalReactionSystem : EntitySystem
@@ -36,12 +35,12 @@ namespace Content.Shared.Chemistry.Reaction
         /// A cache of all reactions indexed by at most ONE of their required reactants.
         /// I.e., even if a reaction has more than one reagent, it will only ever appear once in this dictionary.
         /// </summary>
-        private FrozenDictionary<string, List<ReactionPrototype>> _reactionsSingle = default!;
+        private FrozenDictionary<ProtoId<ReagentPrototype>, List<ReactionPrototype>> _reactionsSingle = default!;
 
         /// <summary>
         ///     A cache of all reactions indexed by one of their required reactants.
         /// </summary>
-        private FrozenDictionary<string, List<ReactionPrototype>> _reactions = default!;
+        private FrozenDictionary<ProtoId<ReagentPrototype>, List<ReactionPrototype>> _reactions = default!;
 
         public override void Initialize()
         {
@@ -57,7 +56,7 @@ namespace Content.Shared.Chemistry.Reaction
         private void InitializeReactionCache()
         {
             // Construct single-reaction dictionary.
-            var dict = new Dictionary<string, List<ReactionPrototype>>();
+            var dict = new Dictionary<ProtoId<ReagentPrototype>, List<ReactionPrototype>>();
             foreach (var reaction in ProtoMan.EnumeratePrototypes<ReactionPrototype>())
             {
                 // For this dictionary we only need to cache based on the first reagent.
@@ -92,7 +91,7 @@ namespace Content.Shared.Chemistry.Reaction
         /// <summary>
         ///     Checks if a solution can undergo a specified reaction.
         /// </summary>
-        /// <param name="solution">The solution to check.</param>
+        /// <param name="soln">The solution to check.</param>
         /// <param name="reaction">The reaction to check.</param>
         /// <param name="lowestUnitReactions">How many times this reaction can occur.</param>
         /// <returns></returns>
@@ -166,7 +165,7 @@ namespace Content.Shared.Chemistry.Reaction
         ///     Perform a reaction on a solution. This assumes all reaction criteria are met.
         ///     Removes the reactants from the solution, adds products, and returns a list of products.
         /// </summary>
-        private List<string> PerformReaction(Entity<SolutionComponent> soln, ReactionPrototype reaction, FixedPoint2 unitReactions)
+        private List<ProtoId<ReagentPrototype>> PerformReaction(Entity<SolutionComponent> soln, ReactionPrototype reaction, FixedPoint2 unitReactions)
         {
             var (uid, comp) = soln;
             var solution = comp.Solution;
@@ -184,7 +183,7 @@ namespace Content.Shared.Chemistry.Reaction
             }
 
             //Create products
-            var products = new List<string>();
+            var products = new List<ProtoId<ReagentPrototype>>();
             foreach (var product in reaction.Products)
             {
                 products.Add(product.Key);
@@ -226,7 +225,7 @@ namespace Content.Shared.Chemistry.Reaction
         /// </summary>
         private bool ProcessReactions(Entity<SolutionComponent> soln, SortedSet<ReactionPrototype> reactions, ReactionMixerComponent? mixerComponent)
         {
-            List<string>? products = null;
+            List<ProtoId<ReagentPrototype>>? products = null;
 
             // attempt to perform any applicable reaction
             foreach (var reaction in reactions)

--- a/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
@@ -24,8 +24,8 @@ namespace Content.Shared.Chemistry.Reaction
         /// <summary>
         /// Reactants required for the reaction to occur.
         /// </summary>
-        [DataField("reactants", customTypeSerializer:typeof(PrototypeIdDictionarySerializer<ReactantPrototype, ReagentPrototype>))]
-        public Dictionary<string, ReactantPrototype> Reactants = new();
+        [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<ReactantPrototype, ReagentPrototype>))]
+        public Dictionary<ProtoId<ReagentPrototype>, ReactantPrototype> Reactants = new();
 
         /// <summary>
         ///     The minimum temperature the reaction can occur at.
@@ -36,7 +36,7 @@ namespace Content.Shared.Chemistry.Reaction
         /// <summary>
         ///     If true, this reaction will attempt to conserve thermal energy.
         /// </summary>
-        [DataField("conserveEnergy")]
+        [DataField]
         public bool ConserveEnergy = true;
 
         /// <summary>
@@ -54,8 +54,8 @@ namespace Content.Shared.Chemistry.Reaction
         /// <summary>
         /// Reagents created when the reaction occurs.
         /// </summary>
-        [DataField("products", customTypeSerializer:typeof(PrototypeIdDictionarySerializer<FixedPoint2, ReagentPrototype>))]
-        public Dictionary<string, FixedPoint2> Products = new();
+        [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<FixedPoint2, ReagentPrototype>))]
+        public Dictionary<ProtoId<ReagentPrototype>, FixedPoint2> Products = new();
 
         /// <summary>
         /// Effects to be triggered when the reaction occurs.
@@ -66,10 +66,10 @@ namespace Content.Shared.Chemistry.Reaction
         /// How dangerous is this effect? Stuff like bicaridine should be low, while things like methamphetamine
         /// or potas/water should be high.
         /// </summary>
-        [DataField("impact", serverOnly: true)] public LogImpact Impact = LogImpact.Low;
+        [DataField(serverOnly: true)] public LogImpact Impact = LogImpact.Low;
 
         // TODO SERV3: Empty on the client, (de)serialize on the server with module manager is server module
-        [DataField("sound", serverOnly: true)] public SoundSpecifier Sound { get; private set; } = new SoundPathSpecifier("/Audio/Effects/Chemistry/bubbles.ogg");
+        [DataField(serverOnly: true)] public SoundSpecifier Sound { get; private set; } = new SoundPathSpecifier("/Audio/Effects/Chemistry/bubbles.ogg");
 
         /// <summary>
         /// If true, this reaction will only consume only integer multiples of the reactant amounts. If there are not
@@ -119,21 +119,11 @@ namespace Content.Shared.Chemistry.Reaction
     /// <summary>
     /// Prototype for chemical reaction reactants.
     /// </summary>
-    [DataDefinition]
-    public sealed partial class ReactantPrototype
-    {
-        [DataField("amount")]
-        private FixedPoint2 _amount = FixedPoint2.New(1);
-        [DataField("catalyst")]
-        private bool _catalyst;
-
-        /// <summary>
-        /// Minimum amount of the reactant needed for the reaction to occur.
-        /// </summary>
-        public FixedPoint2 Amount => _amount;
-        /// <summary>
-        /// Whether or not the reactant is a catalyst. Catalysts aren't removed when a reaction occurs.
-        /// </summary>
-        public bool Catalyst => _catalyst;
-    }
+    /// <param name="Amount">Minimum amount of the reactant needed for the reaction to occur.</param>
+    /// <param name="Catalyst">Whether or not the reactant is a catalyst. Catalysts aren't removed when a reaction occurs.</param>
+    [DataRecord]
+    public partial record struct ReactantPrototype(
+        FixedPoint2 Amount,
+        bool Catalyst
+    );
 }

--- a/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
@@ -4,7 +4,6 @@ using Content.Shared.EntityEffects;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
 
 namespace Content.Shared.Chemistry.Reaction
 {
@@ -25,7 +24,7 @@ namespace Content.Shared.Chemistry.Reaction
         /// Reactants required for the reaction to occur.
         /// </summary>
         [DataField]
-        public Dictionary<ProtoId<ReagentPrototype>, ReactantPrototype> Reactants = new();
+        public Dictionary<ProtoId<ReagentPrototype>, ReactantInfo> Reactants = new();
 
         /// <summary>
         ///     The minimum temperature the reaction can occur at.
@@ -117,12 +116,12 @@ namespace Content.Shared.Chemistry.Reaction
     }
 
     /// <summary>
-    /// Prototype for chemical reaction reactants.
+    /// Details about a reactant in a <see cref="ReactionPrototype.Reactants">reaction</see>.
     /// </summary>
     /// <param name="Amount">Minimum amount of the reactant needed for the reaction to occur.</param>
     /// <param name="Catalyst">Whether or not the reactant is a catalyst. Catalysts aren't removed when a reaction occurs.</param>
     [DataRecord]
-    public partial record struct ReactantPrototype(
+    public partial record struct ReactantInfo(
         FixedPoint2 Amount,
         bool Catalyst
     );

--- a/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
@@ -24,7 +24,7 @@ namespace Content.Shared.Chemistry.Reaction
         /// <summary>
         /// Reactants required for the reaction to occur.
         /// </summary>
-        [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<ReactantPrototype, ReagentPrototype>))]
+        [DataField]
         public Dictionary<ProtoId<ReagentPrototype>, ReactantPrototype> Reactants = new();
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Content.Shared.Chemistry.Reaction
         /// <summary>
         /// Reagents created when the reaction occurs.
         /// </summary>
-        [DataField(customTypeSerializer: typeof(PrototypeIdDictionarySerializer<FixedPoint2, ReagentPrototype>))]
+        [DataField]
         public Dictionary<ProtoId<ReagentPrototype>, FixedPoint2> Products = new();
 
         /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title, specifically by first replacing them in `ReactionPrototype` where appropriate, and then unravelling the build errors that caused by replacing other spots

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
`string` has zero semantic intent while `ProtoId<ReagentPrototype>` has a lot more. Strong typing good.

## Technical details
<!-- Summary of code changes for easier review. -->
There should be zero functional changes, it's literally just replacing `string` with typed-`string` in places where the compiler demanded it after I messed with one prototype definition.

I did also delete a guidebook `PublicAPI` function because it wasn't used and I'm pretty sure it was implicitly converting a `MixingCategory` prototype ID into a reagent ID. This is a case where strongly typed strings lead to a bug being found statically.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
I'm just relying on automation, tbh

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
**C#**
The fields `Reactants` and `Products` on `ReactionPrototype` have had their types changed such that the `string` portion is replaced with `ProtoId<ReagentPrototype>`.
There is no functional change.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
n/a, not player facing.