### PR TITLE
Hotfix: move construction condition from BaseUtility to surveillance camera

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -4,9 +4,6 @@
   id: BaseUtility
   category: construction-category-utilities
   placementMode: SnapgridCenter
-  conditions:
-  - !type:AgainstWall
-    offset: 0 # expects a wall to the north when the camera is in its north facing
 
 - type: construction
   abstract: true
@@ -23,6 +20,9 @@
   id: camera
   graph: SurveillanceCamera
   targetNode: camera
+  conditions:
+  - !type:AgainstWall
+    offset: 0 # expects a wall to the north when the camera is in its north facing
 
 - type: construction
   parent: BaseUtilityWallmount


### PR DESCRIPTION
## About the PR

Fixes a misplaced condition.

## Why / Balance

Must've goofed in one of the cleanup or AgainstWall condition merges.

## Technical details

Inheritance ops.  Only the camera should be placed up against a wall.

## Test plan

Build camera up against a wall, then in space.  It should only work up against a wall.
Build disposals in the middle of nowhere, it should work.

## Media

On the current head of master, these cable terminals would be unplaceable.
<img width="331" height="223" alt="image" src="https://github.com/user-attachments/assets/4e269d6c-7ed0-432b-ba8f-ba0a23756f03" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog