### PR TITLE
ContentTileDefiniton cleanup + default uniform distribution for PlacementVariants

### DIFF
--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -1,143 +1,139 @@
 using Content.Shared.Atmos;
-using Content.Shared.Light.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Shuttles.Systems;
 using Content.Shared.Tools;
 using Robust.Shared.Audio;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 using Robust.Shared.Utility;
 
-namespace Content.Shared.Maps
+namespace Content.Shared.Maps;
+
+[Prototype("tile")]
+public sealed partial class ContentTileDefinition : IPrototype, IInheritingPrototype, ITileDefinition
 {
-    [Prototype("tile")]
-    public sealed partial class ContentTileDefinition : IPrototype, IInheritingPrototype, ITileDefinition
+    public static readonly ProtoId<ToolQualityPrototype> PryingToolQuality = "Prying";
+
+    public const string SpaceID = "Space";
+
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<ContentTileDefinition>))]
+    public string[]? Parents { get; private set; }
+
+    [NeverPushInheritance]
+    [AbstractDataField]
+    public bool Abstract { get; private set; }
+
+    [IdDataField] public string ID { get; private set; } = string.Empty;
+
+    public ushort TileId { get; private set; }
+
+    [DataField]
+    public string Name { get; private set; } = "";
+    [DataField] public ResPath? Sprite { get; private set; }
+
+    [DataField] public Dictionary<Direction, ResPath> EdgeSprites { get; private set; } = new();
+
+    [DataField] public int EdgeSpritePriority { get; private set; } = 0;
+
+    [DataField("isSubfloor")] public bool IsSubFloor { get; private set; }
+
+    [DataField]
+    public ProtoId<ContentTileDefinition>? BaseTurf { get; private set; }
+
+    /// <summary>
+    /// On what tiles this tile can be placed on. BaseTurf is already included.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<ContentTileDefinition>> BaseWhitelist { get; private set; } = new();
+
+    [DataField]
+    public PrototypeFlags<ToolQualityPrototype> DeconstructTools { get; set; } = new();
+
+    /// <summary>
+    /// Effective mass of this tile for grid impacts.
+    /// </summary>
+    [DataField]
+    public float Mass = SharedShuttleSystem.TileDensityMultiplier;
+
+    /// <remarks>
+    /// Legacy AF but nice to have.
+    /// </remarks>
+    public bool CanCrowbar => DeconstructTools.Contains(PryingToolQuality);
+
+    /// <summary>
+    /// These play when the mob has shoes on.
+    /// </summary>
+    [DataField] public SoundSpecifier? FootstepSounds { get; private set; }
+
+    /// <summary>
+    /// These play when the mob has no shoes on.
+    /// </summary>
+    [DataField] public SoundSpecifier? BarestepSounds { get; private set; } = new SoundCollectionSpecifier("BarestepHard");
+
+    /// <summary>
+    /// Base friction modifier for this tile.
+    /// </summary>
+    [DataField] public float Friction { get; set; } = 1f;
+
+    [DataField] public byte Variants { get; set; } = 1;
+
+    /// <summary>
+    ///     Allows the tile to be rotated/mirrored when placed on a grid.
+    /// </summary>
+    [DataField] public bool AllowRotationMirror { get; set; } = false;
+
+    /// <summary>
+    /// This controls what variants the `variantize` command is allowed to use.
+    /// If null, the distribution will be uniform.
+    /// </summary>
+    [DataField] public float[]? PlacementVariants { get; set; } = null;
+
+    [DataField] public float ThermalConductivity = 0.04f;
+
+    // Heat capacity is opt-in, not opt-out.
+    [DataField] public float HeatCapacity = Atmospherics.MinimumHeatCapacity;
+
+    [DataField("itemDrop")]
+    public EntProtoId ItemDropPrototypeName { get; private set; } = "FloorTileItemSteel";
+
+    // TODO rename data-field in yaml
+    /// <summary>
+    /// Whether or not the tile is exposed to the map's atmosphere.
+    /// </summary>
+    [DataField("isSpace")] public bool MapAtmosphere { get; private set; }
+
+    /// <summary>
+    ///     Friction override for mob mover in <see cref="SharedMoverController"/>
+    /// </summary>
+    [DataField]
+    public float? MobFriction { get; private set; }
+
+    /// <summary>
+    ///     Accel override for mob mover in <see cref="SharedMoverController"/>
+    /// </summary>
+    [DataField]
+    public float? MobAcceleration { get; private set; }
+
+    [DataField] public bool Sturdy { get; private set; } = true;
+
+    /// <summary>
+    /// Can weather affect this tile.
+    /// </summary>
+    [DataField] public bool Weather = false;
+
+    /// <summary>
+    /// Is this tile immune to RCD deconstruct.
+    /// </summary>
+    [DataField] public bool Indestructible = false;
+
+    /// <summary>
+    ///     Hide this tile in the tile placement editor.
+    /// </summary>
+    [DataField] public bool EditorHidden { get; private set; } = false;
+
+    public void AssignTileId(ushort id)
     {
-        public static readonly ProtoId<ToolQualityPrototype> PryingToolQuality = "Prying";
-
-        public const string SpaceID = "Space";
-
-        [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<ContentTileDefinition>))]
-        public string[]? Parents { get; private set; }
-
-        [NeverPushInheritance]
-        [AbstractDataFieldAttribute]
-        public bool Abstract { get; private set; }
-
-        [IdDataField] public string ID { get; private set; } = string.Empty;
-
-        public ushort TileId { get; private set; }
-
-        [DataField("name")]
-        public string Name { get; private set; } = "";
-        [DataField("sprite")] public ResPath? Sprite { get; private set; }
-
-        [DataField("edgeSprites")] public Dictionary<Direction, ResPath> EdgeSprites { get; private set; } = new();
-
-        [DataField("edgeSpritePriority")] public int EdgeSpritePriority { get; private set; } = 0;
-
-        [DataField("isSubfloor")] public bool IsSubFloor { get; private set; }
-
-        [DataField("baseTurf")]
-        public ProtoId<ContentTileDefinition>? BaseTurf { get; private set; }
-
-        /// <summary>
-        /// On what tiles this tile can be placed on. BaseTurf is already included.
-        /// </summary>
-        [DataField]
-        public List<ProtoId<ContentTileDefinition>> BaseWhitelist { get; private set; } = new();
-
-        [DataField]
-        public PrototypeFlags<ToolQualityPrototype> DeconstructTools { get; set; } = new();
-
-        /// <summary>
-        /// Effective mass of this tile for grid impacts.
-        /// </summary>
-        [DataField]
-        public float Mass = SharedShuttleSystem.TileDensityMultiplier;
-
-        /// <remarks>
-        /// Legacy AF but nice to have.
-        /// </remarks>
-        public bool CanCrowbar => DeconstructTools.Contains(PryingToolQuality);
-
-        /// <summary>
-        /// These play when the mob has shoes on.
-        /// </summary>
-        [DataField("footstepSounds")] public SoundSpecifier? FootstepSounds { get; private set; }
-
-        /// <summary>
-        /// These play when the mob has no shoes on.
-        /// </summary>
-        [DataField("barestepSounds")] public SoundSpecifier? BarestepSounds { get; private set; } = new SoundCollectionSpecifier("BarestepHard");
-
-        /// <summary>
-        /// Base friction modifier for this tile.
-        /// </summary>
-        [DataField("friction")] public float Friction { get; set; } = 1f;
-
-        [DataField("variants")] public byte Variants { get; set; } = 1;
-
-        /// <summary>
-        ///     Allows the tile to be rotated/mirrored when placed on a grid.
-        /// </summary>
-        [DataField] public bool AllowRotationMirror { get; set; } = false;
-
-        /// <summary>
-        /// This controls what variants the `variantize` command is allowed to use.
-        /// </summary>
-        [DataField("placementVariants")] public float[] PlacementVariants { get; set; } = { 1f };
-
-        [DataField("thermalConductivity")] public float ThermalConductivity = 0.04f;
-
-        // Heat capacity is opt-in, not opt-out.
-        [DataField("heatCapacity")] public float HeatCapacity = Atmospherics.MinimumHeatCapacity;
-
-        [DataField("itemDrop", customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
-        public string ItemDropPrototypeName { get; private set; } = "FloorTileItemSteel";
-
-        // TODO rename data-field in yaml
-        /// <summary>
-        /// Whether or not the tile is exposed to the map's atmosphere.
-        /// </summary>
-        [DataField("isSpace")] public bool MapAtmosphere { get; private set; }
-
-        /// <summary>
-        ///     Friction override for mob mover in <see cref="SharedMoverController"/>
-        /// </summary>
-        [DataField("mobFriction")]
-        public float? MobFriction { get; private set; }
-
-        /// <summary>
-        ///     Accel override for mob mover in <see cref="SharedMoverController"/>
-        /// </summary>
-        [DataField("mobAcceleration")]
-        public float? MobAcceleration { get; private set; }
-
-        [DataField("sturdy")] public bool Sturdy { get; private set; } = true;
-
-        /// <summary>
-        /// Can weather affect this tile.
-        /// </summary>
-        [DataField("weather")] public bool Weather = false;
-
-        /// <summary>
-        /// Is this tile immune to RCD deconstruct.
-        /// </summary>
-        [DataField("indestructible")] public bool Indestructible = false;
-
-        /// <summary>
-        ///     Hide this tile in the tile placement editor.
-        /// </summary>
-        [DataField] public bool EditorHidden { get; private set; } = false;
-
-        public void AssignTileId(ushort id)
-        {
-            TileId = id;
-        }
+        TileId = id;
     }
 }

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -95,7 +95,7 @@ public sealed partial class ContentTileDefinition : IPrototype, IInheritingProto
     [DataField] public float HeatCapacity = Atmospherics.MinimumHeatCapacity;
 
     [DataField("itemDrop")]
-    public EntProtoId ItemDropPrototypeName { get; private set; } = "FloorTileItemSteel";
+    public EntProtoId? ItemDropPrototypeName { get; private set; } = "FloorTileItemSteel";
 
     // TODO rename data-field in yaml
     /// <summary>

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -79,7 +79,7 @@ public sealed partial class ContentTileDefinition : IPrototype, IInheritingProto
     [DataField] public byte Variants { get; set; } = 1;
 
     /// <summary>
-    ///     Allows the tile to be rotated/mirrored when placed on a grid.
+    /// Allows the tile to be rotated/mirrored when placed on a grid.
     /// </summary>
     [DataField] public bool AllowRotationMirror { get; set; } = false;
 
@@ -104,13 +104,13 @@ public sealed partial class ContentTileDefinition : IPrototype, IInheritingProto
     [DataField("isSpace")] public bool MapAtmosphere { get; private set; }
 
     /// <summary>
-    ///     Friction override for mob mover in <see cref="SharedMoverController"/>
+    /// Friction override for mob mover in <see cref="SharedMoverController"/>
     /// </summary>
     [DataField]
     public float? MobFriction { get; private set; }
 
     /// <summary>
-    ///     Accel override for mob mover in <see cref="SharedMoverController"/>
+    /// Accel override for mob mover in <see cref="SharedMoverController"/>
     /// </summary>
     [DataField]
     public float? MobAcceleration { get; private set; }
@@ -128,7 +128,7 @@ public sealed partial class ContentTileDefinition : IPrototype, IInheritingProto
     [DataField] public bool Indestructible = false;
 
     /// <summary>
-    ///     Hide this tile in the tile placement editor.
+    /// Hide this tile in the tile placement editor.
     /// </summary>
     [DataField] public bool EditorHidden { get; private set; } = false;
 

--- a/Content.Shared/Maps/TileSystem.cs
+++ b/Content.Shared/Maps/TileSystem.cs
@@ -309,7 +309,7 @@ public sealed partial class TileSystem : EntitySystem
             previousTileId = tileDef.BaseTurf.Value;
         }
 
-        if (spawnItem)
+        if (spawnItem && tileDef.ItemDropPrototypeName != null)
         {
             //Actually spawn the relevant tile item at the right position and give it some random offset.
             var tileItem = Spawn(tileDef.ItemDropPrototypeName, coordinates);

--- a/Content.Shared/Maps/TileSystem.cs
+++ b/Content.Shared/Maps/TileSystem.cs
@@ -122,6 +122,10 @@ public sealed partial class TileSystem : EntitySystem
     /// </summary>
     public byte PickVariant(ContentTileDefinition tile, IRobustRandom random)
     {
+        // Null variants? Uniform distribution.
+        if (tile.PlacementVariants == null)
+            return random.NextByte(tile.Variants);
+
         var variants = tile.PlacementVariants;
 
         var sum = variants.Sum();

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -31,11 +31,6 @@
   name: tiles-steel-floor
   sprite: /Textures/Tiles/steel.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteel
 
 - type: tile
@@ -44,11 +39,6 @@
   name: tiles-steel-floor-checker-light
   sprite: /Textures/Tiles/cafeteria.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteelCheckerLight
 
 - type: tile
@@ -57,11 +47,6 @@
   name: tiles-steel-floor-checker-dark
   sprite: /Textures/Tiles/checker_dark.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteelCheckerDark
 
 - type: tile
@@ -70,11 +55,6 @@
   name: tiles-steel-floor-mini
   sprite: /Textures/Tiles/steel_mini.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteelMini
 
 - type: tile
@@ -83,11 +63,6 @@
   name: tiles-steel-floor-pavement
   sprite: /Textures/Tiles/steel_pavement.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteelPavement
 
 - type: tile
@@ -96,11 +71,6 @@
   name: tiles-steel-floor-diagonal
   sprite: /Textures/Tiles/steel_diagonal.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteelDiagonal
 
 - type: tile
@@ -116,11 +86,6 @@
   name: tiles-steel-floor-mono
   sprite: /Textures/Tiles/steel_mono.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteelMono
 
 - type: tile
@@ -129,11 +94,6 @@
   name: tiles-steel-floor-pavement-vertical
   sprite: /Textures/Tiles/steel_pavement_vertical.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteelPavementVertical
 
 - type: tile
@@ -142,11 +102,6 @@
   name: tiles-steel-floor-herringbone
   sprite: /Textures/Tiles/steel_herringbone.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteelHerringbone
 
 - type: tile
@@ -155,11 +110,6 @@
   name: tiles-steel-floor-diagonal-mini
   sprite: /Textures/Tiles/steel_diagonal_mini.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteelDiagonalMini
 
 - type: tile
@@ -168,11 +118,6 @@
   name: tiles-steel-floor-slats-continuous
   sprite: /Textures/Tiles/steel_slats_continuous.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteelSlatsContinuous
   allowRotationMirror: true
 
@@ -182,11 +127,6 @@
   name: tiles-steel-floor-vertical-slats-bordered
   sprite: /Textures/Tiles/steel_vertical_slats_bordered.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteelVerticalSlatsBordered
 
 - type: tile
@@ -195,11 +135,6 @@
   name: tiles-steel-floor-horizontal-slats-bordered
   sprite: /Textures/Tiles/steel_horizontal_slats_bordered.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteelHorizontalSlatsBordered
 
 - type: tile
@@ -226,11 +161,6 @@
   name: tiles-plastic-floor
   sprite: /Textures/Tiles/plastic.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteel
 
 - type: tile
@@ -239,11 +169,6 @@
   name: tiles-wood
   sprite: /Textures/Tiles/wood.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepWood
   barestepSounds:
@@ -256,11 +181,6 @@
   name: tiles-white-floor
   sprite: /Textures/Tiles/white.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
@@ -271,11 +191,6 @@
   name: tiles-white-floor-mini
   sprite: /Textures/Tiles/white_mini.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemWhiteMini
@@ -286,11 +201,6 @@
   name: tiles-white-floor-slats-continuous
   sprite: /Textures/Tiles/white_slats_continuous.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemWhiteSlatsContinuous
   allowRotationMirror: true
 
@@ -300,11 +210,6 @@
   name: tiles-white-floor-vertical-slats-bordered
   sprite: /Textures/Tiles/white_vertical_slats_bordered.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemWhiteVerticalSlatsBordered
 
 - type: tile
@@ -313,11 +218,6 @@
   name: tiles-white-floor-horizontal-slats-bordered
   sprite: /Textures/Tiles/white_horizontal_slats_bordered.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemWhiteHorizontalSlatsBordered
 
 - type: tile
@@ -326,11 +226,6 @@
   name: tiles-white-floor-pavement
   sprite: /Textures/Tiles/white_pavement.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemWhitePavement
@@ -341,11 +236,6 @@
   name: tiles-white-floor-diagonal
   sprite: /Textures/Tiles/white_diagonal.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemWhiteDiagonal
@@ -365,11 +255,6 @@
   name: tiles-white-floor-mono
   sprite: /Textures/Tiles/white_mono.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemWhiteMono
@@ -380,11 +265,6 @@
   name: tiles-white-floor-pavement-vertical
   sprite: /Textures/Tiles/white_pavement_vertical.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemWhitePavementVertical
@@ -395,11 +275,6 @@
   name: tiles-white-floor-herringbone
   sprite: /Textures/Tiles/white_herringbone.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemWhiteHerringbone
@@ -410,11 +285,6 @@
   name: tiles-white-floor-diagonal-mini
   sprite: /Textures/Tiles/white_diagonal_mini.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemWhiteDiagonalMini
@@ -425,11 +295,6 @@
   name: tiles-plastic-white-floor
   sprite: /Textures/Tiles/white_plastic.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemWhite
@@ -440,11 +305,6 @@
   name: tiles-dark-floor
   sprite: /Textures/Tiles/dark.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemDark
@@ -455,11 +315,6 @@
   name: tiles-dark-floor-mini
   sprite: /Textures/Tiles/dark_mini.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemDarkMini
@@ -470,11 +325,6 @@
   name: tiles-dark-floor-slats-continuous
   sprite: /Textures/Tiles/dark_slats_continuous.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemDarkSlatsContinuous
   allowRotationMirror: true
 
@@ -484,11 +334,6 @@
   name: tiles-dark-floor-vertical-slats-bordered
   sprite: /Textures/Tiles/dark_vertical_slats_bordered.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemDarkVerticalSlatsBordered
 
 - type: tile
@@ -497,11 +342,6 @@
   name: tiles-dark-floor-horizontal-slats-bordered
   sprite: /Textures/Tiles/dark_horizontal_slats_bordered.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemDarkHorizontalSlatsBordered
 
 - type: tile
@@ -510,11 +350,6 @@
   name: tiles-dark-floor-pavement
   sprite: /Textures/Tiles/dark_pavement.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemDarkPavement
@@ -525,11 +360,6 @@
   name: tiles-dark-floor-diagonal
   sprite: /Textures/Tiles/dark_diagonal.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemDarkDiagonal
@@ -549,11 +379,6 @@
   name: tiles-dark-floor-mono
   sprite: /Textures/Tiles/dark_mono.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemDarkMono
@@ -564,11 +389,6 @@
   name: tiles-dark-floor-pavement-vertical
   sprite: /Textures/Tiles/dark_pavement_vertical.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemDarkPavementVertical
@@ -579,11 +399,6 @@
   name: tiles-dark-floor-herringbone
   sprite: /Textures/Tiles/dark_herringbone.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemDarkHerringbone
@@ -594,11 +409,6 @@
   name: tiles-dark-floor-diagonal-mini
   sprite: /Textures/Tiles/dark_diagonal_mini.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemDarkDiagonalMini
@@ -609,11 +419,6 @@
   name: tiles-plastic-dark-floor
   sprite: /Textures/Tiles/dark_plastic.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemDark
@@ -669,11 +474,6 @@
   name: tiles-dirty-steel-floor
   sprite: /Textures/Tiles/steel_dirty.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepPlating
   itemDrop: FloorTileItemDirty
@@ -720,11 +520,6 @@
   name: tiles-lime-floor
   sprite: /Textures/Tiles/lime.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemLime
 
 - type: tile
@@ -784,11 +579,6 @@
   name: tiles-bar-floor
   sprite: /Textures/Tiles/bar.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemBar
 
 - type: tile
@@ -829,12 +619,6 @@
   name: tiles-steel-floor
   sprite: /Textures/Tiles/steel_damaged.png
   variants: 5
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemSteel #This should probably be made null when it becomes possible to make it such, in SS13 prying destroyed tiles wouldn't give you anything.
 
 # Concrete
@@ -844,11 +628,6 @@
   name: tiles-concrete-tile
   sprite: /Textures/Tiles/Planet/Concrete/concrete.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemConcrete
@@ -859,11 +638,6 @@
   name: tiles-concrete-slab
   sprite: /Textures/Tiles/Planet/Concrete/concrete_mono.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemConcreteMono
@@ -874,11 +648,6 @@
   name: tiles-concrete-smooth
   sprite: /Textures/Tiles/Planet/Concrete/concrete_smooth.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemConcreteSmooth
@@ -889,11 +658,6 @@
   name: tiles-gray-concrete-tile
   sprite: /Textures/Tiles/Planet/Concrete/grayconcrete.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemGrayConcrete
@@ -904,11 +668,6 @@
   name: tiles-gray-concrete-slab
   sprite: /Textures/Tiles/Planet/Concrete/grayconcrete_mono.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemGrayConcreteMono
@@ -919,11 +678,6 @@
   name: tiles-gray-concrete-smooth
   sprite: /Textures/Tiles/Planet/Concrete/grayconcrete_smooth.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemGrayConcreteSmooth
@@ -934,11 +688,6 @@
   name: tiles-old-concrete-tile
   sprite: /Textures/Tiles/Planet/Concrete/oldconcrete.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemOldConcrete
@@ -949,11 +698,6 @@
   name: tiles-old-concrete-slab
   sprite: /Textures/Tiles/Planet/Concrete/oldconcrete_mono.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemOldConcreteMono
@@ -964,11 +708,6 @@
   name: tiles-old-concrete-smooth
   sprite: /Textures/Tiles/Planet/Concrete/oldconcrete_smooth.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: FloorTileItemOldConcreteSmooth
@@ -1052,11 +791,6 @@
   name: tiles-boxing-ring-floor
   sprite: /Textures/Tiles/boxing.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   friction: 1.25
   itemDrop: FloorTileItemBoxing
 
@@ -1066,11 +800,6 @@
   name: tiles-gym-floor
   sprite: /Textures/Tiles/gym.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   friction: 1.25
   itemDrop: FloorTileItemGym
 
@@ -1081,11 +810,6 @@
   name: tiles-white-shuttle-floor
   sprite: /Textures/Tiles/shuttlewhite.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemShuttleWhite
 
 - type: tile
@@ -1094,11 +818,6 @@
   name: tiles-grey-shuttle-floor
   sprite: /Textures/Tiles/shuttlegrey.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemShuttleGrey
 
 - type: tile
@@ -1107,11 +826,6 @@
   name: tiles-black-shuttle-floor
   sprite: /Textures/Tiles/shuttleblack.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemShuttleBlack
 
 - type: tile
@@ -1120,11 +834,6 @@
   name: tiles-blue-shuttle-floor
   sprite: /Textures/Tiles/shuttleblue.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemShuttleBlue
 
 - type: tile
@@ -1133,11 +842,6 @@
   name: tiles-orange-shuttle-floor
   sprite: /Textures/Tiles/shuttleorange.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemShuttleOrange
 
 - type: tile
@@ -1146,11 +850,6 @@
   name: tiles-purple-shuttle-floor
   sprite: /Textures/Tiles/shuttlepurple.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemShuttlePurple
 
 - type: tile
@@ -1159,11 +858,6 @@
   name: tiles-red-shuttle-floor
   sprite: /Textures/Tiles/shuttlered.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemShuttleRed
 
 
@@ -1192,11 +886,6 @@
   name: tiles-glass-floor
   sprite: /Textures/Tiles/glass.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: SheetGlass1
@@ -1207,11 +896,6 @@
   name: tiles-reinforced-glass-floor
   sprite: /Textures/Tiles/rglass.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   itemDrop: SheetRGlass1
@@ -1221,9 +905,6 @@
   parent: BaseStationTile
   name: tiles-metal-foam
   sprite: /Textures/Tiles/foammetal.png
-  variants: 1
-  placementVariants:
-  - 1.0
   footstepSounds:
     collection: FootstepHull
   itemDrop: SheetSteel1
@@ -1262,17 +943,6 @@
   name: tiles-asphalt
   sprite: /Textures/Tiles/Planet/Concrete/asphalt.png
   variants: 10
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   baseTurf: FloorDirt
   isSubfloor: true
   footstepSounds:
@@ -1309,11 +979,6 @@
   name: tiles-dark-grass-floor
   sprite: /Textures/Tiles/grassdark.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   baseTurf: FloorDirt
   isSubfloor: true
   footstepSounds:
@@ -1326,11 +991,6 @@
   name: tiles-light-grass-floor
   sprite: /Textures/Tiles/grasslight.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   baseTurf: FloorDirt
   isSubfloor: true
   footstepSounds:
@@ -1343,11 +1003,6 @@
   name: tiles-dirt-floor
   sprite: /Textures/Tiles/dirt.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   baseTurf: Plating
   isSubfloor: true
   footstepSounds:
@@ -1363,19 +1018,19 @@
   sprite: /Textures/Tiles/Asteroid/asteroid.png
   variants: 13
   placementVariants:
-    - 0.8
-    - 0.0166 #Should be roughly 20%.... I think??? I don't know dude, I'm just a YAML monkey.
-    - 0.0166
-    - 0.0166
-    - 0.0166
-    - 0.0166
-    - 0.0166
-    - 0.0166
-    - 0.0166
-    - 0.0166
-    - 0.0166
-    - 0.0116
-    - 0.0116
+  - 0.8
+  - 0.0166 #Should be roughly 20%.... I think??? I don't know dude, I'm just a YAML monkey.
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0116
+  - 0.0116
   baseTurf: Space
   isSubfloor: true
   footstepSounds:
@@ -1482,22 +1137,6 @@
   name: tiles-asteroid-ironsand-borderless
   sprite: /Textures/Tiles/Asteroid/ironsand.png
   variants: 15
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   baseTurf: Space
   isSubfloor: true
   footstepSounds:
@@ -1578,14 +1217,6 @@
   name: tiles-cave
   sprite: /Textures/Tiles/cave.png
   variants: 7
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   baseTurf: Space
   isSubfloor: true
   footstepSounds:
@@ -1597,15 +1228,6 @@
   name: tiles-cave-drought
   sprite: /Textures/Tiles/cavedrought.png
   variants: 8
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   baseTurf: Space
   isSubfloor: true
   footstepSounds:
@@ -1618,11 +1240,6 @@
   name: tiles-flesh-floor
   sprite: /Textures/Tiles/meat.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepBlood
   itemDrop: FloorTileItemFlesh
@@ -1643,11 +1260,6 @@
   name: tiles-techmaint3-floor
   sprite: /Textures/Tiles/grating_maint.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepHull
   itemDrop: FloorTileItemGratingMaint
@@ -1658,11 +1270,6 @@
   name: tiles-wood2
   sprite: /Textures/Tiles/wood_tile.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepWood
   barestepSounds:
@@ -1675,14 +1282,6 @@
   name: tiles-wood3
   sprite: /Textures/Tiles/wood_broken.png
   variants: 7
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepWood
   barestepSounds:
@@ -1705,14 +1304,6 @@
   name: tiles-chromite
   sprite: /Textures/Tiles/chromite.png
   variants: 7
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   baseTurf: Space
   isSubfloor: true
   footstepSounds:
@@ -1747,11 +1338,6 @@
   name: tiles-astro-grass
   sprite: /Textures/Tiles/Planet/Grass/grass.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   edgeSpritePriority: 1
   edgeSprites:
     SouthEast: /Textures/Tiles/Planet/Grass/single_edge.png
@@ -1875,11 +1461,6 @@
   name: tiles-wood-large
   sprite: /Textures/Tiles/wood_large.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepWood
   barestepSounds:
@@ -1933,11 +1514,6 @@
   name: tiles-dark-squiggly
   sprite: /Textures/Tiles/dark_squiggly.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   itemDrop: FloorTileItemDarkSquiggly
   allowRotationMirror: true
 
@@ -1956,15 +1532,6 @@
   name: tiles-white-marble
   sprite: /Textures/Tiles/white_marble.png
   variants: 8
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   friction: 0.8
@@ -1976,15 +1543,6 @@
   name: tiles-dark-marble
   sprite: /Textures/Tiles/dark_marble.png
   variants: 8
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   friction: 0.8
@@ -1996,15 +1554,6 @@
   name: tiles-plasma-marble
   sprite: /Textures/Tiles/plasmarble.png
   variants: 8
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   friction: 0.8
@@ -2016,15 +1565,6 @@
   name: tiles-uranium-marble
   sprite: /Textures/Tiles/uranium_marble.png
   variants: 8
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   footstepSounds:
     collection: FootstepTile
   friction: 0.8

--- a/Resources/Prototypes/Tiles/ironsand.yml
+++ b/Resources/Prototypes/Tiles/ironsand.yml
@@ -14,11 +14,6 @@
   name: tiles-ironsand-concrete-tile
   sprite: /Textures/Tiles/Planet/Concrete/ironsandconcrete.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   baseTurf: Plating
   isSubfloor: false
   deconstructTools: [ Prying ]
@@ -32,11 +27,6 @@
   name: tiles-ironsand-concrete-slab
   sprite: /Textures/Tiles/Planet/Concrete/ironsandconcrete_mono.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   baseTurf: Plating
   isSubfloor: false
   deconstructTools: [ Prying ]
@@ -50,11 +40,6 @@
   name: tiles-ironsand-concrete-smooth
   sprite: /Textures/Tiles/Planet/Concrete/ironsandconcrete_smooth.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   baseTurf: Plating
   isSubfloor: false
   deconstructTools: [ Prying ]
@@ -68,11 +53,6 @@
   name: tiles-ironsand-packed
   sprite: /Textures/Tiles/Asteroid/ironsand_packed.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   baseTurf: Space
   isSubfloor: true
   footstepSounds:
@@ -85,11 +65,6 @@
   name: tiles-ironsand-paved
   sprite: /Textures/Tiles/Asteroid/ironsand_uneven_paved.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   baseTurf: Space
   isSubfloor: false
   footstepSounds:

--- a/Resources/Prototypes/Tiles/planet.yml
+++ b/Resources/Prototypes/Tiles/planet.yml
@@ -14,11 +14,6 @@
   name: tiles-dirt-planet-floor
   sprite: /Textures/Tiles/Planet/dirt.rsi/dirt.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
 
 # Desert
 - type: tile
@@ -27,26 +22,12 @@
   name: tiles-desert-floor
   sprite: /Textures/Tiles/Planet/Desert/desert.png
   variants: 6
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
 
 - type: tile
   id: FloorLowDesert
   name: tiles-low-desert-floor
   sprite: /Textures/Tiles/Planet/Desert/low_desert.png
   variants: 6
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
 
 # Grass
 - type: tile
@@ -55,11 +36,6 @@
   name: tiles-grass-planet-floor
   sprite: /Textures/Tiles/Planet/Grass/grass.png
   variants: 4
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
-  - 1.0
   edgeSpritePriority: 1
   edgeSprites:
     SouthEast: /Textures/Tiles/Planet/Grass/single_edge.png

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -52,10 +52,6 @@
   name: tiles-plating
   sprite: /Textures/Tiles/plating_damaged.png
   variants: 3
-  placementVariants:
-  - 1.0
-  - 1.0
-  - 1.0
 
 - type: tile
   id: PlatingAsteroid


### PR DESCRIPTION
## About the PR

Cleans up ContentTileDefinition.

Makes ContentTileDefinition.PlacementVariants nullable, and defaults it to null - if the field is null, it will be treated as a uniform distribution.  This saves a ton of unnecessary YAML definitions.

**Hide whitespace option recommended on GitHub.**

## Why / Balance
There are exactly three uses of non-uniform placementVariants in the codebase as-is, the rest are bloat.

nearly-free -500 line diff

ContentTileDefinition cleanup soon.

## Technical details

ContentTileDefinitions cleanup:
- File-scoped namespace for ContentTileDefinitions
- Removed redundant DataField names
- ItemDropPrototypeName turned from a string into a nullable EntProtoId
  - Made nullable to reference a comment made 3 years ago where tiles may not want to spawn anything when pried up.
- Unused imports cleaned up.

YAML slaml: all redundant PlacementVariants destroyed

Is the ItemDropPrototypeName change a breaking change?  Existing YAML definitions should be fine, and uses should be compatible since it's castable to/from string?

## Test plan

Run `variantize` with your grid a bunch, should work!

## Media

https://github.com/user-attachments/assets/9b3747e3-e947-4a98-ae6a-61b6e85c290b

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog