### PR TITLE
Fix initial appearance of empty gas canisters

### DIFF
--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
@@ -91,8 +91,7 @@ public sealed partial class GasCanisterSystem : SharedGasCanisterSystem
     {
         _atmos.React(entity.Comp.Air, entity.Comp);
 
-        if (!TryComp<NodeContainerComponent>(entity, out var nodeContainer)
-            || !TryComp<AppearanceComponent>(entity, out var appearance))
+        if (!TryComp<NodeContainerComponent>(entity, out var nodeContainer))
             return;
 
         if (!_nodeContainer.TryGetNode(nodeContainer, entity.Comp.PortName, out PortablePipeNode? portNode))
@@ -125,26 +124,10 @@ public sealed partial class GasCanisterSystem : SharedGasCanisterSystem
         if (MathHelper.CloseToPercent(entity.Comp.Air.Pressure, entity.Comp.LastPressure))
             return;
 
-        DirtyUI(entity, entity.Comp, nodeContainer);
-
         entity.Comp.LastPressure = entity.Comp.Air.Pressure;
 
-        if (entity.Comp.Air.Pressure < 10)
-        {
-            _appearance.SetData(entity, GasCanisterVisuals.PressureState, 0, appearance);
-        }
-        else if (entity.Comp.Air.Pressure < Atmospherics.OneAtmosphere)
-        {
-            _appearance.SetData(entity, GasCanisterVisuals.PressureState, 1, appearance);
-        }
-        else if (entity.Comp.Air.Pressure < (15 * Atmospherics.OneAtmosphere))
-        {
-            _appearance.SetData(entity, GasCanisterVisuals.PressureState, 2, appearance);
-        }
-        else
-        {
-            _appearance.SetData(entity, GasCanisterVisuals.PressureState, 3, appearance);
-        }
+        DirtyUI(entity, entity.Comp, nodeContainer);
+        UpdateAppearance(entity);
     }
 
     /// <summary>

--- a/Content.Shared/Atmos/Piping/Unary/Systems/SharedGasCanisterSystem.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Systems/SharedGasCanisterSystem.cs
@@ -44,6 +44,7 @@ public abstract partial class SharedGasCanisterSystem : GasMaxPressureSystem<Gas
     {
         // Fixes empty canisters not populating UI elements
         DirtyUI(ent.Owner, ent);
+        UpdateAppearance(ent);
     }
 
     private void OnCanisterStartup(Entity<GasCanisterComponent> ent, ref ComponentStartup args)
@@ -149,4 +150,27 @@ public abstract partial class SharedGasCanisterSystem : GasMaxPressureSystem<Gas
     }
 
     protected abstract void DirtyUI(EntityUid uid, GasCanisterComponent? component = null, NodeContainerComponent? nodes = null);
+
+    protected void UpdateAppearance(Entity<GasCanisterComponent> entity)
+    {
+        if (!TryComp<AppearanceComponent>(entity, out var appearance))
+            return;
+
+        if (entity.Comp.Air.Pressure < 10)
+        {
+            _appearance.SetData(entity, GasCanisterVisuals.PressureState, 0, appearance);
+        }
+        else if (entity.Comp.Air.Pressure < Atmospherics.OneAtmosphere)
+        {
+            _appearance.SetData(entity, GasCanisterVisuals.PressureState, 1, appearance);
+        }
+        else if (entity.Comp.Air.Pressure < (15 * Atmospherics.OneAtmosphere))
+        {
+            _appearance.SetData(entity, GasCanisterVisuals.PressureState, 2, appearance);
+        }
+        else
+        {
+            _appearance.SetData(entity, GasCanisterVisuals.PressureState, 3, appearance);
+        }
+    }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

When spawning an empty gas canister (e.g. "storage canister"), the visuals did not match the actual state of the entity. Now they do.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bug.

## Technical details
<!-- Summary of code changes for easier review. -->

Appearance update code was only run on server after a AtmosDeviceUpdateEvent, and if the pressure in the GasCanisterComponent changed. Just moved the appearance code into the shared system, and call it from the MapInitEvent.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Spawn a "storage canister" - observe how the canister's "low pressure" light blinks. Open the canister's UI and see that there is indeed no gas contained.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:
<img width="109" height="128" alt="2026-07-14_18-05" src="https://github.com/user-attachments/assets/c67ffcc7-e2f6-4131-9afe-3e8ab0b03274" />
After (this, but blinking):
<img width="153" height="142" alt="2026-07-14_18-00" src="https://github.com/user-attachments/assets/5baeb1d5-88c1-48ad-a3b4-4ee53554e523" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
