### PR TITLE
Cleanup: Resolve remaining PopupSystem warnings in Content.Shared

### DIFF
--- a/Content.Server/Morgue/CrematoriumSystem.cs
+++ b/Content.Server/Morgue/CrematoriumSystem.cs
@@ -30,7 +30,7 @@ public sealed partial class CrematoriumSystem : SharedCrematoriumSystem
 
             if (mind.OwnedEntity is { Valid: true } entity)
             {
-                Popup.PopupEntity(Loc.GetString("crematorium-entity-storage-component-suicide-message"), entity);
+                Popup.PopupEntity(Loc.GetString("crematorium-entity-storage-component-suicide-message"), entity, entity);
             }
         }
 

--- a/Content.Shared/Abilities/Goliath/GoliathTentacleSystem.cs
+++ b/Content.Shared/Abilities/Goliath/GoliathTentacleSystem.cs
@@ -33,7 +33,7 @@ public sealed partial class GoliathTentacleSystem : EntitySystem
 
         // TODO: animation
 
-        _popup.PopupPredicted(Loc.GetString("tentacle-ability-use-popup", ("entity", args.Performer)), args.Performer, args.Performer, type: PopupType.SmallCaution);
+        _popup.PopupEntity(Loc.GetString("tentacle-ability-use-popup", ("entity", args.Performer)), args.Performer, type: PopupType.SmallCaution);
         _stun.TryAddStunDuration(args.Performer, TimeSpan.FromSeconds(0.8f));
 
         var coords = args.Target;

--- a/Content.Shared/Abilities/Mime/MimePowersSystem.cs
+++ b/Content.Shared/Abilities/Mime/MimePowersSystem.cs
@@ -51,7 +51,7 @@ public sealed partial class MimePowersSystem : EntitySystem
 
             mime.ReadyToRepent = true;
             Dirty(uid, mime);
-            _popupSystem.PopupClient(Loc.GetString("mime-ready-to-repent"), uid, uid);
+            _popupSystem.PopupEntity(Loc.GetString("mime-ready-to-repent"), uid, uid);
         }
     }
 
@@ -97,13 +97,13 @@ public sealed partial class MimePowersSystem : EntitySystem
         // Check if the tile is blocked by a wall or mob, and don't create the wall if so
         if (_turf.IsTileBlocked(tile.Value, CollisionGroup.Impassable | CollisionGroup.Opaque))
         {
-            _popupSystem.PopupClient(Loc.GetString("mime-invisible-wall-failed"), ent, ent);
+            _popupSystem.PopupEntity(Loc.GetString("mime-invisible-wall-failed"), ent, ent);
             return;
         }
 
         var messageSelf = Loc.GetString("mime-invisible-wall-popup-self", ("mime", Identity.Entity(ent.Owner, EntityManager)));
         var messageOthers = Loc.GetString("mime-invisible-wall-popup-others", ("mime", Identity.Entity(ent.Owner, EntityManager)));
-        _popupSystem.PopupPredicted(messageSelf, messageOthers, ent, ent);
+        _popupSystem.PopupEntity(messageSelf, messageOthers, ent, ent);
 
         // Make sure we set the invisible wall to despawn properly
         PredictedSpawnAtPosition(ent.Comp.WallPrototype, _turf.GetTileCenter(tile.Value));
@@ -163,7 +163,7 @@ public sealed partial class MimePowersSystem : EntitySystem
 
         if (!mimePowers.ReadyToRepent)
         {
-            _popupSystem.PopupClient(Loc.GetString("mime-not-ready-repent"), uid, uid);
+            _popupSystem.PopupEntity(Loc.GetString("mime-not-ready-repent"), uid, uid);
             return;
         }
 

--- a/Content.Shared/Access/Systems/ActivatableUIRequiresAccessSystem.cs
+++ b/Content.Shared/Access/Systems/ActivatableUIRequiresAccessSystem.cs
@@ -24,7 +24,7 @@ public sealed partial class ActivatableUIRequiresAccessSystem : EntitySystem
         {
             args.Cancel();
             if (activatableUI.Comp.PopupMessage != null && !args.Silent)
-                _popup.PopupClient(Loc.GetString(activatableUI.Comp.PopupMessage), activatableUI, args.User);
+                _popup.PopupEntity(Loc.GetString(activatableUI.Comp.PopupMessage), activatableUI, args.User);
         }
     }
 }

--- a/Content.Shared/Actions/ConfirmableActionSystem.cs
+++ b/Content.Shared/Actions/ConfirmableActionSystem.cs
@@ -68,7 +68,7 @@ public sealed partial class ConfirmableActionSystem : EntitySystem
         comp.NextUnprime = comp.NextConfirm + comp.PrimeTime;
         Dirty(uid, comp);
 
-        _popup.PopupClient(Loc.GetString(comp.Popup), user, user, PopupType.LargeCaution);
+        _popup.PopupEntity(Loc.GetString(comp.Popup), user, user, PopupType.LargeCaution);
     }
 
     private void Unprime(Entity<ConfirmableActionComponent> ent)

--- a/Content.Shared/Actions/DangerousActionSystem.cs
+++ b/Content.Shared/Actions/DangerousActionSystem.cs
@@ -27,7 +27,7 @@ public sealed partial class DangerousActionSystem : EntitySystem
         if (!_pacifiedQuery.HasComp(args.User))
             return;
         //if found popup message and cancel
-        _popup.PopupEntity(Loc.GetString(ent.Comp.PacificationMessage),args.User,args.User,PopupType.Small);
+        _popup.PopupEntity(Loc.GetString(ent.Comp.PacificationMessage), args.User, args.User);
         args.Cancelled = true;
     }
 

--- a/Content.Shared/Actions/DangerousActionSystem.cs
+++ b/Content.Shared/Actions/DangerousActionSystem.cs
@@ -27,7 +27,7 @@ public sealed partial class DangerousActionSystem : EntitySystem
         if (!_pacifiedQuery.HasComp(args.User))
             return;
         //if found popup message and cancel
-        _popup.PopupClient(Loc.GetString(ent.Comp.PacificationMessage),args.User,args.User,PopupType.Small);
+        _popup.PopupEntity(Loc.GetString(ent.Comp.PacificationMessage),args.User,args.User,PopupType.Small);
         args.Cancelled = true;
     }
 

--- a/Content.Shared/Actions/PopupOnActionSystem.cs
+++ b/Content.Shared/Actions/PopupOnActionSystem.cs
@@ -44,7 +44,7 @@ public sealed partial class PopupOnActionSystem : EntitySystem
 
         // Popup to show to the performer.
         // If there is a target the popup is located on the target, if there is no target it is located on the user.
-        _popup.PopupClient(selfMessage, target ?? args.Performer, args.Performer, ent.Comp.PopupType);
+        _popup.PopupEntity(selfMessage, target ?? args.Performer, args.Performer, ent.Comp.PopupType);
 
         // Popup to show to the target.
         // Located on the target.

--- a/Content.Shared/Animals/ShearableSystem.cs
+++ b/Content.Shared/Animals/ShearableSystem.cs
@@ -139,7 +139,7 @@ public sealed partial class SharedShearableSystem : EntitySystem
                 var feedbackPopupString = Loc.GetString("shearable-system-no-product",
                     ("target", Identity.Entity(ent.Owner, EntityManager)),
                     ("product", shearedProduct.Name));
-                _popup.PopupClient(feedbackPopupString, ent.Owner, userUid);
+                _popup.PopupEntity(feedbackPopupString, ent.Owner, userUid);
             }
 
             // Fail
@@ -191,7 +191,7 @@ public sealed partial class SharedShearableSystem : EntitySystem
             var feedbackPopupString = Loc.GetString("shearable-system-no-product",
                 ("target", Identity.Entity(ent.Owner, EntityManager)),
                 ("product", shearedProduct.Name));
-            _popup.PopupClient(feedbackPopupString, ent.Owner, args.Args.User);
+            _popup.PopupEntity(feedbackPopupString, ent.Owner, args.Args.User);
             return;
         }
 
@@ -215,7 +215,7 @@ public sealed partial class SharedShearableSystem : EntitySystem
         }
 
         // Success message.
-        _popup.PopupClient(Loc.GetString("shearable-system-success", ("target", Identity.Entity(ent.Owner, EntityManager)), ("product", shearedProduct.Name)), ent.Owner, args.Args.User, PopupType.Medium);
+        _popup.PopupEntity(Loc.GetString("shearable-system-success", ("target", Identity.Entity(ent.Owner, EntityManager)), ("product", shearedProduct.Name)), ent.Owner, args.Args.User, PopupType.Medium);
     }
 
     /// <summary>

--- a/Content.Shared/Animals/Systems/SharedParrotMemorySystem.cs
+++ b/Content.Shared/Animals/Systems/SharedParrotMemorySystem.cs
@@ -36,7 +36,7 @@ public abstract partial class SharedParrotMemorySystem : EntitySystem
             Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/clear-parrot.png")),
             Act = () =>
             {
-                _popup.PopupClient(Loc.GetString("parrot-popup-memory-cleared"), entity.Owner, user);
+                _popup.PopupEntity(Loc.GetString("parrot-popup-memory-cleared"), entity.Owner, user);
 
                 if (_net.IsServer)
                     entity.Comp.SpeechMemories.Clear();

--- a/Content.Shared/Animals/UdderSystem.cs
+++ b/Content.Shared/Animals/UdderSystem.cs
@@ -115,7 +115,7 @@ public sealed partial class UdderSystem : EntitySystem
         var quantity = solution.Volume;
         if (quantity == 0)
         {
-            _popupSystem.PopupClient(Loc.GetString("udder-system-dry"), entity.Owner, args.Args.User);
+            _popupSystem.PopupEntity(Loc.GetString("udder-system-dry"), entity.Owner, args.Args.User);
             return;
         }
 
@@ -125,7 +125,7 @@ public sealed partial class UdderSystem : EntitySystem
         var split = _solutionContainerSystem.SplitSolution(entity.Comp.Solution.Value, quantity);
         _solutionContainerSystem.TryAddSolution(targetSoln.Value, split);
 
-        _popupSystem.PopupClient(Loc.GetString("udder-system-success", ("amount", quantity), ("target", Identity.Entity(args.Args.Used.Value, EntityManager))), entity.Owner,
+        _popupSystem.PopupEntity(Loc.GetString("udder-system-success", ("amount", quantity), ("target", Identity.Entity(args.Args.Used.Value, EntityManager))), entity.Owner,
             args.Args.User, PopupType.Medium);
     }
 

--- a/Content.Shared/Anomaly/AnomalySynchronizerSystem.cs
+++ b/Content.Shared/Anomaly/AnomalySynchronizerSystem.cs
@@ -168,7 +168,7 @@ public sealed partial class AnomalySynchronizerSystem : EntitySystem
         if (ent.Comp.PulseOnConnect)
             _anomaly.DoAnomalyPulse(anomaly, anomaly);
 
-        _popup.PopupPredicted(Loc.GetString("anomaly-sync-connected"), ent, user, PopupType.Medium);
+        _popup.PopupEntity(Loc.GetString("anomaly-sync-connected"), ent, PopupType.Medium);
         _audio.PlayPredicted(ent.Comp.ConnectedSound, ent, user);
     }
 
@@ -184,7 +184,7 @@ public sealed partial class AnomalySynchronizerSystem : EntitySystem
             _anomaly.DoAnomalyPulse(ent.Comp.ConnectedAnomaly.Value, anomaly);
         }
 
-        _popup.PopupPredicted(Loc.GetString("anomaly-sync-disconnected"), ent, user, PopupType.Large);
+        _popup.PopupEntity(Loc.GetString("anomaly-sync-disconnected"), ent, PopupType.Large);
         _audio.PlayPredicted(ent.Comp.DisconnectedSound, ent, user);
 
         ent.Comp.ConnectedAnomaly = null;

--- a/Content.Shared/Anomaly/AnomalySynchronizerSystem.cs
+++ b/Content.Shared/Anomaly/AnomalySynchronizerSystem.cs
@@ -89,7 +89,7 @@ public sealed partial class AnomalySynchronizerSystem : EntitySystem
     {
         if (!_power.IsPowered(ent.Owner))
         {
-            _popup.PopupClient(Loc.GetString("base-computer-ui-component-not-powered", ("machine", ent)), ent, user);
+            _popup.PopupEntity(Loc.GetString("base-computer-ui-component-not-powered", ("machine", ent)), ent, user);
             return false;
         }
 
@@ -98,7 +98,7 @@ public sealed partial class AnomalySynchronizerSystem : EntitySystem
 
         if (anomaly.Owner is { Valid: false }) // no anomaly in range
         {
-            _popup.PopupClient(Loc.GetString("anomaly-sync-no-anomaly"), ent, user);
+            _popup.PopupEntity(Loc.GetString("anomaly-sync-no-anomaly"), ent, user);
             return false;
         }
 

--- a/Content.Shared/Anomaly/SharedAnomalyScannerSystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalyScannerSystem.cs
@@ -76,7 +76,7 @@ public abstract partial class SharedAnomalyScannerSystem : EntitySystem
             return;
 
         Audio.PlayPredicted(component.CompleteSound, uid, args.User);
-        Popup.PopupEntity(Loc.GetString("anomaly-scanner-component-scan-complete"), uid);
+        Popup.PopupEntity(Loc.GetString("anomaly-scanner-component-scan-complete"), uid, uid);
 
         UI.OpenUi(uid, AnomalyScannerUiKey.Key, args.User);
 

--- a/Content.Shared/Anomaly/SharedAnomalyScannerSystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalyScannerSystem.cs
@@ -76,7 +76,7 @@ public abstract partial class SharedAnomalyScannerSystem : EntitySystem
             return;
 
         Audio.PlayPredicted(component.CompleteSound, uid, args.User);
-        Popup.PopupPredicted(Loc.GetString("anomaly-scanner-component-scan-complete"), uid, args.User);
+        Popup.PopupEntity(Loc.GetString("anomaly-scanner-component-scan-complete"), uid);
 
         UI.OpenUi(uid, AnomalyScannerUiKey.Key, args.User);
 

--- a/Content.Shared/Anomaly/SharedAnomalyScannerSystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalyScannerSystem.cs
@@ -76,7 +76,7 @@ public abstract partial class SharedAnomalyScannerSystem : EntitySystem
             return;
 
         Audio.PlayPredicted(component.CompleteSound, uid, args.User);
-        Popup.PopupEntity(Loc.GetString("anomaly-scanner-component-scan-complete"), uid, uid);
+        Popup.PopupEntity(Loc.GetString("anomaly-scanner-component-scan-complete"), uid, args.User);
 
         UI.OpenUi(uid, AnomalyScannerUiKey.Key, args.User);
 

--- a/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
@@ -123,7 +123,7 @@ public abstract partial class SharedAtmosPipeLayersSystem : EntitySystem
 
         if (TryComp<SubFloorHideComponent>(ent, out var subFloorHide) && subFloorHide.IsUnderCover)
         {
-            _popup.PopupClient(Loc.GetString("atmos-pipe-layers-component-cannot-adjust-pipes"), ent, args.User);
+            _popup.PopupEntity(Loc.GetString("atmos-pipe-layers-component-cannot-adjust-pipes"), ent, args.User);
             return;
         }
 
@@ -142,7 +142,7 @@ public abstract partial class SharedAtmosPipeLayersSystem : EntitySystem
                 var toolName = Loc.GetString(toolProto.ToolName).ToLower();
                 var message = Loc.GetString("atmos-pipe-layers-component-tool-missing", ("toolName", toolName));
 
-                _popup.PopupClient(message, ent, args.User);
+                _popup.PopupEntity(message, ent, args.User);
             }
 
             return;
@@ -218,7 +218,7 @@ public abstract partial class SharedAtmosPipeLayersSystem : EntitySystem
             var layerName = GetPipeLayerName(ent.Comp.CurrentPipeLayer);
             var message = Loc.GetString("atmos-pipe-layers-component-change-layer", ("layerName", layerName));
 
-            _popup.PopupClient(message, ent, user);
+            _popup.PopupEntity(message, ent, user);
         }
     }
 

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -341,7 +341,7 @@ public sealed partial class SleepingSystem : EntitySystem
             if (user != null)
             {
                 _audio.PlayPredicted(ent.Comp.WakeAttemptSound, ent, user);
-                _popupSystem.PopupClient(Loc.GetString("wake-other-failure", ("target", Identity.Entity(ent, EntityManager))), ent, user, PopupType.SmallCaution);
+                _popupSystem.PopupEntity(Loc.GetString("wake-other-failure", ("target", Identity.Entity(ent, EntityManager))), ent, user, PopupType.SmallCaution);
             }
             return false;
         }
@@ -349,7 +349,7 @@ public sealed partial class SleepingSystem : EntitySystem
         if (user != null)
         {
             _audio.PlayPredicted(ent.Comp.WakeAttemptSound, ent, user);
-            _popupSystem.PopupClient(Loc.GetString("wake-other-success", ("target", Identity.Entity(ent, EntityManager))), ent, user);
+            _popupSystem.PopupEntity(Loc.GetString("wake-other-success", ("target", Identity.Entity(ent, EntityManager))), ent, user);
         }
 
         return RemComp<SleepingComponent>(ent);

--- a/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
@@ -231,11 +231,7 @@ public abstract partial class SharedBloodstreamSystem : EntitySystem
 
             // We'll play a special sound and popup for feedback.
             // Only the burned entity can see the popup.
-            // TODO: Make the PopupSystem API more sane so that this is handled by a single method.
-            if (args.Origin == ent.Owner) // predict the popup on the client if they caused damage to themselves
-                _popup.PopupClient(Loc.GetString("bloodstream-component-wounds-cauterized"), ent, ent, PopupType.Medium);
-            else
-                _popup.PopupEntity(Loc.GetString("bloodstream-component-wounds-cauterized"), ent, ent, PopupType.Medium);
+            _popup.PopupEntity(Loc.GetString("bloodstream-component-wounds-cauterized"), ent, ent, PopupType.Medium);
             _audio.PlayPredicted(ent.Comp.BloodHealedSound, ent, args.Origin);
         }
     }

--- a/Content.Shared/Body/Systems/SharedInternalsSystem.cs
+++ b/Content.Shared/Body/Systems/SharedInternalsSystem.cs
@@ -85,7 +85,7 @@ public abstract partial class SharedInternalsSystem : EntitySystem
         if (internals.BreathTools.Count == 0)
         {
             var message = user == target ? Loc.GetString("internals-self-no-breath-tool") : Loc.GetString("internals-other-no-breath-tool", ("ent", Identity.Name(target, EntityManager, user)));
-            _popupSystem.PopupClient(message, target, user);
+            _popupSystem.PopupEntity(message, target, user);
             return false;
         }
 
@@ -96,7 +96,7 @@ public abstract partial class SharedInternalsSystem : EntitySystem
         if (tank == null)
         {
             var message = user == target ? Loc.GetString("internals-self-no-tank") : Loc.GetString("internals-other-no-tank", ("ent", Identity.Name(target, EntityManager, user)));
-            _popupSystem.PopupClient(message, target, user);
+            _popupSystem.PopupEntity(message, target, user);
             return false;
         }
 

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -238,7 +238,7 @@ public abstract partial class SharedBuckleSystem
             _whitelistSystem.IsWhitelistPass(strapComp.Blacklist, buckleUid))
         {
             if (popup)
-                _popup.PopupClient(Loc.GetString("buckle-component-cannot-fit-message"), user, PopupType.Medium);
+                _popup.PopupEntity(Loc.GetString("buckle-component-cannot-fit-message"), user, PopupType.Medium);
 
             return false;
         }
@@ -258,7 +258,7 @@ public abstract partial class SharedBuckleSystem
         if (user != null && !HasComp<HandsComponent>(user))
         {
             if (popup)
-                _popup.PopupClient(Loc.GetString("buckle-component-no-hands-message"), user);
+                _popup.PopupEntity(Loc.GetString("buckle-component-no-hands-message"), user.Value, user);
 
             return false;
         }
@@ -272,7 +272,8 @@ public abstract partial class SharedBuckleSystem
                     : "buckle-component-other-already-buckled-message",
                 ("owner", Identity.Entity(buckleUid, EntityManager)));
 
-                _popup.PopupClient(message, user);
+                if (user != null)
+                    _popup.PopupEntity(message, user.Value, user);
             }
 
             return false;
@@ -295,7 +296,7 @@ public abstract partial class SharedBuckleSystem
                     : "buckle-component-other-cannot-buckle-message",
                 ("owner", Identity.Entity(buckleUid, EntityManager)));
 
-                _popup.PopupClient(message, user);
+                _popup.PopupEntity(message, user.Value, user);
             }
 
             return false;
@@ -310,7 +311,7 @@ public abstract partial class SharedBuckleSystem
                     : "buckle-component-other-cannot-buckle-message",
                 ("owner", Identity.Entity(buckleUid, EntityManager)));
 
-                _popup.PopupClient(message, user);
+                _popup.PopupEntity(message, user.Value, user);
             }
 
             return false;

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -296,7 +296,8 @@ public abstract partial class SharedBuckleSystem
                     : "buckle-component-other-cannot-buckle-message",
                 ("owner", Identity.Entity(buckleUid, EntityManager)));
 
-                _popup.PopupEntity(message, user.Value, user);
+                if (user != null)
+                    _popup.PopupEntity(message, user.Value, user);
             }
 
             return false;
@@ -311,7 +312,8 @@ public abstract partial class SharedBuckleSystem
                     : "buckle-component-other-cannot-buckle-message",
                 ("owner", Identity.Entity(buckleUid, EntityManager)));
 
-                _popup.PopupEntity(message, user.Value, user);
+                if (user != null)
+                    _popup.PopupEntity(message, user.Value, user);
             }
 
             return false;

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -237,8 +237,8 @@ public abstract partial class SharedBuckleSystem
         if (_whitelistSystem.IsWhitelistFail(strapComp.Whitelist, buckleUid) ||
             _whitelistSystem.IsWhitelistPass(strapComp.Blacklist, buckleUid))
         {
-            if (popup)
-                _popup.PopupEntity(Loc.GetString("buckle-component-cannot-fit-message"), user, PopupType.Medium);
+            if (popup && user != null)
+                _popup.PopupEntity(Loc.GetString("buckle-component-cannot-fit-message"), user.Value, user, PopupType.Medium);
 
             return false;
         }
@@ -265,15 +265,14 @@ public abstract partial class SharedBuckleSystem
 
         if (buckleComp.Buckled && !TryUnbuckle(buckleUid, user, buckleComp))
         {
-            if (popup)
+            if (popup && user != null)
             {
                 var message = Loc.GetString(buckleUid == user
                     ? "buckle-component-already-buckled-message"
                     : "buckle-component-other-already-buckled-message",
                 ("owner", Identity.Entity(buckleUid, EntityManager)));
 
-                if (user != null)
-                    _popup.PopupEntity(message, user.Value, user);
+                _popup.PopupEntity(message, user.Value, user);
             }
 
             return false;

--- a/Content.Shared/Burial/BurialSystem.cs
+++ b/Content.Shared/Burial/BurialSystem.cs
@@ -118,7 +118,7 @@ public sealed partial class BurialSystem : EntitySystem
         {
             var selfMessage = Loc.GetString("grave-start-digging-user", ("grave", uid), ("tool", used));
             var othersMessage = Loc.GetString("grave-start-digging-others", ("user", user), ("grave", uid), ("tool", used));
-            _popupSystem.PopupEntity(selfMessage, othersMessage, user);
+            _popupSystem.PopupEntity(selfMessage, othersMessage, user, user);
             component.ActiveShovelDigging = true;
             Dirty(uid, component);
         }

--- a/Content.Shared/Burial/BurialSystem.cs
+++ b/Content.Shared/Burial/BurialSystem.cs
@@ -64,7 +64,7 @@ public sealed partial class BurialSystem : EntitySystem
         }
         else
         {
-            _popupSystem.PopupClient(Loc.GetString("grave-digging-requires-tool", ("grave", args.Target)), uid, args.User);
+            _popupSystem.PopupEntity(Loc.GetString("grave-digging-requires-tool", ("grave", args.Target)), uid, args.User);
         }
 
         args.Handled = true;
@@ -85,7 +85,7 @@ public sealed partial class BurialSystem : EntitySystem
         if (args.Handled || !args.Complex)
             return;
 
-        _popupSystem.PopupClient(Loc.GetString("grave-digging-requires-tool", ("grave", args.Target)), uid, args.User);
+        _popupSystem.PopupEntity(Loc.GetString("grave-digging-requires-tool", ("grave", args.Target)), uid, args.User);
         args.Handled = true;
     }
 
@@ -124,7 +124,7 @@ public sealed partial class BurialSystem : EntitySystem
         }
         else
         {
-            _popupSystem.PopupClient(Loc.GetString("grave-start-digging-user-trapped", ("grave", uid)), user, user, PopupType.Medium);
+            _popupSystem.PopupEntity(Loc.GetString("grave-start-digging-user-trapped", ("grave", uid)), user, user, PopupType.Medium);
         }
     }
 

--- a/Content.Shared/Burial/BurialSystem.cs
+++ b/Content.Shared/Burial/BurialSystem.cs
@@ -118,7 +118,7 @@ public sealed partial class BurialSystem : EntitySystem
         {
             var selfMessage = Loc.GetString("grave-start-digging-user", ("grave", uid), ("tool", used));
             var othersMessage = Loc.GetString("grave-start-digging-others", ("user", user), ("grave", uid), ("tool", used));
-            _popupSystem.PopupPredicted(selfMessage, othersMessage, user, user);
+            _popupSystem.PopupEntity(selfMessage, othersMessage, user);
             component.ActiveShovelDigging = true;
             Dirty(uid, component);
         }

--- a/Content.Shared/CartridgeLoader/Cartridges/LogProbeCartridgeSystem.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/LogProbeCartridgeSystem.cs
@@ -46,7 +46,7 @@ public sealed partial class LogProbeCartridgeSystem : EntitySystem
 
         //Play scanning sound with slightly randomized pitch
         _audio.PlayPredicted(ent.Comp.SoundScan, target, args.Args.User);
-        _popup.PopupPredictedCursor(Loc.GetString("log-probe-scan", ("device", target)), args.Args.User);
+        _popup.PopupCursor(Loc.GetString("log-probe-scan", ("device", target)), args.Args.User);
 
         ent.Comp.EntityName = Name(target);
         ent.Comp.PulledAccessLogs.Clear();

--- a/Content.Shared/CartridgeLoader/Cartridges/NetProbeCartridgeSystem.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/NetProbeCartridgeSystem.cs
@@ -45,7 +45,7 @@ public sealed partial class NetProbeCartridgeSystem : EntitySystem
         // Why is there no NextFloat(float min, float max)???
         var audioParams = AudioParams.Default.WithVolume(-2f).WithVariation(0.2f);
         _audioSystem.PlayPredicted(component.SoundScan, target, args.Args.User, audioParams);
-        _popupSystem.PopupPredictedCursor(Loc.GetString("net-probe-scan", ("device", target)), args.Args.User);
+        _popupSystem.PopupCursor(Loc.GetString("net-probe-scan", ("device", target)), args.Args.User);
 
         // Limit the amount of saved probe results to 9
         // This is hardcoded because the UI doesn't support a dynamic number of results

--- a/Content.Shared/Changeling/Systems/ChangelingAbilitySystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingAbilitySystem.cs
@@ -60,7 +60,7 @@ public sealed partial class ChangelingAbilitySystem : EntitySystem
         var selfPopup = Loc.TryGetString(ent.Comp.ActivatedPopupSelf, out var self, ("user", Identity.Entity(args.Performer, EntityManager)), ("restraint", toDelete.First())) ? self : null;
         var othersPopup = Loc.TryGetString(ent.Comp.ActivatedPopup, out var others, ("user", Identity.Entity(args.Performer, EntityManager)), ("restraint", toDelete.First())) ? others : null;
 
-        _popup.PopupPredicted(selfPopup, othersPopup, args.Performer, args.Performer, PopupType.LargeCaution);
+        _popup.PopupEntity(selfPopup, othersPopup, args.Performer, args.Performer, PopupType.LargeCaution);
         _audio.PlayPredicted(ent.Comp.ActivatedSound, args.Performer, args.Performer);
 
         foreach (var deleted in toDelete)

--- a/Content.Shared/Changeling/Systems/ChangelingClonerSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingClonerSystem.cs
@@ -149,7 +149,7 @@ public sealed partial class ChangelingClonerSystem : EntitySystem
         var targetIdentity = Identity.Entity(target, EntityManager);
         var userMsg = Loc.GetString("changeling-cloner-component-draw-user", ("user", userIdentity), ("target", targetIdentity));
         var targetMsg = Loc.GetString("changeling-cloner-component-draw-target", ("user", userIdentity), ("target", targetIdentity));
-        _popup.PopupClient(userMsg, target, user);
+        _popup.PopupEntity(userMsg, target, user);
 
         if (user != target) // don't show the warning if using the item on yourself
             _popup.PopupEntity(targetMsg, user, target, PopupType.LargeCaution);
@@ -185,7 +185,7 @@ public sealed partial class ChangelingClonerSystem : EntitySystem
         var targetIdentity = Identity.Entity(target, EntityManager);
         var userMsg = Loc.GetString("changeling-cloner-component-inject-user", ("user", userIdentity), ("target", targetIdentity));
         var targetMsg = Loc.GetString("changeling-cloner-component-inject-target", ("user", userIdentity), ("target", targetIdentity));
-        _popup.PopupClient(userMsg, target, user);
+        _popup.PopupEntity(userMsg, target, user);
 
         if (user != target) // don't show the warning if using the item on yourself
             _popup.PopupEntity(targetMsg, user, target, PopupType.LargeCaution);
@@ -282,7 +282,7 @@ public sealed partial class ChangelingClonerSystem : EntitySystem
         if (user == null)
             return;
 
-        _popup.PopupClient(Loc.GetString("changeling-cloner-component-reset-popup"), user.Value, user.Value);
+        _popup.PopupEntity(Loc.GetString("changeling-cloner-component-reset-popup"), user.Value, user.Value);
     }
 }
 

--- a/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
@@ -88,7 +88,7 @@ public sealed partial class ChangelingDevourSystem : EntitySystem
 
         var selfMessage = Loc.GetString("changeling-devour-begin-windup-self", ("user", Identity.Entity(ent.Owner, EntityManager)));
         var othersMessage = Loc.GetString("changeling-devour-begin-windup-others", ("user", Identity.Entity(ent.Owner, EntityManager)));
-        _popupSystem.PopupPredicted(
+        _popupSystem.PopupEntity(
             selfMessage,
             othersMessage,
             args.Performer,
@@ -113,7 +113,7 @@ public sealed partial class ChangelingDevourSystem : EntitySystem
 
         var selfMessage = Loc.GetString("changeling-devour-begin-consume-self", ("user", Identity.Entity(ent.Owner, EntityManager)));
         var othersMessage = Loc.GetString("changeling-devour-begin-consume-others", ("user", Identity.Entity(ent.Owner, EntityManager)));
-        _popupSystem.PopupPredicted(
+        _popupSystem.PopupEntity(
             selfMessage,
             othersMessage,
             ent.Owner,
@@ -160,7 +160,7 @@ public sealed partial class ChangelingDevourSystem : EntitySystem
 
         var selfMessage = Loc.GetString("changeling-devour-consume-complete-self", ("user", Identity.Entity(ent.Owner, EntityManager)));
         var othersMessage = Loc.GetString("changeling-devour-consume-complete-others", ("user", Identity.Entity(ent.Owner, EntityManager)));
-        _popupSystem.PopupPredicted(
+        _popupSystem.PopupEntity(
             selfMessage,
             othersMessage,
             ent.Owner,

--- a/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
@@ -203,42 +203,42 @@ public sealed partial class ChangelingDevourSystem : EntitySystem
         if (!HasComp<HumanoidProfileComponent>(victim))
         {
             if (showPopup)
-                _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-cannot-devour"), changeling.Owner, changeling.Owner, PopupType.Medium);
+                _popupSystem.PopupEntity(Loc.GetString("changeling-devour-attempt-failed-cannot-devour"), changeling.Owner, changeling.Owner, PopupType.Medium);
             return false;
         }
 
         if (HasComp<RecentlyDevouredComponent>(victim))
         {
             if (showPopup)
-                _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-devoured-recently"), changeling.Owner, changeling.Owner, PopupType.Medium);
+                _popupSystem.PopupEntity(Loc.GetString("changeling-devour-attempt-failed-devoured-recently"), changeling.Owner, changeling.Owner, PopupType.Medium);
             return false;
         }
 
         if (checkDead && !_mobState.IsDead(victim))
         {
             if (showPopup)
-                _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-not-dead"), changeling.Owner, changeling.Owner, PopupType.Medium);
+                _popupSystem.PopupEntity(Loc.GetString("changeling-devour-attempt-failed-not-dead"), changeling.Owner, changeling.Owner, PopupType.Medium);
             return false;
         }
 
         if (HasComp<RottingComponent>(victim))
         {
             if (showPopup)
-                _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-rotting"), changeling.Owner, changeling.Owner, PopupType.Medium);
+                _popupSystem.PopupEntity(Loc.GetString("changeling-devour-attempt-failed-rotting"), changeling.Owner, changeling.Owner, PopupType.Medium);
             return false;
         }
 
         if (checkProtected && IsTargetProtected(victim, changeling))
         {
             if (showPopup)
-                _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-protected"), changeling.Owner, changeling.Owner, PopupType.Medium);
+                _popupSystem.PopupEntity(Loc.GetString("changeling-devour-attempt-failed-protected"), changeling.Owner, changeling.Owner, PopupType.Medium);
             return false;
         }
 
         if (!_changelingIdentity.HasIdentity(changeling.Owner, victim) && !_changelingIdentity.HasFreeDisguiseSlot(changeling.Owner))
         {
             if (showPopup)
-                _popupSystem.PopupClient(Loc.GetString("changeling-devour-attempt-failed-no-space"), changeling.Owner, changeling.Owner, PopupType.Medium);
+                _popupSystem.PopupEntity(Loc.GetString("changeling-devour-attempt-failed-no-space"), changeling.Owner, changeling.Owner, PopupType.Medium);
             return false;
         }
 

--- a/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
@@ -113,7 +113,7 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
         if (!_changelingIdentity.TryGetDataFromIdentity((ent.Owner, identity), targetIdentity.Value, out _))
             return; // this identity does not belong to this player
 
-        _popup.PopupClient(Loc.GetString("changeling-transform-bui-drop-identity-entity-popup", ("entity", targetIdentity.Value)), ent.Owner, PopupType.Large);
+        _popup.PopupEntity(Loc.GetString("changeling-transform-bui-drop-identity-entity-popup", ("entity", targetIdentity.Value)), ent.Owner, ent.Owner, PopupType.Large);
         _changelingIdentity.DropStoredIdentity(ent.Owner, targetIdentity.Value);
     }
 

--- a/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
@@ -129,7 +129,7 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
 
         var selfMessage = Loc.GetString("changeling-transform-attempt-self", ("user", Identity.Entity(ent.Owner, EntityManager)));
         var othersMessage = Loc.GetString("changeling-transform-attempt-others", ("user", Identity.Entity(ent.Owner, EntityManager)));
-        _popup.PopupPredicted(
+        _popup.PopupEntity(
             selfMessage,
             othersMessage,
             ent,

--- a/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
@@ -78,7 +78,7 @@ public sealed partial class InjectorSystem : EntitySystem
             // Are use using an injector capable of targeting a mob?
             if (injector.Comp.IgnoreMobs)
             {
-                _popup.PopupClient(Loc.GetString("injector-component-ignore-mobs"), args.Target.Value, args.User);
+                _popup.PopupEntity(Loc.GetString("injector-component-ignore-mobs"), args.Target.Value, args.User);
                 return;
             }
 
@@ -138,7 +138,7 @@ public sealed partial class InjectorSystem : EntitySystem
                 Act = () =>
                 {
                     injector.Comp.CurrentTransferAmount = toggleAmount;
-                    _popup.PopupClient(Loc.GetString("comp-solution-transfer-set-amount", ("amount", toggleAmount)), user, user);
+                    _popup.PopupEntity(Loc.GetString("comp-solution-transfer-set-amount", ("amount", toggleAmount)), user, user);
                     Dirty(injector);
                 },
 
@@ -158,7 +158,7 @@ public sealed partial class InjectorSystem : EntitySystem
                     Act = () =>
                     {
                         injector.Comp.CurrentTransferAmount = amount;
-                        _popup.PopupClient(Loc.GetString("comp-solution-transfer-set-amount", ("amount", amount)), user, user);
+                        _popup.PopupEntity(Loc.GetString("comp-solution-transfer-set-amount", ("amount", amount)), user, user);
                         Dirty(injector);
                     },
 
@@ -217,7 +217,7 @@ public sealed partial class InjectorSystem : EntitySystem
             return false;
 
         // Create a pop-up for the user.
-        _popup.PopupClient(Loc.GetString(activeMode.PopupUserAttempt), target, user);
+        _popup.PopupEntity(Loc.GetString(activeMode.PopupUserAttempt), target, user);
 
         if (user == target)
         {
@@ -285,7 +285,7 @@ public sealed partial class InjectorSystem : EntitySystem
             // Check if we have anything to inject.
             if (injectorSolution.Volume == 0)
             {
-                _popup.PopupClient(Loc.GetString("injector-component-empty-message", ("injector", injector)), target, user);
+                _popup.PopupEntity(Loc.GetString("injector-component-empty-message", ("injector", injector)), target, user);
                 return false;
             }
 
@@ -348,19 +348,19 @@ public sealed partial class InjectorSystem : EntitySystem
         if (!_solutionContainer.ResolveSolution(injector.Owner, injector.Comp.SolutionName, ref injector.Comp.Solution, out var solution)
             || solution.AvailableVolume == 0)
         {
-            _popup.PopupClient(Loc.GetString("injector-component-cannot-toggle-draw-message"), user, user);
+            _popup.PopupEntity(Loc.GetString("injector-component-cannot-toggle-draw-message"), user, user);
             return false; // If already full, fail drawing.
         }
 
         if (!_solutionContainer.TryGetDrawableSolution(target, out _, out var drawableSol))
         {
-            _popup.PopupClient(Loc.GetString("injector-component-cannot-draw-message", ("target", Identity.Entity(target, EntityManager))), injector, user);
+            _popup.PopupEntity(Loc.GetString("injector-component-cannot-draw-message", ("target", Identity.Entity(target, EntityManager))), injector, user);
             return false;
         }
 
         if (drawableSol.Volume == 0)
         {
-            _popup.PopupClient(Loc.GetString("injector-component-target-is-empty-message", ("target", Identity.Entity(target, EntityManager))), injector, user);
+            _popup.PopupEntity(Loc.GetString("injector-component-target-is-empty-message", ("target", Identity.Entity(target, EntityManager))), injector, user);
             return false;
         }
 
@@ -413,7 +413,7 @@ public sealed partial class InjectorSystem : EntitySystem
                     return TryDraw(injector, user, target, drawableSolution.Value);
 
                 msg = target == user ? "injector-component-cannot-draw-message-self" : "injector-component-cannot-draw-message";
-                _popup.PopupClient(Loc.GetString(msg, ("target", Identity.Entity(target, EntityManager))), injector, user);
+                _popup.PopupEntity(Loc.GetString(msg, ("target", Identity.Entity(target, EntityManager))), injector, user);
                 break;
             }
             case InjectorBehavior.Dynamic:
@@ -434,7 +434,7 @@ public sealed partial class InjectorSystem : EntitySystem
                 throw new ArgumentOutOfRangeException();
         }
 
-        _popup.PopupClient(Loc.GetString(msg, ("target", Identity.Entity(target, EntityManager))), injector, user);
+        _popup.PopupEntity(Loc.GetString(msg, ("target", Identity.Entity(target, EntityManager))), injector, user);
         return false;
     }
 
@@ -455,7 +455,7 @@ public sealed partial class InjectorSystem : EntitySystem
                 out var injectorSolution) || injectorSolution.Volume == 0)
         {
             // If empty, show a popup.
-            _popup.PopupClient(Loc.GetString("injector-component-empty-message", ("injector", injector)), user, user);
+            _popup.PopupEntity(Loc.GetString("injector-component-empty-message", ("injector", injector)), user, user);
             return false;
         }
 
@@ -494,7 +494,7 @@ public sealed partial class InjectorSystem : EntitySystem
         if (realTransferAmount <= 0)
         {
             LocId msg = target == user ? "injector-component-target-already-full-message-self" : "injector-component-target-already-full-message";
-            _popup.PopupClient(
+            _popup.PopupEntity(
                 Loc.GetString(msg,
                     ("target", Identity.Entity(target, EntityManager))),
                 injector.Owner,
@@ -523,11 +523,11 @@ public sealed partial class InjectorSystem : EntitySystem
         else if (ev.OverrideMessage != null)
             msgSuccess = ev.OverrideMessage;
 
-        _popup.PopupClient(Loc.GetString(msgSuccess, ("amount", removedSolution.Volume), ("target", Identity.Entity(target, EntityManager))), target, user);
+        _popup.PopupEntity(Loc.GetString(msgSuccess, ("amount", removedSolution.Volume), ("target", Identity.Entity(target, EntityManager))), target, user);
 
         // it is IMPERATIVE that when an injector is instant, that it has a pop-up.
         if (activeMode.InjectPopupTarget != null && target != user)
-            _popup.PopupClient(Loc.GetString(activeMode.InjectPopupTarget), target, target);
+            _popup.PopupEntity(Loc.GetString(activeMode.InjectPopupTarget), target, target);
 
         // Some injectors like hyposprays have sound, some like syringes have not.
         if (activeMode.InjectSound != null)
@@ -552,7 +552,7 @@ public sealed partial class InjectorSystem : EntitySystem
     {
         if (!_solutionContainer.ResolveSolution(injector.Owner, injector.Comp.SolutionName, ref injector.Comp.Solution, out var solution) || solution.AvailableVolume == 0)
         {
-            _popup.PopupClient("injector-component-cannot-toggle-draw-message", user, user);
+            _popup.PopupEntity("injector-component-cannot-toggle-draw-message", user, user);
             return false;
         }
 
@@ -575,7 +575,7 @@ public sealed partial class InjectorSystem : EntitySystem
         {
             LocId msg = target.Owner == user ? "injector-component-target-is-empty-message-self" : "injector-component-target-is-empty-message";
             var targetIdentity = Identity.Entity(target, EntityManager);
-            _popup.PopupClient(Loc.GetString(msg, ("target", targetIdentity)), injector.Owner, user);
+            _popup.PopupEntity(Loc.GetString(msg, ("target", targetIdentity)), injector.Owner, user);
             return false;
         }
 
@@ -599,7 +599,7 @@ public sealed partial class InjectorSystem : EntitySystem
 
         LocId msgSuccess = target.Owner == user ? "injector-component-draw-success-message-self" : "injector-component-draw-success-message";
         var targetIdentitySuccess = Identity.Entity(target, EntityManager);
-        _popup.PopupClient(
+        _popup.PopupEntity(
             Loc.GetString(msgSuccess, ("amount", removedSolution.Volume), ("target", targetIdentitySuccess)),
             target,
             user);
@@ -631,7 +631,7 @@ public sealed partial class InjectorSystem : EntitySystem
         LocId msg = target.Owner == user ? "injector-component-draw-success-message-self" : "injector-component-draw-success-message";
         var targetIdentity = Identity.Entity(target, EntityManager);
         var finalMessage = Loc.GetString(msg, ("amount", transferAmount), ("target", targetIdentity));
-        _popup.PopupClient(finalMessage, target, user);
+        _popup.PopupEntity(finalMessage, target, user);
 
         AfterDraw(injector, user, target);
     }
@@ -729,7 +729,7 @@ public sealed partial class InjectorSystem : EntitySystem
 
         var modeName = Loc.GetString(newMode.Name);
         var message = Loc.GetString("injector-component-mode-changed-text", ("mode", modeName));
-        _popup.PopupClient(message, user, user);
+        _popup.PopupEntity(message, user, user);
     }
 
     /// <summary>
@@ -768,7 +768,7 @@ public sealed partial class InjectorSystem : EntitySystem
             return;
         }
         if (errorMessage != null)
-            _popup.PopupClient(Loc.GetString(errorMessage), user, user);
+            _popup.PopupEntity(Loc.GetString(errorMessage), user, user);
     }
     #endregion Mode Toggling
 }

--- a/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
@@ -469,7 +469,7 @@ public sealed partial class InjectorSystem : EntitySystem
         {
             // Clowns will now also fumble Syringes.
             if (selfEv.OverrideMessage != null)
-                _popup.PopupEntity(selfEv.OverrideMessage, user);
+                _popup.PopupEntity(selfEv.OverrideMessage, user, user);
             return true;
         }
 

--- a/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
@@ -469,7 +469,7 @@ public sealed partial class InjectorSystem : EntitySystem
         {
             // Clowns will now also fumble Syringes.
             if (selfEv.OverrideMessage != null)
-                _popup.PopupPredicted(selfEv.OverrideMessage, user, user);
+                _popup.PopupEntity(selfEv.OverrideMessage, user);
             return true;
         }
 
@@ -483,7 +483,7 @@ public sealed partial class InjectorSystem : EntitySystem
         {
             var userMessage = Loc.GetString("injector-component-blocked-user");
             var otherMessage = Loc.GetString("injector-component-blocked-other", ("target", target), ("user", user));
-            _popup.PopupPredicted(userMessage, otherMessage, target, user, PopupType.SmallCaution);
+            _popup.PopupEntity(userMessage, otherMessage, target, user, PopupType.SmallCaution);
             return true;
         }
 

--- a/Content.Shared/Chemistry/EntitySystems/ScoopableSolutionSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/ScoopableSolutionSystem.cs
@@ -40,7 +40,7 @@ public sealed partial class ScoopableSolutionSystem : EntitySystem
         if (scooped == 0)
             return false;
 
-        _popup.PopupClient(Loc.GetString(ent.Comp.Popup, ("scooped", ent.Owner), ("beaker", beaker)), user, user);
+        _popup.PopupEntity(Loc.GetString(ent.Comp.Popup, ("scooped", ent.Owner), ("beaker", beaker)), user, user);
 
         if (srcSolution.Volume == 0 && ent.Comp.Delete)
         {

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerMixerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerMixerSystem.cs
@@ -60,14 +60,14 @@ public abstract partial class SharedSolutionContainerMixerSystem : EntitySystem
         if (!HasPower(entity))
         {
             if (user != null)
-                _popup.PopupClient(Loc.GetString("solution-container-mixer-no-power"), entity, user.Value);
+                _popup.PopupEntity(Loc.GetString("solution-container-mixer-no-power"), entity, user.Value);
             return;
         }
 
         if (!_container.TryGetContainer(uid, comp.ContainerId, out var container) || container.Count == 0)
         {
             if (user != null)
-                _popup.PopupClient(Loc.GetString("solution-container-mixer-popup-nothing-to-mix"), entity, user.Value);
+                _popup.PopupEntity(Loc.GetString("solution-container-mixer-popup-nothing-to-mix"), entity, user.Value);
             return;
         }
 

--- a/Content.Shared/Chemistry/EntitySystems/SolutionSpikerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionSpikerSystem.cs
@@ -50,14 +50,14 @@ public sealed partial class SolutionSpikerSystem : EntitySystem
 
         if (targetSolution.Volume == 0 && !source.Comp.IgnoreEmpty)
         {
-            _popup.PopupClient(Loc.GetString(source.Comp.PopupEmpty, ("spiked-entity", target), ("spike-entity", source)), user, user);
+            _popup.PopupEntity(Loc.GetString(source.Comp.PopupEmpty, ("spiked-entity", target), ("spike-entity", source)), user, user);
             return false;
         }
 
         if (!_solution.ForceAddSolution(targetSoln.Value, sourceSolution))
             return false;
 
-        _popup.PopupClient(Loc.GetString(source.Comp.Popup, ("spiked-entity", target), ("spike-entity", source)), user, user);
+        _popup.PopupEntity(Loc.GetString(source.Comp.Popup, ("spiked-entity", target), ("spike-entity", source)), user, user);
         sourceSolution.RemoveAllSolution();
         if (source.Comp.Delete)
             QueueDel(source);

--- a/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
@@ -78,7 +78,7 @@ public sealed partial class SolutionTransferSystem : EntitySystem
             {
                 ent.Comp.TransferAmount = amount;
 
-                _popup.PopupClient(Loc.GetString("comp-solution-transfer-set-amount", ("amount", amount)), ent.Owner, user);
+                _popup.PopupEntity(Loc.GetString("comp-solution-transfer-set-amount", ("amount", amount)), ent.Owner, user);
 
                 Dirty(ent.Owner, ent.Comp);
             };
@@ -97,7 +97,7 @@ public sealed partial class SolutionTransferSystem : EntitySystem
         ent.Comp.TransferAmount = newTransferAmount;
 
         if (message.Actor is { Valid: true } user)
-            _popup.PopupClient(Loc.GetString("comp-solution-transfer-set-amount", ("amount", newTransferAmount)), ent.Owner, user);
+            _popup.PopupEntity(Loc.GetString("comp-solution-transfer-set-amount", ("amount", newTransferAmount)), ent.Owner, user);
 
         Dirty(ent.Owner, ent.Comp);
     }
@@ -275,7 +275,7 @@ public sealed partial class SolutionTransferSystem : EntitySystem
             return;
 
         var message = Loc.GetString("comp-solution-transfer-transfer-solution", ("amount", transferred), ("target", data.TargetEntity));
-        _popup.PopupClient(message, data.SourceEntity, data.User);
+        _popup.PopupEntity(message, data.SourceEntity, data.User);
     }
 
     /// <summary>
@@ -296,7 +296,7 @@ public sealed partial class SolutionTransferSystem : EntitySystem
             ? "comp-solution-transfer-fill-fully"
             : "comp-solution-transfer-fill-normal";
 
-        _popup.PopupClient(Loc.GetString(msg, ("owner", data.SourceEntity), ("amount", transferred), ("target", data.TargetEntity)), data.TargetEntity, data.User);
+        _popup.PopupEntity(Loc.GetString(msg, ("owner", data.SourceEntity), ("amount", transferred), ("target", data.TargetEntity)), data.TargetEntity, data.User);
     }
 
     /// <summary>
@@ -338,14 +338,14 @@ public sealed partial class SolutionTransferSystem : EntitySystem
         RaiseLocalEvent(data.SourceEntity, ref transferAttempt);
         if (transferAttempt.CancelReason is {} reason)
         {
-            _popup.PopupClient(reason, data.SourceEntity, data.User);
+            _popup.PopupEntity(reason, data.SourceEntity, data.User);
             return false;
         }
 
         var sourceSolution = data.Source.Comp.Solution;
         if (sourceSolution.Volume == 0)
         {
-            _popup.PopupClient(Loc.GetString("comp-solution-transfer-is-empty", ("target", data.SourceEntity)), data.SourceEntity, data.User);
+            _popup.PopupEntity(Loc.GetString("comp-solution-transfer-is-empty", ("target", data.SourceEntity)), data.SourceEntity, data.User);
             return false;
         }
 
@@ -353,14 +353,14 @@ public sealed partial class SolutionTransferSystem : EntitySystem
         RaiseLocalEvent(data.TargetEntity, ref transferAttempt);
         if (transferAttempt.CancelReason is {} targetReason)
         {
-            _popup.PopupClient(targetReason, data.TargetEntity, data.User);
+            _popup.PopupEntity(targetReason, data.TargetEntity, data.User);
             return false;
         }
 
         var targetSolution = data.Target.Comp.Solution;
         if (targetSolution.AvailableVolume == 0)
         {
-            _popup.PopupClient(Loc.GetString("comp-solution-transfer-is-full", ("target", data.TargetEntity)), data.TargetEntity, data.User);
+            _popup.PopupEntity(Loc.GetString("comp-solution-transfer-is-full", ("target", data.TargetEntity)), data.TargetEntity, data.User);
             return false;
         }
 

--- a/Content.Shared/Chemistry/Reaction/ReactionMixerSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactionMixerSystem.cs
@@ -88,7 +88,7 @@ public sealed partial class ReactionMixerSystem : EntitySystem
         if (!TryMix(ent.AsNullable(), args.Target.Value))
             return;
 
-        _popup.PopupClient(
+        _popup.PopupEntity(
             Loc.GetString(ent.Comp.MixMessage,
                 ("mixed", Identity.Entity(args.Target.Value, EntityManager)),
                 ("mixer", Identity.Entity(ent.Owner, EntityManager))),

--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -339,7 +339,7 @@ public sealed partial class ClimbSystem : VirtualController
                 ("climbable", climbable));
         }
 
-        _popupSystem.PopupPredicted(selfMessage, othersMessage, uid, user);
+        _popupSystem.PopupEntity(selfMessage, othersMessage, uid, user);
     }
 
     /// <summary>

--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -207,7 +207,7 @@ public sealed partial class ClimbSystem : VirtualController
              : CanVault(comp, user, entityToMove, climbable, out reason);
         if (!canVault)
         {
-            _popupSystem.PopupClient(reason, user, user);
+            _popupSystem.PopupEntity(reason, user, user);
             return false;
         }
 

--- a/Content.Shared/Clothing/EntitySystems/FleetingClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/FleetingClothingSystem.cs
@@ -77,13 +77,13 @@ public sealed partial class FleetingClothingSystem : EntitySystem
                 othersMessage = Loc.GetString(ent.Comp.SelfUnquipPopupOthers, ("item", ent.Owner));
 
             // Use the wearer for the popup location because the item item itself will get deleted.
-            _popup.PopupPredicted(selfMessage, othersMessage, args.EquipTarget, args.User, PopupType.LargeCaution);
+            _popup.PopupEntity(selfMessage, othersMessage, args.EquipTarget, args.User, PopupType.LargeCaution);
         }
         else
         {
             // Show the same popup message for everyone.
             if (ent.Comp.RemovedPopup != null)
-                _popup.PopupPredicted(Loc.GetString(ent.Comp.RemovedPopup, ("item", ent.Owner)), args.EquipTarget, args.User, PopupType.LargeCaution);
+                _popup.PopupEntity(Loc.GetString(ent.Comp.RemovedPopup, ("item", ent.Owner)), args.EquipTarget, PopupType.LargeCaution);
         }
     }
 

--- a/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
@@ -57,7 +57,7 @@ public sealed partial class MaskSystem : EntitySystem
 
         var dir = mask.IsToggled ? "down" : "up";
         var msg = $"action-mask-pull-{dir}-popup-message";
-        _popupSystem.PopupClient(Loc.GetString(msg, ("mask", uid)), args.Performer, args.Performer);
+        _popupSystem.PopupEntity(Loc.GetString(msg, ("mask", uid)), args.Performer, args.Performer);
     }
 
     private void OnGotUnequipped(EntityUid uid, MaskComponent mask, GotUnequippedEvent args)

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -240,7 +240,7 @@ public sealed partial class ToggleableClothingSystem : EntitySystem
             _inventorySystem.TryUnequip(user, parent, component.Slot, force: true);
         else if (_inventorySystem.TryGetSlotEntity(parent, component.Slot, out var existing))
         {
-            _popupSystem.PopupClient(Loc.GetString("toggleable-clothing-remove-first", ("entity", existing)),
+            _popupSystem.PopupEntity(Loc.GetString("toggleable-clothing-remove-first", ("entity", existing)),
                 user,
                 user);
         }

--- a/Content.Shared/Clumsy/ClumsySystem.cs
+++ b/Content.Shared/Clumsy/ClumsySystem.cs
@@ -88,7 +88,7 @@ public sealed partial class ClumsySystem : EntitySystem
         if (ent.Comp.CatchingFailDamage != null)
             _damageable.ChangeDamage(ent.Owner, ent.Comp.CatchingFailDamage, origin: args.Item);
 
-        // Collisions don't work properly with PopupPredicted or PlayPredicted.
+        // Collisions don't work properly with PlayPredicted.
         // So we make this server only.
         if (_net.IsClient)
             return;
@@ -149,7 +149,7 @@ public sealed partial class ClumsySystem : EntitySystem
         if (args.PuttingOnTable == ent.Owner)
         {
             // You are slamming yourself onto the table.
-            _popup.PopupPredicted(
+            _popup.PopupEntity(
                 Loc.GetString(ent.Comp.VaulingFailedMessageSelf, ("bonkable", args.BeingClimbedOn)),
                 Loc.GetString(ent.Comp.VaulingFailedMessageOthers, ("victim", gettingPutOnTableName), ("bonkable", args.BeingClimbedOn)),
                 ent,
@@ -159,13 +159,12 @@ public sealed partial class ClumsySystem : EntitySystem
         {
             // Someone else slamed you onto the table.
             // This is only run in server so you need to use popup entity.
-            _popup.PopupPredicted(
+            _popup.PopupEntity(
                 Loc.GetString(ent.Comp.VaulingFailedMessageForced,
                     ("bonker", puttingOnTableName),
                     ("victim", gettingPutOnTableName),
                     ("bonkable", args.BeingClimbedOn)),
-                ent,
-                null);
+                ent);
         }
 
         args.Cancel();

--- a/Content.Shared/Clumsy/ClumsySystem.cs
+++ b/Content.Shared/Clumsy/ClumsySystem.cs
@@ -95,8 +95,7 @@ public sealed partial class ClumsySystem : EntitySystem
 
         var selfMessage = Loc.GetString(ent.Comp.CatchingFailedMessageSelf, ("item", ent.Owner), ("catcher", Identity.Entity(ent.Owner, EntityManager)));
         var othersMessage = Loc.GetString(ent.Comp.CatchingFailedMessageOthers, ("item", ent.Owner), ("catcher", Identity.Entity(ent.Owner, EntityManager)));
-        _popup.PopupEntity(selfMessage, ent.Owner, ent.Owner);
-        _popup.PopupEntity(othersMessage, ent.Owner, Filter.PvsExcept(ent.Owner), true);
+        _popup.PopupEntity(selfMessage, othersMessage, ent.Owner, ent.Owner);
         _audio.PlayPvs(ent.Comp.ClumsySound, ent);
     }
 

--- a/Content.Shared/CombatMode/Pacification/PacificationSystem.cs
+++ b/Content.Shared/CombatMode/Pacification/PacificationSystem.cs
@@ -56,7 +56,7 @@ public sealed partial class PacificationSystem : EntitySystem
             return;
 
         var targetName = Identity.Entity(target, EntityManager);
-        _popup.PopupClient(Loc.GetString(reason, ("entity", targetName)), user, user);
+        _popup.PopupEntity(Loc.GetString(reason, ("entity", targetName)), user, user);
         user.Comp.NextPopupTime = _timing.CurTime + user.Comp.PopupCooldown;
         user.Comp.LastAttackedEntity = target;
     }

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -47,7 +47,7 @@ public abstract partial class SharedCombatModeSystem : EntitySystem
         SetInCombatMode(uid, !component.IsInCombatMode, component);
 
         var msg = component.IsInCombatMode ? "action-popup-combat-enabled" : "action-popup-combat-disabled";
-        _popup.PopupClient(Loc.GetString(msg), args.Performer, args.Performer);
+        _popup.PopupEntity(Loc.GetString(msg), args.Performer, args.Performer);
     }
 
     public void SetCanDisarm(EntityUid entity, bool canDisarm, CombatModeComponent? component = null)

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -91,7 +91,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         if (!Valid(uid, userUid, usingUid, false, out var failMessage))
         {
             if (failMessage != null)
-                _popup.PopupClient(failMessage, uid, userUid);
+                _popup.PopupEntity(failMessage, uid, userUid);
             return;
         }
 
@@ -139,7 +139,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         _transformSystem.Unanchor(uid, xform);
         RaiseLocalEvent(uid, new UserUnanchoredEvent(args.User, used));
 
-        _popup.PopupClient(Loc.GetString("anchorable-unanchored"), uid, args.User);
+        _popup.PopupEntity(Loc.GetString("anchorable-unanchored"), uid, args.User);
 
         _adminLogger.Add(
             LogType.Unanchor,
@@ -157,7 +157,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         if (TryComp<PhysicsComponent>(uid, out var anchorBody) &&
             !TileFree(xform.Coordinates, anchorBody))
         {
-            _popup.PopupClient(Loc.GetString("anchorable-occupied"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("anchorable-occupied"), uid, args.User);
             return;
         }
 
@@ -177,7 +177,7 @@ public sealed partial class AnchorableSystem : EntitySystem
 
             if (AnyUnstackable(uid, coordinates))
             {
-                _popup.PopupClient(Loc.GetString("construction-step-condition-no-unstackable-in-tile"), uid, args.User);
+                _popup.PopupEntity(Loc.GetString("construction-step-condition-no-unstackable-in-tile"), uid, args.User);
                 return;
             }
 
@@ -191,7 +191,7 @@ public sealed partial class AnchorableSystem : EntitySystem
 
         RaiseLocalEvent(uid, new UserAnchoredEvent(args.User, used));
 
-        _popup.PopupClient(Loc.GetString("anchorable-anchored"), uid, args.User);
+        _popup.PopupEntity(Loc.GetString("anchorable-anchored"), uid, args.User);
 
         _adminLogger.Add(
             LogType.Anchor,
@@ -246,7 +246,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         if (!Valid(uid, userUid, usingUid, true, out var failMessage, anchorable, usingTool))
         {
             if (failMessage != null)
-                _popup.PopupClient(Loc.GetString(failMessage), uid, userUid);
+                _popup.PopupEntity(Loc.GetString(failMessage), uid, userUid);
             return;
         }
 
@@ -258,7 +258,7 @@ public sealed partial class AnchorableSystem : EntitySystem
 
         if (AnyUnstackable(uid, transform.Coordinates))
         {
-            _popup.PopupClient(Loc.GetString("construction-step-condition-no-unstackable-in-tile"), uid, userUid);
+            _popup.PopupEntity(Loc.GetString("construction-step-condition-no-unstackable-in-tile"), uid, userUid);
             return;
         }
 
@@ -317,7 +317,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         if (TileFree(coordinates, entity.Comp))
             return true;
 
-        _popup.PopupClient(Loc.GetString("anchorable-occupied"), entity, user);
+        _popup.PopupEntity(Loc.GetString("anchorable-occupied"), entity, user);
         return false;
     }
 

--- a/Content.Shared/Construction/EntitySystems/BlockAnchorOnSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/BlockAnchorOnSystem.cs
@@ -36,7 +36,7 @@ public sealed partial class BlockAnchorOnSystem : EntitySystem
         if (!HasOverlap((ent, ent.Comp, Transform(ent))))
             return;
 
-        _popup.PopupPredicted(Loc.GetString("anchored-already-present"), ent, null);
+        _popup.PopupEntity(Loc.GetString("anchored-already-present"), ent);
         _xform.Unanchor(ent, Transform(ent));
     }
 
@@ -51,7 +51,7 @@ public sealed partial class BlockAnchorOnSystem : EntitySystem
         if (!HasOverlap((ent, ent.Comp, Transform(ent))))
             return;
 
-        _popup.PopupPredicted(Loc.GetString("anchored-already-present"), ent, args.User);
+        _popup.PopupEntity(Loc.GetString("anchored-already-present"), ent);
         args.Cancel();
     }
 

--- a/Content.Shared/Construction/EntitySystems/BlockAnchorOnSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/BlockAnchorOnSystem.cs
@@ -51,7 +51,7 @@ public sealed partial class BlockAnchorOnSystem : EntitySystem
         if (!HasOverlap((ent, ent.Comp, Transform(ent))))
             return;
 
-        _popup.PopupEntity(Loc.GetString("anchored-already-present"), ent);
+        _popup.PopupEntity(Loc.GetString("anchored-already-present"), ent, args.User);
         args.Cancel();
     }
 

--- a/Content.Shared/Construction/SharedFlatpackSystem.cs
+++ b/Content.Shared/Construction/SharedFlatpackSystem.cs
@@ -90,7 +90,7 @@ public abstract partial class SharedFlatpackSystem : EntitySystem
 
         if (!_anchorable.TileFree((grid, gridComp), buildPos, layer, mask))
         {
-            _popup.PopupPredicted(Loc.GetString("flatpack-unpack-no-room"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("flatpack-unpack-no-room"), uid);
             return;
         }
 

--- a/Content.Shared/Construction/SharedFlatpackSystem.cs
+++ b/Content.Shared/Construction/SharedFlatpackSystem.cs
@@ -90,7 +90,7 @@ public abstract partial class SharedFlatpackSystem : EntitySystem
 
         if (!_anchorable.TileFree((grid, gridComp), buildPos, layer, mask))
         {
-            _popup.PopupEntity(Loc.GetString("flatpack-unpack-no-room"), uid);
+            _popup.PopupEntity(Loc.GetString("flatpack-unpack-no-room"), uid, args.User);
             return;
         }
 

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -249,9 +249,9 @@ namespace Content.Shared.Containers.ItemSlots
                 //
                 // doing a check to make sure that they're all the same or something is probably frivolous
                 if (lockedFailPopup != null)
-                    _popupSystem.PopupClient(Loc.GetString(lockedFailPopup), uid, args.User);
+                    _popupSystem.PopupEntity(Loc.GetString(lockedFailPopup), uid, args.User);
                 else if (whitelistFailPopup != null)
-                    _popupSystem.PopupClient(Loc.GetString(whitelistFailPopup), uid, args.User);
+                    _popupSystem.PopupEntity(Loc.GetString(whitelistFailPopup), uid, args.User);
                 return;
             }
 
@@ -269,7 +269,7 @@ namespace Content.Shared.Containers.ItemSlots
                 Insert(uid, slot, args.Used, args.User, excludeUserAudio: true);
 
                 if (slot.InsertSuccessPopup.HasValue)
-                    _popupSystem.PopupClient(Loc.GetString(slot.InsertSuccessPopup), uid, args.User);
+                    _popupSystem.PopupEntity(Loc.GetString(slot.InsertSuccessPopup), uid, args.User);
 
                 args.Handled = true;
                 return;
@@ -519,7 +519,7 @@ namespace Content.Shared.Containers.ItemSlots
             if (slot.Locked)
             {
                 if (popup.HasValue && slot.LockedFailPopup.HasValue)
-                    _popupSystem.PopupClient(Loc.GetString(slot.LockedFailPopup), uid, popup.Value);
+                    _popupSystem.PopupEntity(Loc.GetString(slot.LockedFailPopup), uid, popup.Value);
                 return false;
             }
 

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -141,7 +141,7 @@ namespace Content.Shared.Cuffs
 
             if (args.Cancelled)
             {
-                _popup.PopupClient(Loc.GetString("cuffable-component-cannot-interact-message"), args.Target, args.User);
+                _popup.PopupEntity(Loc.GetString("cuffable-component-cannot-interact-message"), args.Target, args.User);
             }
         }
 
@@ -216,7 +216,7 @@ namespace Content.Shared.Cuffs
                 ? Loc.GetString("handcuff-component-cuff-interrupt-buckled-message")
                 : Loc.GetString("handcuff-component-cuff-interrupt-unbuckled-message");
 
-            _popup.PopupClient(message, ent, user);
+            _popup.PopupEntity(message, ent, user);
         }
 
         private void OnBuckleAttemptEvent(Entity<CuffableComponent> ent, ref BuckleAttemptEvent args)
@@ -303,7 +303,7 @@ namespace Content.Shared.Cuffs
             }
             else
             {
-                _popup.PopupClient(Loc.GetString("cuffable-component-remove-cuffs-fail-message"), user, user);
+                _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-fail-message"), user, user);
             }
         }
 
@@ -314,7 +314,7 @@ namespace Content.Shared.Cuffs
 
             if (!args.CanReach)
             {
-                _popup.PopupClient(Loc.GetString("handcuff-component-too-far-away-error"), args.User, args.User);
+                _popup.PopupEntity(Loc.GetString("handcuff-component-too-far-away-error"), args.User, args.User);
                 return;
             }
 
@@ -359,15 +359,15 @@ namespace Content.Shared.Cuffs
 
                 if (target == user)
                 {
-                    _popup.PopupClient(Loc.GetString("handcuff-component-cuff-self-success-message"), user, user);
+                    _popup.PopupEntity(Loc.GetString("handcuff-component-cuff-self-success-message"), user, user);
                     _adminLog.Add(LogType.Action, LogImpact.Medium,
                         $"{ToPrettyString(user):player} has cuffed himself");
                 }
                 else
                 {
-                    _popup.PopupClient(Loc.GetString("handcuff-component-cuff-other-success-message",
+                    _popup.PopupEntity(Loc.GetString("handcuff-component-cuff-other-success-message",
                         ("otherName", Identity.Name(target, EntityManager, user))), user, user);
-                    _popup.PopupClient(Loc.GetString("handcuff-component-cuff-by-other-success-message",
+                    _popup.PopupEntity(Loc.GetString("handcuff-component-cuff-by-other-success-message",
                         ("otherName", Identity.Name(user, EntityManager, target))), target, target);
                     _adminLog.Add(LogType.Action, LogImpact.High,
                         $"{ToPrettyString(user):player} has cuffed {ToPrettyString(target):player}");
@@ -377,16 +377,16 @@ namespace Content.Shared.Cuffs
             {
                 if (target == user)
                 {
-                    _popup.PopupClient(Loc.GetString("handcuff-component-cuff-interrupt-self-message"), user, user);
+                    _popup.PopupEntity(Loc.GetString("handcuff-component-cuff-interrupt-self-message"), user, user);
                 }
                 else
                 {
                     // TODO Fix popup message wording
                     // This message assumes that the user being handcuffed is the one that caused the handcuff to fail.
 
-                    _popup.PopupClient(Loc.GetString("handcuff-component-cuff-interrupt-message",
+                    _popup.PopupEntity(Loc.GetString("handcuff-component-cuff-interrupt-message",
                         ("targetName", Identity.Name(target, EntityManager, user))), user, user);
-                    _popup.PopupClient(Loc.GetString("handcuff-component-cuff-interrupt-other-message",
+                    _popup.PopupEntity(Loc.GetString("handcuff-component-cuff-interrupt-other-message",
                         ("otherName", Identity.Name(user, EntityManager, target)),
                         ("otherEnt", user)), target, target);
                 }
@@ -504,21 +504,21 @@ namespace Content.Shared.Cuffs
 
             if (!TryComp<HandsComponent>(target, out var hands))
             {
-                _popup.PopupClient(Loc.GetString("handcuff-component-target-has-no-hands-error",
+                _popup.PopupEntity(Loc.GetString("handcuff-component-target-has-no-hands-error",
                     ("targetName", Identity.Name(target, EntityManager, user))), user, user);
                 return true;
             }
 
             if (cuffable.CuffedHandCount >= hands.Count)
             {
-                _popup.PopupClient(Loc.GetString("handcuff-component-target-has-no-free-hands-error",
+                _popup.PopupEntity(Loc.GetString("handcuff-component-target-has-no-free-hands-error",
                     ("targetName", Identity.Name(target, EntityManager, user))), user, user);
                 return true;
             }
 
             if (!_hands.CanDrop(user, handcuff))
             {
-                _popup.PopupClient(Loc.GetString("handcuff-component-cannot-drop-cuffs", ("target", Identity.Name(target, EntityManager, user))), user, user);
+                _popup.PopupEntity(Loc.GetString("handcuff-component-cannot-drop-cuffs", ("target", Identity.Name(target, EntityManager, user))), user, user);
                 return false;
             }
 
@@ -552,11 +552,11 @@ namespace Content.Shared.Cuffs
 
             if (target == user)
             {
-                _popup.PopupClient(Loc.GetString("handcuff-component-target-self"), user, user);
+                _popup.PopupEntity(Loc.GetString("handcuff-component-target-self"), user, user);
             }
             else
             {
-                _popup.PopupClient(Loc.GetString("handcuff-component-start-cuffing-target-message",
+                _popup.PopupEntity(Loc.GetString("handcuff-component-start-cuffing-target-message",
                     ("targetName", Identity.Name(target, EntityManager, user))), user, user);
                 _popup.PopupEntity(Loc.GetString("handcuff-component-start-cuffing-by-other-message",
                     ("otherName", Identity.Name(user, EntityManager, target))), target, target);
@@ -625,7 +625,7 @@ namespace Content.Shared.Cuffs
 
             if (!isOwner && !_interaction.InRangeUnobstructed(user, target.Owner))
             {
-                _popup.PopupClient(Loc.GetString("cuffable-component-cannot-remove-cuffs-too-far-message"), user, user);
+                _popup.PopupEntity(Loc.GetString("cuffable-component-cannot-remove-cuffs-too-far-message"), user, user);
                 return;
             }
 
@@ -673,11 +673,11 @@ namespace Content.Shared.Cuffs
 
             if (isOwner)
             {
-                _popup.PopupClient(Loc.GetString("cuffable-component-start-uncuffing-self"), user, user);
+                _popup.PopupEntity(Loc.GetString("cuffable-component-start-uncuffing-self"), user, user);
             }
             else
             {
-                _popup.PopupClient(Loc.GetString("cuffable-component-start-uncuffing-target-message",
+                _popup.PopupEntity(Loc.GetString("cuffable-component-start-uncuffing-target-message",
                     ("targetName", Identity.Name(target, EntityManager, user))),
                     user,
                     user);
@@ -742,14 +742,14 @@ namespace Content.Shared.Cuffs
                 {
                     if (shoved)
                     {
-                        _popup.PopupClient(Loc.GetString("cuffable-component-remove-cuffs-push-success-message",
+                        _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-push-success-message",
                             ("otherName", Identity.Name(user.Value, EntityManager, user))),
                             user.Value,
                             user.Value);
                     }
                     else
                     {
-                        _popup.PopupClient(Loc.GetString("cuffable-component-remove-cuffs-success-message"), user.Value, user.Value);
+                        _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-success-message"), user.Value, user.Value);
                     }
                 }
 
@@ -770,7 +770,7 @@ namespace Content.Shared.Cuffs
             {
                 if (user != target)
                 {
-                    _popup.PopupClient(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
+                    _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
                         ("cuffedHandCount", cuffable.CuffedHandCount),
                         ("otherName", Identity.Name(user.Value, EntityManager, user.Value))), user.Value, user.Value);
                     _popup.PopupEntity(Loc.GetString(
@@ -780,7 +780,7 @@ namespace Content.Shared.Cuffs
                 }
                 else
                 {
-                    _popup.PopupClient(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
+                    _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
                         ("cuffedHandCount", cuffable.CuffedHandCount)), user.Value, user.Value);
                 }
             }

--- a/Content.Shared/Damage/Systems/DamageOnAttackedSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageOnAttackedSystem.cs
@@ -81,7 +81,7 @@ public sealed partial class DamageOnAttackedSystem : EntitySystem
             _audioSystem.PlayPredicted(entity.Comp.InteractSound, entity, args.User);
 
             if (entity.Comp.PopupText != null)
-                _popupSystem.PopupClient(Loc.GetString(entity.Comp.PopupText), args.User, args.User);
+                _popupSystem.PopupEntity(Loc.GetString(entity.Comp.PopupText), args.User, args.User);
 
         }
     }

--- a/Content.Shared/Damage/Systems/DamageOnInteractSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageOnInteractSystem.cs
@@ -88,7 +88,7 @@ public sealed partial class DamageOnInteractSystem : EntitySystem
             _audioSystem.PlayPredicted(entity.Comp.InteractSound, args.Target, args.User);
 
             if (entity.Comp.PopupText != null)
-                _popupSystem.PopupClient(Loc.GetString(entity.Comp.PopupText), args.User, args.User);
+                _popupSystem.PopupEntity(Loc.GetString(entity.Comp.PopupText), args.User, args.User);
 
             // Attempt to paralyze the user after they have taken damage
             if (_random.Prob(entity.Comp.StunChance))

--- a/Content.Shared/Damage/Systems/DamagePopupSystem.cs
+++ b/Content.Shared/Damage/Systems/DamagePopupSystem.cs
@@ -32,8 +32,7 @@ public sealed partial class DamagePopupSystem : EntitySystem
                 _ => "Invalid type",
             };
 
-            // Turn this back into (msg, ent.Owner, args.Origin) when shooting gets predicted.
-            _popupSystem.PopupPredicted(msg, ent.Owner, null);
+            _popupSystem.PopupEntity(msg, ent.Owner);
         }
     }
 
@@ -44,7 +43,7 @@ public sealed partial class DamagePopupSystem : EntitySystem
             var next = (DamagePopupType)(((int)ent.Comp.Type + 1) % Enum.GetValues<DamagePopupType>().Length);
             ent.Comp.Type = next;
             Dirty(ent);
-            _popupSystem.PopupPredicted(Loc.GetString("damage-popup-component-switched", ("setting", ent.Comp.Type)), ent.Owner, args.User);
+            _popupSystem.PopupEntity(Loc.GetString("damage-popup-component-switched", ("setting", ent.Comp.Type)), ent.Owner);
         }
     }
 }

--- a/Content.Shared/Delivery/SharedDeliverySystem.cs
+++ b/Content.Shared/Delivery/SharedDeliverySystem.cs
@@ -145,9 +145,9 @@ public abstract partial class SharedDeliverySystem : EntitySystem
             {
                 _audio.PlayPredicted(ent.Comp.OpenSound, ent.Owner, user);
 
-                if(ent.Comp.ContainedDeliveryAmount == 0)
+                if (ent.Comp.ContainedDeliveryAmount == 0)
                 {
-                    _popup.PopupPredicted(Loc.GetString("delivery-teleporter-empty", ("entity", ent)), null, ent, user);
+                    _popup.PopupEntity(Loc.GetString("delivery-teleporter-empty", ("entity", ent)), ent, user);
                     return;
                 }
 
@@ -184,8 +184,9 @@ public abstract partial class SharedDeliverySystem : EntitySystem
             GrantSpesoReward(ent.AsNullable());
 
         if (!force)
-            _popup.PopupPredicted(Loc.GetString("delivery-unlocked-self", ("delivery", deliveryName)),
-                Loc.GetString("delivery-unlocked-others", ("delivery", deliveryName), ("recipient", Identity.Entity(user, EntityManager)), ("possadj", user)), user, user);
+            _popup.PopupEntity(Loc.GetString("delivery-unlocked-self", ("delivery", deliveryName)),
+                Loc.GetString("delivery-unlocked-others", ("delivery", deliveryName), ("recipient", Identity.Entity(user, EntityManager)), ("possadj", user)),
+                user, user);
 
         return true;
     }
@@ -212,8 +213,9 @@ public abstract partial class SharedDeliverySystem : EntitySystem
         DirtyField(ent.Owner, ent.Comp, nameof(DeliveryComponent.IsOpened));
 
         if (!force)
-            _popup.PopupPredicted(Loc.GetString("delivery-opened-self", ("delivery", deliveryName)),
-                Loc.GetString("delivery-opened-others", ("delivery", deliveryName), ("recipient", Identity.Entity(user, EntityManager)), ("possadj", user)), user, user);
+            _popup.PopupEntity(Loc.GetString("delivery-opened-self", ("delivery", deliveryName)),
+                Loc.GetString("delivery-opened-others", ("delivery", deliveryName), ("recipient", Identity.Entity(user, EntityManager)), ("possadj", user)),
+                user, user);
 
         if (!_container.TryGetContainer(ent, ent.Comp.Container, out var container))
             return;

--- a/Content.Shared/Devour/DevourSystem.cs
+++ b/Content.Shared/Devour/DevourSystem.cs
@@ -80,14 +80,14 @@ public sealed partial class DevourSystem : EntitySystem
                 case MobState.Invalid:
                 case MobState.Alive:
                 default:
-                    _popupSystem.PopupClient(Loc.GetString("devour-action-popup-message-fail-target-alive"), ent.Owner, ent.Owner);
+                    _popupSystem.PopupEntity(Loc.GetString("devour-action-popup-message-fail-target-alive"), ent.Owner, ent.Owner);
                     break;
             }
 
             return;
         }
 
-        _popupSystem.PopupClient(Loc.GetString("devour-action-popup-message-structure"), ent.Owner, ent.Owner);
+        _popupSystem.PopupEntity(Loc.GetString("devour-action-popup-message-structure"), ent.Owner, ent.Owner);
 
         if (ent.Comp.SoundStructureDevour != null)
             _audioSystem.PlayPredicted(ent.Comp.SoundStructureDevour, ent.Owner, ent.Owner, ent.Comp.SoundStructureDevour.Params);

--- a/Content.Shared/Dice/SharedDiceSystem.cs
+++ b/Content.Shared/Dice/SharedDiceSystem.cs
@@ -81,7 +81,7 @@ public abstract partial class SharedDiceSystem : EntitySystem
         var popupString = Loc.GetString("dice-component-on-roll-land",
             ("die", entity),
             ("currentSide", entity.Comp.CurrentValue));
-        _popup.PopupPredicted(popupString, entity, user);
+        _popup.PopupEntity(popupString, entity);
         _audio.PlayPredicted(entity.Comp.Sound, entity, user);
     }
 }

--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.Interactions.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.Interactions.cs
@@ -145,7 +145,7 @@ public abstract partial class SharedDisposalUnitSystem
         {
             // TODO: If ContainerIsInsertingAttemptEvent ever ends up having the user
             // attached to the event, we'll be able to predict the pop up
-            _popup.PopupPredicted(Loc.GetString("disposal-unit-is-full"), ent, null);
+            _popup.PopupEntity(Loc.GetString("disposal-unit-is-full"), ent);
 
             args.Cancel();
             return;

--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.Interactions.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.Interactions.cs
@@ -143,8 +143,7 @@ public abstract partial class SharedDisposalUnitSystem
 
         if (GetContainedEntityCount(ent) >= ent.Comp.MaxCapacity)
         {
-            // TODO: If ContainerIsInsertingAttemptEvent ever ends up having the user
-            // attached to the event, we'll be able to predict the pop up
+            // TODO: Add user to ContainerIsInsertingAttemptEvent, scope the popup to the inserter
             _popup.PopupEntity(Loc.GetString("disposal-unit-is-full"), ent);
 
             args.Cancel();

--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.Interactions.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.Interactions.cs
@@ -143,7 +143,7 @@ public abstract partial class SharedDisposalUnitSystem
 
         if (GetContainedEntityCount(ent) >= ent.Comp.MaxCapacity)
         {
-            // TODO: Add user to ContainerIsInsertingAttemptEvent, scope the popup to the inserter
+            // TODO: Add user to ContainerIsInsertingAttemptEvent, show the popup only to the entity doing the insertion.
             _popup.PopupEntity(Loc.GetString("disposal-unit-is-full"), ent);
 
             args.Cancel();

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -82,14 +82,14 @@ public abstract partial class SharedFirelockSystem : EntitySystem
     {
         if (ent.Comp.Temperature)
         {
-            _popupSystem.PopupClient(Loc.GetString("firelock-component-is-holding-fire-message"),
+            _popupSystem.PopupEntity(Loc.GetString("firelock-component-is-holding-fire-message"),
                 ent.Owner,
                 user,
                 PopupType.MediumCaution);
         }
         else if (ent.Comp.Pressure)
         {
-            _popupSystem.PopupClient(Loc.GetString("firelock-component-is-holding-pressure-message"),
+            _popupSystem.PopupEntity(Loc.GetString("firelock-component-is-holding-pressure-message"),
                 ent.Owner,
                 user,
                 PopupType.MediumCaution);

--- a/Content.Shared/Doors/Systems/SharedTurnstileSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedTurnstileSystem.cs
@@ -73,7 +73,7 @@ public abstract partial class SharedTurnstileSystem : EntitySystem
         {
             if (_timing.CurTime >= ent.Comp.NextResistTime)
             {
-                _popup.PopupClient(Loc.GetString("turnstile-component-popup-resist", ("turnstile", ent.Owner)), ent, args.OtherEntity);
+                _popup.PopupEntity(Loc.GetString("turnstile-component-popup-resist", ("turnstile", ent.Owner)), ent, args.OtherEntity);
                 ent.Comp.NextResistTime = _timing.CurTime + TimeSpan.FromSeconds(0.1);
                 Dirty(ent);
             }

--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -64,7 +64,7 @@ public sealed partial class EmagSystem : EntitySystem
         Entity<LimitedChargesComponent?> chargesEnt = ent.Owner;
         if (_sharedCharges.IsEmpty(chargesEnt))
         {
-            _popup.PopupClient(Loc.GetString("emag-no-charges"), user, user);
+            _popup.PopupEntity(Loc.GetString("emag-no-charges"), user, user);
             return false;
         }
 

--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -76,7 +76,7 @@ public sealed partial class EmagSystem : EntitySystem
         if (!emaggedEvent.Handled)
             return false;
 
-        _popup.PopupPredicted(Loc.GetString("emag-success", ("target", Identity.Entity(target, EntityManager))), user, user, PopupType.Medium);
+        _popup.PopupEntity(Loc.GetString("emag-success", ("target", Identity.Entity(target, EntityManager))), user, PopupType.Medium);
 
         _audio.PlayPredicted(ent.Comp.EmagSound, ent, ent);
 

--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -76,7 +76,7 @@ public sealed partial class EmagSystem : EntitySystem
         if (!emaggedEvent.Handled)
             return false;
 
-        _popup.PopupEntity(Loc.GetString("emag-success", ("target", Identity.Entity(target, EntityManager))), user, PopupType.Medium);
+        _popup.PopupEntity(Loc.GetString("emag-success", ("target", Identity.Entity(target, EntityManager))), user, user, PopupType.Medium);
 
         _audio.PlayPredicted(ent.Comp.EmagSound, ent, ent);
 

--- a/Content.Shared/Engineering/Systems/InflatableSafeDisassemblySystem.cs
+++ b/Content.Shared/Engineering/Systems/InflatableSafeDisassemblySystem.cs
@@ -28,10 +28,9 @@ public sealed partial class InflatableSafeDisassemblySystem : EntitySystem
         if (!HasComp<BalloonPopperComponent>(args.Used))
             return;
 
-        _popupSystem.PopupPredicted(
+        _popupSystem.PopupEntity(
             Loc.GetString("inflatable-safe-disassembly", ("item", args.Used), ("target", ent.Owner)),
-            ent,
-            args.User);
+            ent);
 
         _disassembleOnAltVerbSystem.StartDisassembly((ent, Comp<DisassembleOnAltVerbComponent>(ent)), args.User);
         args.Handled = true;

--- a/Content.Shared/Engineering/Systems/InflatableSafeDisassemblySystem.cs
+++ b/Content.Shared/Engineering/Systems/InflatableSafeDisassemblySystem.cs
@@ -30,7 +30,8 @@ public sealed partial class InflatableSafeDisassemblySystem : EntitySystem
 
         _popupSystem.PopupEntity(
             Loc.GetString("inflatable-safe-disassembly", ("item", args.Used), ("target", ent.Owner)),
-            ent);
+            ent,
+            args.User);
 
         _disassembleOnAltVerbSystem.StartDisassembly((ent, Comp<DisassembleOnAltVerbComponent>(ent)), args.User);
         args.Handled = true;

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -168,9 +168,9 @@ public abstract partial class SharedEnsnareableSystem : EntitySystem
             return;
 
         if (user == target)
-            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free", ("ensnare", ensnare)), target);
+            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free", ("ensnare", ensnare)), target, target);
         else
-            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-other", ("ensnare", ensnare), ("user", Identity.Entity(target, EntityManager))), user);
+            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-other", ("ensnare", ensnare), ("user", Identity.Entity(target, EntityManager))), user, user);
     }
 
     private void OnStripEnsnareMessage(EntityUid uid, EnsnareableComponent component, StrippingEnsnareButtonPressed args)

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -75,9 +75,9 @@ public abstract partial class SharedEnsnareableSystem : EntitySystem
         if (args.Cancelled || component.Container == null || !Container.Remove(args.Args.Used.Value, component.Container))
         {
             if (args.User == args.Target)
-                Popup.PopupPredicted(Loc.GetString("ensnare-component-try-free-fail", ("ensnare", args.Args.Used)), uid, args.User, PopupType.MediumCaution);
+                Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-fail", ("ensnare", args.Args.Used)), uid, PopupType.MediumCaution);
             else if (args.Target != null)
-                Popup.PopupPredicted(Loc.GetString("ensnare-component-try-free-fail-other", ("ensnare", args.Args.Used), ("user", args.Target)), uid, args.User, PopupType.MediumCaution);
+                Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-fail-other", ("ensnare", args.Args.Used), ("user", args.Target)), uid, PopupType.MediumCaution);
 
             return;
         }
@@ -88,9 +88,9 @@ public abstract partial class SharedEnsnareableSystem : EntitySystem
         ensnaring.Ensnared = null;
 
         if (args.User == args.Target)
-            Popup.PopupPredicted(Loc.GetString("ensnare-component-try-free-complete", ("ensnare", args.Args.Used)), uid, args.User, PopupType.Medium);
+            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-complete", ("ensnare", args.Args.Used)), uid, PopupType.Medium);
         else if (args.Target != null)
-            Popup.PopupPredicted(Loc.GetString("ensnare-component-try-free-complete-other", ("ensnare", args.Args.Used), ("user", args.Target)), uid, args.User, PopupType.Medium);
+            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-complete-other", ("ensnare", args.Args.Used), ("user", args.Target)), uid, PopupType.Medium);
 
         UpdateAlert(args.Args.Target.Value, component);
         var ev = new EnsnareRemoveEvent(ensnaring.WalkSpeed, ensnaring.SprintSpeed);
@@ -168,9 +168,9 @@ public abstract partial class SharedEnsnareableSystem : EntitySystem
             return;
 
         if (user == target)
-            Popup.PopupPredicted(Loc.GetString("ensnare-component-try-free", ("ensnare", ensnare)), target, target);
+            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free", ("ensnare", ensnare)), target);
         else
-            Popup.PopupPredicted(Loc.GetString("ensnare-component-try-free-other", ("ensnare", ensnare), ("user", Identity.Entity(target, EntityManager))), user, user);
+            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-other", ("ensnare", ensnare), ("user", Identity.Entity(target, EntityManager))), user);
     }
 
     private void OnStripEnsnareMessage(EntityUid uid, EnsnareableComponent component, StrippingEnsnareButtonPressed args)

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -75,9 +75,9 @@ public abstract partial class SharedEnsnareableSystem : EntitySystem
         if (args.Cancelled || component.Container == null || !Container.Remove(args.Args.Used.Value, component.Container))
         {
             if (args.User == args.Target)
-                Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-fail", ("ensnare", args.Args.Used)), uid, PopupType.MediumCaution);
+                Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-fail", ("ensnare", args.Args.Used)), uid, args.User, PopupType.MediumCaution);
             else if (args.Target != null)
-                Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-fail-other", ("ensnare", args.Args.Used), ("user", args.Target)), uid, PopupType.MediumCaution);
+                Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-fail-other", ("ensnare", args.Args.Used), ("user", args.Target)), uid, args.User, PopupType.MediumCaution);
 
             return;
         }
@@ -88,9 +88,9 @@ public abstract partial class SharedEnsnareableSystem : EntitySystem
         ensnaring.Ensnared = null;
 
         if (args.User == args.Target)
-            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-complete", ("ensnare", args.Args.Used)), uid, PopupType.Medium);
+            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-complete", ("ensnare", args.Args.Used)), uid, args.User, PopupType.Medium);
         else if (args.Target != null)
-            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-complete-other", ("ensnare", args.Args.Used), ("user", args.Target)), uid, PopupType.Medium);
+            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-complete-other", ("ensnare", args.Args.Used), ("user", args.Target)), uid, args.User, PopupType.Medium);
 
         UpdateAlert(args.Args.Target.Value, component);
         var ev = new EnsnareRemoveEvent(ensnaring.WalkSpeed, ensnaring.SprintSpeed);

--- a/Content.Shared/Execution/SharedExecutionSystem.cs
+++ b/Content.Shared/Execution/SharedExecutionSystem.cs
@@ -157,7 +157,7 @@ public sealed partial class SharedExecutionSystem : EntitySystem
     {
         if (predict)
         {
-            _popup.PopupClient(
+            _popup.PopupEntity(
                Loc.GetString(locString, ("attacker", Identity.Entity(attacker, EntityManager)), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
                attacker,
                attacker,

--- a/Content.Shared/Execution/SharedExecutionSystem.cs
+++ b/Content.Shared/Execution/SharedExecutionSystem.cs
@@ -146,33 +146,20 @@ public sealed partial class SharedExecutionSystem : EntitySystem
         if (!TryComp<DamageableComponent>(args.Victim, out var damageableComponent))
             return;
 
-        ShowExecutionInternalPopup(internalMsg, args.Victim, args.Victim, entity, false);
+        ShowExecutionInternalPopup(internalMsg, args.Victim, args.Victim, entity);
         ShowExecutionExternalPopup(externalMsg, args.Victim, args.Victim, entity);
         _audio.PlayPredicted(melee.HitSound, args.Victim, args.Victim);
         _suicide.ApplyLethalDamage((args.Victim, damageableComponent), melee.Damage);
         args.Handled = true;
     }
 
-    private void ShowExecutionInternalPopup(string locString, EntityUid attacker, EntityUid victim, EntityUid weapon, bool predict = true)
+    private void ShowExecutionInternalPopup(string locString, EntityUid attacker, EntityUid victim, EntityUid weapon)
     {
-        if (predict)
-        {
-            _popup.PopupEntity(
-               Loc.GetString(locString, ("attacker", Identity.Entity(attacker, EntityManager)), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
-               attacker,
-               attacker,
-               PopupType.MediumCaution
-               );
-        }
-        else
-        {
-            _popup.PopupEntity(
-               Loc.GetString(locString, ("attacker", Identity.Entity(attacker, EntityManager)), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
-               attacker,
-               attacker,
-               PopupType.MediumCaution
-               );
-        }
+        _popup.PopupEntity(
+            Loc.GetString(locString, ("attacker", Identity.Entity(attacker, EntityManager)), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
+            attacker,
+            attacker,
+            PopupType.MediumCaution);
     }
 
     private void ShowExecutionExternalPopup(string locString, EntityUid attacker, EntityUid victim, EntityUid weapon)
@@ -182,8 +169,7 @@ public sealed partial class SharedExecutionSystem : EntitySystem
             attacker,
             Filter.PvsExcept(attacker),
             true,
-            PopupType.MediumCaution
-            );
+            PopupType.MediumCaution);
     }
 
     private void OnExecutionDoAfter(Entity<ExecutionComponent> entity, ref ExecutionDoAfterEvent args)

--- a/Content.Shared/Execution/SharedExecutionSystem.cs
+++ b/Content.Shared/Execution/SharedExecutionSystem.cs
@@ -12,7 +12,6 @@ using Content.Shared.Verbs;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Interaction.Events;
-using Robust.Shared.Player;
 using Robust.Shared.Audio.Systems;
 
 namespace Content.Shared.Execution;
@@ -73,13 +72,11 @@ public sealed partial class SharedExecutionSystem : EntitySystem
 
         if (attacker == victim)
         {
-            ShowExecutionInternalPopup(comp.InternalSelfExecutionMessage, attacker, victim, weapon);
-            ShowExecutionExternalPopup(comp.ExternalSelfExecutionMessage, attacker, victim, weapon);
+            ShowExecutionPopup(comp.InternalSelfExecutionMessage, comp.ExternalSelfExecutionMessage, attacker, victim, weapon);
         }
         else
         {
-            ShowExecutionInternalPopup(comp.InternalMeleeExecutionMessage, attacker, victim, weapon);
-            ShowExecutionExternalPopup(comp.ExternalMeleeExecutionMessage, attacker, victim, weapon);
+            ShowExecutionPopup(comp.InternalMeleeExecutionMessage, comp.ExternalMeleeExecutionMessage, attacker, victim, weapon);
         }
 
         var doAfter =
@@ -146,29 +143,19 @@ public sealed partial class SharedExecutionSystem : EntitySystem
         if (!TryComp<DamageableComponent>(args.Victim, out var damageableComponent))
             return;
 
-        ShowExecutionInternalPopup(internalMsg, args.Victim, args.Victim, entity);
-        ShowExecutionExternalPopup(externalMsg, args.Victim, args.Victim, entity);
+        ShowExecutionPopup(internalMsg, externalMsg, args.Victim, args.Victim, entity);
         _audio.PlayPredicted(melee.HitSound, args.Victim, args.Victim);
         _suicide.ApplyLethalDamage((args.Victim, damageableComponent), melee.Damage);
         args.Handled = true;
     }
 
-    private void ShowExecutionInternalPopup(string locString, EntityUid attacker, EntityUid victim, EntityUid weapon)
+    private void ShowExecutionPopup(string targetMessage, string otherMessage, EntityUid attacker, EntityUid victim, EntityUid weapon)
     {
         _popup.PopupEntity(
-            Loc.GetString(locString, ("attacker", Identity.Entity(attacker, EntityManager)), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
+            Loc.GetString(targetMessage, ("attacker", Identity.Entity(attacker, EntityManager)), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
+            Loc.GetString(otherMessage, ("attacker", Identity.Entity(attacker, EntityManager)), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
             attacker,
             attacker,
-            PopupType.MediumCaution);
-    }
-
-    private void ShowExecutionExternalPopup(string locString, EntityUid attacker, EntityUid victim, EntityUid weapon)
-    {
-        _popup.PopupEntity(
-            Loc.GetString(locString, ("attacker", Identity.Entity(attacker, EntityManager)), ("victim", Identity.Entity(victim, EntityManager)), ("weapon", weapon)),
-            attacker,
-            Filter.PvsExcept(attacker),
-            true,
             PopupType.MediumCaution);
     }
 
@@ -214,8 +201,7 @@ public sealed partial class SharedExecutionSystem : EntitySystem
 
         if (attacker != victim)
         {
-            _execution.ShowExecutionInternalPopup(internalMsg, attacker, victim, entity);
-            _execution.ShowExecutionExternalPopup(externalMsg, attacker, victim, entity);
+            _execution.ShowExecutionPopup(internalMsg, externalMsg, attacker, victim, entity);
         }
     }
 }

--- a/Content.Shared/Eye/Blinding/Systems/ActivatableUIRequiresVisionSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/ActivatableUIRequiresVisionSystem.cs
@@ -25,7 +25,7 @@ public sealed partial class ActivatableUIRequiresVisionSystem : EntitySystem
         if (TryComp<BlindableComponent>(args.User, out var blindable) && blindable.IsBlind)
         {
             if (!args.Silent)
-                _popupSystem.PopupEntity(Loc.GetString("blindness-fail-attempt"), args.User, Shared.Popups.PopupType.MediumCaution);
+                _popupSystem.PopupEntity(Loc.GetString("blindness-fail-attempt"), args.User, args.User, PopupType.MediumCaution);
             args.Cancel();
         }
     }

--- a/Content.Shared/Eye/Blinding/Systems/ActivatableUIRequiresVisionSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/ActivatableUIRequiresVisionSystem.cs
@@ -25,7 +25,7 @@ public sealed partial class ActivatableUIRequiresVisionSystem : EntitySystem
         if (TryComp<BlindableComponent>(args.User, out var blindable) && blindable.IsBlind)
         {
             if (!args.Silent)
-                _popupSystem.PopupClient(Loc.GetString("blindness-fail-attempt"), args.User, Shared.Popups.PopupType.MediumCaution);
+                _popupSystem.PopupEntity(Loc.GetString("blindness-fail-attempt"), args.User, Shared.Popups.PopupType.MediumCaution);
             args.Cancel();
         }
     }

--- a/Content.Shared/FingerprintReader/FingerprintReaderSystem.cs
+++ b/Content.Shared/FingerprintReader/FingerprintReaderSystem.cs
@@ -65,7 +65,7 @@ public sealed partial class FingerprintReaderSystem : EntitySystem
             denyReason = Loc.GetString("fingerprint-reader-fail-gloves", ("blocker", gloves));
 
             if (showPopup)
-                _popup.PopupClient(denyReason, target, user);
+                _popup.PopupEntity(denyReason, target, user);
 
             return false;
         }
@@ -77,7 +77,7 @@ public sealed partial class FingerprintReaderSystem : EntitySystem
             denyReason = Loc.GetString("fingerprint-reader-fail");
 
             if (showPopup)
-                _popup.PopupClient(denyReason, target, user);
+                _popup.PopupEntity(denyReason, target, user);
 
             return false;
         }

--- a/Content.Shared/Flash/SharedFlashSystem.cs
+++ b/Content.Shared/Flash/SharedFlashSystem.cs
@@ -189,7 +189,7 @@ public abstract partial class SharedFlashSystem : EntitySystem
         {
             _appearance.SetData(ent.Owner, FlashVisuals.Burnt, true); // TODO: Reset if charges are refilled.
             _tag.AddTag(ent.Owner, TrashTag);
-            _popup.PopupClient(Loc.GetString("flash-component-becomes-empty"), user);
+            _popup.PopupEntity(Loc.GetString("flash-component-becomes-empty"), user, user);
         }
 
         return true;

--- a/Content.Shared/Flash/SharedFlashSystem.cs
+++ b/Content.Shared/Flash/SharedFlashSystem.cs
@@ -189,7 +189,8 @@ public abstract partial class SharedFlashSystem : EntitySystem
         {
             _appearance.SetData(ent.Owner, FlashVisuals.Burnt, true); // TODO: Reset if charges are refilled.
             _tag.AddTag(ent.Owner, TrashTag);
-            _popup.PopupEntity(Loc.GetString("flash-component-becomes-empty"), user, user);
+            if (user != null)
+                _popup.PopupEntity(Loc.GetString("flash-component-becomes-empty"), user.Value, user);
         }
 
         return true;

--- a/Content.Shared/Fluids/EntitySystems/DrainSystem.cs
+++ b/Content.Shared/Fluids/EntitySystems/DrainSystem.cs
@@ -221,7 +221,7 @@ public sealed partial class DrainSystem : EntitySystem
 
         if (drainSolution.AvailableVolume > 0)
         {
-            _popup.PopupPredicted(Loc.GetString("drain-component-unclog-notapplicable", ("object", args.Target.Value)), args.Target.Value, args.User);
+            _popup.PopupEntity(Loc.GetString("drain-component-unclog-notapplicable", ("object", args.Target.Value)), args.Target.Value);
             return;
         }
 
@@ -244,7 +244,7 @@ public sealed partial class DrainSystem : EntitySystem
 
         if (!SharedRandomExtensions.PredictedProb(_timing, ent.Comp.UnclogProbability, GetNetEntity(ent)))
         {
-            _popup.PopupPredicted(Loc.GetString("drain-component-unclog-fail", ("object", args.Target.Value)), args.Target.Value, args.User);
+            _popup.PopupEntity(Loc.GetString("drain-component-unclog-fail", ("object", args.Target.Value)), args.Target.Value);
             return;
         }
 
@@ -253,7 +253,7 @@ public sealed partial class DrainSystem : EntitySystem
 
         _solutionContainerSystem.RemoveAllSolution(ent.Comp.Solution.Value);
         _audio.PlayPredicted(ent.Comp.UnclogSound, args.Target.Value, args.User);
-        _popup.PopupPredicted(Loc.GetString("drain-component-unclog-success", ("object", args.Target.Value)), args.Target.Value, args.User);
+        _popup.PopupEntity(Loc.GetString("drain-component-unclog-success", ("object", args.Target.Value)), args.Target.Value);
     }
 
     // Prevent a debug assert.

--- a/Content.Shared/Fluids/EntitySystems/DrainSystem.cs
+++ b/Content.Shared/Fluids/EntitySystems/DrainSystem.cs
@@ -221,7 +221,7 @@ public sealed partial class DrainSystem : EntitySystem
 
         if (drainSolution.AvailableVolume > 0)
         {
-            _popup.PopupEntity(Loc.GetString("drain-component-unclog-notapplicable", ("object", args.Target.Value)), args.Target.Value);
+            _popup.PopupEntity(Loc.GetString("drain-component-unclog-notapplicable", ("object", args.Target.Value)), args.Target.Value, args.User);
             return;
         }
 
@@ -244,7 +244,7 @@ public sealed partial class DrainSystem : EntitySystem
 
         if (!SharedRandomExtensions.PredictedProb(_timing, ent.Comp.UnclogProbability, GetNetEntity(ent)))
         {
-            _popup.PopupEntity(Loc.GetString("drain-component-unclog-fail", ("object", args.Target.Value)), args.Target.Value);
+            _popup.PopupEntity(Loc.GetString("drain-component-unclog-fail", ("object", args.Target.Value)), args.Target.Value, args.User);
             return;
         }
 
@@ -253,7 +253,7 @@ public sealed partial class DrainSystem : EntitySystem
 
         _solutionContainerSystem.RemoveAllSolution(ent.Comp.Solution.Value);
         _audio.PlayPredicted(ent.Comp.UnclogSound, args.Target.Value, args.User);
-        _popup.PopupEntity(Loc.GetString("drain-component-unclog-success", ("object", args.Target.Value)), args.Target.Value);
+        _popup.PopupEntity(Loc.GetString("drain-component-unclog-success", ("object", args.Target.Value)), args.Target.Value, args.User);
     }
 
     // Prevent a debug assert.

--- a/Content.Shared/Fluids/EntitySystems/DrainSystem.cs
+++ b/Content.Shared/Fluids/EntitySystems/DrainSystem.cs
@@ -89,7 +89,7 @@ public sealed partial class DrainSystem : EntitySystem
         // Find the solution in the container that is emptied.
         if (!_solutionContainerSystem.TryGetDrainableSolution(container, out var containerSoln, out var containerSolution) || containerSolution.Volume == FixedPoint2.Zero)
         {
-            _popup.PopupClient(
+            _popup.PopupEntity(
                 Loc.GetString("drain-component-empty-verb-using-is-empty-message", ("object", container)),
                 ent.Owner,
                 user);
@@ -118,7 +118,7 @@ public sealed partial class DrainSystem : EntitySystem
         {
             var solutionToSpill = _solutionContainerSystem.SplitSolution(containerSoln.Value, amountToSpillOnGround);
             _puddle.TrySpillAt(Transform(ent.Owner).Coordinates, solutionToSpill, out _);
-            _popup.PopupClient(
+            _popup.PopupEntity(
                 Loc.GetString("drain-component-empty-verb-target-is-full-message", ("object", ent.Owner)),
                 ent.Owner,
                 user);

--- a/Content.Shared/Fluids/EntitySystems/SolutionDumpingSystem.cs
+++ b/Content.Shared/Fluids/EntitySystems/SolutionDumpingSystem.cs
@@ -119,14 +119,14 @@ public sealed partial class SolutionDumpingSystem : EntitySystem
         sourceSolEnt = null;
         if (!_actionBlocker.CanComplexInteract(user))
         {
-            _popup.PopupClient(Loc.GetString("mopping-system-no-hands"), user, user);
+            _popup.PopupEntity(Loc.GetString("mopping-system-no-hands"), user, user);
             return false;
         }
 
         if (!_solContainer.TryGetSolution(sourceContainer, sourceSolutionName, out sourceSolEnt)
             || sourceSolEnt.Value.Comp.Solution.Volume == FixedPoint2.Zero)
         {
-            _popup.PopupClient(Loc.GetString("mopping-system-empty", ("used", sourceContainer)),
+            _popup.PopupEntity(Loc.GetString("mopping-system-empty", ("used", sourceContainer)),
                 sourceContainer,
                 user);
             return false;
@@ -134,7 +134,7 @@ public sealed partial class SolutionDumpingSystem : EntitySystem
 
         if (checkAvailableVolume && targetSol.AvailableVolume == FixedPoint2.Zero)
         {
-            _popup.PopupClient(Loc.GetString("mopping-system-full", ("used", targetContainer)), targetContainer, user);
+            _popup.PopupEntity(Loc.GetString("mopping-system-full", ("used", targetContainer)), targetContainer, user);
             return false;
         }
 

--- a/Content.Shared/Fluids/SharedAbsorbentSystem.cs
+++ b/Content.Shared/Fluids/SharedAbsorbentSystem.cs
@@ -162,7 +162,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
         var absorbentSolution = absorbentSoln.Comp.Solution;
         if (absorbentSolution.Volume <= 0)
         {
-            _popups.PopupClient(Loc.GetString("mopping-system-target-container-empty", ("target", target)), user, user);
+            _popups.PopupEntity(Loc.GetString("mopping-system-target-container-empty", ("target", target)), user, user);
             return false;
         }
 
@@ -173,7 +173,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
 
         if (transferAmount <= 0)
         {
-            _popups.PopupClient(Loc.GetString("mopping-system-full", ("used", absorbEnt)), absorbEnt, user);
+            _popups.PopupEntity(Loc.GetString("mopping-system-full", ("used", absorbEnt)), absorbEnt, user);
             return false;
         }
 
@@ -208,7 +208,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
             && absorbentSolution.AvailableVolume == FixedPoint2.Zero)
         {
             // Nothing to transfer to refillable and no room to absorb anything extra
-            _popups.PopupClient(Loc.GetString("mopping-system-puddle-space", ("used", absorbEnt)), user, user);
+            _popups.PopupEntity(Loc.GetString("mopping-system-puddle-space", ("used", absorbEnt)), user, user);
 
             // We can return cleanly because nothing was split from absorbent solution
             return false;
@@ -227,7 +227,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
         if (waterFromRefillable.Volume == FixedPoint2.Zero && contaminantsFromAbsorbent.Volume == FixedPoint2.Zero)
         {
             // Nothing to transfer in either direction
-            _popups.PopupClient(Loc.GetString("mopping-system-target-container-empty-water", ("target", target)),
+            _popups.PopupEntity(Loc.GetString("mopping-system-target-container-empty-water", ("target", target)),
                 user,
                 user);
 
@@ -249,7 +249,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
 
         if (refillableSolution.AvailableVolume <= 0)
         {
-            _popups.PopupClient(Loc.GetString("mopping-system-full", ("used", target)), user, user);
+            _popups.PopupEntity(Loc.GetString("mopping-system-full", ("used", target)), user, user);
         }
         else
         {
@@ -292,7 +292,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
                 puddleSolution.GetTotalPrototypeQuantity(Puddle.GetAbsorbentReagents(puddleSolution));
             if (puddleAbsorberVolume == puddleSolution.Volume)
             {
-                _popups.PopupClient(Loc.GetString("mopping-system-puddle-already-mopped", ("target", target)),
+                _popups.PopupEntity(Loc.GetString("mopping-system-puddle-already-mopped", ("target", target)),
                     target,
                     user);
                 return true;
@@ -305,7 +305,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
             // No material
             if (available == FixedPoint2.Zero)
             {
-                _popups.PopupClient(Loc.GetString("mopping-system-no-water", ("used", absorbEnt)), absorbEnt, user);
+                _popups.PopupEntity(Loc.GetString("mopping-system-no-water", ("used", absorbEnt)), absorbEnt, user);
                 return true;
             }
 

--- a/Content.Shared/Fluids/SharedPuddleSystem.Spillable.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Spillable.cs
@@ -169,7 +169,7 @@ public abstract partial class SharedPuddleSystem
 
             Reactive.DoEntityReaction(hit, splitSolution, ReactionMethod.Touch);
 
-            Popups.PopupClient(Loc.GetString("spill-melee-hit-attacker",
+            Popups.PopupEntity(Loc.GetString("spill-melee-hit-attacker",
                     ("amount", totalSplit / hitCount),
                     ("spillable", entity.Owner),
                     ("target", Identity.Entity(hit, EntityManager, args.User))),

--- a/Content.Shared/Foldable/DeployFoldableSystem.cs
+++ b/Content.Shared/Foldable/DeployFoldableSystem.cs
@@ -69,7 +69,7 @@ public sealed partial class DeployFoldableSystem : EntitySystem
         if (!TryComp(ent.Owner, out PhysicsComponent? anchorBody)
             || !_anchorable.TileFree(args.ClickLocation, anchorBody))
         {
-            _popup.PopupEntity(Loc.GetString("foldable-deploy-fail", ("object", ent)), ent);
+            _popup.PopupEntity(Loc.GetString("foldable-deploy-fail", ("object", ent)), ent, args.User);
             return;
         }
 

--- a/Content.Shared/Foldable/DeployFoldableSystem.cs
+++ b/Content.Shared/Foldable/DeployFoldableSystem.cs
@@ -69,7 +69,7 @@ public sealed partial class DeployFoldableSystem : EntitySystem
         if (!TryComp(ent.Owner, out PhysicsComponent? anchorBody)
             || !_anchorable.TileFree(args.ClickLocation, anchorBody))
         {
-            _popup.PopupPredicted(Loc.GetString("foldable-deploy-fail", ("object", ent)), ent, args.User);
+            _popup.PopupEntity(Loc.GetString("foldable-deploy-fail", ("object", ent)), ent);
             return;
         }
 

--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -101,9 +101,9 @@ public sealed partial class FoldableSystem : EntitySystem
         if (!result && folder != null)
         {
             if (comp.IsFolded)
-                _popup.PopupPredicted(Loc.GetString("foldable-unfold-fail", ("object", uid)), uid, folder.Value);
+                _popup.PopupEntity(Loc.GetString("foldable-unfold-fail", ("object", uid)), uid);
             else
-                _popup.PopupPredicted(Loc.GetString("foldable-fold-fail", ("object", uid)), uid, folder.Value);
+                _popup.PopupEntity(Loc.GetString("foldable-fold-fail", ("object", uid)), uid);
         }
         return result;
     }

--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -101,9 +101,9 @@ public sealed partial class FoldableSystem : EntitySystem
         if (!result && folder != null)
         {
             if (comp.IsFolded)
-                _popup.PopupEntity(Loc.GetString("foldable-unfold-fail", ("object", uid)), uid);
+                _popup.PopupEntity(Loc.GetString("foldable-unfold-fail", ("object", uid)), uid, folder.Value);
             else
-                _popup.PopupEntity(Loc.GetString("foldable-fold-fail", ("object", uid)), uid);
+                _popup.PopupEntity(Loc.GetString("foldable-fold-fail", ("object", uid)), uid, folder.Value);
         }
         return result;
     }

--- a/Content.Shared/Friends/Systems/PettableFriendSystem.cs
+++ b/Content.Shared/Friends/Systems/PettableFriendSystem.cs
@@ -36,7 +36,7 @@ public sealed partial class PettableFriendSystem : EntitySystem
         if (!_factionException.IsIgnored(exception, user))
         {
             // you have made a new friend :)
-            _popup.PopupClient(Loc.GetString(comp.SuccessString, ("target", uid)), user, user);
+            _popup.PopupEntity(Loc.GetString(comp.SuccessString, ("target", uid)), user, user);
             _factionException.IgnoreEntity(exception, user);
             args.Handled = true;
             return;
@@ -45,7 +45,7 @@ public sealed partial class PettableFriendSystem : EntitySystem
         if (_useDelayQuery.TryComp(uid, out var useDelay) && !_useDelay.TryResetDelay((uid, useDelay), true))
             return;
 
-        _popup.PopupClient(Loc.GetString(comp.FailureString, ("target", uid)), user, user);
+        _popup.PopupEntity(Loc.GetString(comp.FailureString, ("target", uid)), user, user);
     }
 
     private void OnRehydrated(Entity<PettableFriendComponent> ent, ref GotRehydratedEvent args)

--- a/Content.Shared/Glue/GlueSystem.cs
+++ b/Content.Shared/Glue/GlueSystem.cs
@@ -74,7 +74,7 @@ public sealed partial class GlueSystem : EntitySystem
         // This effectively means any unremoveable item could be removed with a bottle of glue.
         if (HasComp<GluedComponent>(target) || !HasComp<ItemComponent>(target) || HasComp<UnremoveableComponent>(target))
         {
-            _popup.PopupClient(Loc.GetString("glue-failure", ("target", target)), actor, actor, PopupType.Medium);
+            _popup.PopupEntity(Loc.GetString("glue-failure", ("target", target)), actor, actor, PopupType.Medium);
             return false;
         }
 
@@ -84,7 +84,7 @@ public sealed partial class GlueSystem : EntitySystem
             if (quantity > 0)
             {
                 _audio.PlayPredicted(entity.Comp.Squeeze, entity.Owner, actor);
-                _popup.PopupClient(Loc.GetString("glue-success", ("target", target)), actor, actor, PopupType.Medium);
+                _popup.PopupEntity(Loc.GetString("glue-success", ("target", target)), actor, actor, PopupType.Medium);
                 _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(actor):actor} glued {ToPrettyString(target):subject} with {ToPrettyString(entity.Owner):tool}");
                 var gluedComp = EnsureComp<GluedComponent>(target);
                 gluedComp.Duration = quantity.Double() * entity.Comp.DurationPerUnit;
@@ -93,7 +93,7 @@ public sealed partial class GlueSystem : EntitySystem
             }
         }
 
-        _popup.PopupClient(Loc.GetString("glue-failure", ("target", target)), actor, actor, PopupType.Medium);
+        _popup.PopupEntity(Loc.GetString("glue-failure", ("target", target)), actor, actor, PopupType.Medium);
         return false;
     }
 

--- a/Content.Shared/Gravity/SharedGravityGeneratorSystem.cs
+++ b/Content.Shared/Gravity/SharedGravityGeneratorSystem.cs
@@ -22,7 +22,7 @@ public abstract partial class SharedGravityGeneratorSystem : EntitySystem
         if (!ent.Comp.GravityActive)
             return;
 
-        _popupSystem.PopupClient(Loc.GetString("gravity-generator-unanchoring-failed"), ent.Owner, args.User, PopupType.Medium);
+        _popupSystem.PopupEntity(Loc.GetString("gravity-generator-unanchoring-failed"), ent.Owner, args.User, PopupType.Medium);
 
         args.Cancel();
     }

--- a/Content.Shared/Guardian/GuardianSystem.cs
+++ b/Content.Shared/Guardian/GuardianSystem.cs
@@ -201,7 +201,7 @@ public sealed partial class GuardianSystem : EntitySystem
     {
         if (ent.Comp.Used)
         {
-            _popup.PopupEntity(Loc.GetString(ent.Comp.EmptyPopup), user);
+            _popup.PopupEntity(Loc.GetString(ent.Comp.EmptyPopup), user, user);
 
             return;
         }
@@ -414,7 +414,7 @@ public sealed partial class GuardianSystem : EntitySystem
         }
 
         _container.Insert(guardian.Owner, host.Comp.GuardianContainer);
-        _popup.PopupEntity(Loc.GetString(host.Comp.GuardianHostRecall), host.Owner);
+        _popup.PopupEntity(Loc.GetString(host.Comp.GuardianHostRecall), host.Owner, host.Owner);
         guardian.Comp.GuardianLoose = false;
 
         Dirty(host);

--- a/Content.Shared/Guardian/GuardianSystem.cs
+++ b/Content.Shared/Guardian/GuardianSystem.cs
@@ -84,7 +84,7 @@ public sealed partial class GuardianSystem : EntitySystem
 
         if (_container.IsEntityInContainer(ent.Owner))
         {
-            _popup.PopupPredicted(Loc.GetString("guardian-inside-container"), ent.Owner, ent.Owner);
+            _popup.PopupEntity(Loc.GetString("guardian-inside-container"), ent.Owner);
             return;
         }
 
@@ -119,7 +119,7 @@ public sealed partial class GuardianSystem : EntitySystem
             return;
         }
 
-        _popup.PopupPredicted(Loc.GetString("guardian-available"), host.Value, host.Value);
+        _popup.PopupEntity(Loc.GetString("guardian-available"), host.Value);
     }
 
     private void OnHostInit(Entity<GuardianHostComponent> ent, ref ComponentInit args)
@@ -149,7 +149,7 @@ public sealed partial class GuardianSystem : EntitySystem
         if (args.Cancelled || args.Target != ent.Comp.Host)
             return;
 
-        _popup.PopupPredictedCursor(Loc.GetString("guardian-attack-host"), ent.Owner, PopupType.LargeCaution);
+        _popup.PopupCursor(Loc.GetString("guardian-attack-host"), ent.Owner, PopupType.LargeCaution);
         args.Cancel();
     }
 
@@ -159,7 +159,7 @@ public sealed partial class GuardianSystem : EntitySystem
         if (args.Args.Cancelled)
             return;
 
-        _popup.PopupPredictedCursor(Loc.GetString("guardian-attack-host"),
+        _popup.PopupCursor(Loc.GetString("guardian-attack-host"),
             args.Args.Attacker,
             PopupType.LargeCaution);
         args.Args.Cancelled = true;
@@ -201,7 +201,7 @@ public sealed partial class GuardianSystem : EntitySystem
     {
         if (ent.Comp.Used)
         {
-            _popup.PopupPredicted(Loc.GetString(ent.Comp.EmptyPopup), user, user);
+            _popup.PopupEntity(Loc.GetString(ent.Comp.EmptyPopup), user);
 
             return;
         }
@@ -211,14 +211,14 @@ public sealed partial class GuardianSystem : EntitySystem
         {
             var msg = Loc.GetString("guardian-activator-invalid-target",
                 ("entity", Identity.Entity(target, EntityManager, user)));
-            _popup.PopupPredicted(msg, user, user);
+            _popup.PopupEntity(msg, user);
             return;
         }
 
         // If user is already a host don't duplicate.
         if (HasComp<GuardianHostComponent>(target))
         {
-            _popup.PopupPredicted(Loc.GetString("guardian-already-present-invalid-creation"), user, user);
+            _popup.PopupEntity(Loc.GetString("guardian-already-present-invalid-creation"), user);
             return;
         }
 
@@ -414,7 +414,7 @@ public sealed partial class GuardianSystem : EntitySystem
         }
 
         _container.Insert(guardian.Owner, host.Comp.GuardianContainer);
-        _popup.PopupPredicted(Loc.GetString(host.Comp.GuardianHostRecall), host.Owner, host.Owner);
+        _popup.PopupEntity(Loc.GetString(host.Comp.GuardianHostRecall), host.Owner);
         guardian.Comp.GuardianLoose = false;
 
         Dirty(host);

--- a/Content.Shared/Guardian/GuardianSystem.cs
+++ b/Content.Shared/Guardian/GuardianSystem.cs
@@ -84,7 +84,7 @@ public sealed partial class GuardianSystem : EntitySystem
 
         if (_container.IsEntityInContainer(ent.Owner))
         {
-            _popup.PopupEntity(Loc.GetString("guardian-inside-container"), ent.Owner);
+            _popup.PopupEntity(Loc.GetString("guardian-inside-container"), ent.Owner, ent.Owner);
             return;
         }
 
@@ -119,7 +119,7 @@ public sealed partial class GuardianSystem : EntitySystem
             return;
         }
 
-        _popup.PopupEntity(Loc.GetString("guardian-available"), host.Value);
+        _popup.PopupEntity(Loc.GetString("guardian-available"), host.Value, host.Value);
     }
 
     private void OnHostInit(Entity<GuardianHostComponent> ent, ref ComponentInit args)
@@ -211,14 +211,14 @@ public sealed partial class GuardianSystem : EntitySystem
         {
             var msg = Loc.GetString("guardian-activator-invalid-target",
                 ("entity", Identity.Entity(target, EntityManager, user)));
-            _popup.PopupEntity(msg, user);
+            _popup.PopupEntity(msg, user, user);
             return;
         }
 
         // If user is already a host don't duplicate.
         if (HasComp<GuardianHostComponent>(target))
         {
-            _popup.PopupEntity(Loc.GetString("guardian-already-present-invalid-creation"), user);
+            _popup.PopupEntity(Loc.GetString("guardian-already-present-invalid-creation"), user, user);
             return;
         }
 

--- a/Content.Shared/Guardian/GuardianSystem.cs
+++ b/Content.Shared/Guardian/GuardianSystem.cs
@@ -259,7 +259,7 @@ public sealed partial class GuardianSystem : EntitySystem
             _audio.PlayPredicted(ent.Comp.UsedSound,
                 ent.Owner,
                 args.Args.Target);
-            _popup.PopupClient(Loc.GetString(ent.Comp.GuardianHauntedPopup),
+            _popup.PopupEntity(Loc.GetString(ent.Comp.GuardianHauntedPopup),
                 args.Args.Target.Value,
                 args.Args.Target.Value);
             // Exhaust the activator
@@ -286,7 +286,7 @@ public sealed partial class GuardianSystem : EntitySystem
 
         if (args.NewMobState == MobState.Critical)
         {
-            _popup.PopupClient(Loc.GetString(ent.Comp.GuardianHostCritWarn),
+            _popup.PopupEntity(Loc.GetString(ent.Comp.GuardianHostCritWarn),
                 ent.Comp.HostedGuardian.Value,
                 ent.Comp.HostedGuardian.Value);
             _audio.PlayPredicted(guardianComp.CriticalSound, ent.Comp.HostedGuardian.Value, args.Target);
@@ -315,7 +315,7 @@ public sealed partial class GuardianSystem : EntitySystem
             origin: args.Origin,
             ignoreResistances: true,
             interruptsDoAfters: false);
-        _popup.PopupClient(Loc.GetString(ent.Comp.GuardianDamagePopup), ent.Comp.Host.Value, ent.Comp.Host.Value);
+        _popup.PopupEntity(Loc.GetString(ent.Comp.GuardianDamagePopup), ent.Comp.Host.Value, ent.Comp.Host.Value);
     }
 
     /// <summary>

--- a/Content.Shared/HijackBeacon/HijackBeaconSystem.cs
+++ b/Content.Shared/HijackBeacon/HijackBeaconSystem.cs
@@ -298,7 +298,7 @@ public sealed partial class HijackBeaconSystem : EntitySystem
             return;
 
         _transform.AnchorEntity(ent, beaconXForm);
-        _popup.PopupPredicted(Loc.GetString("hijack-beacon-popup-anchor"), ent, null);
+        _popup.PopupEntity(Loc.GetString("hijack-beacon-popup-anchor"), ent);
     }
 
     /// <summary>
@@ -312,7 +312,7 @@ public sealed partial class HijackBeaconSystem : EntitySystem
             return;
 
         _transform.Unanchor(ent, beaconXForm);
-        _popup.PopupPredicted(Loc.GetString("hijack-beacon-popup-unanchor"), ent, null);
+        _popup.PopupEntity(Loc.GetString("hijack-beacon-popup-unanchor"), ent);
     }
 
     /// <summary>

--- a/Content.Shared/HotPotato/SharedHotPotatoSystem.cs
+++ b/Content.Shared/HotPotato/SharedHotPotatoSystem.cs
@@ -57,10 +57,9 @@ public abstract partial class SharedHotPotatoSystem : EntitySystem
 
             if (!_hands.IsHolding((hitEntity, hands), ent.Owner, out _) && _hands.TryForcePickupAnyHand(hitEntity, ent.Owner, handsComp: hands))
             {
-                _popup.PopupPredicted(
+                _popup.PopupEntity(
                     Loc.GetString("hot-potato-passed", ("from", Identity.Entity(args.User, EntityManager)), ("to", Identity.Entity(hitEntity, EntityManager))),
                     ent.Owner,
-                    args.User,
                     PopupType.Medium);
                 break;
             }

--- a/Content.Shared/HotPotato/SharedHotPotatoSystem.cs
+++ b/Content.Shared/HotPotato/SharedHotPotatoSystem.cs
@@ -65,7 +65,7 @@ public abstract partial class SharedHotPotatoSystem : EntitySystem
                 break;
             }
 
-            _popup.PopupClient(
+            _popup.PopupEntity(
                 Loc.GetString("hot-potato-failed", ("to", Identity.Entity(hitEntity, EntityManager))),
                 ent.Owner,
                 args.User,

--- a/Content.Shared/Implants/SharedImplanterSystem.cs
+++ b/Content.Shared/Implants/SharedImplanterSystem.cs
@@ -117,7 +117,7 @@ public abstract partial class SharedImplanterSystem : EntitySystem
                 // show popup to the user saying implant failed
                 var name = Identity.Name(target, EntityManager, args.User);
                 var msg = Loc.GetString("implanter-component-implant-failed", ("implant", implant), ("target", name));
-                _popup.PopupClient(msg, target, args.User);
+                _popup.PopupEntity(msg, target, args.User);
                 // prevent further interaction since popup was shown
                 args.Handled = true;
                 return;
@@ -199,7 +199,7 @@ public abstract partial class SharedImplanterSystem : EntitySystem
         if (!_doAfter.TryStartDoAfter(args))
             return;
 
-        _popup.PopupClient(Loc.GetString("injector-component-needle-injecting-user"), target, user);
+        _popup.PopupEntity(Loc.GetString("injector-component-needle-injecting-user"), target, user);
 
         if (user != target)
         {
@@ -224,7 +224,7 @@ public abstract partial class SharedImplanterSystem : EntitySystem
         if (!_doAfter.TryStartDoAfter(args))
             return;
 
-        _popup.PopupClient(Loc.GetString("injector-component-needle-injecting-user"), target, user);
+        _popup.PopupEntity(Loc.GetString("injector-component-needle-injecting-user"), target, user);
 
         if (user != target)
         {
@@ -268,7 +268,7 @@ public abstract partial class SharedImplanterSystem : EntitySystem
         {
             var name = Identity.Name(target, EntityManager, user);
             var msg = Loc.GetString("implanter-component-implant-already", ("implant", implant), ("target", name));
-            _popup.PopupClient(msg, target, user);
+            _popup.PopupEntity(msg, target, user);
             return;
         }
 
@@ -424,7 +424,7 @@ public abstract partial class SharedImplanterSystem : EntitySystem
         var failedPermanentMessage = Loc.GetString("implanter-draw-failed-permanent",
             ("implant", implantName),
             ("target", targetName));
-        _popup.PopupClient(failedPermanentMessage, target, user);
+        _popup.PopupEntity(failedPermanentMessage, target, user);
     }
 
     /// <summary>

--- a/Content.Shared/Implants/SharedImplanterSystem.cs
+++ b/Content.Shared/Implants/SharedImplanterSystem.cs
@@ -447,7 +447,7 @@ public abstract partial class SharedImplanterSystem : EntitySystem
         _damageable.TryChangeDamage(user, ent.Comp.DeimplantFailureDamage, ignoreResistances: true, origin: ent.Owner);
         var userName = Identity.Entity(user, EntityManager);
         var failedCatastrophicallyMessage = Loc.GetString("implanter-draw-failed-catastrophically", ("user", userName));
-        _popup.PopupEntity(failedCatastrophicallyMessage, user, PopupType.MediumCaution);
+        _popup.PopupEntity(failedCatastrophicallyMessage, user, user, PopupType.MediumCaution);
         _audio.PlayPredicted(ent.Comp.ImplanterDrawFailSound, ent, user);
     }
 

--- a/Content.Shared/Implants/SharedImplanterSystem.cs
+++ b/Content.Shared/Implants/SharedImplanterSystem.cs
@@ -447,7 +447,7 @@ public abstract partial class SharedImplanterSystem : EntitySystem
         _damageable.TryChangeDamage(user, ent.Comp.DeimplantFailureDamage, ignoreResistances: true, origin: ent.Owner);
         var userName = Identity.Entity(user, EntityManager);
         var failedCatastrophicallyMessage = Loc.GetString("implanter-draw-failed-catastrophically", ("user", userName));
-        _popup.PopupPredicted(failedCatastrophicallyMessage, user, user, PopupType.MediumCaution);
+        _popup.PopupEntity(failedCatastrophicallyMessage, user, PopupType.MediumCaution);
         _audio.PlayPredicted(ent.Comp.ImplanterDrawFailSound, ent, user);
     }
 

--- a/Content.Shared/Interaction/InteractionPopupSystem.cs
+++ b/Content.Shared/Interaction/InteractionPopupSystem.cs
@@ -138,7 +138,7 @@ public sealed partial class InteractionPopupSystem : EntitySystem
             return;
         }
 
-        _popupSystem.PopupClient(msg, uid, user);
+        _popupSystem.PopupEntity(msg, uid, user);
 
         if (sfx == null)
             return;

--- a/Content.Shared/Interaction/InteractionPopupSystem.cs
+++ b/Content.Shared/Interaction/InteractionPopupSystem.cs
@@ -127,18 +127,16 @@ public sealed partial class InteractionPopupSystem : EntitySystem
             _popupSystem.PopupEntity(msgOthers, uid, Filter.PvsExcept(user, entityManager: EntityManager), true);
         }
 
+        _popupSystem.PopupEntity(msg, uid, user);
+
         if (!predict)
         {
-            _popupSystem.PopupEntity(msg, uid, user);
-
             if (component.SoundPerceivedByOthers)
                 _audio.PlayPvs(sfx, target);
             else
                 _audio.PlayEntity(sfx, Filter.Entities(user, target), target, false);
             return;
         }
-
-        _popupSystem.PopupEntity(msg, uid, user);
 
         if (sfx == null)
             return;

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -829,7 +829,7 @@ namespace Content.Shared.Interaction
             if (!inRange && popup && _gameTiming.IsFirstTimePredicted)
             {
                 var message = Loc.GetString("interaction-system-user-interaction-cannot-reach");
-                _popupSystem.PopupClient(message, origin, origin);
+                _popupSystem.PopupEntity(message, origin, origin);
             }
 
             return inRange;

--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -93,14 +93,14 @@ public sealed partial class SmartEquipSystem : EntitySystem
 
         if (!TryComp<InventoryComponent>(uid, out var inventory) || !_inventory.HasSlot(uid, equipmentSlot, inventory))
         {
-            _popup.PopupClient(Loc.GetString("smart-equip-missing-equipment-slot", ("slotName", equipmentSlot)), uid, uid);
+            _popup.PopupEntity(Loc.GetString("smart-equip-missing-equipment-slot", ("slotName", equipmentSlot)), uid, uid);
             return;
         }
 
         // early out if we have an item and cant drop it at all
         if (handItem != null && !_hands.CanDropHeld(uid, hands.ActiveHandId))
         {
-            _popup.PopupClient(Loc.GetString("smart-equip-cant-drop"), uid, uid);
+            _popup.PopupEntity(Loc.GetString("smart-equip-cant-drop"), uid, uid);
             return;
         }
 
@@ -129,13 +129,13 @@ public sealed partial class SmartEquipSystem : EntitySystem
         {
             if (handItem == null)
             {
-                _popup.PopupClient(emptyEquipmentSlotString, uid, uid);
+                _popup.PopupEntity(emptyEquipmentSlotString, uid, uid);
                 return;
             }
 
             if (!_inventory.CanEquip(uid, handItem.Value, equipmentSlot, out var reason))
             {
-                _popup.PopupClient(Loc.GetString(reason), uid, uid);
+                _popup.PopupEntity(Loc.GetString(reason), uid, uid);
                 return;
             }
 
@@ -150,7 +150,7 @@ public sealed partial class SmartEquipSystem : EntitySystem
             switch (handItem)
             {
                 case null when storage.Container.ContainedEntities.Count == 0:
-                    _popup.PopupClient(emptyEquipmentSlotString, uid, uid);
+                    _popup.PopupEntity(emptyEquipmentSlotString, uid, uid);
                     return;
                 case null:
                     var removing = storage.Container.ContainedEntities[^1];
@@ -162,7 +162,7 @@ public sealed partial class SmartEquipSystem : EntitySystem
             if (!_storage.CanInsert(slotItem, handItem.Value, out var reason))
             {
                 if (reason != null)
-                    _popup.PopupClient(Loc.GetString(reason), uid, uid);
+                    _popup.PopupEntity(Loc.GetString(reason), uid, uid);
 
                 return;
             }
@@ -196,7 +196,7 @@ public sealed partial class SmartEquipSystem : EntitySystem
 
                 if (toEjectFrom == null)
                 {
-                    _popup.PopupClient(emptyEquipmentSlotString, uid, uid);
+                    _popup.PopupEntity(emptyEquipmentSlotString, uid, uid);
                     return;
                 }
 
@@ -218,7 +218,7 @@ public sealed partial class SmartEquipSystem : EntitySystem
 
             if (toInsertTo == null)
             {
-                _popup.PopupClient(Loc.GetString("smart-equip-no-valid-item-slot-insert", ("item", handItem.Value)), uid, uid);
+                _popup.PopupEntity(Loc.GetString("smart-equip-no-valid-item-slot-insert", ("item", handItem.Value)), uid, uid);
                 return;
             }
 
@@ -232,7 +232,7 @@ public sealed partial class SmartEquipSystem : EntitySystem
 
         if (!_inventory.CanUnequip(uid, equipmentSlot, out var inventoryReason))
         {
-            _popup.PopupClient(Loc.GetString(inventoryReason), uid, uid);
+            _popup.PopupEntity(Loc.GetString(inventoryReason), uid, uid);
             return;
         }
 

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -488,7 +488,7 @@ public abstract partial class InventorySystem
         // the reason we check for > 1 is because the first item is always the one we are trying to unequip,
         // whereas we only want to notify for extra dropped items.
         if (!silent && firstRun && itemsDropped > 1)
-            _popup.PopupClient(Loc.GetString("inventory-component-dropped-from-unequip", ("items", itemsDropped - 1)), target, target);
+            _popup.PopupEntity(Loc.GetString("inventory-component-dropped-from-unequip", ("items", itemsDropped - 1)), target, target);
 
         // TODO: Inventory needs a hot cleanup hoo boy
         // Check if something else (AKA toggleable) dumped it into a container.

--- a/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
+++ b/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
@@ -130,7 +130,7 @@ public abstract partial class SharedVirtualItemSystem : EntitySystem
                     continue;
 
                 if (!silent && !TerminatingOrDeleted(held))
-                    _popup.PopupClient(Loc.GetString("virtual-item-dropped-other", ("dropped", held)), user, user);
+                    _popup.PopupEntity(Loc.GetString("virtual-item-dropped-other", ("dropped", held)), user, user);
 
                 empty = hand;
                 break;

--- a/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
@@ -186,10 +186,7 @@ public sealed partial class ItemToggleSystem : EntitySystem
 
             if (showPopup && attempt.Popup != null && user != null)
             {
-                if (predicted)
-                    _popup.PopupEntity(attempt.Popup, uid, user.Value);
-                else
-                    _popup.PopupEntity(attempt.Popup, uid, user.Value);
+                _popup.PopupEntity(attempt.Popup, uid, user.Value);
             }
 
             return false;
@@ -244,10 +241,7 @@ public sealed partial class ItemToggleSystem : EntitySystem
 
             if (showPopup && attempt.Popup != null && user != null)
             {
-                if (predicted)
-                    _popup.PopupEntity(attempt.Popup, uid, user.Value);
-                else
-                    _popup.PopupEntity(attempt.Popup, uid, user.Value);
+                _popup.PopupEntity(attempt.Popup, uid, user.Value);
             }
 
             return false;
@@ -261,18 +255,14 @@ public sealed partial class ItemToggleSystem : EntitySystem
     {
         var (uid, comp) = ent;
         var soundToPlay = comp.SoundActivate;
+
         if (predicted)
-        {
             _audio.PlayPredicted(soundToPlay, uid, user);
-            if (showPopup && ent.Comp.PopupActivate != null && user != null)
-                _popup.PopupEntity(Loc.GetString(ent.Comp.PopupActivate), user.Value, user.Value);
-        }
         else
-        {
             _audio.PlayPvs(soundToPlay, uid);
-            if (showPopup && ent.Comp.PopupActivate != null && user != null)
-                _popup.PopupEntity(Loc.GetString(ent.Comp.PopupActivate), user.Value, user.Value);
-        }
+
+        if (showPopup && ent.Comp.PopupActivate != null && user != null)
+            _popup.PopupEntity(Loc.GetString(ent.Comp.PopupActivate), user.Value, user.Value);
 
         comp.Activated = true;
         UpdateVisuals((uid, comp));

--- a/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
@@ -187,7 +187,7 @@ public sealed partial class ItemToggleSystem : EntitySystem
             if (showPopup && attempt.Popup != null && user != null)
             {
                 if (predicted)
-                    _popup.PopupClient(attempt.Popup, uid, user.Value);
+                    _popup.PopupEntity(attempt.Popup, uid, user.Value);
                 else
                     _popup.PopupEntity(attempt.Popup, uid, user.Value);
             }
@@ -245,7 +245,7 @@ public sealed partial class ItemToggleSystem : EntitySystem
             if (showPopup && attempt.Popup != null && user != null)
             {
                 if (predicted)
-                    _popup.PopupClient(attempt.Popup, uid, user.Value);
+                    _popup.PopupEntity(attempt.Popup, uid, user.Value);
                 else
                     _popup.PopupEntity(attempt.Popup, uid, user.Value);
             }
@@ -265,7 +265,7 @@ public sealed partial class ItemToggleSystem : EntitySystem
         {
             _audio.PlayPredicted(soundToPlay, uid, user);
             if (showPopup && ent.Comp.PopupActivate != null && user != null)
-                _popup.PopupClient(Loc.GetString(ent.Comp.PopupActivate), user.Value, user.Value);
+                _popup.PopupEntity(Loc.GetString(ent.Comp.PopupActivate), user.Value, user.Value);
         }
         else
         {
@@ -293,7 +293,7 @@ public sealed partial class ItemToggleSystem : EntitySystem
         {
             _audio.PlayPredicted(soundToPlay, uid, user);
             if (showPopup && ent.Comp.PopupDeactivate != null && user != null)
-                _popup.PopupClient(Loc.GetString(ent.Comp.PopupDeactivate), user.Value, user.Value);
+                _popup.PopupEntity(Loc.GetString(ent.Comp.PopupDeactivate), user.Value, user.Value);
         }
         else
         {

--- a/Content.Shared/Item/MultiHandedItemSystem.cs
+++ b/Content.Shared/Item/MultiHandedItemSystem.cs
@@ -43,7 +43,7 @@ public sealed partial class MultiHandedItemSystem : EntitySystem
         args.Cancel();
 
         if (args.ShowPopup)
-            _popup.PopupPredictedCursor(
+            _popup.PopupCursor(
                 Loc.GetString("multi-handed-item-pick-up-fail",
                     ("number", ent.Comp.HandsNeeded - 1),
                     ("item", ent.Owner)),

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -86,7 +86,7 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
         _popups.PopupEntity(Loc.GetString("item-recall-item-summon-self", ("item", ent)),
                                Loc.GetString("item-recall-item-summon-others", ("item", ent), ("name", Identity.Entity(user, EntityManager))),
                                user, user);
-        _popups.PopupCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates);
+        _popups.PopupCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates, user);
 
         _hands.TryForcePickupAnyHand(user, ent);
     }

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -50,17 +50,17 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
 
             if (markItem == null)
             {
-                _popups.PopupClient(Loc.GetString("item-recall-item-mark-empty"), args.Performer, args.Performer);
+                _popups.PopupEntity(Loc.GetString("item-recall-item-mark-empty"), args.Performer, args.Performer);
                 return;
             }
 
             if (HasComp<RecallMarkerComponent>(markItem))
             {
-                _popups.PopupClient(Loc.GetString("item-recall-item-already-marked", ("item", markItem)), args.Performer, args.Performer);
+                _popups.PopupEntity(Loc.GetString("item-recall-item-already-marked", ("item", markItem)), args.Performer, args.Performer);
                 return;
             }
 
-            _popups.PopupClient(Loc.GetString("item-recall-item-marked", ("item", markItem.Value)), args.Performer, args.Performer);
+            _popups.PopupEntity(Loc.GetString("item-recall-item-marked", ("item", markItem.Value)), args.Performer, args.Performer);
             TryMarkItem(ent, markItem.Value);
             return;
         }
@@ -131,7 +131,7 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
             // This line will only do something once that is fixed.
             if (action.Comp.AttachedEntity is {} user)
             {
-                _popups.PopupClient(Loc.GetString("item-recall-item-unmark", ("item", item)), user, user, PopupType.MediumCaution);
+                _popups.PopupEntity(Loc.GetString("item-recall-item-unmark", ("item", item)), user, user, PopupType.MediumCaution);
                 RemoveFromPvsOverride(item, user);
             }
 

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -83,10 +83,10 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
         if (TryComp<EmbeddableProjectileComponent>(ent, out var projectile))
             _proj.EmbedDetach(ent, projectile, user);
 
-        _popups.PopupPredicted(Loc.GetString("item-recall-item-summon-self", ("item", ent)),
+        _popups.PopupEntity(Loc.GetString("item-recall-item-summon-self", ("item", ent)),
                                Loc.GetString("item-recall-item-summon-others", ("item", ent), ("name", Identity.Entity(user, EntityManager))),
                                user, user);
-        _popups.PopupPredictedCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates, user);
+        _popups.PopupCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates);
 
         _hands.TryForcePickupAnyHand(user, ent);
     }
@@ -129,7 +129,7 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
             // For some reason client thinks the station grid owns the action on client and this doesn't work. It doesn't work in PopupEntity(mispredicts) and PopupPredicted either(doesnt show).
             // I don't have the heart to move this code to server because of this small thing.
             // This line will only do something once that is fixed.
-            if (action.Comp.AttachedEntity is {} user)
+            if (action.Comp.AttachedEntity is { } user)
             {
                 _popups.PopupEntity(Loc.GetString("item-recall-item-unmark", ("item", item)), user, user, PopupType.MediumCaution);
                 RemoveFromPvsOverride(item, user);

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -126,7 +126,7 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
 
         if (TryComp<ItemRecallComponent>(action, out var itemRecall))
         {
-            // For some reason client thinks the station grid owns the action on client and this doesn't work. It doesn't work in PopupEntity(mispredicts) and PopupPredicted either(doesnt show).
+            // For some reason client thinks the station grid owns the action on client and this doesn't work.
             // I don't have the heart to move this code to server because of this small thing.
             // This line will only do something once that is fixed.
             if (action.Comp.AttachedEntity is { } user)

--- a/Content.Shared/Kitchen/EntitySystems/SharedReagentGrinderSystem.cs
+++ b/Content.Shared/Kitchen/EntitySystems/SharedReagentGrinderSystem.cs
@@ -159,7 +159,7 @@ public abstract partial class SharedReagentGrinderSystem : EntitySystem
             if (!HasComp<FitsInDispenserComponent>(heldEnt))
             {
                 // This is ugly but we can't use whitelistFailPopup because there are 2 containers with different whitelists.
-                _popupSystem.PopupClient(Loc.GetString("reagent-grinder-component-cannot-put-entity-message"), ent.Owner, args.User);
+                _popupSystem.PopupEntity(Loc.GetString("reagent-grinder-component-cannot-put-entity-message"), ent.Owner, args.User);
             }
 
             // Entity did NOT pass the whitelist for grind/juice.

--- a/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
+++ b/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
@@ -166,7 +166,7 @@ public sealed partial class SharedKitchenSpikeSystem : EntitySystem
 
         var victimIdentity = Identity.Entity(victim.Value, EntityManager);
 
-        _popupSystem.PopupPredicted(Loc.GetString("comp-kitchen-spike-begin-butcher-self", ("victim", victimIdentity)),
+        _popupSystem.PopupEntity(Loc.GetString("comp-kitchen-spike-begin-butcher-self", ("victim", victimIdentity)),
             Loc.GetString("comp-kitchen-spike-begin-butcher", ("user", Identity.Entity(args.User, EntityManager)), ("victim", victimIdentity)),
             ent,
             args.User,
@@ -290,7 +290,7 @@ public sealed partial class SharedKitchenSpikeSystem : EntitySystem
 
         var victimIdentity = Identity.Entity(args.Target.Value, EntityManager);
 
-        _popupSystem.PopupPredicted(Loc.GetString("comp-kitchen-spike-butcher-self", ("victim", victimIdentity)),
+        _popupSystem.PopupEntity(Loc.GetString("comp-kitchen-spike-butcher-self", ("victim", victimIdentity)),
             Loc.GetString("comp-kitchen-spike-butcher", ("user", Identity.Entity(args.User, EntityManager)), ("victim", victimIdentity)),
             ent,
             args.User,
@@ -457,7 +457,7 @@ public sealed partial class SharedKitchenSpikeSystem : EntitySystem
                 ("hook", hook));
         }
 
-        _popupSystem.PopupPredicted(messageSelf, messageOthers, hook, user, PopupType.MediumCaution);
+        _popupSystem.PopupEntity(messageSelf, messageOthers, hook, user, PopupType.MediumCaution);
     }
 
     /// <summary>

--- a/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
+++ b/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
@@ -132,7 +132,7 @@ public sealed partial class SharedKitchenSpikeSystem : EntitySystem
             return;
 
         var quality = ProtoMan.Index(ent.Comp.RequiredToolQuality);
-        _popupSystem.PopupClient(Loc.GetString("comp-kitchen-spike-need-tool-quality",
+        _popupSystem.PopupEntity(Loc.GetString("comp-kitchen-spike-need-tool-quality",
             ("target", Identity.Entity(victim.Value, EntityManager)),
             ("quality", Loc.GetString(quality.Name))),
             ent,
@@ -154,7 +154,7 @@ public sealed partial class SharedKitchenSpikeSystem : EntitySystem
         if (!TryComp<ToolComponent>(args.Used, out var tool) || !_toolSystem.HasQuality(args.Used, ent.Comp.RequiredToolQuality, tool))
         {
             var quality = ProtoMan.Index(ent.Comp.RequiredToolQuality);
-            _popupSystem.PopupClient(Loc.GetString("comp-kitchen-spike-need-tool-quality",
+            _popupSystem.PopupEntity(Loc.GetString("comp-kitchen-spike-need-tool-quality",
                 ("target", Identity.Entity(victim.Value, EntityManager)),
                 ("quality", Loc.GetString(quality.Name))),
                 ent,

--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -109,7 +109,7 @@ public sealed partial class LockSystem : EntitySystem
             return;
 
         if (!args.Silent)
-            _sharedPopupSystem.PopupClient(Loc.GetString("entity-storage-component-locked-message"), uid, args.User);
+            _sharedPopupSystem.PopupEntity(Loc.GetString("entity-storage-component-locked-message"), uid, args.User);
 
         args.Cancelled = true;
     }
@@ -176,7 +176,7 @@ public sealed partial class LockSystem : EntitySystem
 
         if (user is { Valid: true })
         {
-            _sharedPopupSystem.PopupClient(Loc.GetString("lock-comp-do-lock-success",
+            _sharedPopupSystem.PopupEntity(Loc.GetString("lock-comp-do-lock-success",
                 ("entityName", Identity.Name(uid, EntityManager))), uid, user);
         }
 
@@ -209,7 +209,7 @@ public sealed partial class LockSystem : EntitySystem
 
         if (user is { Valid: true })
         {
-            _sharedPopupSystem.PopupClient(Loc.GetString("lock-comp-do-unlock-success",
+            _sharedPopupSystem.PopupEntity(Loc.GetString("lock-comp-do-unlock-success",
                 ("entityName", Identity.Name(uid, EntityManager))), uid, user.Value);
         }
 
@@ -352,7 +352,7 @@ public sealed partial class LockSystem : EntitySystem
         if (!quiet)
         {
             var denyReason = accessEv.DenyReason ?? Loc.GetString(_defaultDenyReason);
-            _sharedPopupSystem.PopupClient(denyReason, ent, user);
+            _sharedPopupSystem.PopupEntity(denyReason, ent, user);
         }
 
         return false;
@@ -430,7 +430,7 @@ public sealed partial class LockSystem : EntitySystem
 
         if (!args.Silent)
         {
-            _sharedPopupSystem.PopupClient(Loc.GetString("construction-step-condition-wire-panel-close"),
+            _sharedPopupSystem.PopupEntity(Loc.GetString("construction-step-condition-wire-panel-close"),
                 ent,
                 args.User);
         }
@@ -446,7 +446,7 @@ public sealed partial class LockSystem : EntitySystem
         if (!TryComp<LockComponent>(ent, out var lockComp) || !lockComp.Locked)
             return;
 
-        _sharedPopupSystem.PopupClient(Loc.GetString("lock-comp-generic-fail",
+        _sharedPopupSystem.PopupEntity(Loc.GetString("lock-comp-generic-fail",
             ("target", Identity.Entity(ent, EntityManager))),
             ent,
             args.User);
@@ -461,7 +461,7 @@ public sealed partial class LockSystem : EntitySystem
         if (!TryComp<LockComponent>(ent, out var lockComp) || !lockComp.Locked)
             return;
 
-        _sharedPopupSystem.PopupClient(Loc.GetString("lock-comp-generic-fail",
+        _sharedPopupSystem.PopupEntity(Loc.GetString("lock-comp-generic-fail",
                 ("target", Identity.Entity(ent, EntityManager))),
             ent,
             args.User);
@@ -483,7 +483,7 @@ public sealed partial class LockSystem : EntitySystem
 
         if (lockComp.Locked && component.Popup != null)
         {
-            _sharedPopupSystem.PopupClient(Loc.GetString(component.Popup), uid, args.User);
+            _sharedPopupSystem.PopupEntity(Loc.GetString(component.Popup), uid, args.User);
         }
 
         _audio.PlayPredicted(component.AccessDeniedSound, uid, args.User);
@@ -518,7 +518,7 @@ public sealed partial class LockSystem : EntitySystem
 
         if (lockComp.Locked && component.LockedPopup != null)
         {
-            _sharedPopupSystem.PopupClient(Loc.GetString(component.LockedPopup,
+            _sharedPopupSystem.PopupEntity(Loc.GetString(component.LockedPopup,
                     ("target", Identity.Entity(uid, EntityManager))),
                 uid,
                 args.User);

--- a/Content.Shared/Lock/LockingWhitelistSystem.cs
+++ b/Content.Shared/Lock/LockingWhitelistSystem.cs
@@ -21,7 +21,7 @@ public sealed partial class LockingWhitelistSystem : EntitySystem
             return;
 
         if (!args.Silent)
-            _popupSystem.PopupClient(Loc.GetString("locking-whitelist-component-lock-toggle-deny"), ent.Owner);
+            _popupSystem.PopupEntity(Loc.GetString("locking-whitelist-component-lock-toggle-deny"), ent.Owner, ent.Owner);
 
         args.Cancelled = true;
     }

--- a/Content.Shared/Lube/LubeSystem.cs
+++ b/Content.Shared/Lube/LubeSystem.cs
@@ -65,7 +65,7 @@ public sealed partial class LubeSystem : EntitySystem
     {
         if (HasComp<LubedComponent>(target) || !HasComp<ItemComponent>(target))
         {
-            _popup.PopupClient(Loc.GetString("lube-failure", ("target", Identity.Entity(target, EntityManager))), actor, actor, PopupType.Medium);
+            _popup.PopupEntity(Loc.GetString("lube-failure", ("target", Identity.Entity(target, EntityManager))), actor, actor, PopupType.Medium);
             return false;
         }
 
@@ -75,7 +75,7 @@ public sealed partial class LubeSystem : EntitySystem
             if (quantity > 0)
             {
                 _audio.PlayPredicted(entity.Comp.Squeeze, entity.Owner, actor);
-                _popup.PopupClient(Loc.GetString("lube-success", ("target", Identity.Entity(target, EntityManager))), actor, actor, PopupType.Medium);
+                _popup.PopupEntity(Loc.GetString("lube-success", ("target", Identity.Entity(target, EntityManager))), actor, actor, PopupType.Medium);
                 _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(actor):actor} lubed {ToPrettyString(target):subject} with {ToPrettyString(entity.Owner):tool}");
                 var lubed = EnsureComp<LubedComponent>(target);
                 var rand = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(entity));
@@ -85,7 +85,7 @@ public sealed partial class LubeSystem : EntitySystem
                 return true;
             }
         }
-        _popup.PopupClient(Loc.GetString("lube-failure", ("target", Identity.Entity(target, EntityManager))), actor, actor, PopupType.Medium);
+        _popup.PopupEntity(Loc.GetString("lube-failure", ("target", Identity.Entity(target, EntityManager))), actor, actor, PopupType.Medium);
         return false;
     }
 }

--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -116,7 +116,7 @@ public abstract partial class SharedMagicSystem : EntitySystem
             return;
 
         args.Cancelled = true;
-        _popup.PopupClient(Loc.GetString("spell-requirements-failed"), args.Performer, args.Performer);
+        _popup.PopupEntity(Loc.GetString("spell-requirements-failed"), args.Performer, args.Performer);
 
         // TODO: Pre-cast do after, either here or in SharedActionsSystem
     }

--- a/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
+++ b/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
@@ -281,7 +281,7 @@ public abstract partial class SharedCryoPodSystem : EntitySystem
 
         if (cryoPodComponent.Locked)
         {
-            _popup.PopupClient(Loc.GetString("cryo-pod-locked"), uid, userId);
+            _popup.PopupEntity(Loc.GetString("cryo-pod-locked"), uid, userId);
             return;
         }
 

--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -72,7 +72,7 @@ public sealed partial class HealingSystem : EntitySystem
                 var popup = (args.User == target.Owner)
                     ? Loc.GetString("medical-item-stop-bleeding-self")
                     : Loc.GetString("medical-item-stop-bleeding", ("target", Identity.Entity(target.Owner, EntityManager)));
-                _popupSystem.PopupClient(popup, target, args.User);
+                _popupSystem.PopupEntity(popup, target, args.User);
             }
         }
 
@@ -118,7 +118,7 @@ public sealed partial class HealingSystem : EntitySystem
 
         if (!args.Repeat)
         {
-            _popupSystem.PopupClient(Loc.GetString("medical-item-finished-using", ("item", args.Used)), target.Owner, args.User);
+            _popupSystem.PopupEntity(Loc.GetString("medical-item-finished-using", ("item", args.Used)), target.Owner, args.User);
             return;
         }
 
@@ -200,7 +200,7 @@ public sealed partial class HealingSystem : EntitySystem
 
         if (!HasDamage(healing, target!))
         {
-            _popupSystem.PopupClient(Loc.GetString("medical-item-cant-use", ("item", healing.Owner)), healing, user);
+            _popupSystem.PopupEntity(Loc.GetString("medical-item-cant-use", ("item", healing.Owner)), healing, user);
             return false;
         }
 

--- a/Content.Shared/Medical/SharedDefibrillatorSystem.cs
+++ b/Content.Shared/Medical/SharedDefibrillatorSystem.cs
@@ -90,7 +90,7 @@ public abstract partial class SharedDefibrillatorSystem : EntitySystem
 
         if (!_toggle.IsActivated(ent.Owner))
         {
-            _popup.PopupClient(Loc.GetString("defibrillator-not-on"), ent.Owner, user);
+            _popup.PopupEntity(Loc.GetString("defibrillator-not-on"), ent.Owner, user);
             return false;
         }
 

--- a/Content.Shared/Medical/Stethoscope/StethoscopeSystem.cs
+++ b/Content.Shared/Medical/Stethoscope/StethoscopeSystem.cs
@@ -97,11 +97,11 @@ public sealed partial class StethoscopeSystem : EntitySystem
     {
         // TODO: Add check for respirator component when it gets moved to shared.
         // If the mob is dead or cannot asphyxiation damage, the popup shows nothing.
-        if (!TryComp<MobStateComponent>(target, out var mobState)                        ||
-            _mobState.IsDead(target, mobState)                                           ||
-            !_damageable.GetAllDamage(target).DamageDict.TryGetValue(DamageToListenFor, out var asphyxDmg))
+        if (!TryComp<MobStateComponent>(target, out var mobState)
+            || _mobState.IsDead(target, mobState)
+            || !_damageable.GetAllDamage(target).DamageDict.TryGetValue(DamageToListenFor, out var asphyxDmg))
         {
-            _popup.PopupEntity(Loc.GetString("stethoscope-nothing"), target);
+            _popup.PopupEntity(Loc.GetString("stethoscope-nothing"), target, user);
             stethoscope.Comp.LastMeasuredDamage = null;
             return;
         }
@@ -111,7 +111,7 @@ public sealed partial class StethoscopeSystem : EntitySystem
         // Don't show the change if this is the first time listening.
         if (stethoscope.Comp.LastMeasuredDamage == null)
         {
-            _popup.PopupEntity(absString, target);
+            _popup.PopupEntity(absString, target, user);
         }
         else
         {

--- a/Content.Shared/Medical/Stethoscope/StethoscopeSystem.cs
+++ b/Content.Shared/Medical/Stethoscope/StethoscopeSystem.cs
@@ -101,7 +101,7 @@ public sealed partial class StethoscopeSystem : EntitySystem
             _mobState.IsDead(target, mobState)                                           ||
             !_damageable.GetAllDamage(target).DamageDict.TryGetValue(DamageToListenFor, out var asphyxDmg))
         {
-            _popup.PopupPredicted(Loc.GetString("stethoscope-nothing"), target, user);
+            _popup.PopupEntity(Loc.GetString("stethoscope-nothing"), target);
             stethoscope.Comp.LastMeasuredDamage = null;
             return;
         }
@@ -111,12 +111,12 @@ public sealed partial class StethoscopeSystem : EntitySystem
         // Don't show the change if this is the first time listening.
         if (stethoscope.Comp.LastMeasuredDamage == null)
         {
-            _popup.PopupPredicted(absString, target, user);
+            _popup.PopupEntity(absString, target);
         }
         else
         {
             var deltaString = GetDeltaDamageString(stethoscope.Comp.LastMeasuredDamage.Value, asphyxDmg);
-            _popup.PopupPredicted(Loc.GetString("stethoscope-combined-status", ("absolute", absString), ("delta", deltaString)), target, user);
+            _popup.PopupEntity(Loc.GetString("stethoscope-combined-status", ("absolute", absString), ("delta", deltaString)), target);
         }
 
         stethoscope.Comp.LastMeasuredDamage = asphyxDmg;

--- a/Content.Shared/Medical/Stethoscope/StethoscopeSystem.cs
+++ b/Content.Shared/Medical/Stethoscope/StethoscopeSystem.cs
@@ -116,7 +116,7 @@ public sealed partial class StethoscopeSystem : EntitySystem
         else
         {
             var deltaString = GetDeltaDamageString(stethoscope.Comp.LastMeasuredDamage.Value, asphyxDmg);
-            _popup.PopupEntity(Loc.GetString("stethoscope-combined-status", ("absolute", absString), ("delta", deltaString)), target);
+            _popup.PopupEntity(Loc.GetString("stethoscope-combined-status", ("absolute", absString), ("delta", deltaString)), target, user);
         }
 
         stethoscope.Comp.LastMeasuredDamage = asphyxDmg;

--- a/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
+++ b/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
@@ -335,7 +335,7 @@ public abstract partial class SharedSuitSensorSystem : EntitySystem
         if (userUid != null)
         {
             var msg = Loc.GetString("suit-sensor-mode-state", ("mode", GetModeName(mode)));
-            _popupSystem.PopupClient(msg, sensors, userUid.Value);
+            _popupSystem.PopupEntity(msg, sensors, userUid.Value);
         }
     }
 

--- a/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
@@ -62,7 +62,7 @@ public abstract partial class SharedJetpackSystem : EntitySystem
             if (transform.GridUid == gridUid && ev.HasGravity &&
                 _jetpackQuery.TryGetComponent(user.Jetpack, out var jetpack))
             {
-                _popup.PopupClient(Loc.GetString("jetpack-to-grid"), uid, uid);
+                _popup.PopupEntity(Loc.GetString("jetpack-to-grid"), uid, uid);
 
                 SetEnabled(user.Jetpack, jetpack, false, uid);
             }
@@ -92,7 +92,7 @@ public abstract partial class SharedJetpackSystem : EntitySystem
         {
             SetEnabled(component.Jetpack, jetpack, false, uid);
 
-            _popup.PopupClient(Loc.GetString("jetpack-to-grid"), uid, uid);
+            _popup.PopupEntity(Loc.GetString("jetpack-to-grid"), uid, uid);
         }
     }
 
@@ -132,7 +132,7 @@ public abstract partial class SharedJetpackSystem : EntitySystem
 
         if (TryComp(uid, out TransformComponent? xform) && !CanEnableOnGrid(xform.GridUid))
         {
-            _popup.PopupClient(Loc.GetString("jetpack-no-station"), uid, args.Performer);
+            _popup.PopupEntity(Loc.GetString("jetpack-no-station"), uid, args.Performer);
 
             return;
         }

--- a/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
@@ -72,7 +72,7 @@ public sealed partial class SharedJumpAbilitySystem : EntitySystem
         if (_gravity.IsWeightless(args.Performer) || _standing.IsDown(args.Performer))
         {
             if (entity.Comp.JumpFailedPopup != null)
-                _popup.PopupClient(Loc.GetString(entity.Comp.JumpFailedPopup.Value), args.Performer, args.Performer);
+                _popup.PopupEntity(Loc.GetString(entity.Comp.JumpFailedPopup.Value), args.Performer, args.Performer);
             return;
         }
 

--- a/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
+++ b/Content.Shared/Ninja/Systems/DashAbilitySystem.cs
@@ -57,7 +57,7 @@ public sealed partial class DashAbilitySystem : EntitySystem
 
         if (!_hands.IsHolding(user, uid, out var _))
         {
-            _popup.PopupClient(Loc.GetString("dash-ability-not-held", ("item", uid)), user, user);
+            _popup.PopupEntity(Loc.GetString("dash-ability-not-held", ("item", uid)), user, user);
             return;
         }
 
@@ -66,13 +66,13 @@ public sealed partial class DashAbilitySystem : EntitySystem
         if (!_examine.InRangeUnOccluded(origin, target, SharedInteractionSystem.MaxRaycastRange, null))
         {
             // can only dash if the destination is visible on screen
-            _popup.PopupClient(Loc.GetString("dash-ability-cant-see", ("item", uid)), user, user);
+            _popup.PopupEntity(Loc.GetString("dash-ability-cant-see", ("item", uid)), user, user);
             return;
         }
 
         if (!_sharedCharges.TryUseCharge(uid))
         {
-            _popup.PopupClient(Loc.GetString("dash-ability-no-charges", ("item", uid)), user, user);
+            _popup.PopupEntity(Loc.GetString("dash-ability-no-charges", ("item", uid)), user, user);
             return;
         }
 

--- a/Content.Shared/Ninja/Systems/SharedNinjaGlovesSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedNinjaGlovesSystem.cs
@@ -93,7 +93,7 @@ public abstract partial class SharedNinjaGlovesSystem : EntitySystem
             return;
 
         var message = Loc.GetString(args.Activated ? "ninja-gloves-on" : "ninja-gloves-off");
-        _popup.PopupClient(message, user, user);
+        _popup.PopupEntity(message, user, user);
 
         if (args.Activated && _ninja.NinjaQuery.TryComp(user, out var ninja))
             EnableGloves(ent, (user, ninja));

--- a/Content.Shared/Ninja/Systems/SharedNinjaSuitSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedNinjaSuitSystem.cs
@@ -118,7 +118,7 @@ public abstract partial class SharedNinjaSuitSystem : EntitySystem
 
         // previously cloaked, disable abilities for a short time
         _audio.PlayPredicted(comp.RevealSound, uid, user);
-        Popup.PopupClient(Loc.GetString("ninja-revealed"), user, user, PopupType.MediumCaution);
+        Popup.PopupEntity(Loc.GetString("ninja-revealed"), user, user, PopupType.MediumCaution);
         _useDelay.TryResetDelay(uid, id: comp.DisableDelayId);
     }
 

--- a/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
@@ -104,7 +104,7 @@ public abstract partial class SharedSpaceNinjaSystem : EntitySystem
     /// </summary>
     private void OnShotAttempted(Entity<SpaceNinjaComponent> ent, ref ShotAttemptedEvent args)
     {
-        Popup.PopupClient(Loc.GetString("gun-disabled"), ent, ent);
+        Popup.PopupEntity(Loc.GetString("gun-disabled"), ent, ent);
         args.Cancel();
     }
 }

--- a/Content.Shared/Nutrition/EntitySystems/FoodSequenceSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/FoodSequenceSystem.cs
@@ -124,7 +124,7 @@ public sealed partial class FoodSequenceSystem : SharedFoodSequenceSystem
         if (start.Comp.FoodLayers.Count >= start.Comp.MaxLayers && !elementIndexed.Final || start.Comp.Finished)
         {
             if (user is not null)
-                _popup.PopupClient(Loc.GetString("food-sequence-no-space"), start, user.Value);
+                _popup.PopupEntity(Loc.GetString("food-sequence-no-space"), start, user.Value);
             return false;
         }
 

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
@@ -76,7 +76,7 @@ public sealed partial class IngestionSystem
         if (!_transform.GetMapCoordinates(user).InRange(_transform.GetMapCoordinates(target), MaxFeedDistance))
         {
             var message = Loc.GetString("interaction-system-user-interaction-cannot-reach");
-            _popup.PopupClient(message, user, user);
+            _popup.PopupEntity(message, user, user);
             return false;
         }
 
@@ -87,7 +87,7 @@ public sealed partial class IngestionSystem
             return true;
 
         if (attempt.Blocker != null)
-            _popup.PopupClient(Loc.GetString("ingestion-remove-mask", ("entity", attempt.Blocker.Value)), target, user);
+            _popup.PopupEntity(Loc.GetString("ingestion-remove-mask", ("entity", attempt.Blocker.Value)), target, user);
 
         return false;
     }
@@ -314,7 +314,7 @@ public sealed partial class IngestionSystem
 
         if (solution == null)
         {
-            _popup.PopupClient(Loc.GetString("ingestion-try-use-is-empty", ("entity", ingested)), ingested, user);
+            _popup.PopupEntity(Loc.GetString("ingestion-try-use-is-empty", ("entity", ingested)), ingested, user);
             return false;
         }
 

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
@@ -83,7 +83,7 @@ public sealed partial class IngestionSystem
         {
             args.Cancelled = true;
 
-            _popup.PopupClient(Loc.GetString("ingestion-try-use-is-empty", ("entity", entity)), entity, args.User);
+            _popup.PopupEntity(Loc.GetString("ingestion-try-use-is-empty", ("entity", entity)), entity, args.User);
             return;
         }
 
@@ -101,7 +101,7 @@ public sealed partial class IngestionSystem
 
         args.Cancelled = true;
 
-        _popup.PopupClient(Loc.GetString("edible-has-used-storage", ("food", ent), ("verb", GetEdibleVerb(ent.Owner))), args.User, args.User);
+        _popup.PopupEntity(Loc.GetString("edible-has-used-storage", ("food", ent), ("verb", GetEdibleVerb(ent.Owner))), args.User, args.User);
     }
 
     private void OnItemSlotsEdible(Entity<ItemSlotsComponent> ent, ref EdibleEvent args)
@@ -114,7 +114,7 @@ public sealed partial class IngestionSystem
 
         args.Cancelled = true;
 
-        _popup.PopupClient(Loc.GetString("edible-has-used-storage", ("food", ent), ("verb", GetEdibleVerb(ent.Owner))), args.User, args.User);
+        _popup.PopupEntity(Loc.GetString("edible-has-used-storage", ("food", ent), ("verb", GetEdibleVerb(ent.Owner))), args.User, args.User);
     }
 
     private void OnOpenableEdible(Entity<OpenableComponent> ent, ref EdibleEvent args)

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Utensils.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Utensils.cs
@@ -43,7 +43,7 @@ public sealed partial class IngestionSystem
         //Prevents food usage with a wrong utensil
         if (ev.Types != UtensilType.None && (ev.Types & utensil.Comp.Types) == 0)
         {
-            _popup.PopupClient(Loc.GetString("ingestion-try-use-wrong-utensil", ("verb", GetEdibleVerb(target)), ("food", target), ("utensil", utensil.Owner)), user, user);
+            _popup.PopupEntity(Loc.GetString("ingestion-try-use-wrong-utensil", ("verb", GetEdibleVerb(target)), ("food", target), ("utensil", utensil.Owner)), user, user);
             return true;
         }
 
@@ -120,7 +120,7 @@ public sealed partial class IngestionSystem
         if (!required || (usedTypes & requiredTypes) == requiredTypes)
             return true;
 
-        _popup.PopupClient(Loc.GetString("ingestion-you-need-to-hold-utensil", ("utensil", requiredTypes ^ usedTypes)), entity, entity);
+        _popup.PopupEntity(Loc.GetString("ingestion-you-need-to-hold-utensil", ("utensil", requiredTypes ^ usedTypes)), entity, entity);
         return false;
 
     }

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -251,9 +251,9 @@ public sealed partial class IngestionSystem : EntitySystem
                 return;
 
             if (forceFed)
-                _popup.PopupClient(Loc.GetString("ingestion-cant-digest-other", ("target", entity), ("entity", food)), entity, args.User);
+                _popup.PopupEntity(Loc.GetString("ingestion-cant-digest-other", ("target", entity), ("entity", food)), entity, args.User);
             else
-                _popup.PopupClient(Loc.GetString("ingestion-cant-digest", ("entity", food)), entity, entity);
+                _popup.PopupEntity(Loc.GetString("ingestion-cant-digest", ("entity", food)), entity, entity);
 
             return;
         }
@@ -333,11 +333,11 @@ public sealed partial class IngestionSystem : EntitySystem
         if (stomachToUse == null)
         {
             // Very long
-            _popup.PopupClient(Loc.GetString("ingestion-you-cannot-ingest-any-more", ("verb", GetEdibleVerb(food))), entity, entity);
+            _popup.PopupEntity(Loc.GetString("ingestion-you-cannot-ingest-any-more", ("verb", GetEdibleVerb(food))), entity, entity);
             if (!forceFed)
                 return;
 
-            _popup.PopupClient(Loc.GetString("ingestion-other-cannot-ingest-any-more", ("target", entity), ("verb", GetEdibleVerb(food))), args.Target.Value, args.User);
+            _popup.PopupEntity(Loc.GetString("ingestion-other-cannot-ingest-any-more", ("target", entity), ("verb", GetEdibleVerb(food))), args.Target.Value, args.User);
             return;
         }
 
@@ -348,11 +348,11 @@ public sealed partial class IngestionSystem : EntitySystem
         if (beforeEv.Cancelled || beforeEv.Min > beforeEv.Max)
         {
             // Very long x2
-            _popup.PopupClient(Loc.GetString("ingestion-you-cannot-ingest-any-more", ("verb", GetEdibleVerb(food))), entity, entity);
+            _popup.PopupEntity(Loc.GetString("ingestion-you-cannot-ingest-any-more", ("verb", GetEdibleVerb(food))), entity, entity);
             if (!forceFed)
                 return;
 
-            _popup.PopupClient(Loc.GetString("ingestion-other-cannot-ingest-any-more", ("target", entity), ("verb", GetEdibleVerb(food))), args.Target.Value, args.User);
+            _popup.PopupEntity(Loc.GetString("ingestion-other-cannot-ingest-any-more", ("target", entity), ("verb", GetEdibleVerb(food))), args.Target.Value, args.User);
             return;
         }
 
@@ -460,7 +460,7 @@ public sealed partial class IngestionSystem : EntitySystem
             var userName = Identity.Entity(args.User, EntityManager);
             _popup.PopupEntity(Loc.GetString("edible-force-feed-success", ("user", userName), ("verb", edible.Verb), ("flavors", flavors), ("satiated", args.Satiated)), entity, entity);
 
-            _popup.PopupClient(Loc.GetString("edible-force-feed-success-user", ("target", targetName), ("verb", edible.Verb)), args.User, args.User);
+            _popup.PopupEntity(Loc.GetString("edible-force-feed-success-user", ("target", targetName), ("verb", edible.Verb)), args.User, args.User);
 
             // log successful forced feeding
             // TODO: Use correct verb

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -468,7 +468,7 @@ public sealed partial class IngestionSystem : EntitySystem
         }
         else
         {
-            _popup.PopupPredicted(Loc.GetString(edible.Message, ("food", entity.Owner), ("flavors", flavors), ("satiated", args.Satiated)),
+            _popup.PopupEntity(Loc.GetString(edible.Message, ("food", entity.Owner), ("flavors", flavors), ("satiated", args.Satiated)),
                 Loc.GetString(edible.OtherMessage),
                 args.User,
                 args.User);

--- a/Content.Shared/Nutrition/EntitySystems/MessyDrinkerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/MessyDrinkerSystem.cs
@@ -41,7 +41,7 @@ public sealed partial class MessyDrinkerSystem : EntitySystem
             return;
 
         if (ent.Comp.SpillMessagePopup != null)
-            _popup.PopupPredicted(Loc.GetString(ent.Comp.SpillMessagePopup), null, ent, ent, PopupType.MediumCaution);
+            _popup.PopupEntity(Loc.GetString(ent.Comp.SpillMessagePopup), ent, ent, PopupType.MediumCaution);
 
         var split = ev.Split.SplitSolution(ent.Comp.SpillAmount);
 

--- a/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
@@ -162,10 +162,7 @@ public sealed partial class OpenableSystem : EntitySystem
 
         if (user != null)
         {
-            if (predicted)
-                _popup.PopupEntity(Loc.GetString(comp.ClosedPopup, ("owner", uid)), user.Value, user.Value);
-            else
-                _popup.PopupEntity(Loc.GetString(comp.ClosedPopup, ("owner", uid)), user.Value, user.Value);
+            _popup.PopupEntity(Loc.GetString(comp.ClosedPopup, ("owner", uid)), user.Value, user.Value);
         }
 
         return true;

--- a/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
@@ -163,7 +163,7 @@ public sealed partial class OpenableSystem : EntitySystem
         if (user != null)
         {
             if (predicted)
-                _popup.PopupClient(Loc.GetString(comp.ClosedPopup, ("owner", uid)), user.Value, user.Value);
+                _popup.PopupEntity(Loc.GetString(comp.ClosedPopup, ("owner", uid)), user.Value, user.Value);
             else
                 _popup.PopupEntity(Loc.GetString(comp.ClosedPopup, ("owner", uid)), user.Value, user.Value);
         }

--- a/Content.Shared/Nutrition/EntitySystems/PressurizedSolutionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/PressurizedSolutionSystem.cs
@@ -187,7 +187,7 @@ public sealed partial class PressurizedSolutionSystem : EntitySystem
 
             var selfMessage = Loc.GetString(entity.Comp.SprayHolderMessageSelf, ("victim", victimName), ("drink", drinkName));
             var othersMessage = Loc.GetString(entity.Comp.SprayHolderMessageOthers, ("victim", victimName), ("drink", drinkName));
-            _popup.PopupPredicted(selfMessage, othersMessage, target.Value, target.Value);
+            _popup.PopupEntity(selfMessage, othersMessage, target.Value, target.Value);
         }
         else
         {

--- a/Content.Shared/Nutrition/EntitySystems/ShakeableSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/ShakeableSystem.cs
@@ -86,7 +86,7 @@ public sealed partial class ShakeableSystem : EntitySystem
 
         var selfMessage = Loc.GetString(entity.Comp.ShakePopupMessageSelf, ("user", userName), ("shakeable", shakeableName));
         var othersMessage = Loc.GetString(entity.Comp.ShakePopupMessageOthers, ("user", userName), ("shakeable", shakeableName));
-        _popup.PopupPredicted(selfMessage, othersMessage, user, user);
+        _popup.PopupEntity(selfMessage, othersMessage, user, user);
 
         _audio.PlayPredicted(entity.Comp.ShakeSound, entity, user);
 

--- a/Content.Shared/Nutrition/EntitySystems/SharedCreamPieSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SharedCreamPieSystem.cs
@@ -131,26 +131,19 @@ public abstract partial class SharedCreamPieSystem : EntitySystem
         SetCreamPied(creamPied.AsNullable(), true);
 
         // Throwing is not predicted, so the thrower is not equal to the client predicting the collision, so we cannot pass in a user.
-        // TODO: Make the popup API sane.
         if (_net.IsClient)
             return;
 
-        // Shown only to the player that was hit.
         _popup.PopupEntity(
             Loc.GetString(
                 "cream-pied-component-on-hit-by-message",
                 ("thrown", args.Thrown)),
-            creamPied.Owner, creamPied.Owner);
-
-        var otherPlayers = Filter.PvsExcept(creamPied.Owner);
-
-        // Show to everyone else.
-        _popup.PopupEntity(
             Loc.GetString(
                 "cream-pied-component-on-hit-by-message-others",
                 ("owner", Identity.Entity(creamPied.Owner, EntityManager)),
                 ("thrown", args.Thrown)),
-            creamPied.Owner, otherPlayers, false);
+            creamPied.Owner,
+            creamPied.Owner);
     }
 
     private void OnRejuvenate(Entity<CreamPiedComponent> ent, ref RejuvenateEvent args)

--- a/Content.Shared/PDA/SharedRingerSystem.cs
+++ b/Content.Shared/PDA/SharedRingerSystem.cs
@@ -209,9 +209,8 @@ public abstract partial class SharedRingerSystem : EntitySystem
 
         UpdateRingerUi(ent);
 
-        _popup.PopupPredicted(Loc.GetString("comp-ringer-vibration-popup"),
+        _popup.PopupEntity(Loc.GetString("comp-ringer-vibration-popup"),
             ent,
-            ent.Owner,
             Filter.Pvs(ent, 0.05f),
             false,
             PopupType.Medium);

--- a/Content.Shared/PDA/SharedRingerSystem.cs
+++ b/Content.Shared/PDA/SharedRingerSystem.cs
@@ -211,7 +211,6 @@ public abstract partial class SharedRingerSystem : EntitySystem
 
         _popup.PopupEntity(Loc.GetString("comp-ringer-vibration-popup"),
             ent,
-            ent.Owner,
             Filter.Pvs(ent, 0.05f),
             false,
             PopupType.Medium);

--- a/Content.Shared/PDA/SharedRingerSystem.cs
+++ b/Content.Shared/PDA/SharedRingerSystem.cs
@@ -211,6 +211,7 @@ public abstract partial class SharedRingerSystem : EntitySystem
 
         _popup.PopupEntity(Loc.GetString("comp-ringer-vibration-popup"),
             ent,
+            ent.Owner,
             Filter.Pvs(ent, 0.05f),
             false,
             PopupType.Medium);

--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -120,7 +120,7 @@ public sealed partial class PaperSystem : EntitySystem
                 if (entity.Comp.EditingDisabled)
                 {
                     var paperEditingDisabledMessage = Loc.GetString("paper-tamper-proof-modified-message");
-                    _popupSystem.PopupClient(paperEditingDisabledMessage, entity, args.User);
+                    _popupSystem.PopupEntity(paperEditingDisabledMessage, entity, args.User);
 
                     args.Handled = true;
                     return;
@@ -133,7 +133,7 @@ public sealed partial class PaperSystem : EntitySystem
                     if (ev.FailReason is not null)
                     {
                         var fileWriteMessage = Loc.GetString(ev.FailReason);
-                        _popupSystem.PopupClient(fileWriteMessage, entity.Owner, args.User);
+                        _popupSystem.PopupEntity(fileWriteMessage, entity.Owner, args.User);
                     }
 
                     args.Handled = true;
@@ -164,7 +164,7 @@ public sealed partial class PaperSystem : EntitySystem
             var stampPaperSelfMessage = Loc.GetString("paper-component-action-stamp-paper-self",
                     ("target", args.Target),
                     ("stamp", args.Used));
-            _popupSystem.PopupClient(stampPaperSelfMessage, args.User, args.User);
+            _popupSystem.PopupEntity(stampPaperSelfMessage, args.User, args.User);
 
             _audio.PlayPredicted(stampComp.Sound, entity, args.User);
 

--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -159,12 +159,10 @@ public sealed partial class PaperSystem : EntitySystem
                     ("user", args.User),
                     ("target", args.Target),
                     ("stamp", args.Used));
-
-            _popupSystem.PopupEntity(stampPaperOtherMessage, args.User, Filter.PvsExcept(args.User, entityManager: EntityManager), true);
             var stampPaperSelfMessage = Loc.GetString("paper-component-action-stamp-paper-self",
                     ("target", args.Target),
                     ("stamp", args.Used));
-            _popupSystem.PopupEntity(stampPaperSelfMessage, args.User, args.User);
+            _popupSystem.PopupEntity(stampPaperSelfMessage, stampPaperOtherMessage, args.User, args.User);
 
             _audio.PlayPredicted(stampComp.Sound, entity, args.User);
 

--- a/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.WrappedParcel.cs
+++ b/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.WrappedParcel.cs
@@ -105,9 +105,8 @@ public sealed partial class ParcelWrappingSystem
         // Unwrap the package and if something was in it, show a popup describing "wow something came out!"
         if (UnwrapInternal(user: null, parcel) is { } contents)
         {
-            _popup.PopupPredicted(Loc.GetString("parcel-wrap-popup-parcel-destroyed", ("contents", contents)),
+            _popup.PopupEntity(Loc.GetString("parcel-wrap-popup-parcel-destroyed", ("contents", contents)),
                 contents,
-                null,
                 PopupType.MediumCaution);
         }
     }

--- a/Content.Shared/Plunger/Systems/PlungerSystem.cs
+++ b/Content.Shared/Plunger/Systems/PlungerSystem.cs
@@ -60,7 +60,7 @@ public sealed partial class PlungerSystem : EntitySystem
         if (!TryComp(target, out PlungerUseComponent? plunge))
             return;
 
-        _popup.PopupClient(Loc.GetString("plunger-unblock", ("target", target)), args.User, args.User, PopupType.Medium);
+        _popup.PopupEntity(Loc.GetString("plunger-unblock", ("target", target)), args.User, args.User, PopupType.Medium);
         plunge.Plunged = true;
 
         var spawn = ProtoMan.Index<WeightedRandomEntityPrototype>(plunge.PlungerLoot).Pick(_random);

--- a/Content.Shared/Polymorph/Systems/SharedChameleonProjectorSystem.cs
+++ b/Content.Shared/Polymorph/Systems/SharedChameleonProjectorSystem.cs
@@ -148,13 +148,13 @@ public abstract partial class SharedChameleonProjectorSystem : EntitySystem
     {
         if (_container.IsEntityInContainer(target) || _container.IsEntityInContainer(user))
         {
-            _popup.PopupClient(Loc.GetString("chameleon-projector-inside-container"), target, user);
+            _popup.PopupEntity(Loc.GetString("chameleon-projector-inside-container"), target, user);
             return false;
         }
 
         if (IsInvalid(ent.Comp, target))
         {
-            _popup.PopupClient(Loc.GetString("chameleon-projector-invalid"), target, user);
+            _popup.PopupEntity(Loc.GetString("chameleon-projector-invalid"), target, user);
             return false;
         }
 
@@ -162,7 +162,7 @@ public abstract partial class SharedChameleonProjectorSystem : EntitySystem
         if (TryComp<ItemToggleComponent>(ent.Owner, out var itemToggle) && !_toggle.TryActivate((ent.Owner, itemToggle), user))
             return false;
 
-        _popup.PopupClient(Loc.GetString("chameleon-projector-success"), target, user);
+        _popup.PopupEntity(Loc.GetString("chameleon-projector-success"), target, user);
         Disguise(ent, user, target);
         return true;
     }

--- a/Content.Shared/PowerCell/PowerCellSystem.API.cs
+++ b/Content.Shared/PowerCell/PowerCellSystem.API.cs
@@ -138,10 +138,7 @@ public sealed partial class PowerCellSystem
             if (user == null)
                 return false;
 
-            if (predicted)
-                _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
-            else
-                _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
+            _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
 
             return false;
         }
@@ -151,10 +148,7 @@ public sealed partial class PowerCellSystem
             if (user == null)
                 return false;
 
-            if (predicted)
-                _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
-            else
-                _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
+            _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
 
             return false;
         }
@@ -177,10 +171,7 @@ public sealed partial class PowerCellSystem
             if (user == null)
                 return false;
 
-            if (predicted)
-                _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
-            else
-                _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
+            _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
 
             return false;
         }
@@ -190,10 +181,7 @@ public sealed partial class PowerCellSystem
             if (user == null)
                 return false;
 
-            if (predicted)
-                _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
-            else
-                _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
+            _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
 
             return false;
         }

--- a/Content.Shared/PowerCell/PowerCellSystem.API.cs
+++ b/Content.Shared/PowerCell/PowerCellSystem.API.cs
@@ -139,7 +139,7 @@ public sealed partial class PowerCellSystem
                 return false;
 
             if (predicted)
-                _popup.PopupClient(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
+                _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
             else
                 _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
 
@@ -152,7 +152,7 @@ public sealed partial class PowerCellSystem
                 return false;
 
             if (predicted)
-                _popup.PopupClient(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
+                _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
             else
                 _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
 
@@ -178,7 +178,7 @@ public sealed partial class PowerCellSystem
                 return false;
 
             if (predicted)
-                _popup.PopupClient(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
+                _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
             else
                 _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
 
@@ -191,7 +191,7 @@ public sealed partial class PowerCellSystem
                 return false;
 
             if (predicted)
-                _popup.PopupClient(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
+                _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
             else
                 _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
 

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -95,7 +95,7 @@ public sealed partial class PryingSystem : EntitySystem
         if (!CanPry(target, user, out var message, comp))
         {
             if (!string.IsNullOrWhiteSpace(message))
-                _popup.PopupClient(Loc.GetString(message), target, user);
+                _popup.PopupEntity(Loc.GetString(message), target, user);
             // If we have reached this point we want the event that caused this
             // to be marked as handled.
             return true;
@@ -185,7 +185,7 @@ public sealed partial class PryingSystem : EntitySystem
         if (!CanPry(uid, args.User, out var message, comp))
         {
             if (!string.IsNullOrWhiteSpace(message))
-                _popup.PopupClient(Loc.GetString(message), uid, args.User);
+                _popup.PopupEntity(Loc.GetString(message), uid, args.User);
             return;
         }
 

--- a/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
@@ -47,11 +47,11 @@ public sealed partial class RCDAmmoSystem : EntitySystem
         var count = Math.Min(charges.MaxCharges - current, comp.Charges);
         if (count <= 0)
         {
-            _popup.PopupClient(Loc.GetString("rcd-ammo-component-after-interact-full"), target, user);
+            _popup.PopupEntity(Loc.GetString("rcd-ammo-component-after-interact-full"), target, user);
             return;
         }
 
-        _popup.PopupClient(Loc.GetString("rcd-ammo-component-after-interact-refilled"), target, user);
+        _popup.PopupEntity(Loc.GetString("rcd-ammo-component-after-interact-refilled"), target, user);
         _sharedCharges.AddCharges(target, count);
         comp.Charges -= count;
         Dirty(uid, comp);

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -145,7 +145,7 @@ public sealed partial class RCDSystem : EntitySystem
 
         if (!TryComp<MapGridComponent>(gridUid, out var mapGrid))
         {
-            _popup.PopupClient(Loc.GetString("rcd-component-no-valid-grid"), uid, user);
+            _popup.PopupEntity(Loc.GetString("rcd-component-no-valid-grid"), uid, user);
             return;
         }
         var tile = _mapSystem.GetTileRef(gridUid.Value, mapGrid, location);
@@ -344,7 +344,7 @@ public sealed partial class RCDSystem : EntitySystem
         if (charges == 0)
         {
             if (popMsgs)
-                _popup.PopupClient(Loc.GetString("rcd-component-no-ammo-message"), uid, user);
+                _popup.PopupEntity(Loc.GetString("rcd-component-no-ammo-message"), uid, user);
 
             return false;
         }
@@ -352,7 +352,7 @@ public sealed partial class RCDSystem : EntitySystem
         if (prototype.Cost > charges)
         {
             if (popMsgs)
-                _popup.PopupClient(Loc.GetString("rcd-component-insufficient-ammo-message"), uid, user);
+                _popup.PopupEntity(Loc.GetString("rcd-component-insufficient-ammo-message"), uid, user);
 
             return false;
         }
@@ -386,7 +386,7 @@ public sealed partial class RCDSystem : EntitySystem
         if (prototype.ConstructionRules.Contains(RcdConstructionRule.MustBuildOnEmptyTile) && !tile.Tile.IsEmpty)
         {
             if (popMsgs)
-                _popup.PopupClient(Loc.GetString("rcd-component-must-build-on-empty-tile-message"), uid, user);
+                _popup.PopupEntity(Loc.GetString("rcd-component-must-build-on-empty-tile-message"), uid, user);
 
             return false;
         }
@@ -395,7 +395,7 @@ public sealed partial class RCDSystem : EntitySystem
         if (!prototype.ConstructionRules.Contains(RcdConstructionRule.CanBuildOnEmptyTile) && tile.Tile.IsEmpty)
         {
             if (popMsgs)
-                _popup.PopupClient(Loc.GetString("rcd-component-cannot-build-on-empty-tile-message"), uid, user);
+                _popup.PopupEntity(Loc.GetString("rcd-component-cannot-build-on-empty-tile-message"), uid, user);
 
             return false;
         }
@@ -404,7 +404,7 @@ public sealed partial class RCDSystem : EntitySystem
         if (prototype.ConstructionRules.Contains(RcdConstructionRule.MustBuildOnSubfloor) && !_turf.GetContentTileDefinition(tile).IsSubFloor)
         {
             if (popMsgs)
-                _popup.PopupClient(Loc.GetString("rcd-component-must-build-on-subfloor-message"), uid, user);
+                _popup.PopupEntity(Loc.GetString("rcd-component-must-build-on-subfloor-message"), uid, user);
 
             return false;
         }
@@ -416,7 +416,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (!_floors.CanPlaceTile(gridUid, mapGrid, tile.GridIndices, out var reason))
             {
                 if (popMsgs)
-                    _popup.PopupClient(reason, uid, user);
+                    _popup.PopupEntity(reason, uid, user);
 
                 return false;
             }
@@ -431,7 +431,7 @@ public sealed partial class RCDSystem : EntitySystem
                 if (replacementContentDef.BaseTurf != tileDef.ID && !replacementContentDef.BaseWhitelist.Contains(tileDef.ID))
                 {
                     if (popMsgs)
-                        _popup.PopupClient(Loc.GetString("rcd-component-cannot-build-on-empty-tile-message"), uid, user);
+                        _popup.PopupEntity(Loc.GetString("rcd-component-cannot-build-on-empty-tile-message"), uid, user);
 
                     return false;
                 }
@@ -441,7 +441,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (tileDef.ID == prototype.Prototype)
             {
                 if (popMsgs)
-                    _popup.PopupClient(Loc.GetString("rcd-component-cannot-build-identical-tile"), uid, user);
+                    _popup.PopupEntity(Loc.GetString("rcd-component-cannot-build-identical-tile"), uid, user);
 
                 return false;
             }
@@ -477,7 +477,7 @@ public sealed partial class RCDSystem : EntitySystem
                 if (isIdentical)
                 {
                     if (popMsgs)
-                        _popup.PopupClient(Loc.GetString("rcd-component-cannot-build-identical-entity"), uid, user);
+                        _popup.PopupEntity(Loc.GetString("rcd-component-cannot-build-identical-entity"), uid, user);
 
                     return false;
                 }
@@ -489,7 +489,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (isCatwalk && _tags.HasTag(ent, CatwalkTag))
             {
                 if (popMsgs)
-                    _popup.PopupClient(Loc.GetString("rcd-component-cannot-build-on-occupied-tile-message"), uid, user);
+                    _popup.PopupEntity(Loc.GetString("rcd-component-cannot-build-on-occupied-tile-message"), uid, user);
 
                 return false;
             }
@@ -509,7 +509,7 @@ public sealed partial class RCDSystem : EntitySystem
 
                     // Collision was detected
                     if (popMsgs)
-                        _popup.PopupClient(Loc.GetString("rcd-component-cannot-build-on-occupied-tile-message"), uid, user);
+                        _popup.PopupEntity(Loc.GetString("rcd-component-cannot-build-on-occupied-tile-message"), uid, user);
 
                     return false;
                 }
@@ -528,7 +528,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (tile.Tile.IsEmpty)
             {
                 if (popMsgs)
-                    _popup.PopupClient(Loc.GetString("rcd-component-nothing-to-deconstruct-message"), uid, user);
+                    _popup.PopupEntity(Loc.GetString("rcd-component-nothing-to-deconstruct-message"), uid, user);
 
                 return false;
             }
@@ -537,7 +537,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (_turf.IsTileBlocked(tile, CollisionGroup.MobMask))
             {
                 if (popMsgs)
-                    _popup.PopupClient(Loc.GetString("rcd-component-tile-obstructed-message"), uid, user);
+                    _popup.PopupEntity(Loc.GetString("rcd-component-tile-obstructed-message"), uid, user);
 
                 return false;
             }
@@ -548,7 +548,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (tileDef.Indestructible)
             {
                 if (popMsgs)
-                    _popup.PopupClient(Loc.GetString("rcd-component-tile-indestructible-message"), uid, user);
+                    _popup.PopupEntity(Loc.GetString("rcd-component-tile-indestructible-message"), uid, user);
 
                 return false;
             }
@@ -561,7 +561,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (!TryComp<RCDDeconstructableComponent>(target, out var deconstructible) || !deconstructible.Deconstructable)
             {
                 if (popMsgs)
-                    _popup.PopupClient(Loc.GetString("rcd-component-deconstruct-target-not-on-whitelist-message"), uid, user);
+                    _popup.PopupEntity(Loc.GetString("rcd-component-deconstruct-target-not-on-whitelist-message"), uid, user);
 
                 return false;
             }

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -53,7 +53,7 @@ public sealed partial class EncryptionKeySystem : EntitySystem
             _hands.PickupOrDrop(args.User, ent, dropNear: true);
         }
 
-        _popup.PopupPredicted(Loc.GetString("encryption-keys-all-extracted"), uid, args.User);
+        _popup.PopupEntity(Loc.GetString("encryption-keys-all-extracted"), uid);
         _audio.PlayPredicted(component.KeyExtractionSound, uid, args.User);
     }
 

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -53,7 +53,7 @@ public sealed partial class EncryptionKeySystem : EntitySystem
             _hands.PickupOrDrop(args.User, ent, dropNear: true);
         }
 
-        _popup.PopupEntity(Loc.GetString("encryption-keys-all-extracted"), uid, uid);
+        _popup.PopupEntity(Loc.GetString("encryption-keys-all-extracted"), uid, args.User);
         _audio.PlayPredicted(component.KeyExtractionSound, uid, args.User);
     }
 

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -53,7 +53,7 @@ public sealed partial class EncryptionKeySystem : EntitySystem
             _hands.PickupOrDrop(args.User, ent, dropNear: true);
         }
 
-        _popup.PopupEntity(Loc.GetString("encryption-keys-all-extracted"), uid);
+        _popup.PopupEntity(Loc.GetString("encryption-keys-all-extracted"), uid, uid);
         _audio.PlayPredicted(component.KeyExtractionSound, uid, args.User);
     }
 

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -106,25 +106,25 @@ public sealed partial class EncryptionKeySystem : EntitySystem
     {
         if (!component.KeysUnlocked)
         {
-            _popup.PopupClient(Loc.GetString("encryption-keys-are-locked"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-keys-are-locked"), uid, args.User);
             return;
         }
 
         if (TryComp<WiresPanelComponent>(uid, out var panel) && !panel.Open)
         {
-            _popup.PopupClient(Loc.GetString("encryption-keys-panel-locked"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-keys-panel-locked"), uid, args.User);
             return;
         }
 
         if (component.KeySlots <= component.KeyContainer.ContainedEntities.Count)
         {
-            _popup.PopupClient(Loc.GetString("encryption-key-slots-already-full"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-key-slots-already-full"), uid, args.User);
             return;
         }
 
         if (_container.Insert(args.Used, component.KeyContainer))
         {
-            _popup.PopupClient(Loc.GetString("encryption-key-successfully-installed"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-key-successfully-installed"), uid, args.User);
             _audio.PlayPredicted(component.KeyInsertionSound, args.Target, args.User);
             args.Handled = true;
             return;
@@ -136,19 +136,19 @@ public sealed partial class EncryptionKeySystem : EntitySystem
     {
         if (!component.KeysUnlocked)
         {
-            _popup.PopupClient(Loc.GetString("encryption-keys-are-locked"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-keys-are-locked"), uid, args.User);
             return;
         }
 
         if (!_wires.IsPanelOpen(uid))
         {
-            _popup.PopupClient(Loc.GetString("encryption-keys-panel-locked"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-keys-panel-locked"), uid, args.User);
             return;
         }
 
         if (component.KeyContainer.ContainedEntities.Count == 0)
         {
-            _popup.PopupClient(Loc.GetString("encryption-keys-no-keys"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-keys-no-keys"), uid, args.User);
             return;
         }
 

--- a/Content.Shared/Radio/EntitySystems/SharedJammerSystem.cs
+++ b/Content.Shared/Radio/EntitySystems/SharedJammerSystem.cs
@@ -52,7 +52,7 @@ public abstract partial class SharedJammerSystem : EntitySystem
 
         var state = Loc.GetString(args.Activated ? "radio-jammer-component-on-state" : "radio-jammer-component-off-state");
         var message = Loc.GetString("radio-jammer-component-on-use", ("state", state));
-        _popup.PopupPredicted(message, args.User.Value, args.User.Value);
+        _popup.PopupEntity(message, args.User.Value);
     }
 
     private void OnRefreshChargeRate(Entity<RadioJammerComponent> entity, ref RefreshChargeRateEvent args)

--- a/Content.Shared/Radio/EntitySystems/SharedJammerSystem.cs
+++ b/Content.Shared/Radio/EntitySystems/SharedJammerSystem.cs
@@ -52,7 +52,7 @@ public abstract partial class SharedJammerSystem : EntitySystem
 
         var state = Loc.GetString(args.Activated ? "radio-jammer-component-on-state" : "radio-jammer-component-off-state");
         var message = Loc.GetString("radio-jammer-component-on-use", ("state", state));
-        _popup.PopupEntity(message, args.User.Value);
+        _popup.PopupEntity(message, args.User.Value, args.User.Value);
     }
 
     private void OnRefreshChargeRate(Entity<RadioJammerComponent> entity, ref RefreshChargeRateEvent args)

--- a/Content.Shared/Radio/EntitySystems/SharedJammerSystem.cs
+++ b/Content.Shared/Radio/EntitySystems/SharedJammerSystem.cs
@@ -88,7 +88,7 @@ public abstract partial class SharedJammerSystem : EntitySystem
                     // The range should be updated when it turns on again!
                     _jammer.TrySetRange(entity.Owner, GetCurrentRange(entity));
 
-                    _popup.PopupClient(Loc.GetString(setting.Message), user, user);
+                    _popup.PopupEntity(Loc.GetString(setting.Message), user, user);
                 },
                 Text = Loc.GetString(setting.Name),
             };

--- a/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
+++ b/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
@@ -67,7 +67,7 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
 
         if (!_powerReceiver.IsPowered(args.Target.Value))
         {
-            _popup.PopupClient(Loc.GetString("door-remote-no-power"), args.User, args.User);
+            _popup.PopupEntity(Loc.GetString("door-remote-no-power"), args.User, args.User);
             return;
         }
 
@@ -88,7 +88,7 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
                 if (isAirlock)
                     _doorSystem.Deny(args.Target.Value, doorComp, user: args.User, predicted: true);
 
-                _popup.PopupClient(Loc.GetString("door-remote-denied"), args.User, args.User);
+                _popup.PopupEntity(Loc.GetString("door-remote-denied"), args.User, args.User);
                 return;
             }
         }

--- a/Content.Shared/Repairable/RepairableSystem.cs
+++ b/Content.Shared/Repairable/RepairableSystem.cs
@@ -51,7 +51,7 @@ public sealed partial class RepairableSystem : EntitySystem
         if (!args.Repeat)
         {
             var str = Loc.GetString("comp-repairable-repair", ("target", ent.Owner), ("tool", args.Used!));
-            _popup.PopupClient(str, ent.Owner, args.User);
+            _popup.PopupEntity(str, ent.Owner, args.User);
 
             var ev = new RepairedEvent(ent, args.User);
             RaiseLocalEvent(ent.Owner, ref ev);

--- a/Content.Shared/Research/Systems/BlueprintSystem.cs
+++ b/Content.Shared/Research/Systems/BlueprintSystem.cs
@@ -87,7 +87,7 @@ public sealed partial class BlueprintSystem : EntitySystem
         var currentRecipes = GetBlueprintRecipes(ent);
         if (currentRecipes.Count != 0 && currentRecipes.IsSupersetOf(blueprint.Comp.ProvidedRecipes))
         {
-            _popup.PopupEntity(Loc.GetString("blueprint-receiver-popup-recipe-exists"), ent);
+            _popup.PopupEntity(Loc.GetString("blueprint-receiver-popup-recipe-exists"), ent, user);
             return false;
         }
 

--- a/Content.Shared/Research/Systems/BlueprintSystem.cs
+++ b/Content.Shared/Research/Systems/BlueprintSystem.cs
@@ -60,7 +60,7 @@ public sealed partial class BlueprintSystem : EntitySystem
                 ("user", userId),
                 ("blueprint", bpId),
                 ("receiver", machineId));
-            _popup.PopupPredicted(msg, ent, user);
+            _popup.PopupEntity(msg, ent);
         }
 
         _container.Insert(blueprint.Owner, _container.GetContainer(ent, ent.Comp.ContainerId));
@@ -87,7 +87,7 @@ public sealed partial class BlueprintSystem : EntitySystem
         var currentRecipes = GetBlueprintRecipes(ent);
         if (currentRecipes.Count != 0 && currentRecipes.IsSupersetOf(blueprint.Comp.ProvidedRecipes))
         {
-            _popup.PopupPredicted(Loc.GetString("blueprint-receiver-popup-recipe-exists"), ent, user);
+            _popup.PopupEntity(Loc.GetString("blueprint-receiver-popup-recipe-exists"), ent);
             return false;
         }
 

--- a/Content.Shared/Research/Systems/SharedResearchStealerSystem.cs
+++ b/Content.Shared/Research/Systems/SharedResearchStealerSystem.cs
@@ -39,7 +39,7 @@ public abstract partial class SharedResearchStealerSystem : EntitySystem
         // fail fast if theres no techs to steal right now
         if (database.UnlockedTechnologies.Count == 0)
         {
-            _popup.PopupClient(Loc.GetString("ninja-download-fail"), uid, uid);
+            _popup.PopupEntity(Loc.GetString("ninja-download-fail"), uid, uid);
             return;
         }
 

--- a/Content.Shared/Research/TechnologyDisk/Systems/TechnologyDiskSystem.cs
+++ b/Content.Shared/Research/TechnologyDisk/Systems/TechnologyDiskSystem.cs
@@ -138,7 +138,7 @@ public sealed partial class TechnologyDiskSystem : EntitySystem
                 _research.AddLatheRecipe(target, recipe, database);
             }
         }
-        _popup.PopupClient(Loc.GetString("tech-disk-inserted"), target, args.User);
+        _popup.PopupEntity(Loc.GetString("tech-disk-inserted"), target, args.User);
         PredictedQueueDel(ent.Owner);
         args.Handled = true;
     }

--- a/Content.Shared/RetractableItemAction/RetractableItemActionSystem.cs
+++ b/Content.Shared/RetractableItemAction/RetractableItemActionSystem.cs
@@ -58,7 +58,7 @@ public sealed partial class RetractableItemActionSystem : EntitySystem
             && !_hands.IsHolding(args.Performer, ent.Comp.ActionItemUid)
             && !_hands.CanDropHeld(args.Performer, activeHand, false))
         {
-            _popups.PopupClient(Loc.GetString("retractable-item-hand-cannot-drop"), args.Performer, args.Performer);
+            _popups.PopupEntity(Loc.GetString("retractable-item-hand-cannot-drop"), args.Performer, args.Performer);
             return;
         }
 

--- a/Content.Shared/Rotatable/RotatableSystem.cs
+++ b/Content.Shared/Rotatable/RotatableSystem.cs
@@ -138,7 +138,7 @@ public sealed partial class RotatableSystem : EntitySystem
         if (!rotatableComp.RotateWhileAnchored && TryComp<PhysicsComponent>(entity, out var physics) &&
             physics.BodyType == BodyType.Static)
         {
-            _popup.PopupClient(Loc.GetString("rotatable-component-try-rotate-stuck"), entity, player);
+            _popup.PopupEntity(Loc.GetString("rotatable-component-try-rotate-stuck"), entity, player);
             return false;
         }
 
@@ -163,7 +163,7 @@ public sealed partial class RotatableSystem : EntitySystem
         if (!rotatableComp.RotateWhileAnchored && TryComp<PhysicsComponent>(entity, out var physics) &&
             physics.BodyType == BodyType.Static)
         {
-            _popup.PopupClient(Loc.GetString("rotatable-component-try-rotate-stuck"), entity, player);
+            _popup.PopupEntity(Loc.GetString("rotatable-component-try-rotate-stuck"), entity, player);
             return false;
         }
 
@@ -187,7 +187,7 @@ public sealed partial class RotatableSystem : EntitySystem
         // Check if the object is anchored.
         if (TryComp<PhysicsComponent>(entity, out var physics) && physics.BodyType == BodyType.Static)
         {
-            _popup.PopupClient(Loc.GetString("flippable-component-try-flip-is-stuck"), entity, player);
+            _popup.PopupEntity(Loc.GetString("flippable-component-try-flip-is-stuck"), entity, player);
             return false;
         }
 

--- a/Content.Shared/Salvage/Fulton/SharedFultonSystem.cs
+++ b/Content.Shared/Salvage/Fulton/SharedFultonSystem.cs
@@ -118,12 +118,12 @@ public abstract partial class SharedFultonSystem : EntitySystem
             {
                 component.Beacon = args.Target.Value;
                 Audio.PlayPredicted(beacon.LinkSound, uid, args.User);
-                _popup.PopupClient(Loc.GetString("fulton-linked"), uid, args.User);
+                _popup.PopupEntity(Loc.GetString("fulton-linked"), uid, args.User);
             }
             else
             {
                 component.Beacon = EntityUid.Invalid;
-                _popup.PopupClient(Loc.GetString("fulton-folded"), uid, args.User);
+                _popup.PopupEntity(Loc.GetString("fulton-folded"), uid, args.User);
             }
 
             return;
@@ -131,19 +131,19 @@ public abstract partial class SharedFultonSystem : EntitySystem
 
         if (Deleted(component.Beacon))
         {
-            _popup.PopupClient(Loc.GetString("fulton-not-found"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("fulton-not-found"), uid, args.User);
             return;
         }
 
         if (!CanApplyFulton(args.Target.Value, component))
         {
-            _popup.PopupClient(Loc.GetString("fulton-invalid"), uid, uid);
+            _popup.PopupEntity(Loc.GetString("fulton-invalid"), uid, uid);
             return;
         }
 
         if (HasComp<FultonedComponent>(args.Target))
         {
-            _popup.PopupClient(Loc.GetString("fulton-fultoned"), uid, uid);
+            _popup.PopupEntity(Loc.GetString("fulton-fultoned"), uid, uid);
             return;
         }
 

--- a/Content.Shared/Security/Systems/SharedGenpopSystem.cs
+++ b/Content.Shared/Security/Systems/SharedGenpopSystem.cs
@@ -81,7 +81,7 @@ public abstract partial class SharedGenpopSystem : EntitySystem
 
         if (!_accessReader.IsAllowed(user, ent))
         {
-            _popup.PopupClient(Loc.GetString("lock-comp-has-user-access-fail"), user);
+            _popup.PopupEntity(Loc.GetString("lock-comp-has-user-access-fail"), user, user);
             return;
         }
 
@@ -106,7 +106,7 @@ public abstract partial class SharedGenpopSystem : EntitySystem
         if (!_accessReader.FindPotentialAccessItems(args.User).Contains(ent.Comp.LinkedId.Value))
         {
             if (!args.Silent)
-                _popup.PopupClient(Loc.GetString("lock-comp-has-user-access-fail"), ent, args.User);
+                _popup.PopupEntity(Loc.GetString("lock-comp-has-user-access-fail"), ent, args.User);
             args.Cancelled = true;
             return;
         }
@@ -115,7 +115,7 @@ public abstract partial class SharedGenpopSystem : EntitySystem
             !expireIdCard.Expired)
         {
             if (!args.Silent)
-                _popup.PopupClient(Loc.GetString("genpop-prisoner-id-popup-not-served"), ent, args.User);
+                _popup.PopupEntity(Loc.GetString("genpop-prisoner-id-popup-not-served"), ent, args.User);
             args.Cancelled = true;
         }
     }

--- a/Content.Shared/SelectableComponentAdder/SelectableComponentAdderSystem.cs
+++ b/Content.Shared/SelectableComponentAdder/SelectableComponentAdderSystem.cs
@@ -39,7 +39,7 @@ public sealed partial class SelectableComponentAdderSystem : EntitySystem
                     if (entry.Popup == null)
                         return;
                     var message = Loc.GetString(entry.Popup.Value, ("target", target));
-                    _popup.PopupClient(message, target, user);
+                    _popup.PopupEntity(message, target, user);
                 },
                 Text = Loc.GetString(entry.VerbName),
             };

--- a/Content.Shared/Sericulture/SericultureSystem.cs
+++ b/Content.Shared/Sericulture/SericultureSystem.cs
@@ -76,7 +76,7 @@ public abstract partial class SharedSericultureSystem : EntitySystem
                 _hungerSystem.GetHunger(hungerComp) - comp.HungerCost,
                 hungerComp))
         {
-            _popupSystem.PopupClient(Loc.GetString(comp.PopupText), uid, uid);
+            _popupSystem.PopupEntity(Loc.GetString(comp.PopupText), uid, uid);
             return;
         }
 
@@ -104,7 +104,7 @@ public abstract partial class SharedSericultureSystem : EntitySystem
                 _hungerSystem.GetHunger(hungerComp) - comp.HungerCost,
                 hungerComp))
         {
-            _popupSystem.PopupClient(Loc.GetString(comp.PopupText), uid, uid);
+            _popupSystem.PopupEntity(Loc.GetString(comp.PopupText), uid, uid);
             return;
         }
 

--- a/Content.Shared/Shuttles/Systems/SharedEmergencyShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedEmergencyShuttleSystem.cs
@@ -31,6 +31,6 @@ public abstract partial class SharedEmergencyShuttleSystem : EntitySystem
         args.Cancel();
 
         if (!args.Silent)
-            Popup.PopupClient(Loc.GetString("emergency-shuttle-console-no-early-launches"), ent, args.User);
+            Popup.PopupEntity(Loc.GetString("emergency-shuttle-console-no-early-launches"), ent, args.User);
     }
 }

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.API.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.API.cs
@@ -210,13 +210,13 @@ public abstract partial class SharedBorgSystem
 
         if (chassis.Comp.ModuleContainer.ContainedEntities.Count >= chassis.Comp.MaxModules)
         {
-            _popup.PopupClient(Loc.GetString("borg-module-too-many"), chassis.Owner, user);
+            _popup.PopupEntity(Loc.GetString("borg-module-too-many"), chassis.Owner, user);
             return false;
         }
 
         if (_whitelist.IsWhitelistFail(chassis.Comp.ModuleWhitelist, module))
         {
-            _popup.PopupClient(Loc.GetString("borg-module-whitelist-deny"), chassis.Owner, user);
+            _popup.PopupEntity(Loc.GetString("borg-module-whitelist-deny"), chassis.Owner, user);
             return false;
         }
 
@@ -230,7 +230,7 @@ public abstract partial class SharedBorgSystem
                 if (containedItemModuleComp.Hands.Count == itemModuleComp.Hands.Count &&
                     containedItemModuleComp.Hands.All(itemModuleComp.Hands.Contains))
                 {
-                    _popup.PopupClient(Loc.GetString("borg-module-duplicate"), chassis.Owner, user);
+                    _popup.PopupEntity(Loc.GetString("borg-module-duplicate"), chassis.Owner, user);
                     return false;
                 }
             }
@@ -242,7 +242,7 @@ public abstract partial class SharedBorgSystem
 
         if (attemptEv.Cancelled)
         {
-            _popup.PopupClient(attemptEv.Reason, chassis.Owner, user);
+            _popup.PopupEntity(attemptEv.Reason, chassis.Owner, user);
             return false;
         }
 

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -224,7 +224,7 @@ public abstract partial class SharedBorgSystem : EntitySystem
         {
             if (brain != null || module != null)
             {
-                _popup.PopupClient(Loc.GetString("borg-panel-not-open"), chassis, args.User);
+                _popup.PopupEntity(Loc.GetString("borg-panel-not-open"), chassis, args.User);
             }
             return;
         }

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -234,7 +234,6 @@ public abstract partial class SharedBorgSystem : EntitySystem
         {
             if (TryComp<ActorComponent>(used, out var actor) && !CanPlayerBeBorged(actor.PlayerSession))
             {
-                // Don't use PopupClient because CanPlayerBeBorged is not predicted.
                 _popup.PopupEntity(Loc.GetString("borg-player-not-allowed"), used, args.User);
                 return;
             }
@@ -327,7 +326,6 @@ public abstract partial class SharedBorgSystem : EntitySystem
 
         if (!CanPlayerBeBorged(session))
         {
-            // Don't use PopupClient because MindAddedMessage and CanPlayerBeBorged are not predicted.
             _popup.PopupEntity(Loc.GetString("borg-player-not-allowed-eject"), brain);
             _container.RemoveEntity(borg, brain);
             _throwing.TryThrow(brain, _random.NextVector2() * 5, 5f);

--- a/Content.Shared/Silicons/Bots/MedibotSystem.cs
+++ b/Content.Shared/Silicons/Bots/MedibotSystem.cs
@@ -95,7 +95,7 @@ public sealed partial class MedibotSystem : EntitySystem
 
         if (HasComp<NPCRecentlyInjectedComponent>(target))
         {
-            _popup.PopupClient(Loc.GetString("medibot-recently-injected"), medibot, medibot);
+            _popup.PopupEntity(Loc.GetString("medibot-recently-injected"), medibot, medibot);
             return false;
         }
 
@@ -105,14 +105,14 @@ public sealed partial class MedibotSystem : EntitySystem
 
         if (mobState.CurrentState != MobState.Alive && mobState.CurrentState != MobState.Critical)
         {
-            _popup.PopupClient(Loc.GetString("medibot-target-dead"), medibot, medibot);
+            _popup.PopupEntity(Loc.GetString("medibot-target-dead"), medibot, medibot);
             return false;
         }
 
         var total = _damageable.GetTotalDamage((target, damageable));
         if (total == 0 && !HasComp<EmaggedComponent>(medibot))
         {
-            _popup.PopupClient(Loc.GetString("medibot-target-healthy"), medibot, medibot);
+            _popup.PopupEntity(Loc.GetString("medibot-target-healthy"), medibot, medibot);
             return false;
         }
 
@@ -137,7 +137,7 @@ public sealed partial class MedibotSystem : EntitySystem
         _solutionContainer.TryAddReagent(injectable.Value, treatment.Reagent, treatment.Quantity, out _);
 
         _popup.PopupEntity(Loc.GetString("injector-component-feel-prick-message"), target, target);
-        _popup.PopupClient(Loc.GetString("medibot-target-injected"), medibot, medibot);
+        _popup.PopupEntity(Loc.GetString("medibot-target-injected"), medibot, medibot);
 
         _audio.PlayPredicted(medibot.Comp.InjectSound, medibot, medibot);
 

--- a/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
+++ b/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
@@ -46,7 +46,7 @@ public abstract partial class SharedSiliconLawSystem : EntitySystem
         // prevent self-emagging
         if (uid == args.UserUid)
         {
-            _popup.PopupClient(Loc.GetString("law-emag-cannot-emag-self"), uid, args.UserUid);
+            _popup.PopupEntity(Loc.GetString("law-emag-cannot-emag-self"), uid, args.UserUid);
             return;
         }
 
@@ -54,7 +54,7 @@ public abstract partial class SharedSiliconLawSystem : EntitySystem
             TryComp<WiresPanelComponent>(uid, out var panel) &&
             !panel.Open)
         {
-            _popup.PopupClient(Loc.GetString("law-emag-require-panel"), uid, args.UserUid);
+            _popup.PopupEntity(Loc.GetString("law-emag-require-panel"), uid, args.UserUid);
             return;
         }
 

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Held.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Held.cs
@@ -195,12 +195,12 @@ public abstract partial class SharedStationAiSystem
 
     private void ShowDeviceNotRespondingPopup(EntityUid toEntity)
     {
-        _popup.PopupClient(Loc.GetString("ai-device-not-responding"), toEntity, PopupType.MediumCaution);
+        _popup.PopupEntity(Loc.GetString("ai-device-not-responding"), toEntity, toEntity, PopupType.MediumCaution);
     }
 
     private void ShowDeviceNoAccessPopup(EntityUid toEntity)
     {
-        _popup.PopupClient(Loc.GetString("ai-device-no-access"), toEntity, PopupType.MediumCaution);
+        _popup.PopupEntity(Loc.GetString("ai-device-no-access"), toEntity, toEntity, PopupType.MediumCaution);
     }
 }
 

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -278,13 +278,13 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
         if (cardHasAi && coreHasAi)
         {
-            _popup.PopupClient(Loc.GetString("intellicard-core-occupied"), args.User, args.User, PopupType.Medium);
+            _popup.PopupEntity(Loc.GetString("intellicard-core-occupied"), args.User, args.User, PopupType.Medium);
             args.Handled = true;
             return;
         }
         if (!cardHasAi && !coreHasAi)
         {
-            _popup.PopupClient(Loc.GetString("intellicard-core-empty"), args.User, args.User, PopupType.Medium);
+            _popup.PopupEntity(Loc.GetString("intellicard-core-empty"), args.User, args.User, PopupType.Medium);
             args.Handled = true;
             return;
         }

--- a/Content.Shared/Singularity/EntitySystems/SharedEmitterSystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedEmitterSystem.cs
@@ -47,7 +47,7 @@ public abstract partial class SharedEmitterSystem : EntitySystem
                 {
                     ent.Comp.BoltType = type;
                     Dirty(ent);
-                    _popup.PopupClient(Loc.GetString("emitter-component-type-set", ("type", proto.Name)), ent.Owner);
+                    _popup.PopupEntity(Loc.GetString("emitter-component-type-set", ("type", proto.Name)), ent.Owner, ent.Owner);
                 },
             };
             args.Verbs.Add(v);

--- a/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
+++ b/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
@@ -119,7 +119,7 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
             return true;
 
         _audio.PlayPredicted(machine.Comp.SoundDeny, machine, user);
-        _popup.PopupEntity(Loc.GetString("smart-fridge-component-try-eject-access-denied"), machine);
+        _popup.PopupEntity(Loc.GetString("smart-fridge-component-try-eject-access-denied"), machine, user);
         return false;
     }
 
@@ -131,7 +131,7 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
         if (!ent.Comp.ContainedEntries.TryGetValue(args.Entry, out var contained))
         {
             _audio.PlayPredicted(ent.Comp.SoundDeny, ent, args.Actor);
-            _popup.PopupEntity(Loc.GetString("smart-fridge-component-try-eject-unknown-entry"), ent);
+            _popup.PopupEntity(Loc.GetString("smart-fridge-component-try-eject-unknown-entry"), ent, args.Actor);
             return;
         }
 
@@ -148,7 +148,7 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
         }
 
         _audio.PlayPredicted(ent.Comp.SoundDeny, ent, args.Actor);
-        _popup.PopupEntity(Loc.GetString("smart-fridge-component-try-eject-out-of-stock"), ent);
+        _popup.PopupEntity(Loc.GetString("smart-fridge-component-try-eject-out-of-stock"), ent, args.Actor);
     }
 
     private void OnGetAltVerb(Entity<SmartFridgeComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)

--- a/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
+++ b/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
@@ -118,8 +118,8 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
         if (_accessReader.IsAllowed(user, machine))
             return true;
 
-        _popup.PopupPredicted(Loc.GetString("smart-fridge-component-try-eject-access-denied"), machine, user);
         _audio.PlayPredicted(machine.Comp.SoundDeny, machine, user);
+        _popup.PopupEntity(Loc.GetString("smart-fridge-component-try-eject-access-denied"), machine);
         return false;
     }
 
@@ -131,7 +131,7 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
         if (!ent.Comp.ContainedEntries.TryGetValue(args.Entry, out var contained))
         {
             _audio.PlayPredicted(ent.Comp.SoundDeny, ent, args.Actor);
-            _popup.PopupPredicted(Loc.GetString("smart-fridge-component-try-eject-unknown-entry"), ent, args.Actor);
+            _popup.PopupEntity(Loc.GetString("smart-fridge-component-try-eject-unknown-entry"), ent);
             return;
         }
 
@@ -148,7 +148,7 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
         }
 
         _audio.PlayPredicted(ent.Comp.SoundDeny, ent, args.Actor);
-        _popup.PopupPredicted(Loc.GetString("smart-fridge-component-try-eject-out-of-stock"), ent, args.Actor);
+        _popup.PopupEntity(Loc.GetString("smart-fridge-component-try-eject-out-of-stock"), ent);
     }
 
     private void OnGetAltVerb(Entity<SmartFridgeComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)

--- a/Content.Shared/Species/Systems/GibActionSystem.cs
+++ b/Content.Shared/Species/Systems/GibActionSystem.cs
@@ -49,7 +49,7 @@ public sealed partial class GibActionSystem : EntitySystem
     private void OnGibAction(EntityUid uid, GibActionComponent comp, GibActionEvent args)
     {
         // When they use the action, gib them.
-        _popupSystem.PopupClient(Loc.GetString(comp.PopupText, ("name", uid)), uid, uid);
+        _popupSystem.PopupEntity(Loc.GetString(comp.PopupText, ("name", uid)), uid, uid);
         _gibbing.Gib(uid, user: args.Performer);
     }
 

--- a/Content.Shared/Species/Systems/ReformSystem.cs
+++ b/Content.Shared/Species/Systems/ReformSystem.cs
@@ -62,7 +62,7 @@ public sealed partial class ReformSystem : EntitySystem
         // Stun them when they use the action for the amount of reform time.
         if (comp.ShouldStun)
             _stunSystem.TryUpdateStunDuration(uid, TimeSpan.FromSeconds(comp.ReformTime));
-        _popupSystem.PopupClient(Loc.GetString(comp.PopupText, ("name", uid)), uid, uid);
+        _popupSystem.PopupEntity(Loc.GetString(comp.PopupText, ("name", uid)), uid, uid);
 
         // Create a doafter & start it
         var doAfter = new DoAfterArgs(EntityManager, uid, comp.ReformTime, new ReformDoAfterEvent(), uid)

--- a/Content.Shared/SprayPainter/SharedSprayPainterSystem.cs
+++ b/Content.Shared/SprayPainter/SharedSprayPainterSystem.cs
@@ -190,14 +190,14 @@ public abstract partial class SharedSprayPainterSystem : EntitySystem
             && Charges.GetCurrentCharges((args.Used, charges)) < targetGroup.Cost)
         {
             var msg = Loc.GetString("spray-painter-interact-no-charges");
-            _popup.PopupClient(msg, args.User, args.User);
+            _popup.PopupEntity(msg, args.User, args.User);
             return;
         }
 
         if (!targetGroup.Styles.TryGetValue(selectedStyle, out var proto))
         {
             var msg = Loc.GetString("spray-painter-style-not-available");
-            _popup.PopupClient(msg, args.User, args.User);
+            _popup.PopupEntity(msg, args.User, args.User);
             return;
         }
 

--- a/Content.Shared/SprayPainter/SprayPainterAmmoSystem.cs
+++ b/Content.Shared/SprayPainter/SprayPainterAmmoSystem.cs
@@ -38,11 +38,11 @@ public sealed partial class SprayPainterAmmoSystem : EntitySystem
         var count = Math.Min(charges.MaxCharges - charges.LastCharges, ent.Comp.Charges);
         if (count <= 0)
         {
-            _popup.PopupClient(Loc.GetString("spray-painter-ammo-after-interact-full"), target, user);
+            _popup.PopupEntity(Loc.GetString("spray-painter-ammo-after-interact-full"), target, user);
             return;
         }
 
-        _popup.PopupClient(Loc.GetString("spray-painter-ammo-after-interact-refilled"), target, user);
+        _popup.PopupEntity(Loc.GetString("spray-painter-ammo-after-interact-refilled"), target, user);
         _charges.AddCharges(target, count);
         ent.Comp.Charges -= count;
         Dirty(ent, ent.Comp);

--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -84,11 +84,11 @@ public abstract partial class SharedStackSystem : EntitySystem
         switch (transferred)
         {
             case > 0:
-                Popup.PopupClient($"+{transferred}", popupPos, args.User);
+                Popup.PopupCoordinates($"+{transferred}", popupPos, args.User);
 
                 if (GetAvailableSpace(recipientStack) == 0)
                 {
-                    Popup.PopupClient(Loc.GetString("comp-stack-becomes-full"),
+                    Popup.PopupCoordinates(Loc.GetString("comp-stack-becomes-full"),
                         popupPos.Offset(new Vector2(0, -0.5f)),
                         args.User);
                 }
@@ -96,7 +96,7 @@ public abstract partial class SharedStackSystem : EntitySystem
                 break;
 
             case 0 when GetAvailableSpace(recipientStack) == 0:
-                Popup.PopupClient(Loc.GetString("comp-stack-already-full"), popupPos, args.User);
+                Popup.PopupCoordinates(Loc.GetString("comp-stack-already-full"), popupPos, args.User);
                 break;
         }
 

--- a/Content.Shared/Sticky/Systems/StickySystem.cs
+++ b/Content.Shared/Sticky/Systems/StickySystem.cs
@@ -87,7 +87,7 @@ public sealed partial class StickySystem : EntitySystem
         if (comp.StickPopupStart != null)
         {
             var msg = Loc.GetString(comp.StickPopupStart);
-            _popup.PopupClient(msg, user, user);
+            _popup.PopupEntity(msg, user, user);
         }
 
         // start sticking object to target
@@ -137,7 +137,7 @@ public sealed partial class StickySystem : EntitySystem
         if (comp.UnstickPopupStart != null)
         {
             var msg = Loc.GetString(comp.UnstickPopupStart);
-            _popup.PopupClient(msg, user, user);
+            _popup.PopupEntity(msg, user, user);
         }
 
         // start unsticking object
@@ -166,7 +166,7 @@ public sealed partial class StickySystem : EntitySystem
         if (comp.StickPopupSuccess != null)
         {
             var msg = Loc.GetString(comp.StickPopupSuccess);
-            _popup.PopupClient(msg, user, user);
+            _popup.PopupEntity(msg, user, user);
         }
 
         // send information to appearance that entity is stuck
@@ -208,7 +208,7 @@ public sealed partial class StickySystem : EntitySystem
         if (comp.UnstickPopupSuccess != null)
         {
             var msg = Loc.GetString(comp.UnstickPopupSuccess);
-            _popup.PopupClient(msg, user, user);
+            _popup.PopupEntity(msg, user, user);
         }
 
         comp.StuckTo = null;

--- a/Content.Shared/Storage/EntitySystems/SecretStashSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SecretStashSystem.cs
@@ -101,7 +101,7 @@ public sealed partial class SecretStashSystem : EntitySystem
         if (HasItemInside(entity))
         {
             var popup = Loc.GetString("comp-secret-stash-action-hide-container-not-empty");
-            _popupSystem.PopupClient(popup, entity, userUid);
+            _popupSystem.PopupEntity(popup, entity, userUid);
             return false;
         }
 
@@ -111,7 +111,7 @@ public sealed partial class SecretStashSystem : EntitySystem
         {
             var msg = Loc.GetString("comp-secret-stash-action-hide-item-too-big",
                 ("item", itemToHideUid), ("stashname", GetStashName(entity)));
-            _popupSystem.PopupClient(msg, entity, userUid);
+            _popupSystem.PopupEntity(msg, entity, userUid);
             return false;
         }
 
@@ -122,7 +122,7 @@ public sealed partial class SecretStashSystem : EntitySystem
         // all done, show success message
         var successMsg = Loc.GetString("comp-secret-stash-action-hide-success",
             ("item", itemToHideUid), ("stashname", GetStashName(entity)));
-        _popupSystem.PopupClient(successMsg, entity, userUid);
+        _popupSystem.PopupEntity(successMsg, entity, userUid);
         return true;
     }
 
@@ -148,7 +148,7 @@ public sealed partial class SecretStashSystem : EntitySystem
         // show success message
         var successMsg = Loc.GetString("comp-secret-stash-action-get-item-found-something",
             ("stashname", GetStashName(entity)));
-        _popupSystem.PopupClient(successMsg, entity, userUid);
+        _popupSystem.PopupEntity(successMsg, entity, userUid);
 
         return true;
     }

--- a/Content.Shared/Storage/EntitySystems/SecretStashSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SecretStashSystem.cs
@@ -234,7 +234,7 @@ public sealed partial class SecretStashSystem : EntitySystem
         if (storedInside != null && storedInside.Count >= 1)
         {
             var popup = Loc.GetString("comp-secret-stash-on-destroyed-popup", ("stashname", GetStashName(entity)));
-            _popupSystem.PopupPredicted(popup, storedInside[0], null, PopupType.MediumCaution);
+            _popupSystem.PopupEntity(popup, storedInside[0], PopupType.MediumCaution);
         }
     }
 

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -422,7 +422,7 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
         if (_weldable.IsWelded(target))
         {
             if (!silent && !component.Contents.Contains(user))
-                Popup.PopupClient(Loc.GetString("entity-storage-component-welded-shut-message"), target, user);
+                Popup.PopupEntity(Loc.GetString("entity-storage-component-welded-shut-message"), target, user);
 
             return false;
         }

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1256,13 +1256,13 @@ public abstract partial class SharedStorageSystem : EntitySystem
 
         if (!CanInsert(ent, toInsert.Value, out var reason, ent.Comp))
         {
-            _popupSystem.PopupClient(Loc.GetString(reason ?? "comp-storage-cant-insert"), ent, player);
+            _popupSystem.PopupEntity(Loc.GetString(reason ?? "comp-storage-cant-insert"), ent, player);
             return false;
         }
 
         if (!_sharedHandsSystem.CanDrop(player, toInsert.Value))
         {
-            _popupSystem.PopupClient(Loc.GetString("comp-storage-cant-drop", ("entity", toInsert.Value)), ent, player);
+            _popupSystem.PopupEntity(Loc.GetString("comp-storage-cant-drop", ("entity", toInsert.Value)), ent, player);
             return false;
         }
 
@@ -1284,7 +1284,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
 
         if (!Insert(uid, toInsert, out _, user: player, uid.Comp, playSound: playSound))
         {
-            _popupSystem.PopupClient(Loc.GetString("comp-storage-cant-insert"), uid, player);
+            _popupSystem.PopupEntity(Loc.GetString("comp-storage-cant-insert"), uid, player);
             return false;
         }
         return true;

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -204,12 +204,13 @@ public abstract partial class SharedStrippableSystem : EntitySystem
 
         if (!stealth)
         {
-            _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner-insert",
-                                                        ("user", Identity.Entity(user, EntityManager)),
-                                                        ("item", _handsSystem.GetActiveItem((user, user.Comp))!.Value)),
-                                                        target,
-                                                        target,
-                                                        PopupType.Large);
+            _popupSystem.PopupEntity(
+                Loc.GetString("strippable-component-alert-owner-insert",
+                    ("user", Identity.Entity(user, EntityManager)),
+                    ("item", _handsSystem.GetActiveItem((user, user.Comp))!.Value)),
+                target,
+                target,
+                PopupType.Large);
         }
 
         var prefix = stealth ? "stealthily " : "";
@@ -300,16 +301,23 @@ public abstract partial class SharedStrippableSystem : EntitySystem
         if (!stealth)
         {
             if (IsStripHidden(slotDef, user))
-                _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner-hidden", ("slot", slot)), target, target, PopupType.Large);
+            {
+                _popupSystem.PopupEntity(
+                    Loc.GetString("strippable-component-alert-owner-hidden",
+                        ("slot", slot)),
+                    target,
+                    target,
+                    PopupType.Large);
+            }
             else
             {
-                _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner",
-                                                            ("user", Identity.Entity(user, EntityManager)),
-                                                            ("item", item)),
-                                                            target,
-                                                            target,
-                                                            PopupType.Large);
-
+                _popupSystem.PopupEntity(
+                    Loc.GetString("strippable-component-alert-owner",
+                        ("user", Identity.Entity(user, EntityManager)),
+                        ("item", item)),
+                    target,
+                    target,
+                    PopupType.Large);
             }
         }
 
@@ -410,13 +418,13 @@ public abstract partial class SharedStrippableSystem : EntitySystem
 
         if (!stealth)
         {
-            _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner-insert-hand",
-                                                        ("user", Identity.Entity(user, EntityManager)),
-                                                        ("item", _handsSystem.GetActiveItem(user)!.Value)),
-                                                        target,
-                                                        target,
-                                                        PopupType.Large);
-
+            _popupSystem.PopupEntity(
+                Loc.GetString("strippable-component-alert-owner-insert-hand",
+                    ("user", Identity.Entity(user, EntityManager)),
+                    ("item", _handsSystem.GetActiveItem(user)!.Value)),
+                target,
+                target,
+                PopupType.Large);
         }
 
         var prefix = stealth ? "stealthily " : "";
@@ -520,11 +528,12 @@ public abstract partial class SharedStrippableSystem : EntitySystem
 
         if (!stealth)
         {
-            _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner",
-                                                        ("user", Identity.Entity(user, EntityManager)),
-                                                        ("item", item)),
-                                                        target,
-                                                        target);
+            _popupSystem.PopupEntity(
+                Loc.GetString("strippable-component-alert-owner",
+                    ("user", Identity.Entity(user, EntityManager)),
+                    ("item", item)),
+                target,
+                target);
         }
 
         var prefix = stealth ? "stealthily " : "";

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -344,7 +344,7 @@ public abstract partial class SharedStunSystem
 
         if (ev.Message != null)
         {
-            _popup.PopupClient(ev.Message.Value.Item1, entity, entity, ev.Message.Value.Item2);
+            _popup.PopupEntity(ev.Message.Value.Item1, entity, entity, ev.Message.Value.Item2);
         }
 
         return !ev.Cancelled;
@@ -374,7 +374,7 @@ public abstract partial class SharedStunSystem
         if (!IntersectingStandingColliders(entity.Owner))
             return false;
 
-        _popup.PopupClient(Loc.GetString("knockdown-component-stand-no-room"), entity, entity, PopupType.SmallCaution);
+        _popup.PopupEntity(Loc.GetString("knockdown-component-stand-no-room"), entity, entity, PopupType.SmallCaution);
         SetAutoStand(entity.Owner);
         return true;
 
@@ -436,11 +436,11 @@ public abstract partial class SharedStunSystem
 
         if (!Stamina.TryTakeStamina(entity, ev.Stamina, entity.Comp, visual: true))
         {
-            _popup.PopupClient(Loc.GetString("knockdown-component-pushup-failure"), entity, entity, PopupType.MediumCaution);
+            _popup.PopupEntity(Loc.GetString("knockdown-component-pushup-failure"), entity, entity, PopupType.MediumCaution);
             return false;
         }
 
-        _popup.PopupClient(Loc.GetString("knockdown-component-pushup-success"), entity, entity);
+        _popup.PopupEntity(Loc.GetString("knockdown-component-pushup-success"), entity, entity);
         _audio.PlayPredicted(entity.Comp.ForceStandSuccessSound, entity.Owner, entity.Owner, AudioParams.Default.WithVariation(0.025f).WithVolume(5f));
 
         return true;

--- a/Content.Shared/SubFloor/SharedSubFloorHideSystem.cs
+++ b/Content.Shared/SubFloor/SharedSubFloorHideSystem.cs
@@ -52,7 +52,7 @@ namespace Content.Shared.SubFloor
             if (TryComp<MapGridComponent>(xform.GridUid, out var grid)
                 && HasFloorCover(xform.GridUid.Value, grid, Map.TileIndicesFor(xform.GridUid.Value, grid, xform.Coordinates)))
             {
-                _popup.PopupClient(Loc.GetString("subfloor-anchor-failure", ("entity", uid)), args.User);
+                _popup.PopupEntity(Loc.GetString("subfloor-anchor-failure", ("entity", uid)), args.User, args.User);
                 args.Cancel();
             }
         }
@@ -63,7 +63,7 @@ namespace Content.Shared.SubFloor
             // despite being partially under the floor.
             if (component.IsUnderCover)
             {
-                _popup.PopupClient(Loc.GetString("subfloor-unanchor-failure", ("entity", uid)), args.User);
+                _popup.PopupEntity(Loc.GetString("subfloor-unanchor-failure", ("entity", uid)), args.User, args.User);
                 args.Cancel();
             }
         }

--- a/Content.Shared/Tabletop/SharedTabletopSystem.cs
+++ b/Content.Shared/Tabletop/SharedTabletopSystem.cs
@@ -101,7 +101,7 @@ public abstract partial class SharedTabletopSystem : EntitySystem
         EnsureComp<TabletopHologramComponent>(hologram);
         session.Entities.Add(hologram);
 
-        _popup.PopupClient(Loc.GetString("tabletop-added-piece"), ent.Owner, args.User);
+        _popup.PopupEntity(Loc.GetString("tabletop-added-piece"), ent.Owner, args.User);
     }
 
     /// <summary>

--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -59,13 +59,13 @@ public sealed partial class SwapTeleporterSystem : EntitySystem
 
         if (comp.LinkedEnt != null)
         {
-            _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-fail-already"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-fail-already"), uid, args.User);
             return;
         }
 
         if (targetComp.LinkedEnt != null)
         {
-            _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-fail-already-other"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-fail-already-other"), uid, args.User);
             return;
         }
 
@@ -75,7 +75,7 @@ public sealed partial class SwapTeleporterSystem : EntitySystem
         Dirty(target, targetComp);
         _appearance.SetData(uid, SwapTeleporterVisuals.Linked, true);
         _appearance.SetData(target, SwapTeleporterVisuals.Linked, true);
-        _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-create"), uid, args.User);
+        _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-create"), uid, args.User);
     }
 
     private void OnGetAltVerb(Entity<SwapTeleporterComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
@@ -111,7 +111,7 @@ public sealed partial class SwapTeleporterSystem : EntitySystem
 
         if (comp.LinkedEnt == null)
         {
-            _popup.PopupClient(Loc.GetString("swap-teleporter-popup-teleport-cancel-link"), ent, user);
+            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-cancel-link"), ent, user);
             return;
         }
 
@@ -124,7 +124,7 @@ public sealed partial class SwapTeleporterSystem : EntitySystem
 
         if (_timing.CurTime < comp.NextTeleportUse)
         {
-            _popup.PopupClient(Loc.GetString("swap-teleporter-popup-teleport-cancel-time"), ent, user);
+            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-cancel-time"), ent, user);
             return;
         }
 
@@ -162,7 +162,7 @@ public sealed partial class SwapTeleporterSystem : EntitySystem
             return;
         }
 
-        _popup.PopupClient(Loc.GetString("swap-teleporter-popup-teleport-other",
+        _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-other",
             ("entity", Identity.Entity(linkedEnt, EntityManager))),
             teleEnt,
             otherTeleEnt,
@@ -204,10 +204,7 @@ public sealed partial class SwapTeleporterSystem : EntitySystem
         _appearance.SetData(ent, SwapTeleporterVisuals.Linked, false);
         Dirty(ent, ent.Comp);
 
-        if (user != null)
-            _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-destroyed"), ent, user.Value);
-        else
-            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-destroyed"), ent);
+        _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-destroyed"), ent, user);
 
         if (linkedNullable is {} linked)
             DestroyLink(linked, user); // the linked one is shown globally

--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -204,7 +204,10 @@ public sealed partial class SwapTeleporterSystem : EntitySystem
         _appearance.SetData(ent, SwapTeleporterVisuals.Linked, false);
         Dirty(ent, ent.Comp);
 
-        _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-destroyed"), ent, user);
+        if (user != null)
+            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-destroyed"), ent, user.Value);
+        else
+            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-destroyed"), ent);
 
         if (linkedNullable is {} linked)
             DestroyLink(linked, user); // the linked one is shown globally

--- a/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
@@ -69,7 +69,7 @@ public abstract partial class SharedEntityHeaterSystem : EntitySystem
         // Still allow changing the setting without power
         ent.Comp.Setting = setting;
         _audio.PlayPredicted(ent.Comp.SettingSound, ent, user);
-        _popup.PopupClient(Loc.GetString("entity-heater-switched-setting", ("setting", setting)), ent, user);
+        _popup.PopupEntity(Loc.GetString("entity-heater-switched-setting", ("setting", setting)), ent, user);
         Dirty(ent);
 
         // Only show the glowing heating element layer if there's power

--- a/Content.Shared/Thief/Systems/ThiefBeaconSystem.cs
+++ b/Content.Shared/Thief/Systems/ThiefBeaconSystem.cs
@@ -84,7 +84,7 @@ public sealed partial class ThiefBeaconSystem : EntitySystem
             return;
 
         _audio.PlayPredicted(beacon.Comp.LinkSound, beacon, user);
-        _popup.PopupClient(Loc.GetString("thief-fulton-set"), beacon, user);
+        _popup.PopupEntity(Loc.GetString("thief-fulton-set"), beacon, user);
         area.Owners.Clear(); // We only reconfigure the beacon for ourselves, we don't need multiple thieves to steal from the same beacon.
         area.Owners.Add(mind);
         area.OwnerCount = area.Owners.Count;
@@ -100,7 +100,7 @@ public sealed partial class ThiefBeaconSystem : EntitySystem
             return;
 
         _audio.PlayPredicted(beacon.Comp.UnlinkSound, beacon, user);
-        _popup.PopupClient(Loc.GetString("thief-fulton-clear"), beacon, user);
+        _popup.PopupEntity(Loc.GetString("thief-fulton-clear"), beacon, user);
         area.Owners.Clear();
         area.OwnerCount = area.Owners.Count;
         Dirty(beacon.Owner, area);

--- a/Content.Shared/Throwing/CatchableSystem.cs
+++ b/Content.Shared/Throwing/CatchableSystem.cs
@@ -72,8 +72,7 @@ public sealed partial class CatchableSystem : EntitySystem
 
         var selfMessage = Loc.GetString("catchable-component-success-self", ("item", ent.Owner), ("catcher", Identity.Entity(args.Target, EntityManager)));
         var othersMessage = Loc.GetString("catchable-component-success-others", ("item", ent.Owner), ("catcher", Identity.Entity(args.Target, EntityManager)));
-        _popup.PopupEntity(selfMessage, args.Target, args.Target);
-        _popup.PopupEntity(othersMessage, args.Target, Filter.PvsExcept(args.Target), true);
+        _popup.PopupEntity(selfMessage, othersMessage, args.Target, args.Target);
         _audio.PlayPvs(ent.Comp.CatchSuccessSound, args.Target);
     }
 }

--- a/Content.Shared/Throwing/CatchableSystem.cs
+++ b/Content.Shared/Throwing/CatchableSystem.cs
@@ -65,7 +65,7 @@ public sealed partial class CatchableSystem : EntitySystem
         // otherwise it will raise the events for that later while still in your hand
         _thrown.StopThrow(ent.Owner, args.Component);
 
-        // Collisions don't work properly with PopupPredicted or PlayPredicted.
+        // Collisions don't work properly with PlayPredicted.
         // So we make this server only.
         if (_net.IsClient)
             return;

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -137,7 +137,7 @@ public sealed partial class FloorTileSystem : EntitySystem
 
                 if (!CanPlaceTile(gridUid, mapGrid, tile.GridIndices, out var reason))
                 {
-                    _popup.PopupClient(reason, args.User, args.User);
+                    _popup.PopupEntity(reason, args.User, args.User);
                     return;
                 }
 

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
@@ -122,15 +122,15 @@ public abstract partial class SharedToolSystem
                 var drained = SolutionContainerSystem.Drain(target, targetSoln.Value, trans);
                 SolutionContainerSystem.TryAddSolution(solution.Value, drained);
                 _audioSystem.PlayPredicted(entity.Comp.WelderRefill, entity, user: args.User);
-                _popup.PopupClient(Loc.GetString("welder-component-after-interact-refueled-message"), entity, args.User);
+                _popup.PopupEntity(Loc.GetString("welder-component-after-interact-refueled-message"), entity, args.User);
             }
             else if (welderSolution.AvailableVolume <= 0)
             {
-                _popup.PopupClient(Loc.GetString("welder-component-already-full", ("owner", entity.Owner)), entity, args.User);
+                _popup.PopupEntity(Loc.GetString("welder-component-already-full", ("owner", entity.Owner)), entity, args.User);
             }
             else
             {
-                _popup.PopupClient(Loc.GetString("welder-component-no-fuel-in-tank", ("target", args.Target)), entity, args.User);
+                _popup.PopupEntity(Loc.GetString("welder-component-no-fuel-in-tank", ("target", args.Target)), entity, args.User);
             }
 
             args.Handled = true;
@@ -141,7 +141,7 @@ public abstract partial class SharedToolSystem
     {
         if (!ItemToggle.IsActivated(entity.Owner))
         {
-            _popup.PopupClient(Loc.GetString("welder-component-welder-not-lit-message", ("owner", entity.Owner)), entity, user);
+            _popup.PopupEntity(Loc.GetString("welder-component-welder-not-lit-message", ("owner", entity.Owner)), entity, user);
             ev.Cancel();
         }
 
@@ -149,7 +149,7 @@ public abstract partial class SharedToolSystem
 
         if (requiredFuel > currentFuel)
         {
-            _popup.PopupClient(Loc.GetString("welder-component-cannot-weld-message", ("owner", entity.Owner)), entity, user);
+            _popup.PopupEntity(Loc.GetString("welder-component-cannot-weld-message", ("owner", entity.Owner)), entity, user);
             ev.Cancel();
         }
     }

--- a/Content.Shared/Tools/Systems/ToolRefinableSystem.cs
+++ b/Content.Shared/Tools/Systems/ToolRefinableSystem.cs
@@ -56,7 +56,7 @@ public sealed partial class ToolRefinablSystem : EntitySystem
         RaiseLocalEvent(args.Target, ref attemptEvent);
         if (attemptEvent.IsCancelled)
         {
-            _popup.PopupEntity(attemptEvent.BlockCause, args.User);
+            _popup.PopupEntity(attemptEvent.BlockCause, args.User, args.User);
             return;
         }
 
@@ -131,7 +131,7 @@ public sealed partial class ToolRefinablSystem : EntitySystem
         RaiseLocalEvent(args.Target.Value, ref getIsBlocked);
         if (getIsBlocked.IsCancelled)
         {
-            _popup.PopupEntity(getIsBlocked.BlockCause, args.User);
+            _popup.PopupEntity(getIsBlocked.BlockCause, args.User, args.User);
             return;
         }
 

--- a/Content.Shared/Tools/Systems/ToolRefinableSystem.cs
+++ b/Content.Shared/Tools/Systems/ToolRefinableSystem.cs
@@ -56,7 +56,7 @@ public sealed partial class ToolRefinablSystem : EntitySystem
         RaiseLocalEvent(args.Target, ref attemptEvent);
         if (attemptEvent.IsCancelled)
         {
-            _popup.PopupPredicted(attemptEvent.BlockCause, args.User, args.User);
+            _popup.PopupEntity(attemptEvent.BlockCause, args.User);
             return;
         }
 
@@ -131,7 +131,7 @@ public sealed partial class ToolRefinablSystem : EntitySystem
         RaiseLocalEvent(args.Target.Value, ref getIsBlocked);
         if (getIsBlocked.IsCancelled)
         {
-            _popup.PopupPredicted(getIsBlocked.BlockCause, args.User, args.User);
+            _popup.PopupEntity(getIsBlocked.BlockCause, args.User);
             return;
         }
 
@@ -218,7 +218,7 @@ public sealed partial class ToolRefinablSystem : EntitySystem
             ? null
             : Loc.GetString(component.PopupForOther, ("user", user), ("target", uid), ("tool", used));
 
-        _popup.PopupPredicted(slicingDoneMessageForUser, slicingDoneMessageForOthers, user, user, component.PopupType);
+        _popup.PopupEntity(slicingDoneMessageForUser, slicingDoneMessageForOthers, user, user, component.PopupType);
     }
 
     /// <summary>

--- a/Content.Shared/Trigger/Systems/DnaScrambleOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/DnaScrambleOnTriggerSystem.cs
@@ -44,7 +44,6 @@ public sealed partial class DnaScrambleOnTriggerSystem : XOnTriggerSystem<DnaScr
         RemComp<DetailExaminableComponent>(target); // remove MRP+ custom description if one exists
         _identity.QueueIdentityUpdate(target); // manually queue identity update since we don't raise the event
 
-        // Can't use PopupClient or PopupPredicted because the trigger might be unpredicted.
         _popup.PopupEntity(Loc.GetString("scramble-on-trigger-popup"), target, target);
 
         var ev = new DnaScrambledEvent(target);

--- a/Content.Shared/Trigger/Systems/PopupOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/PopupOnTriggerSystem.cs
@@ -40,7 +40,7 @@ public sealed partial class PopupOnTriggerSystem : XOnTriggerSystem<PopupOnTrigg
         // Popups play for all entities
         if (ent.Comp.Predicted)
         {
-            _popup.PopupPredicted(Loc.GetString(ent.Comp.Text, ("entity", ent), ("user", user)),
+            _popup.PopupEntity(Loc.GetString(ent.Comp.Text, ("entity", ent), ("user", user)),
                 Loc.GetString(ent.Comp.OtherText ?? ent.Comp.Text, ("entity", ent), ("user", user)),
                 target,
                 ent.Comp.UserIsRecipient ? args.User : ent.Owner,

--- a/Content.Shared/Trigger/Systems/PopupOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/PopupOnTriggerSystem.cs
@@ -20,7 +20,7 @@ public sealed partial class PopupOnTriggerSystem : XOnTriggerSystem<PopupOnTrigg
         {
             if (ent.Comp.Predicted)
             {
-                _popup.PopupClient(Loc.GetString(ent.Comp.Text, ("entity", ent), ("user", user)),
+                _popup.PopupEntity(Loc.GetString(ent.Comp.Text, ("entity", ent), ("user", user)),
                     target,
                     ent.Comp.UserIsRecipient ? args.User : ent.Owner,
                     ent.Comp.PopupType);

--- a/Content.Shared/Trigger/Systems/TriggerOnMobstateChangeSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerOnMobstateChangeSystem.cs
@@ -50,7 +50,7 @@ public sealed partial class TriggerOnMobstateChangeSystem : TriggerOnXSystem
         if (!component.PreventSuicide)
             return;
 
-        _popup.PopupClient(Loc.GetString("suicide-prevented"), args.Victim);
+        _popup.PopupEntity(Loc.GetString("suicide-prevented"), args.Victim, args.Victim);
         args.Handled = true;
     }
 
@@ -62,7 +62,7 @@ public sealed partial class TriggerOnMobstateChangeSystem : TriggerOnXSystem
         if (!component.PreventSuicide)
             return;
 
-        _popup.PopupClient(Loc.GetString("suicide-prevented"), args.Args.Victim);
+        _popup.PopupEntity(Loc.GetString("suicide-prevented"), args.Args.Victim, args.Args.Victim);
         args.Args.Handled = true;
     }
 }

--- a/Content.Shared/Trigger/Systems/TriggerSystem.Condition.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.Condition.cs
@@ -59,7 +59,7 @@ public sealed partial class TriggerSystem
     private void Toggle(Entity<ToggleTriggerConditionComponent> ent, EntityUid user)
     {
         var msg = ent.Comp.Enabled ? ent.Comp.ToggleOff : ent.Comp.ToggleOn;
-        _popup.PopupEntity(Loc.GetString(msg), ent.Owner);
+        _popup.PopupEntity(Loc.GetString(msg), ent.Owner, user);
         ent.Comp.Enabled = !ent.Comp.Enabled;
         Dirty(ent);
     }

--- a/Content.Shared/Trigger/Systems/TriggerSystem.Condition.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.Condition.cs
@@ -59,7 +59,7 @@ public sealed partial class TriggerSystem
     private void Toggle(Entity<ToggleTriggerConditionComponent> ent, EntityUid user)
     {
         var msg = ent.Comp.Enabled ? ent.Comp.ToggleOff : ent.Comp.ToggleOn;
-        _popup.PopupPredicted(Loc.GetString(msg), ent.Owner, user);
+        _popup.PopupEntity(Loc.GetString(msg), ent.Owner);
         ent.Comp.Enabled = !ent.Comp.Enabled;
         Dirty(ent);
     }

--- a/Content.Shared/Trigger/Systems/TriggerSystem.Timer.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.Timer.cs
@@ -100,7 +100,7 @@ public sealed partial class TriggerSystem
                     {
                         ent.Comp.Delay = option;
                         Dirty(ent);
-                        _popup.PopupClient(Loc.GetString("timer-trigger-popup-set", ("time", option.TotalSeconds)), user, user);
+                        _popup.PopupEntity(Loc.GetString("timer-trigger-popup-set", ("time", option.TotalSeconds)), user, user);
                     }
                 });
             }
@@ -125,7 +125,7 @@ public sealed partial class TriggerSystem
         if (ent.Comp.DelayOptions[^1] <= ent.Comp.Delay)
         {
             ent.Comp.Delay = ent.Comp.DelayOptions[0];
-            _popup.PopupClient(Loc.GetString("timer-trigger-popup-set", ("time", ent.Comp.Delay)), ent.Owner, user);
+            _popup.PopupEntity(Loc.GetString("timer-trigger-popup-set", ("time", ent.Comp.Delay)), ent.Owner, user);
             return;
         }
 
@@ -134,7 +134,7 @@ public sealed partial class TriggerSystem
             if (option > ent.Comp.Delay)
             {
                 ent.Comp.Delay = option;
-                _popup.PopupClient(Loc.GetString("timer-trigger-popup-set", ("time", option)), ent.Owner, user);
+                _popup.PopupEntity(Loc.GetString("timer-trigger-popup-set", ("time", option)), ent.Owner, user);
                 return;
             }
         }

--- a/Content.Shared/Trigger/Systems/TriggerSystem.Voice.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.Voice.cs
@@ -148,7 +148,7 @@ public sealed partial class TriggerSystem
         else
             _adminLogger.Add(LogType.Trigger, LogImpact.Low, $"A voice-trigger on {ToPrettyString(ent):entity} has started recording. User: {ToPrettyString(user.Value):user}");
 
-        _popup.PopupPredicted(Loc.GetString("trigger-on-voice-start-recording"), ent, user);
+        _popup.PopupEntity(Loc.GetString("trigger-on-voice-start-recording"), ent);
     }
 
     /// <summary>
@@ -161,7 +161,7 @@ public sealed partial class TriggerSystem
         if (string.IsNullOrWhiteSpace(ent.Comp.KeyPhrase))
             RemComp<ActiveListenerComponent>(ent);
 
-        _popup.PopupPredicted(Loc.GetString("trigger-on-voice-stop-recording"), ent, user);
+        _popup.PopupEntity(Loc.GetString("trigger-on-voice-stop-recording"), ent);
     }
 
 
@@ -207,6 +207,6 @@ public sealed partial class TriggerSystem
         _adminLogger.Add(LogType.Trigger, LogImpact.Low,
             $"A voice-trigger on {ToPrettyString(ent):entity} has been reset to default keyphrase: '{ent.Comp.KeyPhrase}'. User: {ToPrettyString(user):speaker}");
 
-        _popup.PopupPredicted(Loc.GetString("trigger-on-voice-set-default", ("keyphrase", ent.Comp.KeyPhrase)), ent, user);
+        _popup.PopupEntity(Loc.GetString("trigger-on-voice-set-default", ("keyphrase", ent.Comp.KeyPhrase)), ent);
     }
 }

--- a/Content.Shared/Trigger/Systems/TriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.cs
@@ -108,7 +108,7 @@ public sealed partial class TriggerSystem : EntitySystem
         }
 
         if (ent.Comp.Popup != null)
-            _popup.PopupPredicted(Loc.GetString(ent.Comp.Popup.Value, ("device", ent.Owner)), ent.Owner, user);
+            _popup.PopupEntity(Loc.GetString(ent.Comp.Popup.Value, ("device", ent.Owner)), ent.Owner);
 
         AddComp<ActiveTimerTriggerComponent>(ent);
         var curTime = _timing.CurTime;

--- a/Content.Shared/Trigger/Systems/TriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.cs
@@ -108,7 +108,7 @@ public sealed partial class TriggerSystem : EntitySystem
         }
 
         if (ent.Comp.Popup != null)
-            _popup.PopupEntity(Loc.GetString(ent.Comp.Popup.Value, ("device", ent.Owner)), ent.Owner);
+            _popup.PopupEntity(Loc.GetString(ent.Comp.Popup.Value, ("device", ent.Owner)), ent.Owner, user);
 
         AddComp<ActiveTimerTriggerComponent>(ent);
         var curTime = _timing.CurTime;

--- a/Content.Shared/TurretController/SharedDeployableTurretControllerSystem.cs
+++ b/Content.Shared/TurretController/SharedDeployableTurretControllerSystem.cs
@@ -88,7 +88,7 @@ public abstract partial class SharedDeployableTurretControllerSystem : EntitySys
         if (_accessreader.IsAllowed(user, ent))
             return true;
 
-        _popup.PopupClient(Loc.GetString("turret-controls-access-denied"), ent, user);
+        _popup.PopupEntity(Loc.GetString("turret-controls-access-denied"), ent, user);
         _audio.PlayPredicted(ent.Comp.AccessDeniedSound, ent, user);
 
         return false;

--- a/Content.Shared/Turrets/SharedDeployableTurretSystem.cs
+++ b/Content.Shared/Turrets/SharedDeployableTurretSystem.cs
@@ -66,7 +66,7 @@ public abstract partial class SharedDeployableTurretSystem : EntitySystem
 
         if (!_accessReader.IsAllowed(args.User, ent))
         {
-            _popup.PopupClient(Loc.GetString("deployable-turret-component-access-denied"), ent, args.User);
+            _popup.PopupEntity(Loc.GetString("deployable-turret-component-access-denied"), ent, args.User);
             _audio.PlayPredicted(ent.Comp.AccessDeniedSound, ent, args.User);
 
             return;
@@ -80,7 +80,7 @@ public abstract partial class SharedDeployableTurretSystem : EntitySystem
         if (!ent.Comp.Enabled || args.Cancelled)
             return;
 
-        _popup.PopupClient(Loc.GetString("deployable-turret-component-cannot-access-wires"), ent, args.User);
+        _popup.PopupEntity(Loc.GetString("deployable-turret-component-cannot-access-wires"), ent, args.User);
 
         args.Cancelled = true;
     }
@@ -95,7 +95,7 @@ public abstract partial class SharedDeployableTurretSystem : EntitySystem
         if (enabled && ent.Comp.CurrentState == DeployableTurretState.Broken)
         {
             if (user != null)
-                _popup.PopupClient(Loc.GetString("deployable-turret-component-is-broken"), ent, user.Value);
+                _popup.PopupEntity(Loc.GetString("deployable-turret-component-is-broken"), ent, user.Value);
 
             return false;
         }
@@ -103,7 +103,7 @@ public abstract partial class SharedDeployableTurretSystem : EntitySystem
         if (enabled && !HasAmmo(ent))
         {
             if (user != null)
-                _popup.PopupClient(Loc.GetString("deployable-turret-component-no-ammo"), ent, user.Value);
+                _popup.PopupEntity(Loc.GetString("deployable-turret-component-no-ammo"), ent, user.Value);
 
             return false;
         }
@@ -150,7 +150,7 @@ public abstract partial class SharedDeployableTurretSystem : EntitySystem
 
         // Play pop up message
         var msg = enabled ? "deployable-turret-component-activating" : "deployable-turret-component-deactivating";
-        _popup.PopupClient(Loc.GetString(msg), ent, user);
+        _popup.PopupEntity(Loc.GetString(msg), ent, user);
 
         // Update enabled state
         ent.Comp.Enabled = enabled;

--- a/Content.Shared/UserInterface/ActivatableUIRequiresAnchorSystem.cs
+++ b/Content.Shared/UserInterface/ActivatableUIRequiresAnchorSystem.cs
@@ -37,7 +37,7 @@ public sealed partial class ActivatableUIRequiresAnchorSystem : EntitySystem
 
         if (ent.Comp.Popup != null && !args.Silent)
         {
-            _popup.PopupClient(Loc.GetString(ent.Comp.Popup), args.User);
+            _popup.PopupEntity(Loc.GetString(ent.Comp.Popup), args.User, args.User);
         }
 
         args.Cancel();

--- a/Content.Shared/UserInterface/ActivatableUISystem.cs
+++ b/Content.Shared/UserInterface/ActivatableUISystem.cs
@@ -218,7 +218,7 @@ public sealed partial class ActivatableUISystem : EntitySystem
         if (aui.SingleUser && aui.CurrentSingleUser != null && user != aui.CurrentSingleUser)
         {
             var message = Loc.GetString("machine-already-in-use", ("machine", uiEntity));
-            _popupSystem.PopupClient(message, uiEntity, user);
+            _popupSystem.PopupEntity(message, uiEntity, user);
 
             if (_uiSystem.IsUiOpen(uiEntity, aui.Key))
                 return true;

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
@@ -16,7 +16,7 @@ public abstract partial class SharedVendingMachineSystem
     {
         if (!TryComp<WiresPanelComponent>(target, out var panel) || !panel.Open)
         {
-            Popup.PopupPredictedCursor(Loc.GetString("vending-machine-restock-needs-panel-open",
+            Popup.PopupCursor(Loc.GetString("vending-machine-restock-needs-panel-open",
                     ("this", uid),
                     ("user", user),
                     ("target", target)),
@@ -36,7 +36,7 @@ public abstract partial class SharedVendingMachineSystem
     {
         if (!component.CanRestock.Contains(machineComponent.PackPrototypeId))
         {
-            Popup.PopupPredictedCursor(Loc.GetString("vending-machine-restock-invalid-inventory", ("this", uid), ("user", user),
+            Popup.PopupCursor(Loc.GetString("vending-machine-restock-invalid-inventory", ("this", uid), ("user", user),
                 ("target", target)), user);
 
             return false;
@@ -92,7 +92,7 @@ public abstract partial class SharedVendingMachineSystem
         var othersMessage = Loc.GetString("vending-machine-restock-start-others",
             ("user", Identity.Entity(args.User, EntityManager)),
             ("target", target));
-        Popup.PopupPredicted(selfMessage, othersMessage, target, args.User, PopupType.Medium);
+        Popup.PopupEntity(selfMessage, othersMessage, target, args.User, PopupType.Medium);
 
 
         if (!Timing.IsFirstTimePredicted)
@@ -127,7 +127,7 @@ public abstract partial class SharedVendingMachineSystem
         var othersMessage = Loc.GetString("vending-machine-restock-done-others",
             ("user", Identity.Entity(args.User, EntityManager)),
             ("target", ent));
-        Popup.PopupPredicted(userMessage, othersMessage, ent, args.User, PopupType.Medium);
+        Popup.PopupEntity(userMessage, othersMessage, ent, args.User, PopupType.Medium);
 
         Audio.PlayPredicted(restockComponent.SoundRestockDone, ent, args.User);
 

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
@@ -179,7 +179,7 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
         if (_accessReader.IsAllowed(sender, uid, accessReader) || HasComp<EmaggedComponent>(uid))
             return true;
 
-        Popup.PopupClient(Loc.GetString("vending-machine-component-try-eject-access-denied"), uid, sender);
+        Popup.PopupEntity(Loc.GetString("vending-machine-component-try-eject-access-denied"), uid, sender);
         Deny((uid, vendComponent), sender);
         return false;
     }
@@ -221,14 +221,14 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
 
         if (string.IsNullOrEmpty(entry?.ID))
         {
-            Popup.PopupClient(Loc.GetString("vending-machine-component-try-eject-invalid-item"), uid);
+            Popup.PopupEntity(Loc.GetString("vending-machine-component-try-eject-invalid-item"), uid, uid);
             Deny((uid, vendComponent));
             return;
         }
 
         if (entry.Amount <= 0)
         {
-            Popup.PopupClient(Loc.GetString("vending-machine-component-try-eject-out-of-stock"), uid);
+            Popup.PopupEntity(Loc.GetString("vending-machine-component-try-eject-out-of-stock"), uid, uid);
             Deny((uid, vendComponent));
             return;
         }

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -439,7 +439,7 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
         {
             if (ev.Message != null)
             {
-                PopupSystem.PopupClient(ev.Message, weaponUid, user);
+                PopupSystem.PopupEntity(ev.Message, weaponUid, user);
             }
 
             return false;
@@ -875,7 +875,7 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
             {
                 // Notify disarmable
                 if (HasComp<MobStateComponent>(target.Value))
-                    PopupSystem.PopupClient(Loc.GetString("disarm-action-disarmable", ("targetName", target.Value)), target.Value);
+                    PopupSystem.PopupEntity(Loc.GetString("disarm-action-disarmable", ("targetName", target.Value)), target.Value, target.Value);
 
                 return false;
             }

--- a/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
@@ -121,7 +121,7 @@ public sealed partial class BatteryWeaponFireModesSystem : EntitySystem
                 _appearanceSystem.SetData(ent, BatteryWeaponFireModeVisuals.State, prototype.ID, appearance);
 
             if (user != null)
-                _popupSystem.PopupClient(Loc.GetString("gun-set-fire-mode-popup", ("mode", prototype.Name)), ent, user.Value);
+                _popupSystem.PopupEntity(Loc.GetString("gun-set-fire-mode-popup", ("mode", prototype.Name)), ent, user.Value);
         }
 
         if (TryComp(ent, out BatteryAmmoProviderComponent? batteryAmmoProviderComponent))

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -159,7 +159,7 @@ public abstract partial class SharedGunSystem
             CycleCartridge(uid, component, user, appearance);
 
             if (user != null)
-                PopupSystem.PopupClient(Loc.GetString("gun-chamber-bolt-closed"), uid, user.Value);
+                PopupSystem.PopupEntity(Loc.GetString("gun-chamber-bolt-closed"), uid, user.Value);
 
             if (slots != null)
             {
@@ -189,7 +189,7 @@ public abstract partial class SharedGunSystem
             }
 
             if (user != null)
-                PopupSystem.PopupClient(Loc.GetString("gun-chamber-bolt-opened"), uid, user.Value);
+                PopupSystem.PopupEntity(Loc.GetString("gun-chamber-bolt-opened"), uid, user.Value);
 
             if (slots != null)
             {

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -71,7 +71,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem
 
         if (GetCurrentUpgrades(ent).Count >= ent.Comp.MaxUpgradeCount)
         {
-            _popup.PopupPredicted(Loc.GetString("upgradeable-gun-popup-upgrade-limit"), ent, args.User);
+            _popup.PopupEntity(Loc.GetString("upgradeable-gun-popup-upgrade-limit"), ent);
             return;
         }
 
@@ -80,7 +80,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem
 
         if (GetCurrentUpgradeTags(ent).ToHashSet().IsSupersetOf(upgradeComponent.Tags))
         {
-            _popup.PopupPredicted(Loc.GetString("upgradeable-gun-popup-already-present"), ent, args.User);
+            _popup.PopupEntity(Loc.GetString("upgradeable-gun-popup-already-present"), ent);
             return;
         }
 

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -86,7 +86,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem
 
         args.Handled = _container.Insert(args.Used, _container.GetContainer(ent, ent.Comp.UpgradesContainerId));
         _audio.PlayPredicted(ent.Comp.InsertSound, ent, args.User);
-        _popup.PopupClient(Loc.GetString("gun-upgrade-popup-insert", ("upgrade", args.Used),("gun", ent.Owner)), args.User);
+        _popup.PopupEntity(Loc.GetString("gun-upgrade-popup-insert", ("upgrade", args.Used),("gun", ent.Owner)), args.User, args.User);
         _gun.RefreshModifiers(ent.Owner);
 
         _adminLog.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(args.User):player} inserted gun upgrade {ToPrettyString(args.Used)} into {ToPrettyString(ent.Owner)}.");

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -71,7 +71,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem
 
         if (GetCurrentUpgrades(ent).Count >= ent.Comp.MaxUpgradeCount)
         {
-            _popup.PopupEntity(Loc.GetString("upgradeable-gun-popup-upgrade-limit"), ent);
+            _popup.PopupEntity(Loc.GetString("upgradeable-gun-popup-upgrade-limit"), ent, args.User);
             return;
         }
 
@@ -80,7 +80,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem
 
         if (GetCurrentUpgradeTags(ent).ToHashSet().IsSupersetOf(upgradeComponent.Tags))
         {
-            _popup.PopupEntity(Loc.GetString("upgradeable-gun-popup-already-present"), ent);
+            _popup.PopupEntity(Loc.GetString("upgradeable-gun-popup-already-present"), ent, args.User);
             return;
         }
 

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -94,7 +94,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
             {
                 component.LastPopup = time;
                 var message = Loc.GetString("wieldable-component-requires", ("item", uid));
-                _popup.PopupClient(message, args.Used, args.User);
+                _popup.PopupEntity(message, args.Used, args.User);
             }
         }
     }
@@ -252,7 +252,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
         if (!TryComp<HandsComponent>(user, out var hands))
         {
             if (!quiet)
-                _popup.PopupClient(Loc.GetString("wieldable-component-no-hands"), user, user);
+                _popup.PopupEntity(Loc.GetString("wieldable-component-no-hands"), user, user);
             return false;
         }
 
@@ -260,7 +260,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
         if (!_hands.IsHolding((user, hands), wieldable, out _))
         {
             if (!quiet)
-                _popup.PopupClient(Loc.GetString("wieldable-component-not-in-hands", ("item", wieldable.Owner)), user, user);
+                _popup.PopupEntity(Loc.GetString("wieldable-component-not-in-hands", ("item", wieldable.Owner)), user, user);
             return false;
         }
 
@@ -270,7 +270,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
             {
                 var message = Loc.GetString("wieldable-component-not-enough-free-hands",
                     ("number", wieldable.Comp.FreeHandsRequired), ("item", wieldable.Owner));
-                _popup.PopupClient(message, user, user);
+                _popup.PopupEntity(message, user, user);
             }
             return false;
         }
@@ -303,7 +303,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
         if (attemptEv.Cancelled)
         {
             if (attemptEv.Message != null)
-                _popup.PopupClient(attemptEv.Message, user, user);
+                _popup.PopupEntity(attemptEv.Message, user, user);
             return false;
         }
 
@@ -367,7 +367,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
             if (attemptEv.Cancelled)
             {
                 if (attemptEv.Message != null)
-                    _popup.PopupClient(attemptEv.Message, user, user);
+                    _popup.PopupEntity(attemptEv.Message, user, user);
                 return false;
             }
         }

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -339,7 +339,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
 
         var selfMessage = Loc.GetString("wieldable-component-successful-wield", ("item", wieldable.Owner));
         var othersMessage = Loc.GetString("wieldable-component-successful-wield-other", ("user", Identity.Entity(user, EntityManager)), ("item", wieldable.Owner));
-        _popup.PopupPredicted(selfMessage, othersMessage, user, user);
+        _popup.PopupEntity(selfMessage, othersMessage, user, user);
 
         var ev = new ItemWieldedEvent(user);
         RaiseLocalEvent(wieldable.Owner, ref ev);
@@ -416,7 +416,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
 
             var selfMessage = Loc.GetString("wieldable-component-failed-wield", ("item", uid));
             var othersMessage = Loc.GetString("wieldable-component-failed-wield-other", ("user", Identity.Entity(args.User, EntityManager)), ("item", uid));
-            _popup.PopupPredicted(selfMessage, othersMessage, user, user);
+            _popup.PopupEntity(selfMessage, othersMessage, user, user);
         }
     }
 

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAE.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAE.cs
@@ -76,7 +76,7 @@ public abstract partial class SharedXenoArtifactSystem
 
         if (!success)
         {
-            _popup.PopupClient(Loc.GetString("artifact-activation-fail"), artifact, user);
+            _popup.PopupEntity(Loc.GetString("artifact-activation-fail"), artifact, user);
             return false;
         }
 

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERandomTeleportInvokerSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERandomTeleportInvokerSystem.cs
@@ -25,7 +25,7 @@ public sealed partial class XAERandomTeleportInvokerSystem : BaseXAESystem<XAERa
         var component = ent.Comp;
 
         var xform = Transform(args.Artifact);
-        _popup.PopupCoordinates(Loc.GetString("blink-artifact-popup"), xform.Coordinates, args.User, PopupType.Medium);
+        _popup.PopupCoordinates(Loc.GetString("blink-artifact-popup"), xform.Coordinates, PopupType.Medium);
 
         var offsetTo = _random.NextVector2(component.MinRange, component.MaxRange);
 

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERandomTeleportInvokerSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERandomTeleportInvokerSystem.cs
@@ -25,7 +25,7 @@ public sealed partial class XAERandomTeleportInvokerSystem : BaseXAESystem<XAERa
         var component = ent.Comp;
 
         var xform = Transform(args.Artifact);
-        _popup.PopupPredictedCoordinates(Loc.GetString("blink-artifact-popup"), xform.Coordinates, args.User, PopupType.Medium);
+        _popup.PopupCoordinates(Loc.GetString("blink-artifact-popup"), xform.Coordinates, args.User, PopupType.Medium);
 
         var offsetTo = _random.NextVector2(component.MinRange, component.MaxRange);
 

--- a/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
@@ -116,7 +116,7 @@ public abstract partial class SharedArtifactCrusherSystem : EntitySystem
             return;
 
         if (crusher.AutoLock)
-            _popup.PopupPredicted(Loc.GetString("artifact-crusher-autolocks-enable"), uid, user);
+            _popup.PopupEntity(Loc.GetString("artifact-crusher-autolocks-enable"), uid);
 
         crusher.Crushing = true;
         crusher.NextSecond = _timing.CurTime + TimeSpan.FromSeconds(1);


### PR DESCRIPTION
## About the PR

Cleaning up the remainder of the PopupSystem warnings in Content.Shared.

If it's easier to follow along, the first three commits should be independent - the first having only PopupClient uses, the second having PopupPredicted* uses, and the third having the rest of the files I did not save initally in the Content.Shared project.  Oops.

## Why / Balance

500 warning slartillery barrage.  Full solution builds with 751 warnings by my count on the head of this PR, and 1225 on master.

## Technical details


A bit more involved than a find and replace - all functions should be replaced by their aliased PopupEntity versions:
A PopupClient call without a recipient (third arg) has one added.
A PopupPredicted call with a recipient has it removed if no otherString is used. **Note: many uses were wrong on master, and have been addressed.**
PopupPredictedCursor aliases PopupCursor, so should be converted directly.

Left the obsolete PopupClient/PredictedX functions in the SharedPopupSystem if only for downstreams, though now they're unused - should be slated for removal anyways.

Replacement mapping (`str1`, `str2` are strings, `x`, `y` are entityUIDs, `coords` are coordinates, an ellipsis represents unchanged arguments) should be as follows.

```
PopupClient(str1, x) -> PopupEntity(str1, x, x)
PopupClient(str1, x, y) -> PopupEntity(str1, x, y)
PopupClient(str1, coords, x) -> PopupCoordinates(str1, coords, x)
PopupPredicted(str1, x, y) -> PopupEntity(str1, x)
PopupPredicted(str1, str2, x, y) -> PopupEntity(str1, str2, x, y)
PopupPredicted(str1, null, x, y) -> PopupEntity(str1, x, y)
PopupPredictedCoordinates(str1, coords, x) -> PopupCoordinates(str1, coords)
PopupPredictedCursor(...) -> PopupCursor(...)
```

Tried to resolve relevant comments where they were left.  The one in SharedItemRecallSystem.cs, I do not know if it is still relevant.

Any INetManager client/server conditions have been left as-is, I tried to make this diff as small as I could.

## Test plan
Read this _very carefully_.  The finest toothed comb.

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog