### PR TITLE
Change nix flake branch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782745641,
-        "narHash": "sha256-d1Uqn692SLRy743Gy1UTopaBBCAsgNbL9lmb03BxMTw=",
+        "lastModified": 1784160687,
+        "narHash": "sha256-iYL/bixrb6FlHFu/gIuBYzq6c6lM5AAXsXNSWXtIgQc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8cb14136bb517eba32a565a682861eef55c45a06",
+        "rev": "4382ed2b7a6839d4280a9b386db49cbc5907414d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-26.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Development environment for Space Station 14";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-26.05";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
   outputs =
     {


### PR DESCRIPTION
## About the PR
Switched the nix branch prefix from release to nixos. Updated to the current

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

release-YY.MM are the development branches, while nixos-YY.MM are the intended ones for use. 

Targeting release risks pinning untested code and often leads to rebuilding big packages when the nix cache has not caught up.

It is less documented then I like, and have made the mistake myself many times.

See e.g. for the difference between the branches:
https://github.com/NixOS/nixpkgs/blob/4382ed2b7a6839d4280a9b386db49cbc5907414d/CONTRIBUTING.md?plain=1#L352-L357
https://github.com/NixOS/nixpkgs/blob/4382ed2b7a6839d4280a9b386db49cbc5907414d/CONTRIBUTING.md?plain=1#L264-L266

Also see my review comments in #44417: https://github.com/space-wizards/space-station-14/pull/44417#pullrequestreview-4713146543

For transparency: I used an LLM to find a reference for the release vs nixos branch distinction, as I was not happy with the google results.

## Test plan
- enter the devshell through the flake via direnv, or by invoking "nix develop"
- all packages should be coming out of the nix cache, no building required
- build the project, invoke both runclient.sh and runserver.sh
- if you are on nixos-26.05 as an operating system, esp. the client should work, and not complain about the graphics driver

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

