### PR TITLE
Cleanup: ConstructionPrototypes Part 1: Recipes/Construction, A-L, U-Z

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/web.yml
@@ -57,9 +57,6 @@
         doAfter: 3
 
     - to: crate
-      completed:
-      - !type:SnapToGrid
-        southRotation: true
       steps:
       - material: WebSilk
         amount: 10

--- a/Resources/Prototypes/Recipes/Construction/Graphs/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/web.yml
@@ -51,7 +51,6 @@
     - to: chair
       completed:
       - !type:SnapToGrid
-        southRotation: true
       steps:
       - material: WebSilk
         amount: 3

--- a/Resources/Prototypes/Recipes/Construction/atmospherics.yml
+++ b/Resources/Prototypes/Recipes/Construction/atmospherics.yml
@@ -1,5 +1,4 @@
-# Base
-
+# region Base
 - type: construction
   abstract: true
   id: BaseAtmos
@@ -42,7 +41,7 @@
   id: BaseGasTrinary
   graph: GasTrinary
 
-# Machines
+# region Machines
 - type: construction
   parent: BaseAtmos
   id: AirAlarmFixture
@@ -90,7 +89,7 @@
   hide: true
   targetNode: sensorAlt2
 
-# ATMOS PIPES
+# region Pipes
 - type: construction
   parent: BaseGasPipe
   id: GasPipeHalf
@@ -206,7 +205,7 @@
   targetNode: manifold
   placementMode: SnapgridCenter
 
-# ATMOS UNARY
+# region Unary
 - type: construction
   parent: BaseGasUnary
   id: GasVentPump
@@ -227,7 +226,7 @@
   id: GasOutletInjector
   targetNode: outletinjector
 
-  # ATMOS BINARY
+# region Binary
 - type: construction
   parent: BaseGasBinary
   id: GasPressurePump
@@ -379,7 +378,7 @@
   targetNode: bendradiator
   placementMode: SnapgridCenter
 
-# ATMOS TRINARY
+# region Trinary
 - type: construction
   parent: BaseGasTrinary
   id: GasFilter
@@ -391,6 +390,7 @@
   id: GasFilterFlipped
   hide: true
   targetNode: filterflipped
+  mirror: GasFilter
 
 - type: construction
   parent: BaseGasTrinary
@@ -403,6 +403,7 @@
   id: GasMixerFlipped
   hide: true
   targetNode: mixerflipped
+  mirror: GasMixer
 
 - type: construction
   parent: BaseGasTrinary

--- a/Resources/Prototypes/Recipes/Construction/atmospherics.yml
+++ b/Resources/Prototypes/Recipes/Construction/atmospherics.yml
@@ -40,6 +40,7 @@
   parent: BaseGasDevice
   id: BaseGasTrinary
   graph: GasTrinary
+# endregion Base
 
 # region Machines
 - type: construction
@@ -88,6 +89,7 @@
   id: GasPipeSensorAlt2
   hide: true
   targetNode: sensorAlt2
+# endregion Machines
 
 # region Pipes
 - type: construction
@@ -204,6 +206,7 @@
   id: GasPipeManifold
   targetNode: manifold
   placementMode: SnapgridCenter
+# endregion Pipes
 
 # region Unary
 - type: construction
@@ -225,6 +228,7 @@
   parent: BaseGasUnary
   id: GasOutletInjector
   targetNode: outletinjector
+# endregion Unary
 
 # region Binary
 - type: construction
@@ -377,6 +381,7 @@
   name: construction-recipe-heat-exchanger-bend
   targetNode: bendradiator
   placementMode: SnapgridCenter
+# endregion Binary
 
 # region Trinary
 - type: construction
@@ -409,3 +414,4 @@
   parent: BaseGasTrinary
   id: PressureControlledValve
   targetNode: pneumaticvalve
+# endregion Trinary

--- a/Resources/Prototypes/Recipes/Construction/clothing.yml
+++ b/Resources/Prototypes/Recipes/Construction/clothing.yml
@@ -4,6 +4,7 @@
   id: BaseClothing
   category: construction-category-clothing
   objectType: Item
+# endregion Base
 
 # region Clothing
 - type: construction
@@ -95,3 +96,4 @@
   id: ClothingHeadHelmetJustice
   graph: HelmetJustice
   targetNode: helmet
+# endregion Clothing

--- a/Resources/Prototypes/Recipes/Construction/clothing.yml
+++ b/Resources/Prototypes/Recipes/Construction/clothing.yml
@@ -1,119 +1,97 @@
+# region Base
 - type: construction
+  abstract: true
+  id: BaseClothing
+  category: construction-category-clothing
+  objectType: Item
+
+# region Clothing
+- type: construction
+  parent: BaseClothing
   id: ClownHardsuit
   graph: ClownHardsuit
-  startNode: start
   targetNode: clownHardsuit
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: MimeHardsuit
   graph: MimeHardsuit
-  startNode: start
   targetNode: mimeHardsuit
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: BoneArmor
   graph: BoneArmor
-  startNode: start
   targetNode: armor
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: BoneHelmet
   graph: BoneHelmet
-  startNode: start
   targetNode: helmet
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: cardHelmet
   graph: cardHelmet
-  startNode: start
   targetNode: cardhelmet
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: cardArmour
   graph: cardArmour
-  startNode: start
   targetNode: cardarmour
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: BananaClownMask
   graph: BananaClownMask
-  startNode: start
   targetNode: mask
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: BananaClownJumpsuit
   graph: BananaClownJumpsuit
-  startNode: start
   targetNode: jumpsuit
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: BananaClownShoes
   graph: BananaClownShoes
-  startNode: start
   targetNode: shoes
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: ClothingEyesHudMedSec
   graph: HudMedSec
-  startNode: start
   targetNode: medsecHud
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: ClothingShoeSlippersDuck
   graph: ClothingShoeSlippersDuck
-  startNode: start
   targetNode: shoes
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: ClothingShoeSlippersLizard
   graph: ClothingShoeSlippersLizard
-  startNode: start
   targetNode: shoes
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: ClothingEyesGlassesSecurity
   graph: GlassesSecHUD
-  startNode: start
   targetNode: glassesSec
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: ClothingBeltQuiver
   graph: Quiver
-  startNode: start
   targetNode: Quiver
-  category: construction-category-clothing
-  objectType: Item
 
 - type: construction
+  parent: BaseClothing
   id: ClothingHeadHelmetJustice
   graph: HelmetJustice
-  startNode: start
   targetNode: helmet
-  category: construction-category-clothing
-  objectType: Item

--- a/Resources/Prototypes/Recipes/Construction/fun.yml
+++ b/Resources/Prototypes/Recipes/Construction/fun.yml
@@ -1,7 +1,5 @@
 - type: construction
+  parent: BaseWeapon
   id: HornBananium
   graph: BananiumHorn
-  startNode: start
   targetNode: bananiumHorn
-  category: construction-category-weapons
-  objectType: Item

--- a/Resources/Prototypes/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/Recipes/Construction/furniture.yml
@@ -3,7 +3,6 @@
   abstract: true
   id: BaseFurniture
   category: construction-category-furniture
-  objectType: Structure
   placementMode: SnapgridCenter
 
 - type: construction

--- a/Resources/Prototypes/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/Recipes/Construction/furniture.yml
@@ -11,7 +11,7 @@
   parent: BaseFurniture
   id: BaseChair
   graph: Seat
-  conditions:
+  conditions: &TileNotBlocked
   - !type:TileNotBlocked
 
 - type: construction
@@ -19,16 +19,16 @@
   parent: BaseFurniture
   id: BaseTable
   graph: Table
-  conditions:
-  - !type:TileNotBlocked
+  canRotate: false
+  conditions: *TileNotBlocked
 
 - type: construction
   abstract: true
   parent: BaseFurniture
   id: BaseBed
   graph: bed
-  conditions:
-  - !type:TileNotBlocked
+  canRotate: false
+  conditions: *TileNotBlocked
 
 - type: construction
   abstract: true
@@ -352,15 +352,14 @@
   id: MeatSpike
   graph: MeatSpike
   targetNode: MeatSpike
-  conditions:
-  - !type:TileNotBlocked
+  canRotate: false
+  conditions: *TileNotBlocked
 
 - type: construction
   parent: BaseTable # close enough
   id: Bookshelf
   graph: Bookshelf
   targetNode: bookshelf
-  category: construction-category-furniture
 
 - type: construction
   parent: BaseFurniture
@@ -378,5 +377,4 @@
   graph: Mannequin
   targetNode: mannequin
   canRotate: true
-  conditions:
-  - !type:TileNotBlocked
+  conditions: *TileNotBlocked

--- a/Resources/Prototypes/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/Recipes/Construction/furniture.yml
@@ -36,6 +36,7 @@
   id: BaseCurtains
   graph: Curtains
   canBuildInImpassable: true
+# endregion Base
 
 # region Chairs
 - type: construction
@@ -126,6 +127,7 @@
   id: BlueComfBench
   name: construction-recipe-blue-comf-bench
   targetNode: blueComfBench
+# endregion Chairs
 
 # region Tables
 - type: construction
@@ -242,15 +244,9 @@
   parent: BaseTable
   id: TableCounterWood
   targetNode: CounterWood
+# endregion Tables
 
-# region Bathroom
-- type: construction
-  parent: BaseChair # close enough
-  id: ToiletEmpty
-  graph: Toilet
-  targetNode: toilet
-
-# region bedroom
+# region Bedroom
 - type: construction
   parent: BaseBed
   id: Bed
@@ -271,13 +267,7 @@
   id: Dresser
   graph: Dresser
   targetNode: dresser
-
-# region Racks
-- type: construction
-  parent: BaseTable # close enough
-  id: Rack
-  graph: Rack
-  targetNode: Rack
+# endregion Bedroom
 
 # region Curtains
 - type: construction
@@ -360,6 +350,18 @@
   id: Bookshelf
   graph: Bookshelf
   targetNode: bookshelf
+
+- type: construction
+  parent: BaseTable # close enough
+  id: Rack
+  graph: Rack
+  targetNode: Rack
+
+- type: construction
+  parent: BaseChair # close enough
+  id: ToiletEmpty
+  graph: Toilet
+  targetNode: toilet
 
 - type: construction
   parent: BaseFurniture

--- a/Resources/Prototypes/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/Recipes/Construction/furniture.yml
@@ -1,716 +1,382 @@
-#chairs
+# region Base
 - type: construction
-  id: Chair
-  graph: Seat
-  startNode: start
-  targetNode: chair
+  abstract: true
+  id: BaseFurniture
   category: construction-category-furniture
   objectType: Structure
   placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
-  id: Stool
+  abstract: true
+  parent: BaseFurniture
+  id: BaseChair
   graph: Seat
-  startNode: start
-  targetNode: stool
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: StoolBar
-  graph: Seat
-  startNode: start
-  targetNode: stoolBar
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: ChairBrass
-  graph: Seat
-  startNode: start
-  targetNode: chairBrass
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: ChairOfficeLight
-  graph: Seat
-  startNode: start
-  targetNode: chairOffice
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: ChairOfficeDark
-  graph: Seat
-  startNode: start
-  targetNode: chairOfficeDark
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: ChairComfy
-  graph: Seat
-  startNode: start
-  targetNode: chairComfy
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: chairPilotSeat
-  graph: Seat
-  startNode: start
-  targetNode: chairPilotSeat
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: ChairWood
-  graph: Seat
-  startNode: start
-  targetNode: chairWood
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: ChairMeat
-  graph: Seat
-  startNode: start
-  targetNode: chairMeat
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
   conditions:
   - !type:TileNotBlocked
 
 - type: construction
+  abstract: true
+  parent: BaseFurniture
+  id: BaseTable
+  graph: Table
+  conditions:
+  - !type:TileNotBlocked
+
+- type: construction
+  abstract: true
+  parent: BaseFurniture
+  id: BaseBed
+  graph: bed
+  conditions:
+  - !type:TileNotBlocked
+
+- type: construction
+  abstract: true
+  parent: BaseFurniture
+  id: BaseCurtains
+  graph: Curtains
+  canBuildInImpassable: true
+
+# region Chairs
+- type: construction
+  parent: BaseChair
+  id: Chair
+  targetNode: chair
+
+- type: construction
+  parent: BaseChair
+  id: Stool
+  targetNode: stool
+
+- type: construction
+  parent: BaseChair
+  id: StoolBar
+  targetNode: stoolBar
+
+- type: construction
+  parent: BaseChair
+  id: ChairBrass
+  targetNode: chairBrass
+
+- type: construction
+  parent: BaseChair
+  id: ChairOfficeLight
+  targetNode: chairOffice
+
+- type: construction
+  parent: BaseChair
+  id: ChairOfficeDark
+  targetNode: chairOfficeDark
+
+- type: construction
+  parent: BaseChair
+  id: ChairComfy
+  targetNode: chairComfy
+
+- type: construction
+  parent: BaseChair
+  id: chairPilotSeat
+  targetNode: chairPilotSeat
+
+- type: construction
+  parent: BaseChair
+  id: ChairWood
+  targetNode: chairWood
+
+- type: construction
+  parent: BaseChair
+  id: ChairMeat
+  targetNode: chairMeat
+
+- type: construction
+  parent: BaseChair
   id: ChairRitual
   graph: RitualSeat
   startNode: start
   targetNode: chairRitual
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseChair
   id: ChairFolding
-  graph: Seat
-  startNode: start
   targetNode: chairFolding
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseChair
   id: ChairSteelBench
-  graph: Seat
-  startNode: start
   targetNode: chairSteelBench
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseChair
   id: StoolCard
-  graph: Seat
-  startNode: start
   targetNode: stoolCard
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-  - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseChair
   id: ChairWoodBench
-  graph: Seat
-  startNode: start
   targetNode: chairWoodBench
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseChair
   id: RedComfBench
   name: construction-recipe-red-comf-bench
-  graph: Seat
-  startNode: start
   targetNode: redComfBench
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseChair
   id: BlueComfBench
   name: construction-recipe-blue-comf-bench
-  graph: Seat
-  startNode: start
   targetNode: blueComfBench
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
-#tables
+# region Tables
 - type: construction
+  parent: BaseTable
   id: Table
-  graph: Table
-  startNode: start
   targetNode: Table
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseTable
   id: TableReinforced
-  graph: Table
-  startNode: start
   targetNode: TableReinforced
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseTable
   id: TableGlass
-  graph: Table
-  startNode: start
   targetNode: TableGlass
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseTable
   id: TableCard
   graph: Table
-  startNode: start
   targetNode: TableCard
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-  - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseTable
   id: TableReinforcedGlass
-  graph: Table
-  startNode: start
   targetNode: TableReinforcedGlass
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseTable
   id: TablePlasmaGlass
-  graph: Table
-  startNode: start
   targetNode: TablePlasmaGlass
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseTable
   id: TableBrass
-  graph: Table
-  startNode: start
   targetNode: TableBrass
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseTable
   id: TableWood
-  graph: Table
-  startNode: start
   targetNode: TableWood
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseTable
   id: TableCarpet
-  graph: Table
-  startNode: start
   targetNode: TableCarpet
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseTable
   id: TableFancyBlack
   name: construction-recipe-table-fancy-black
-  graph: Table
-  startNode: start
   targetNode: TableFancyBlack
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseTable
   id: TableFancyBlue
   name: construction-recipe-table-fancy-blue
-  graph: Table
-  startNode: start
   targetNode: TableFancyBlue
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseTable
   id: TableFancySkyBlue
   name: construction-recipe-table-fancy-sky-blue
-  graph: Table
-  startNode: start
   targetNode: TableFancySkyBlue
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
+
+- type: construction
+  parent: BaseTable
+  id: TableFancyCyan
+  name: construction-recipe-table-fancy-cyan
+  targetNode: TableFancyCyan
+
+- type: construction
+  parent: BaseTable
+  id: TableFancyGreen
+  name: construction-recipe-table-fancy-green
+  targetNode: TableFancyGreen
+
+- type: construction
+  parent: BaseTable
+  id: TableFancyOrange
+  name: construction-recipe-table-fancy-orange
+  targetNode: TableFancyOrange
+
+- type: construction
+  parent: BaseTable
+  id: TableFancyPurple
+  targetNode: TableFancyPurple
+
+- type: construction
+  parent: BaseTable
+  id: TableFancyPink
+  name: construction-recipe-table-fancy-pink
+  targetNode: TableFancyPink
+
+- type: construction
+  parent: BaseTable
+  id: TableFancyRed
+  name: construction-recipe-table-fancy-red
+  targetNode: TableFancyRed
+
+- type: construction
+  parent: BaseTable
+  id: TableFancyWhite
+  name: construction-recipe-table-fancy-white
+  targetNode: TableFancyWhite
+
+- type: construction
+  parent: BaseTable
+  id: TableCounterMetal
+  targetNode: CounterMetal
+
+- type: construction
+  parent: BaseTable
+  id: TableCounterWood
+  targetNode: CounterWood
+
+# region Bathroom
+- type: construction
+  parent: BaseChair # close enough
+  id: ToiletEmpty
+  graph: Toilet
+  targetNode: toilet
+
+# region bedroom
+- type: construction
+  parent: BaseBed
+  id: Bed
+  targetNode: bed
+
+- type: construction
+  parent: BaseBed
+  id: MedicalBed
+  targetNode: medicalbed
+
+- type: construction
+  parent: BaseBed
+  id: DogBed
+  targetNode: dogbed
+
+- type: construction
+  parent: BaseTable # close enough
+  id: Dresser
+  graph: Dresser
+  targetNode: dresser
+
+# region Racks
+- type: construction
+  parent: BaseTable # close enough
+  id: Rack
+  graph: Rack
+  targetNode: Rack
+
+# region Curtains
+- type: construction
+  parent: BaseCurtains
+  id: Curtains
+  name: construction-recipe-curtains-cloth
+  targetNode: Curtains
+
+- type: construction
+  parent: BaseCurtains
+  id: CurtainsBlack
+  name: construction-recipe-curtains-black
+  targetNode: CurtainsBlack
+
+- type: construction
+  parent: BaseCurtains
+  id: CurtainsBlue
+  name: construction-recipe-curtains-blue
+  targetNode: CurtainsBlue
+
+- type: construction
+  parent: BaseCurtains
+  id: CurtainsSkyBlue
+  name: construction-recipe-curtains-sky-blue
+  targetNode: CurtainsSkyBlue
+
+- type: construction
+  parent: BaseCurtains
+  id: CurtainsCyan
+  name: construction-recipe-curtains-cyan
+  targetNode: CurtainsCyan
+
+- type: construction
+  parent: BaseCurtains
+  id: CurtainsGreen
+  name: construction-recipe-curtains-green
+  targetNode: CurtainsGreen
+
+- type: construction
+  parent: BaseCurtains
+  id: CurtainsOrange
+  name: construction-recipe-curtains-orange
+  targetNode: CurtainsOrange
+
+- type: construction
+  parent: BaseCurtains
+  id: CurtainsPink
+  name: construction-recipe-curtains-pink
+  targetNode: CurtainsPink
+
+- type: construction
+  parent: BaseCurtains
+  id: CurtainsPurple
+  name: construction-recipe-curtains-purple
+  targetNode: CurtainsPurple
+
+- type: construction
+  parent: BaseCurtains
+  id: CurtainsRed
+  name: construction-recipe-curtains-red
+  targetNode: CurtainsRed
+
+- type: construction
+  parent: BaseCurtains
+  id: CurtainsWhite
+  name: construction-recipe-curtains-white
+  targetNode: CurtainsWhite
+
+# region Misc
+- type: construction
+  parent: BaseFurniture
+  id: MeatSpike
+  graph: MeatSpike
+  targetNode: MeatSpike
   conditions:
   - !type:TileNotBlocked
 
 - type: construction
-  id: TableFancyCyan
-  name: construction-recipe-table-fancy-cyan
-  graph: Table
-  startNode: start
-  targetNode: TableFancyCyan
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: TableFancyGreen
-  name: construction-recipe-table-fancy-green
-  graph: Table
-  startNode: start
-  targetNode: TableFancyGreen
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: TableFancyOrange
-  name: construction-recipe-table-fancy-orange
-  graph: Table
-  startNode: start
-  targetNode: TableFancyOrange
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: TableFancyPurple
-  name: construction-recipe-table-fancy-purple
-  graph: Table
-  startNode: start
-  targetNode: TableFancyPurple
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: TableFancyPink
-  name: construction-recipe-table-fancy-pink
-  graph: Table
-  startNode: start
-  targetNode: TableFancyPink
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: TableFancyRed
-  name: construction-recipe-table-fancy-red
-  graph: Table
-  startNode: start
-  targetNode: TableFancyRed
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: TableFancyWhite
-  name: construction-recipe-table-fancy-white
-  graph: Table
-  startNode: start
-  targetNode: TableFancyWhite
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: TableCounterMetal
-  graph: Table
-  startNode: start
-  targetNode: CounterMetal
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: TableCounterWood
-  graph: Table
-  startNode: start
-  targetNode: CounterWood
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-#bathroom
-- type: construction
-  id: ToiletEmpty
-  graph: Toilet
-  startNode: start
-  targetNode: toilet
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-#bedroom
-- type: construction
-  id: Bed
-  graph: bed
-  startNode: start
-  targetNode: bed
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: MedicalBed
-  graph: bed
-  startNode: start
-  targetNode: medicalbed
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: DogBed
-  graph: bed
-  startNode: start
-  targetNode: dogbed
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: Dresser
-  graph: Dresser
-  startNode: start
-  targetNode: dresser
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-#racks
-- type: construction
-  id: Rack
-  graph: Rack
-  startNode: start
-  targetNode: Rack
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-#misc
-- type: construction
-  id: MeatSpike
-  graph: MeatSpike
-  startNode: start
-  targetNode: MeatSpike
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: Curtains
-  name: construction-recipe-curtains-cloth
-  graph: Curtains
-  startNode: start
-  targetNode: Curtains
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-
-- type: construction
-  id: CurtainsBlack
-  name: construction-recipe-curtains-black
-  graph: Curtains
-  startNode: start
-  targetNode: CurtainsBlack
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-
-- type: construction
-  id: CurtainsBlue
-  name: construction-recipe-curtains-blue
-  graph: Curtains
-  startNode: start
-  targetNode: CurtainsBlue
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-
-- type: construction
-  id: CurtainsSkyBlue
-  name: construction-recipe-curtains-sky-blue
-  graph: Curtains
-  startNode: start
-  targetNode: CurtainsSkyBlue
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-
-- type: construction
-  id: CurtainsCyan
-  name: construction-recipe-curtains-cyan
-  graph: Curtains
-  startNode: start
-  targetNode: CurtainsCyan
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-
-- type: construction
-  id: CurtainsGreen
-  name: construction-recipe-curtains-green
-  graph: Curtains
-  startNode: start
-  targetNode: CurtainsGreen
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-
-- type: construction
-  id: CurtainsOrange
-  name: construction-recipe-curtains-orange
-  graph: Curtains
-  startNode: start
-  targetNode: CurtainsOrange
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-
-- type: construction
-  id: CurtainsPink
-  name: construction-recipe-curtains-pink
-  graph: Curtains
-  startNode: start
-  targetNode: CurtainsPink
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-
-- type: construction
-  id: CurtainsPurple
-  name: construction-recipe-curtains-purple
-  graph: Curtains
-  startNode: start
-  targetNode: CurtainsPurple
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-
-- type: construction
-  id: CurtainsRed
-  name: construction-recipe-curtains-red
-  graph: Curtains
-  startNode: start
-  targetNode: CurtainsRed
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-
-- type: construction
-  id: CurtainsWhite
-  name: construction-recipe-curtains-white
-  graph: Curtains
-  startNode: start
-  targetNode: CurtainsWhite
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-
-- type: construction
+  parent: BaseTable # close enough
   id: Bookshelf
   graph: Bookshelf
-  startNode: start
   targetNode: bookshelf
   category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseFurniture
   id: NoticeBoard
   graph: NoticeBoard
-  startNode: start
   targetNode: noticeBoard
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
   canRotate: true
   canBuildInImpassable: true
   conditions:
-    - !type:WallmountCondition
+  - !type:WallmountCondition
 
 - type: construction
+  parent: BaseFurniture
   id: Mannequin
   graph: Mannequin
-  startNode: start
   targetNode: mannequin
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
   canRotate: true
-  canBuildInImpassable: false
   conditions:
-    - !type:TileNotBlocked
+  - !type:TileNotBlocked

--- a/Resources/Prototypes/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/Recipes/Construction/furniture.yml
@@ -10,7 +10,7 @@
   parent: BaseFurniture
   id: BaseChair
   graph: Seat
-  conditions: &TileNotBlocked
+  conditions:
   - !type:TileNotBlocked
 
 - type: construction
@@ -19,7 +19,8 @@
   id: BaseTable
   graph: Table
   canRotate: false
-  conditions: *TileNotBlocked
+  conditions:
+  - !type:TileNotBlocked
 
 - type: construction
   abstract: true
@@ -27,7 +28,8 @@
   id: BaseBed
   graph: bed
   canRotate: false
-  conditions: *TileNotBlocked
+  conditions:
+  - !type:TileNotBlocked
 
 - type: construction
   abstract: true
@@ -342,7 +344,8 @@
   graph: MeatSpike
   targetNode: MeatSpike
   canRotate: false
-  conditions: *TileNotBlocked
+  conditions:
+  - !type:TileNotBlocked
 
 - type: construction
   parent: BaseTable # close enough
@@ -378,4 +381,5 @@
   graph: Mannequin
   targetNode: mannequin
   canRotate: true
-  conditions: *TileNotBlocked
+  conditions:
+  - !type:TileNotBlocked

--- a/Resources/Prototypes/Recipes/Construction/lighting.yml
+++ b/Resources/Prototypes/Recipes/Construction/lighting.yml
@@ -5,6 +5,7 @@
   targetNode: icon
   category: construction-category-utilities
   objectType: Item
+# endregion Base
 
 # region Lights
 - type: construction
@@ -86,3 +87,4 @@
   parent: BaseLight
   id: GreenLightBulb
   graph: GreenLightBulb
+# endregion Lights

--- a/Resources/Prototypes/Recipes/Construction/lighting.yml
+++ b/Resources/Prototypes/Recipes/Construction/lighting.yml
@@ -1,127 +1,88 @@
-﻿- type: construction
+﻿# region Base
+- type: construction
+  abstract: true
+  id: BaseLight
+  targetNode: icon
+  category: construction-category-utilities
+  objectType: Item
+
+# region Lights
+- type: construction
+  parent: BaseLight
   id: CyanLight
   graph: CyanLight
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: BlueLight
   graph: BlueLight
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: YellowLight
   graph: YellowLight
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: PinkLight
   graph: PinkLight
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: OrangeLight
   graph: OrangeLight
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: BlackLight
   graph: BlackLight
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: RedLight
   graph: RedLight
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: GreenLight
   graph: GreenLight
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: CyanLightBulb
   graph: CyanLightBulb
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: BlueLightBulb
   graph: BlueLightBulb
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: YellowLightBulb
   graph: YellowLightBulb
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: PinkLightBulb
   graph: PinkLightBulb
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: OrangeLightBulb
   graph: OrangeLightBulb
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: BlackLightBulb
   graph: BlackLightBulb
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: RedLightBulb
   graph: RedLightBulb
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item
 
 - type: construction
+  parent: BaseLight
   id: GreenLightBulb
   graph: GreenLightBulb
-  startNode: start
-  targetNode: icon
-  category: construction-category-utilities
-  objectType: Item

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -1,295 +1,200 @@
-# SURVEILLANCE
+# region Base
 - type: construction
-  id: camera
-  graph: SurveillanceCamera
-  startNode: start
-  targetNode: camera
+  abstract: true
+  id: BaseUtility
   category: construction-category-utilities
   objectType: Structure
   placementMode: SnapgridCenter
 
 - type: construction
-  id: WallmountTelescreen
-  graph: WallmountTelescreen
-  startNode: start
-  targetNode: Telescreen
-  category: construction-category-utilities
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-
-- type: construction
-  id: StationMap
-  graph: StationMap
-  startNode: start
-  targetNode: station_map
-  category: construction-category-structures
-  placementMode: SnapgridCenter
-  objectType: Structure
-  canRotate: true
+  abstract: true
+  parent: BaseUtility
+  id: BaseUtilityWallmount
   canBuildInImpassable: true
   conditions:
-  - !type:WallmountCondition {}
+  - !type:WallmountCondition
 
-# POWER
+# region Surveillance
 - type: construction
+  parent: BaseUtility
+  id: camera
+  graph: SurveillanceCamera
+  targetNode: camera
+
+- type: construction
+  parent: BaseUtilityWallmount
+  id: WallmountTelescreen
+  graph: WallmountTelescreen
+  targetNode: Telescreen
+
+- type: construction
+  parent: BaseUtilityWallmount
+  id: StationMap
+  graph: StationMap
+  targetNode: station_map
+  category: construction-category-structures
+
+# region Power
+- type: construction
+  parent: BaseUtilityWallmount
   id: APC
   graph: APC
-  startNode: start
   targetNode: apc
-  category: construction-category-utilities
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
 
 - type: construction
+  parent: BaseUtility
   id: CableTerminal
   graph: CableTerminal
-  startNode: start
   targetNode: cable_terminal
-  category: construction-category-utilities
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
 
 - type: construction
+  parent: BaseUtilityWallmount
   id: WallmountSubstation
   graph: WallmountSubstation
-  startNode: start
   targetNode: substation
-  category: construction-category-utilities
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
 
 - type: construction
+  parent: BaseUtilityWallmount
   id: WallmountGenerator
   graph: WallmountGenerator
-  startNode: start
   targetNode: generator
-  category: construction-category-utilities
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
 
 - type: construction
+  parent: BaseUtilityWallmount
   id: WallmountGeneratorAPU
   graph: WallmountGenerator
-  startNode: start
   targetNode: APU
-  category: construction-category-utilities
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
 
-# DISPOSALS
+# region Disposals
 - type: construction
+  parent: BaseUtility
   id: DisposalUnit
   graph: DisposalMachine
-  startNode: start
   targetNode: disposal_unit
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
 
 - type: construction
+  parent: BaseUtility
   id: MailingUnit
   graph: DisposalMachine
-  startNode: start
   targetNode: mailing_unit
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
 
 - type: construction
+  parent: BaseUtility
   id: DisposalPipe
   graph: DisposalPipe
-  startNode: start
   targetNode: pipe
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
 
 - type: construction
+  parent: BaseUtility
   id: DisposalTagger
   graph: DisposalPipe
-  startNode: start
   targetNode: tagger
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
 
 - type: construction
+  parent: BaseUtility
   id: DisposalSignaller
   graph: DisposalPipe
-  startNode: start
   targetNode: signaller
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
 
 - type: construction
+  parent: BaseUtility
   id: DisposalTrunk
   graph: DisposalPipe
-  startNode: start
   targetNode: trunk
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
 
 - type: construction
+  parent: BaseUtility
   id: DisposalRouter
   graph: DisposalPipe
-  startNode: start
   targetNode: router
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
   mirror: DisposalRouterFlipped
 
 - type: construction
-  hide: true
+  parent: BaseUtility
   id: DisposalRouterFlipped
+  hide: true
   graph: DisposalPipe
-  startNode: start
   targetNode: routerflipped
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
   mirror: DisposalRouter
 
 - type: construction
+  parent: BaseUtility
   id: DisposalSignalRouter
   graph: DisposalPipe
-  startNode: start
   targetNode: signal_router
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
   mirror: DisposalSignalRouterFlipped
 
 - type: construction
-  hide: true
+  parent: BaseUtility
   id: DisposalSignalRouterFlipped
+  hide: true
   graph: DisposalPipe
-  startNode: start
   targetNode: signal_router_flipped
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
   mirror: DisposalSignalRouter
 
 - type: construction
+  parent: BaseUtility
   id: DisposalJunction
   graph: DisposalPipe
-  startNode: start
   targetNode: junction
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
   mirror: DisposalJunctionFlipped
 
 - type: construction
-  hide: true
+  parent: BaseUtility
   id: DisposalJunctionFlipped
+  hide: true
   graph: DisposalPipe
-  startNode: start
   targetNode: junctionflipped
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
   mirror: DisposalJunction
 
 - type: construction
+  parent: BaseUtility
   id: DisposalYJunction
   graph: DisposalPipe
-  startNode: start
   targetNode: yJunction
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
 
 - type: construction
+  parent: BaseUtility
   id: DisposalXJunction
   graph: DisposalPipe
-  startNode: start
   targetNode: xJunction
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
 
 - type: construction
+  parent: BaseUtility
   id: DisposalBend
   graph: DisposalPipe
-  startNode: start
   targetNode: bend
-  category: construction-category-utilities
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
 
-# INTERCOM
+# region Intercom
 - type: construction
+  parent: BaseUtilityWallmount
   id: IntercomAssembly
   graph: Intercom
-  startNode: start
   targetNode: intercom
   category: construction-category-structures
-  placementMode: SnapgridCenter
-  objectType: Structure
-  canRotate: true
-  canBuildInImpassable: true
-  conditions:
-  - !type:WallmountCondition {}
 
-# TIMERS
+# region Timers
 - type: construction
+  parent: BaseUtilityWallmount
   id: SignalTimer
   graph: Timer
-  startNode: start
   targetNode: signal
-  category: construction-category-utilities
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-  conditions:
-  - !type:WallmountCondition
 
 - type: construction
+  parent: BaseUtilityWallmount
   id: ScreenTimer
   graph: Timer
-  startNode: start
   targetNode: screen
-  category: construction-category-utilities
-  objectType: Structure
   canRotate: false
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-  conditions:
-  - !type:WallmountCondition
 
 - type: construction
+  parent: ScreenTimer
   id: BrigTimer
-  graph: Timer
-  startNode: start
   targetNode: brig
-  category: construction-category-utilities
-  objectType: Structure
-  canRotate: false
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-  conditions:
-  - !type:WallmountCondition
 
-# DEFENSES
+# region Defenses
 - type: construction
+  parent: BaseUtilityWallmount
   id: WeaponEnergyTurretControlPanel
   graph: WeaponEnergyTurretControlPanel
-  startNode: start
   targetNode: finish
-  category: construction-category-utilities
-  objectType: Structure
-  canRotate: true
-  placementMode: SnapgridCenter
-  canBuildInImpassable: true
-  conditions:
-  - !type:WallmountCondition

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -60,9 +60,8 @@
   targetNode: generator
 
 - type: construction
-  parent: BaseUtilityWallmount
+  parent: WallmountGenerator
   id: WallmountGeneratorAPU
-  graph: WallmountGenerator
   targetNode: APU
 
 # region Disposals
@@ -73,96 +72,83 @@
   targetNode: disposal_unit
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalUnit
   id: MailingUnit
-  graph: DisposalMachine
   targetNode: mailing_unit
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalPipe
   id: DisposalPipe
   graph: DisposalPipe
   targetNode: pipe
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalPipe
   id: DisposalTagger
-  graph: DisposalPipe
   targetNode: tagger
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalPipe
   id: DisposalSignaller
-  graph: DisposalPipe
   targetNode: signaller
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalPipe
   id: DisposalTrunk
-  graph: DisposalPipe
   targetNode: trunk
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalPipe
   id: DisposalRouter
-  graph: DisposalPipe
   targetNode: router
   mirror: DisposalRouterFlipped
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalPipe
   id: DisposalRouterFlipped
   hide: true
-  graph: DisposalPipe
   targetNode: routerflipped
   mirror: DisposalRouter
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalPipe
   id: DisposalSignalRouter
-  graph: DisposalPipe
   targetNode: signal_router
   mirror: DisposalSignalRouterFlipped
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalPipe
   id: DisposalSignalRouterFlipped
   hide: true
-  graph: DisposalPipe
   targetNode: signal_router_flipped
   mirror: DisposalSignalRouter
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalPipe
   id: DisposalJunction
-  graph: DisposalPipe
   targetNode: junction
   mirror: DisposalJunctionFlipped
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalPipe
   id: DisposalJunctionFlipped
   hide: true
-  graph: DisposalPipe
   targetNode: junctionflipped
   mirror: DisposalJunction
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalPipe
   id: DisposalYJunction
-  graph: DisposalPipe
   targetNode: yJunction
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalPipe
   id: DisposalXJunction
-  graph: DisposalPipe
   targetNode: xJunction
 
 - type: construction
-  parent: BaseUtility
+  parent: DisposalPipe
   id: DisposalBend
-  graph: DisposalPipe
   targetNode: bend
 
 # region Intercom
@@ -181,14 +167,12 @@
   targetNode: signal
 
 - type: construction
-  parent: BaseUtilityWallmount
+  parent: SignalTimer
   id: ScreenTimer
-  graph: Timer
   targetNode: screen
-  canRotate: false
 
 - type: construction
-  parent: ScreenTimer
+  parent: SignalTimer
   id: BrigTimer
   targetNode: brig
 

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -3,7 +3,6 @@
   abstract: true
   id: BaseUtility
   category: construction-category-utilities
-  objectType: Structure
   placementMode: SnapgridCenter
 
 - type: construction

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -13,6 +13,7 @@
   canBuildInImpassable: true
   conditions:
   - !type:WallmountCondition
+# endregion Base
 
 # region Surveillance
 - type: construction
@@ -33,6 +34,7 @@
   graph: StationMap
   targetNode: station_map
   category: construction-category-structures
+# endregion Surveillance
 
 # region Power
 - type: construction
@@ -63,6 +65,7 @@
   parent: WallmountGenerator
   id: WallmountGeneratorAPU
   targetNode: APU
+# endregion Power
 
 # region Disposals
 - type: construction
@@ -150,6 +153,7 @@
   parent: DisposalPipe
   id: DisposalBend
   targetNode: bend
+# endregion Disposals
 
 # region Intercom
 - type: construction
@@ -158,6 +162,7 @@
   graph: Intercom
   targetNode: intercom
   category: construction-category-structures
+# endregion Intercom
 
 # region Timers
 - type: construction
@@ -175,6 +180,7 @@
   parent: SignalTimer
   id: BrigTimer
   targetNode: brig
+# endregion Timers
 
 # region Defenses
 - type: construction
@@ -182,3 +188,4 @@
   id: WeaponEnergyTurretControlPanel
   graph: WeaponEnergyTurretControlPanel
   targetNode: finish
+# endregion Defenses

--- a/Resources/Prototypes/Recipes/Construction/weapons.yml
+++ b/Resources/Prototypes/Recipes/Construction/weapons.yml
@@ -4,6 +4,7 @@
   id: BaseWeapon
   category: construction-category-weapons
   objectType: Item
+# endregion Base
 
 # region Weapons
 - type: construction
@@ -149,3 +150,4 @@
   id: CardSword
   graph: CardSword
   targetNode: cardSword
+# endregion Weapons

--- a/Resources/Prototypes/Recipes/Construction/weapons.yml
+++ b/Resources/Prototypes/Recipes/Construction/weapons.yml
@@ -14,10 +14,9 @@
   targetNode: icon
 
 - type: construction
-  parent: BaseWeapon
+  parent: BladedFlatcapGrey
   id: BladedFlatcapBrown
   graph: BladedFlatcapBrown
-  targetNode: icon
 
 - type: construction
   parent: BaseWeapon
@@ -26,22 +25,19 @@
   targetNode: icon
 
 - type: construction
-  parent: BaseWeapon
+  parent: Shiv
   id: ReinforcedShiv
   graph: ReinforcedShiv
-  targetNode: icon
 
 - type: construction
-  parent: BaseWeapon
+  parent: Shiv
   id: PlasmaShiv
   graph: PlasmaShiv
-  targetNode: icon
 
 - type: construction
-  parent: BaseWeapon
+  parent: Shiv
   id: UraniumShiv
   graph: UraniumShiv
-  targetNode: icon
 
 - type: construction
   parent: BaseWeapon
@@ -50,28 +46,24 @@
   targetNode: spear
 
 - type: construction
-  parent: BaseWeapon
+  parent: Spear
   id: SpearReinforced
   graph: SpearReinforced
-  targetNode: spear
 
 - type: construction
-  parent: BaseWeapon
+  parent: Spear
   id: SpearPlasma
   graph: SpearPlasma
-  targetNode: spear
 
 - type: construction
-  parent: BaseWeapon
+  parent: Spear
   id: SpearUranium
   graph: SpearUranium
-  targetNode: spear
 
 - type: construction
-  parent: BaseWeapon
+  parent: Spear
   id: SpearSharkMinnow
   graph: SpearSharkMinnow
-  targetNode: spear
 
 - type: construction
   parent: BaseWeapon
@@ -134,10 +126,9 @@
   targetNode: ImprovisedBow
 
 - type: construction
-  parent: BaseWeapon
+  parent: Spear
   id: SpearBone
   graph: SpearBone
-  targetNode: spear
 
 - type: construction
   parent: BaseWeapon

--- a/Resources/Prototypes/Recipes/Construction/weapons.yml
+++ b/Resources/Prototypes/Recipes/Construction/weapons.yml
@@ -66,6 +66,11 @@
   graph: SpearSharkMinnow
 
 - type: construction
+  parent: Spear
+  id: SpearBone
+  graph: SpearBone
+
+- type: construction
   parent: BaseWeapon
   id: Bola
   graph: Bola
@@ -124,11 +129,6 @@
   id: ImprovisedBow
   graph: ImprovisedBow
   targetNode: ImprovisedBow
-
-- type: construction
-  parent: Spear
-  id: SpearBone
-  graph: SpearBone
 
 - type: construction
   parent: BaseWeapon

--- a/Resources/Prototypes/Recipes/Construction/weapons.yml
+++ b/Resources/Prototypes/Recipes/Construction/weapons.yml
@@ -1,191 +1,151 @@
+# region Base
 - type: construction
+  abstract: true
+  id: BaseWeapon
+  category: construction-category-weapons
+  objectType: Item
+
+# region Weapons
+- type: construction
+  parent: BaseWeapon
   id: BladedFlatcapGrey
   graph: BladedFlatcapGrey
-  startNode: start
   targetNode: icon
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: BladedFlatcapBrown
   graph: BladedFlatcapBrown
-  startNode: start
   targetNode: icon
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: Shiv
   graph: Shiv
-  startNode: start
   targetNode: icon
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: ReinforcedShiv
   graph: ReinforcedShiv
-  startNode: start
   targetNode: icon
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: PlasmaShiv
   graph: PlasmaShiv
-  startNode: start
   targetNode: icon
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: UraniumShiv
   graph: UraniumShiv
-  startNode: start
   targetNode: icon
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: Spear
   graph: Spear
-  startNode: start
   targetNode: spear
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: SpearReinforced
   graph: SpearReinforced
-  startNode: start
   targetNode: spear
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: SpearPlasma
   graph: SpearPlasma
-  startNode: start
   targetNode: spear
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: SpearUranium
   graph: SpearUranium
-  startNode: start
   targetNode: spear
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: SpearSharkMinnow
   graph: SpearSharkMinnow
-  startNode: start
   targetNode: spear
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: Bola
   graph: Bola
-  startNode: start
   targetNode: bola
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: WoodenBuckler
   graph: WoodenBuckler
-  startNode: start
   targetNode: woodenBuckler
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: CardShield
   graph: CardShield
-  startNode: start
   targetNode: cardShield
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: MakeshiftShield
   graph: MakeshiftShield
-  startNode: start
   targetNode: makeshiftShield
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: ImprovisedArrow
   graph: ImprovisedArrow
-  startNode: start
   targetNode: ImprovisedArrow
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: ImprovisedArrowCarp
   graph: ImprovisedArrowCarp
-  startNode: start
   targetNode: ImprovisedArrowCarp
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: ImprovisedArrowPlasma
   graph: ImprovisedArrowPlasma
-  startNode: start
   targetNode: ImprovisedArrowPlasma
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: ImprovisedArrowUranium
   graph: ImprovisedArrowUranium
-  startNode: start
   targetNode: ImprovisedArrowUranium
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: CardArrow
   graph: CardArrow
-  startNode: start
   targetNode: CardArrow
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: ImprovisedBow
   graph: ImprovisedBow
-  startNode: start
   targetNode: ImprovisedBow
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: SpearBone
   graph: SpearBone
-  startNode: start
   targetNode: spear
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: ClothingHandsKnuckleDustersBrass
   graph: ClothingHandsKnuckleDustersBrass
-  startNode: start
   targetNode: icon
-  category: construction-category-weapons
-  objectType: Item
 
 - type: construction
+  parent: BaseWeapon
   id: CardSword
   graph: CardSword
-  startNode: start
   targetNode: cardSword
-  category: construction-category-weapons
-  objectType: Item

--- a/Resources/Prototypes/Recipes/Construction/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/web.yml
@@ -4,7 +4,6 @@
   id: BaseWeb
   graph: WebStructures
   category: construction-category-furniture
-  objectType: Structure
   placementMode: SnapgridCenter
   canRotate: false
   entityWhitelist:

--- a/Resources/Prototypes/Recipes/Construction/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/web.yml
@@ -17,27 +17,30 @@
   id: WallWeb
   targetNode: wall
   category: construction-category-structures
-  conditions: &TileNotBlocked
+  conditions:
   - !type:TileNotBlocked
 
 - type: construction
   parent: BaseWebStructure
   id: TableWeb
   targetNode: table
-  conditions: *TileNotBlocked
+  conditions:
+  - !type:TileNotBlocked
 
 - type: construction
   parent: BaseWebStructure
   id: WebBed
   targetNode: bed
-  conditions: *TileNotBlocked
+  conditions:
+  - !type:TileNotBlocked
 
 - type: construction
   parent: BaseWebStructure
   id: ChairWeb
   targetNode: chair
   canRotate: true
-  conditions: *TileNotBlocked
+  conditions:
+  - !type:TileNotBlocked
 
 - type: construction
   parent: BaseWebStructure
@@ -51,5 +54,6 @@
   id: WebDoor
   targetNode: door
   category: construction-category-structures
-  conditions: *TileNotBlocked
+  conditions:
+  - !type:TileNotBlocked
 # endregion Web

--- a/Resources/Prototypes/Recipes/Construction/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/web.yml
@@ -1,7 +1,7 @@
 # region Base
 - type: construction
   abstract: true
-  id: BaseWeb
+  id: BaseWebStructure
   graph: WebStructures
   category: construction-category-furniture
   placementMode: SnapgridCenter
@@ -13,7 +13,7 @@
 
 # region Web
 - type: construction
-  parent: BaseWeb
+  parent: BaseWebStructure
   id: WallWeb
   targetNode: wall
   category: construction-category-structures
@@ -21,33 +21,33 @@
   - !type:TileNotBlocked
 
 - type: construction
-  parent: BaseWeb
+  parent: BaseWebStructure
   id: TableWeb
   targetNode: table
   conditions: *TileNotBlocked
 
 - type: construction
-  parent: BaseWeb
+  parent: BaseWebStructure
   id: WebBed
   targetNode: bed
   conditions: *TileNotBlocked
 
 - type: construction
-  parent: BaseWeb
+  parent: BaseWebStructure
   id: ChairWeb
   targetNode: chair
   canRotate: true
   conditions: *TileNotBlocked
 
 - type: construction
-  parent: BaseWeb
+  parent: BaseWebStructure
   id: CrateWeb
   targetNode: crate
   placementMode: PlaceFree
   category: construction-category-storage
 
 - type: construction
-  parent: BaseWeb
+  parent: BaseWebStructure
   id: WebDoor
   targetNode: door
   category: construction-category-structures

--- a/Resources/Prototypes/Recipes/Construction/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/web.yml
@@ -1,89 +1,59 @@
+# region Base
 - type: construction
-  id: WallWeb
+  abstract: true
+  id: BaseWeb
   graph: WebStructures
-  startNode: start
+  category: construction-category-furniture
+  objectType: Structure
+  placementMode: SnapgridCenter
+  entityWhitelist:
+    tags:
+    - SpiderCraft
+
+# region Web
+- type: construction
+  parent: BaseWeb
+  id: WallWeb
   targetNode: wall
   category: construction-category-structures
-  objectType: Structure
-  placementMode: SnapgridCenter
   canRotate: false
-  canBuildInImpassable: false
-  entityWhitelist:
-    tags:
-    - SpiderCraft
   conditions:
-    - !type:TileNotBlocked
+  - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseWeb
   id: TableWeb
-  graph: WebStructures
-  startNode: start
   targetNode: table
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
   canRotate: false
-  canBuildInImpassable: false
-  entityWhitelist:
-    tags:
-    - SpiderCraft
   conditions:
-    - !type:TileNotBlocked
+  - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseWeb
   id: WebBed
-  graph: WebStructures
-  startNode: start
   targetNode: bed
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
   canRotate: false
-  canBuildInImpassable: false
-  entityWhitelist:
-    tags:
-    - SpiderCraft
   conditions:
-    - !type:TileNotBlocked
+  - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseWeb
   id: ChairWeb
-  graph: WebStructures
-  startNode: start
   targetNode: chair
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  entityWhitelist:
-    tags:
-    - SpiderCraft
+  conditions:
+  - !type:TileNotBlocked
 
 - type: construction
+  parent: BaseWeb
   id: CrateWeb
-  graph: WebStructures
-  startNode: start
   targetNode: crate
   category: construction-category-storage
-  objectType: Structure
-  placementMode: SnapgridCenter
   canRotate: false
-  canBuildInImpassable: false
-  entityWhitelist:
-    tags:
-    - SpiderCraft
 
 - type: construction
+  parent: BaseWeb
   id: WebDoor
-  graph: WebStructures
-  startNode: start
   targetNode: door
   category: construction-category-structures
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  entityWhitelist:
-    tags:
-    - SpiderCraft
   conditions:
-    - !type:TileNotBlocked
+  - !type:TileNotBlocked

--- a/Resources/Prototypes/Recipes/Construction/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/web.yml
@@ -10,6 +10,7 @@
   entityWhitelist:
     tags:
     - SpiderCraft
+# endregion Base
 
 # region Web
 - type: construction
@@ -43,6 +44,7 @@
   parent: BaseWeb
   id: CrateWeb
   targetNode: crate
+  placementMode: PlaceFree
   category: construction-category-storage
 
 - type: construction
@@ -51,3 +53,4 @@
   targetNode: door
   category: construction-category-structures
   conditions: *TileNotBlocked
+# endregion Web

--- a/Resources/Prototypes/Recipes/Construction/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/web.yml
@@ -36,12 +36,11 @@
   conditions:
   - !type:TileNotBlocked
 
+# FIXME: inconsistent anchoring vs. other chair construction
 - type: construction
   parent: BaseWeb
   id: ChairWeb
   targetNode: chair
-  conditions:
-  - !type:TileNotBlocked
 
 - type: construction
   parent: BaseWeb

--- a/Resources/Prototypes/Recipes/Construction/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/web.yml
@@ -6,6 +6,7 @@
   category: construction-category-furniture
   objectType: Structure
   placementMode: SnapgridCenter
+  canRotate: false
   entityWhitelist:
     tags:
     - SpiderCraft
@@ -16,43 +17,37 @@
   id: WallWeb
   targetNode: wall
   category: construction-category-structures
-  canRotate: false
-  conditions:
+  conditions: &TileNotBlocked
   - !type:TileNotBlocked
 
 - type: construction
   parent: BaseWeb
   id: TableWeb
   targetNode: table
-  canRotate: false
-  conditions:
-  - !type:TileNotBlocked
+  conditions: *TileNotBlocked
 
 - type: construction
   parent: BaseWeb
   id: WebBed
   targetNode: bed
-  canRotate: false
-  conditions:
-  - !type:TileNotBlocked
+  conditions: *TileNotBlocked
 
-# FIXME: inconsistent anchoring vs. other chair construction
 - type: construction
   parent: BaseWeb
   id: ChairWeb
   targetNode: chair
+  canRotate: true
+  conditions: *TileNotBlocked
 
 - type: construction
   parent: BaseWeb
   id: CrateWeb
   targetNode: crate
   category: construction-category-storage
-  canRotate: false
 
 - type: construction
   parent: BaseWeb
   id: WebDoor
   targetNode: door
   category: construction-category-structures
-  conditions:
-  - !type:TileNotBlocked
+  conditions: *TileNotBlocked


### PR DESCRIPTION
## About the PR
Cleans up the ConstructionPrototypes in Recipes/Construction, in files starting with A-L and U-Z.

In addition to Recipes/Construction, Recipes/Crafting still needs to be looked at, likely 3ish independent parts remaining.

A few slight behavioural changes (see Technical Details), and a small bugfix for a flipped gas mixer/filters issue introduced in #44637 - missing mirror for flipped mixer/filter means you can't toggle back to the original once you flipped the construction ghost.

## Why / Balance
Picking up the slack from #44637.

Bugfixes are good.

## Technical details
`# region`/`# endregion` used where appropriate vs. normal comments (files large enough to warrant them)

Web chair construction graph made rotatable, snap removed from web crate (mimicking other crate placement), though other crates still rotatable, will change in respective part.

APC, APU, wallmount substation all added WallmountCondition (they go on walls!).

Apart from this, behaviour kept the same compared to previous construction graphs.

Toilets and Racks moved to Misc region in furniture.yml, being one-offs.  BoneSpear moved up near other spears in weapons.yml

## Test plan
Build the things, note their names and category, their placement mode and rotation, especially:
- web crates
- web chair
- APC
- wallmount substation
- APU

## Media

Web
<img width="228" height="417" alt="image" src="https://github.com/user-attachments/assets/57a14548-640a-48eb-a49b-b03b6c15f2e1" />

Weapons
<img width="470" height="639" alt="image" src="https://github.com/user-attachments/assets/4bd0359f-b789-4fbe-9f3a-cb592488d7b6" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
no
