### PR TITLE
Keep destruction replacements in their original container

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
@@ -45,9 +45,9 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
                 var containerSystem = system.EntityManager.System<SharedContainerSystem>();
                 if (containerSystem.TryGetContainingContainer((owner, null, null), out var container))
                 {
+                    var storageSystem = system.EntityManager.System<SharedStorageSystem>();
                     // Removing the entity clears this location, so save it first.
-                    if (system.EntityManager.System<SharedStorageSystem>()
-                        .TryGetStorageLocation((owner, null), out _, out _, out var location))
+                    if (storageSystem.TryGetStorageLocation((owner, null), out _, out _, out var location))
                         storageLocation = location;
 
                     if (containerSystem.Remove(owner, container, force: true))

--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
@@ -39,27 +39,17 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
             var getRandomVector = () => new Vector2(system.Random.NextFloat(-Offset, Offset), system.Random.NextFloat(-Offset, Offset));
 
             BaseContainer? containingContainer = null;
-            StorageComponent? containingStorage = null;
             ItemStorageLocation? storageLocation = null;
             if (SpawnInContainer && SpawnAfter <= 0)
             {
                 var containerSystem = system.EntityManager.System<SharedContainerSystem>();
                 if (containerSystem.TryGetContainingContainer((owner, null, null), out var container))
                 {
-                    if (container.ID == StorageComponent.ContainerId &&
-                        system.EntityManager.HasComponent<StorageComponent>(container.Owner))
+                    // Removing the entity clears this location, so save it first.
+                    if (system.EntityManager.System<SharedStorageSystem>()
+                        .TryGetStorageLocation((owner, null), out _, out _, out var location))
                     {
-                        var storageSystem = system.EntityManager.System<SharedStorageSystem>();
-                        // Removing the entity clears this location, so save it first.
-                        if (storageSystem.TryGetStorageLocation(
-                                (owner, null),
-                                out _,
-                                out var storage,
-                                out var location))
-                        {
-                            containingStorage = storage;
-                            storageLocation = location;
-                        }
+                        storageLocation = location;
                     }
 
                     if (containerSystem.Remove(owner, container, force: true))
@@ -81,10 +71,9 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
                     containingContainer.ID);
 
                 if (storageLocation is { } location &&
-                    containingStorage != null &&
                     system.EntityManager.System<SharedStorageSystem>().TrySetItemStorageLocation(
                         (spawned, null),
-                        (containingContainer.Owner, containingStorage),
+                        (containingContainer.Owner, null),
                         location))
                 {
                     // Only one replacement can occupy the destroyed entity's old location.

--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
@@ -4,6 +4,7 @@ using Content.Shared.Forensics.Components;
 using Content.Shared.Prototypes;
 using Content.Shared.Stacks;
 using Robust.Server.GameObjects;
+using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -35,6 +36,28 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
 
             var getRandomVector = () => new Vector2(system.Random.NextFloat(-Offset, Offset), system.Random.NextFloat(-Offset, Offset));
 
+            var containerSystem = system.EntityManager.System<SharedContainerSystem>();
+            BaseContainer? containingContainer = null;
+            if (SpawnInContainer &&
+                containerSystem.TryGetContainingContainer((owner, null, null), out var container) &&
+                containerSystem.Remove(owner, container, force: true))
+            {
+                containingContainer = container;
+            }
+
+            EntityUid SpawnEntity(EntProtoId prototype)
+            {
+                if (!SpawnInContainer)
+                    return system.EntityManager.SpawnEntity(prototype, position.Offset(getRandomVector()));
+
+                if (containingContainer == null)
+                    return system.EntityManager.SpawnNextToOrDrop(prototype, owner);
+
+                var spawned = system.EntityManager.SpawnEntity(prototype, position.Offset(getRandomVector()));
+                containerSystem.Insert(spawned, containingContainer);
+                return spawned;
+            }
+
             var executions = 1;
             if (system.EntityManager.TryGetComponent<StackComponent>(owner, out var stack))
             {
@@ -54,9 +77,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
 
                     if (EntityPrototypeHelpers.HasComponent<StackComponent>(entityId, system.PrototypeManager, system.EntityManager.ComponentFactory))
                     {
-                        var spawned = SpawnInContainer
-                            ? system.EntityManager.SpawnNextToOrDrop(entityId, owner)
-                            : system.EntityManager.SpawnEntity(entityId, position.Offset(getRandomVector()));
+                        var spawned = SpawnEntity(entityId);
                         system.StackSystem.SetCount((spawned, null), (int) count);
 
                         TransferForensics(spawned, system, owner);
@@ -65,9 +86,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
                     {
                         for (var i = 0; i < count; i++)
                         {
-                            var spawned = SpawnInContainer
-                                ? system.EntityManager.SpawnNextToOrDrop(entityId, owner)
-                                : system.EntityManager.SpawnEntity(entityId, position.Offset(getRandomVector()));
+                            var spawned = SpawnEntity(entityId);
 
                             TransferForensics(spawned, system, owner);
                         }

--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
@@ -40,7 +40,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
 
             BaseContainer? containingContainer = null;
             ItemStorageLocation? storageLocation = null;
-            if (SpawnInContainer && SpawnAfter <= 0)
+            if (SpawnInContainer)
             {
                 var containerSystem = system.EntityManager.System<SharedContainerSystem>();
                 if (containerSystem.TryGetContainingContainer((owner, null, null), out var container))
@@ -48,9 +48,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
                     // Removing the entity clears this location, so save it first.
                     if (system.EntityManager.System<SharedStorageSystem>()
                         .TryGetStorageLocation((owner, null), out _, out _, out var location))
-                    {
                         storageLocation = location;
-                    }
 
                     if (containerSystem.Remove(owner, container, force: true))
                         containingContainer = container;

--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
@@ -34,6 +34,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
         public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
         {
             var tSys = system.EntityManager.System<TransformSystem>();
+            var storageSystem = system.EntityManager.System<SharedStorageSystem>();
             var position = tSys.GetMapCoordinates(owner);
 
             var getRandomVector = () => new Vector2(system.Random.NextFloat(-Offset, Offset), system.Random.NextFloat(-Offset, Offset));
@@ -43,11 +44,10 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
             if (SpawnInContainer)
             {
                 var containerSystem = system.EntityManager.System<SharedContainerSystem>();
-                if (containerSystem.TryGetContainingContainer((owner, null, null), out var container))
+                if (containerSystem.TryGetContainingContainer(owner, out var container))
                 {
-                    var storageSystem = system.EntityManager.System<SharedStorageSystem>();
                     // Removing the entity clears this location, so save it first.
-                    if (storageSystem.TryGetStorageLocation((owner, null), out _, out _, out var location))
+                    if (storageSystem.TryGetStorageLocation(owner, out _, out _, out var location))
                         storageLocation = location;
 
                     if (containerSystem.Remove(owner, container, force: true))
@@ -55,7 +55,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
                 }
             }
 
-            EntityUid SpawnEntity(EntProtoId prototype)
+            EntityUid SpawnReplacement(EntProtoId prototype)
             {
                 if (!SpawnInContainer)
                     return system.EntityManager.SpawnEntity(prototype, position.Offset(getRandomVector()));
@@ -69,10 +69,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
                     containingContainer.ID);
 
                 if (storageLocation is { } location &&
-                    system.EntityManager.System<SharedStorageSystem>().TrySetItemStorageLocation(
-                        (spawned, null),
-                        (containingContainer.Owner, null),
-                        location))
+                    storageSystem.TrySetItemStorageLocation(spawned, containingContainer.Owner, location))
                 {
                     // Only one replacement can occupy the destroyed entity's old location.
                     storageLocation = null;
@@ -100,7 +97,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
 
                     if (EntityPrototypeHelpers.HasComponent<StackComponent>(entityId, system.PrototypeManager, system.EntityManager.ComponentFactory))
                     {
-                        var spawned = SpawnEntity(entityId);
+                        var spawned = SpawnReplacement(entityId);
                         system.StackSystem.SetCount((spawned, null), (int) count);
 
                         TransferForensics(spawned, system, owner);
@@ -109,7 +106,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
                     {
                         for (var i = 0; i < count; i++)
                         {
-                            var spawned = SpawnEntity(entityId);
+                            var spawned = SpawnReplacement(entityId);
 
                             TransferForensics(spawned, system, owner);
                         }

--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
@@ -3,6 +3,8 @@ using Content.Shared.Destructible.Thresholds;
 using Content.Shared.Forensics.Components;
 using Content.Shared.Prototypes;
 using Content.Shared.Stacks;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
@@ -36,13 +38,33 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
 
             var getRandomVector = () => new Vector2(system.Random.NextFloat(-Offset, Offset), system.Random.NextFloat(-Offset, Offset));
 
-            var containerSystem = system.EntityManager.System<SharedContainerSystem>();
             BaseContainer? containingContainer = null;
-            if (SpawnInContainer &&
-                containerSystem.TryGetContainingContainer((owner, null, null), out var container) &&
-                containerSystem.Remove(owner, container, force: true))
+            StorageComponent? containingStorage = null;
+            ItemStorageLocation? storageLocation = null;
+            if (SpawnInContainer && SpawnAfter <= 0)
             {
-                containingContainer = container;
+                var containerSystem = system.EntityManager.System<SharedContainerSystem>();
+                if (containerSystem.TryGetContainingContainer((owner, null, null), out var container))
+                {
+                    if (container.ID == StorageComponent.ContainerId &&
+                        system.EntityManager.HasComponent<StorageComponent>(container.Owner))
+                    {
+                        var storageSystem = system.EntityManager.System<SharedStorageSystem>();
+                        // Removing the entity clears this location, so save it first.
+                        if (storageSystem.TryGetStorageLocation(
+                                (owner, null),
+                                out _,
+                                out var storage,
+                                out var location))
+                        {
+                            containingStorage = storage;
+                            storageLocation = location;
+                        }
+                    }
+
+                    if (containerSystem.Remove(owner, container, force: true))
+                        containingContainer = container;
+                }
             }
 
             EntityUid SpawnEntity(EntProtoId prototype)
@@ -53,10 +75,23 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
                 if (containingContainer == null)
                     return system.EntityManager.SpawnNextToOrDrop(prototype, owner);
 
-                return system.EntityManager.SpawnInContainerOrDrop(
+                var spawned = system.EntityManager.SpawnInContainerOrDrop(
                     prototype,
                     containingContainer.Owner,
                     containingContainer.ID);
+
+                if (storageLocation is { } location &&
+                    containingStorage != null &&
+                    system.EntityManager.System<SharedStorageSystem>().TrySetItemStorageLocation(
+                        (spawned, null),
+                        (containingContainer.Owner, containingStorage),
+                        location))
+                {
+                    // Only one replacement can occupy the destroyed entity's old location.
+                    storageLocation = null;
+                }
+
+                return spawned;
             }
 
             var executions = 1;

--- a/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/SpawnEntitiesBehavior.cs
@@ -53,9 +53,10 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
                 if (containingContainer == null)
                     return system.EntityManager.SpawnNextToOrDrop(prototype, owner);
 
-                var spawned = system.EntityManager.SpawnEntity(prototype, position.Offset(getRandomVector()));
-                containerSystem.Insert(spawned, containingContainer);
-                return spawned;
+                return system.EntityManager.SpawnInContainerOrDrop(
+                    prototype,
+                    containingContainer.Owner,
+                    containingContainer.ID);
             }
 
             var executions = 1;

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -37,6 +37,7 @@
           Ash:
             min: 1
             max: 1
+        spawnInContainer: true
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: Edible


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Keeps destruction replacements in their original container. Ash from burned paper now stays in the bag, including its original grid position when possible.

## Why / Balance
It's expected

## Technical details
- Destroyed entities are replaced in the same hand, container, or storage-grid position when possible. Delayed replacements
  keep their existing world-position behavior.
- BasePaper now have `spawnInContainer: true`
## Test plan
1. Place paper in a pocket or backpack slot.
2. Burn the paper.
3. Ash should be in the same position

## Media

https://github.com/user-attachments/assets/5a707a0e-d3e5-49c8-9c6f-0cd80926039f



## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Ash from burned paper now remains in its container.
-->
