### PR TITLE
Add components to require uncovered mouth and specific mob states for actions

### DIFF
--- a/Content.Shared/Mobs/Components/ActionRequireMobStateComponent.cs
+++ b/Content.Shared/Mobs/Components/ActionRequireMobStateComponent.cs
@@ -1,0 +1,16 @@
+﻿using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Mobs.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(MobStateSystem))]
+public sealed partial class ActionRequireMobStateComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public HashSet<MobState> States = new();
+
+    [DataField, AutoNetworkedField]
+    public PopupType? Popup = PopupType.SmallCaution;
+}

--- a/Content.Shared/Mobs/Components/ActionRequireMobStateComponent.cs
+++ b/Content.Shared/Mobs/Components/ActionRequireMobStateComponent.cs
@@ -8,9 +8,15 @@ namespace Content.Shared.Mobs.Components;
 [Access(typeof(MobStateSystem))]
 public sealed partial class ActionRequireMobStateComponent : Component
 {
+    /// <summary>
+    /// The required MobState for the action.
+    /// </summary>
     [DataField(required: true), AutoNetworkedField]
     public HashSet<MobState> States = new();
 
+    /// <summary>
+    /// The type of Popup to be used.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public PopupType? Popup = PopupType.SmallCaution;
 }

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -20,7 +20,6 @@ using Content.Shared.Strip.Components;
 using Content.Shared.Throwing;
 using Content.Shared.Tools.Systems;
 using System.Linq;
-using Content.Shared.Popups;
 
 namespace Content.Shared.Mobs.Systems;
 
@@ -236,7 +235,7 @@ public partial class MobStateSystem
         if (ent.Comp.Popup is { } popup)
         {
             var states = string.Join(", ", ent.Comp.States.Order().Select(s => Loc.GetString($"mob-state-{s}")));
-            _popup.PopupClient(Loc.GetString("mob-state-action-requires-state", ("states", states)), args.User, args.User, popup);
+            _popup.PopupEntity(Loc.GetString("mob-state-action-requires-state", ("states", states)), args.User, args.User, popup);
         }
 
         args.Cancelled = true;

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Actions.Events;
 using Content.Shared.Bed.Sleep;
 using Content.Shared.Buckle.Components;
 using Content.Shared.CombatMode.Pacification;
@@ -18,6 +19,8 @@ using Content.Shared.Standing;
 using Content.Shared.Strip.Components;
 using Content.Shared.Throwing;
 using Content.Shared.Tools.Systems;
+using System.Linq;
+using Content.Shared.Popups;
 
 namespace Content.Shared.Mobs.Systems;
 
@@ -49,6 +52,9 @@ public partial class MobStateSystem
         SubscribeLocalEvent<MobStateComponent, AttemptToolRefineEvent>(OnAttemptToolRefine);
 
         SubscribeLocalEvent<MobStateComponent, UnbuckleAttemptEvent>(OnUnbuckleAttempt);
+
+        // Actions
+        SubscribeLocalEvent<ActionRequireMobStateComponent, ActionAttemptEvent>(OnMobStateActionAttempt);
     }
 
     private void OnUnbuckleAttempt(Entity<MobStateComponent> ent, ref UnbuckleAttemptEvent args)
@@ -217,6 +223,23 @@ public partial class MobStateSystem
     private void OnDamageModify(Entity<MobStateComponent> ent, ref DamageModifyEvent args)
     {
         args.Damage *= _damageable.UniversalMobDamageModifier;
+    }
+
+    private void OnMobStateActionAttempt(Entity<ActionRequireMobStateComponent> ent, ref ActionAttemptEvent args)
+    {
+        if (_mobStateQuery.TryComp(args.User, out var mobState) &&
+            ent.Comp.States.Contains(mobState.CurrentState))
+        {
+            return;
+        }
+
+        if (ent.Comp.Popup is { } popup)
+        {
+            var states = string.Join(", ", ent.Comp.States.Order().Select(s => Loc.GetString($"mob-state-{s}")));
+            _popup.PopupClient(Loc.GetString("mob-state-action-requires-state", ("states", states)), args.User, args.User, popup);
+        }
+
+        args.Cancelled = true;
     }
 
     #endregion

--- a/Content.Shared/Mobs/Systems/MobStateSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Mobs.Components;
+using Content.Shared.Popups;
 using Content.Shared.Standing;
 using Robust.Shared.Timing;
 
@@ -16,6 +17,7 @@ public partial class MobStateSystem : EntitySystem
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private DamageableSystem _damageable = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
     private ISawmill _sawmill = default!;
 
     [Dependency] private EntityQuery<MobStateComponent> _mobStateQuery = default!;

--- a/Content.Shared/Nutrition/Components/ActionRequireMouthUncoveredComponent.cs
+++ b/Content.Shared/Nutrition/Components/ActionRequireMouthUncoveredComponent.cs
@@ -1,8 +1,13 @@
-﻿using Content.Shared.Nutrition.EntitySystems;
+﻿using Content.Shared.Inventory;
+using Content.Shared.Nutrition.EntitySystems;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.Nutrition.Components;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(IngestionSystem))]
-public sealed partial class ActionRequireMouthUncoveredComponent : Component;
+public sealed partial class ActionRequireMouthUncoveredComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public SlotFlags Slots = SlotFlags.MASK;
+}

--- a/Content.Shared/Nutrition/Components/ActionRequireMouthUncoveredComponent.cs
+++ b/Content.Shared/Nutrition/Components/ActionRequireMouthUncoveredComponent.cs
@@ -8,6 +8,9 @@ namespace Content.Shared.Nutrition.Components;
 [Access(typeof(IngestionSystem))]
 public sealed partial class ActionRequireMouthUncoveredComponent : Component
 {
+    /// <summary>
+    /// The slots that must be free for the action to be used.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public SlotFlags Slots = SlotFlags.HEAD | SlotFlags.MASK;
 }

--- a/Content.Shared/Nutrition/Components/ActionRequireMouthUncoveredComponent.cs
+++ b/Content.Shared/Nutrition/Components/ActionRequireMouthUncoveredComponent.cs
@@ -9,5 +9,5 @@ namespace Content.Shared.Nutrition.Components;
 public sealed partial class ActionRequireMouthUncoveredComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public SlotFlags Slots = SlotFlags.MASK;
+    public SlotFlags Slots = SlotFlags.HEAD | SlotFlags.MASK;
 }

--- a/Content.Shared/Nutrition/Components/ActionRequireMouthUncoveredComponent.cs
+++ b/Content.Shared/Nutrition/Components/ActionRequireMouthUncoveredComponent.cs
@@ -1,0 +1,8 @@
+﻿using Content.Shared.Nutrition.EntitySystems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Nutrition.Components;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(IngestionSystem))]
+public sealed partial class ActionRequireMouthUncoveredComponent : Component;

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Actions.Events;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Body;
 using Content.Shared.Body.Components;
@@ -88,6 +89,9 @@ public sealed partial class IngestionSystem : EntitySystem
         // Misc
         SubscribeLocalEvent<EdibleComponent, AttemptShakeEvent>(OnAttemptShake);
         SubscribeLocalEvent<EdibleComponent, BeforeToolRefinedEvent>(OnBeforeToolRefined);
+
+        // Actions
+        SubscribeLocalEvent<ActionRequireMouthUncoveredComponent, ActionAttemptEvent>(OnMouthUncoveredActionAttempt);
 
         InitializeBlockers();
         InitializeUtensils();
@@ -534,6 +538,12 @@ public sealed partial class IngestionSystem : EntitySystem
     private void OnAttemptShake(Entity<EdibleComponent> entity, ref AttemptShakeEvent args)
     {
         if (IsEmpty(entity))
+            args.Cancelled = true;
+    }
+
+    private void OnMouthUncoveredActionAttempt(Entity<ActionRequireMouthUncoveredComponent> ent, ref ActionAttemptEvent args)
+    {
+        if (!HasMouthAvailable(args.User, args.User, SlotFlags.HEAD | SlotFlags.MASK))
             args.Cancelled = true;
     }
 }

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -543,7 +543,7 @@ public sealed partial class IngestionSystem : EntitySystem
 
     private void OnMouthUncoveredActionAttempt(Entity<ActionRequireMouthUncoveredComponent> ent, ref ActionAttemptEvent args)
     {
-        if (!HasMouthAvailable(args.User, args.User, SlotFlags.HEAD | SlotFlags.MASK))
+        if (!HasMouthAvailable(args.User, args.User, ent.Comp.Slots))
             args.Cancelled = true;
     }
 }

--- a/Resources/Locale/en-US/mob-state.ftl
+++ b/Resources/Locale/en-US/mob-state.ftl
@@ -1,0 +1,4 @@
+﻿mob-state-action-requires-state = You need to be {$states} to do that!
+mob-state-Alive = Alive
+mob-state-Critical = Critical
+mob-state-Dead = Dead


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
For https://github.com/space-wizards/space-station-14/pull/44677
This doesn't actually add it to any actions

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
2 new components, each one handles events already raised by SharedActionsSystem

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Add the components to Scream action separately, try to use it
You will need checkConsciousness false on the Action component if you require Dead

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/d43f9dd2-11b4-4681-bbd4-744490538650

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
