### PR TITLE
Fix parcel wrap transform parenting via SpawnAtPosition

### DIFF
--- a/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.ParcelWrap.cs
+++ b/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.ParcelWrap.cs
@@ -96,7 +96,7 @@ public sealed partial class ParcelWrappingSystem
         if (target == user)
         {
             var selfMsg = Loc.GetString("parcel-wrap-popup-being-wrapped-self");
-            _popup.PopupClient(selfMsg, user, user);
+            _popup.PopupEntity(selfMsg, user, user);
         }
         else
         {
@@ -142,7 +142,7 @@ public sealed partial class ParcelWrappingSystem
 
         // Spawn the actual parcel entity.
         var targetTransform = Transform(target);
-        var spawned = Spawn(GetParcelPrototype(wrapper, target), targetTransform.Coordinates);
+        var spawned = SpawnAtPosition(GetParcelPrototype(wrapper, target), targetTransform.Coordinates);
         _transform.SetLocalRotation(spawned, targetTransform.LocalRotation);
 
         // If the target is in a container, try to put the parcel in its place in the container.


### PR DESCRIPTION
## About the PR

Fixes some parcel wrap issues resulting from odd parent transform inheritance by spawning attached to the grid/map.

Also handling a PopupEntity warning while we're in the neighbourhood.

With thanks and apologies to B-Kirill.

## Why / Balance

Should resolve #44638.
Should resolve #41159.

## Technical details

Replace Spawn with SpawnAtPosition.

Memories of produce spawns getting stuck to wheelchair-bound people on Frontier.

## Test plan
1. Spawn Urist, buckle them into a chair, make sure the chair's unanchored for convenience.
2. Parcel wrap the Urist.  They should unbuckle.
3. Pull the chair away.  Ta-da, the Urist isn't parented to it.

## Media

The Test Plan in action.

https://github.com/user-attachments/assets/df571c8b-0851-43b0-ae0d-537b84637225

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
eh