### PR TITLE
GameDataScrounger fix IgnorePrototypes handling

### DIFF
--- a/Content.IntegrationTests/Utility/GameDataScrounger.cs
+++ b/Content.IntegrationTests/Utility/GameDataScrounger.cs
@@ -169,14 +169,14 @@ public static partial class GameDataScrounger
             // Take a directory off the stack.
             var dir = explorationStack.Pop();
 
-            if (ignoreList.Contains(dir))
+            if (ignoreList.Contains(Path.GetFullPath(dir)))
                 continue; // It's all abstract anyway.
 
             explorationStack.AddRange(Directory.EnumerateDirectories(dir));
 
             foreach (var file in Directory.EnumerateFiles(dir, "*.yml"))
             {
-                if (ignoreList.Contains(file))
+                if (ignoreList.Contains(Path.GetFullPath(file)))
                     continue; // It's all abstract anyway.
 
                 foreach (var (kind, id) in IndexPrototypesIn(file))
@@ -359,7 +359,7 @@ public static partial class GameDataScrounger
                     if (entry is not YamlScalarNode { Value: {} value })
                         throw new Exception($"An entry in {path} is not a valid YAML scalar/string literal. Entry: {entry}");
 
-                    ignores.Add(value);
+                    ignores.Add(Path.GetFullPath($"{resDir}{value}"));
                 }
             }
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`Resources/IgnoredPrototypes/...` allows you to mark game preset prototypes as abstract, which causes PrototypeManager to correctly refrain from indexing these presets. However, `GameDataScrounger` in the test (which generates the [TestCaseSource] list by reading files directly from disk, regardless of the engine) never applies this ignore list correctly—it compares raw VFS-style strings, such as `/Prototypes/ game_presets.yml`, with absolute paths to files on the OS disk, which never match.

Fixed that