### PR TITLE
Lights and cameras must be constructed against a wall

### DIFF
--- a/Content.Shared/Construction/Conditions/AgainstWall.cs
+++ b/Content.Shared/Construction/Conditions/AgainstWall.cs
@@ -16,8 +16,8 @@ public sealed partial class AgainstWall : IConstructionCondition
     private static readonly ProtoId<TagPrototype> WallTag = "Wall";
 
     /// <summary>
-    /// The angle that the wall must be from the entity's direction, in degrees.
-    /// Defaults to 180 degrees (when placed against a wall to the south, the entity should be facing north)
+    /// The angle to add to the direction of the entity to point it towards the wall.
+    /// Defaults to 180 degrees - lights, for example, should face north when attached to a wall to the south.
     /// </summary>
     [DataField("offset")] private Angle _offset = Angle.FromDegrees(180);
 
@@ -27,9 +27,9 @@ public sealed partial class AgainstWall : IConstructionCondition
         var lookupSys = entManager.System<EntityLookupSystem>();
         var tagSys = entManager.System<TagSystem>();
 
-        var offsetDirection = (direction.ToAngle() + _offset).GetCardinalDir();
+        var towardsWall = (direction.ToAngle() + _offset).GetCardinalDir();
 
-        var againstLocation = new EntityCoordinates(location.EntityId, location.Position + offsetDirection.ToVec());
+        var againstLocation = new EntityCoordinates(location.EntityId, location.Position + towardsWall.ToVec());
 
         foreach (var entity in lookupSys.GetEntitiesIntersecting(againstLocation, LookupFlags.Approximate | LookupFlags.Static))
         {
@@ -40,10 +40,10 @@ public sealed partial class AgainstWall : IConstructionCondition
                 && entManager.TryGetComponent(entity, out TransformComponent? xform))
             {
                 // In a south facing, diagonal walls have flat sides only to the south and east.
-                // If we're attaching from the north or from the west, we cancel that.
+                // If we're attaching to the north or west side (so towardsWall points south or east), we cancel that.
                 var wallDir = xform.LocalRotation.GetCardinalDir();
-                if (wallDir == offsetDirection
-                    || wallDir == offsetDirection.GetClockwise90Degrees())
+                if (wallDir == towardsWall // South check
+                    || wallDir == towardsWall.GetClockwise90Degrees()) // East check
                     continue;
             }
 

--- a/Content.Shared/Construction/Conditions/AgainstWall.cs
+++ b/Content.Shared/Construction/Conditions/AgainstWall.cs
@@ -12,6 +12,7 @@ namespace Content.Shared.Construction.Conditions;
 [DataDefinition]
 public sealed partial class AgainstWall : IConstructionCondition
 {
+    private static readonly ProtoId<TagPrototype> DiagonalTag = "Diagonal";
     private static readonly ProtoId<TagPrototype> WallTag = "Wall";
 
     public bool Condition(EntityUid user, EntityCoordinates location, Direction direction)
@@ -24,8 +25,22 @@ public sealed partial class AgainstWall : IConstructionCondition
 
         foreach (var entity in lookupSys.GetEntitiesIntersecting(againstLocation, LookupFlags.Approximate | LookupFlags.Static))
         {
-            if (tagSys.HasTag(entity, WallTag))
-                return true;
+            if (!tagSys.HasTag(entity, WallTag))
+                continue;
+
+            if (tagSys.HasTag(entity, DiagonalTag)
+                && entManager.TryGetComponent(entity, out TransformComponent? xform))
+            {
+                // In a south facing, diagonal walls have flat sides to the south and west.
+                // When the entity itself is placed to the south, the diagonal wall must be facing north or east to be valid
+                // (i.e. clockwise 90 deg or opposite of the entity's direction)
+                var wallDir = xform.LocalRotation.GetCardinalDir();
+                if (wallDir != direction.GetClockwise90Degrees()
+                    && wallDir != direction.GetOpposite())
+                    continue;
+            }
+
+            return true;
         }
 
         return false;

--- a/Content.Shared/Construction/Conditions/AgainstWall.cs
+++ b/Content.Shared/Construction/Conditions/AgainstWall.cs
@@ -1,0 +1,41 @@
+using Content.Shared.Tag;
+using JetBrains.Annotations;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Construction.Conditions;
+
+/// <summary>
+/// A condition to check that an entity is placed against a wall (e.g. for light fixtures and surveillance cameras)
+/// </summary>
+[UsedImplicitly]
+[DataDefinition]
+public sealed partial class AgainstWall : IConstructionCondition
+{
+    private static readonly ProtoId<TagPrototype> WallTag = "Wall";
+
+    public bool Condition(EntityUid user, EntityCoordinates location, Direction direction)
+    {
+        var entManager = IoCManager.Resolve<IEntityManager>();
+        var lookupSys = entManager.System<EntityLookupSystem>();
+        var tagSys = entManager.System<TagSystem>();
+
+        var againstLocation = new EntityCoordinates(location.EntityId, location.Position - direction.ToVec()); // Subtracting direction: moving backwards relative to placement.
+
+        foreach (var entity in lookupSys.GetEntitiesIntersecting(againstLocation, LookupFlags.Approximate | LookupFlags.Static))
+        {
+            if (tagSys.HasTag(entity, WallTag))
+                return true;
+        }
+
+        return false;
+    }
+
+    public ConstructionGuideEntry GenerateGuideEntry()
+    {
+        return new ConstructionGuideEntry()
+        {
+            Localization = "construction-step-condition-against-wall",
+        };
+    }
+}

--- a/Content.Shared/Construction/Conditions/AgainstWall.cs
+++ b/Content.Shared/Construction/Conditions/AgainstWall.cs
@@ -15,13 +15,21 @@ public sealed partial class AgainstWall : IConstructionCondition
     private static readonly ProtoId<TagPrototype> DiagonalTag = "Diagonal";
     private static readonly ProtoId<TagPrototype> WallTag = "Wall";
 
+    /// <summary>
+    /// The angle that the wall must be from the entity's direction, in degrees.
+    /// Defaults to 180 degrees (when placed against a wall to the south, the entity should be facing north)
+    /// </summary>
+    [DataField("offset")] private Angle _offset = Angle.FromDegrees(180);
+
     public bool Condition(EntityUid user, EntityCoordinates location, Direction direction)
     {
         var entManager = IoCManager.Resolve<IEntityManager>();
         var lookupSys = entManager.System<EntityLookupSystem>();
         var tagSys = entManager.System<TagSystem>();
 
-        var againstLocation = new EntityCoordinates(location.EntityId, location.Position - direction.ToVec()); // Subtracting direction: moving backwards relative to placement.
+        var offsetDirection = (direction.ToAngle() + _offset).GetCardinalDir();
+
+        var againstLocation = new EntityCoordinates(location.EntityId, location.Position + offsetDirection.ToVec());
 
         foreach (var entity in lookupSys.GetEntitiesIntersecting(againstLocation, LookupFlags.Approximate | LookupFlags.Static))
         {
@@ -31,12 +39,11 @@ public sealed partial class AgainstWall : IConstructionCondition
             if (tagSys.HasTag(entity, DiagonalTag)
                 && entManager.TryGetComponent(entity, out TransformComponent? xform))
             {
-                // In a south facing, diagonal walls have flat sides to the south and west.
-                // When the entity itself is placed to the south, the diagonal wall must be facing north or east to be valid
-                // (i.e. clockwise 90 deg or opposite of the entity's direction)
+                // In a south facing, diagonal walls have flat sides only to the south and east.
+                // If we're attaching from the north or from the west, we cancel that.
                 var wallDir = xform.LocalRotation.GetCardinalDir();
-                if (wallDir != direction.GetClockwise90Degrees()
-                    && wallDir != direction.GetOpposite())
+                if (wallDir == offsetDirection
+                    || wallDir == offsetDirection.GetClockwise90Degrees())
                     continue;
             }
 

--- a/Resources/Locale/en-US/construction/conditions/against-wall.ftl
+++ b/Resources/Locale/en-US/construction/conditions/against-wall.ftl
@@ -1,0 +1,1 @@
+construction-step-condition-against-wall = You must place it up against a wall.

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -1065,9 +1065,8 @@
   canRotate: true
   canBuildInImpassable: false
   conditions:
-  # Need an *additional* condition here that forces there to be a wall in the opposite direction to the one used for placement.
-  # Also see below. Didn't add it b/c construction ECS work going on. Cheers, - 20kdc
     - !type:TileNotBlocked
+    - !type:AgainstWall
 
 - type: construction
   id: LightSmallFixture
@@ -1080,8 +1079,8 @@
   canRotate: true
   canBuildInImpassable: false
   conditions:
-  # Same here. - 20kdc
     - !type:TileNotBlocked
+    - !type:AgainstWall
 
 - type: construction
   id: EmergencyLightFixture
@@ -1095,6 +1094,7 @@
   canBuildInImpassable: false
   conditions:
     - !type:TileNotBlocked
+    - !type:AgainstWall
 
 - type: construction
   id: LightGroundFixture
@@ -1121,6 +1121,7 @@
   canBuildInImpassable: false
   conditions:
     - !type:TileNotBlocked
+    - !type:AgainstWall
 
 #conveyor
 - type: construction

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -9,6 +9,7 @@
   placementMode: SnapgridCenter
   conditions:
   - !type:AgainstWall
+    offset: 0 # expects a wall to the north when the camera is in its north facing
 
 - type: construction
   id: WallmountTelescreen

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -7,6 +7,8 @@
   category: construction-category-utilities
   objectType: Structure
   placementMode: SnapgridCenter
+  conditions:
+  - !type:AgainstWall
 
 - type: construction
   id: WallmountTelescreen


### PR DESCRIPTION
## About the PR

This PR adds a new construction condition for entities that should be placed against a wall.  This construction condition is applied to wall-mounted lights and cameras.

## Why / Balance

This change resolves a comment from 20kdc from five years ago. (!!)

Also good for immersion, you shouldn't be able to place a floating light.

## Technical details

Added a ConstructionCondition, `AgainstWall` - the condition checks that there is a wall in an adjacent tile to the entity in a direction settable in a DataField.  The DataField is needed as-is on the repo, as wallmounted lights face north when they should be attached to the south, but cameras face south!

## Test plan
Spawn in on the debug map and try and reproduce the video below - construct lights and cameras in open space, and adjacent to walls.  Entities should only be placed where they make logical sense - on flat surfaces of a wall.  Hop onto the shuttle, position yourself at a jaunty angle (45, 135ish degrees w.r.t. the map), and try and construct lights and cameras onboard again.

## Media

https://github.com/user-attachments/assets/a858bff2-9dc9-4242-aff1-84f465872651

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
:cl:
- add: Constructed lights and cameras now must be placed against a wall.
