### PR TITLE
Innate prying for mechs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -141,6 +141,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
     baseSprintSpeed: 3.6
+  - type: Prying
 
 - type: entity
   id: MechRipleyBattery
@@ -179,6 +180,7 @@
     pilotWhitelist:
       components:
       - HumanoidProfile
+  - type: Prying
 
 - type: entity
   parent: MechHonker


### PR DESCRIPTION
## About the PR
Added the innate ability to pry unpowered doors to the Ripley and H.O.N.K., like Cyborgs have

## Why / Balance
It feels a little bit silly to hop out of your big cargo/clowning mech so that you can use your human hands to pry open a firelock or airlock with a crowbar. It seems like a simple enough action that they should be able to do it, and it might make them more desirable in emergencies, particularly spacing.

I've kept this very light and included the component unmodified, but there is the potential to also allow mechs to pry powered doors (which may have balance implications) or to change how quickly they pry them. It's also worth asking if any other mechs deserve to be able to pry (The HAMTR looks like it might be able to, but the VIM not so much).

## Technical details
yaml only

## Test plan
1. Place an unpowered airlock
2. Pilot a Ripley or a H.O.N.K.
3. Alt-interact with the airlock and observe that it can be pried open
4. Repeat the above steps with a firelock
5. Confirm that powered airlocks cannot be pried open

## Media

https://github.com/user-attachments/assets/88e3c03a-9d67-421b-a7ae-e36b1884f19d




## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
nope

## Changelog
:cl:
- tweak: The Ripley APLU and H.O.N.K. mechs can now pry open firelocks and unpowered airlocks.
