### PR TITLE
fix: Skip thermal regulation if mob is dead

### DIFF
--- a/Content.Server/Body/Systems/ThermalRegulatorSystem.cs
+++ b/Content.Server/Body/Systems/ThermalRegulatorSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Body.Components;
 using Content.Server.Temperature.Systems;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Temperature.Components;
+using Content.Shared.Mobs.Systems;
 using Robust.Shared.Timing;
 
 namespace Content.Server.Body.Systems;
@@ -11,6 +12,7 @@ public sealed partial class ThermalRegulatorSystem : EntitySystem
     [Dependency] private IGameTiming _gameTiming = default!;
     [Dependency] private TemperatureSystem _tempSys = default!;
     [Dependency] private ActionBlockerSystem _actionBlockerSys = default!;
+    [Dependency] private MobStateSystem _mobState = default!;
 
     public override void Initialize()
     {
@@ -39,6 +41,11 @@ public sealed partial class ThermalRegulatorSystem : EntitySystem
                 continue;
 
             regulator.NextUpdate += regulator.UpdateInterval;
+
+            // The dead shouldn't be able to regulate their own body temperature.
+            if (_mobState.IsDead(uid))
+                return;
+
             ProcessThermalRegulation((uid, regulator));
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Dead mobs can no longer regulate body temperature.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- It's more realistic.
- I looked into this after couple failures to revive dead Tropico using cryogenics during my shifts.
- This allows dead mobs with low [heat capacity](https://github.com/space-wizards/space-station-14/blob/c0c1cd2948b0cdb9e28dc4411fb38d0e628c06fd/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs#L90)(size and density) to be chilled to the appropriate temperature for cryogenics chemicals.</br>Followig mobs are not able to be chilled enough for cryogenics while they are regulating body temperature:
  - crab
  - ferret
  - bat
  - bee
  - frog
  - duck
  - slug
  - ...
- Dead mobs in cryo pod will cool faster and eventually cool down to the pod's temperature.
  - Setting the cryogenics freezer temperature too low will have more consequences on patients. 
- Dead mobs will exchange heat faster with atmos environment and eventually match the gas temperature.
  - Extreme temperature condition will have more consequences on dead patients. 

## Technical details
<!-- Summary of code changes for easier review. -->
I copied exactly how [RespiratorSystem](https://github.com/space-wizards/space-station-14/blob/c0c1cd2948b0cdb9e28dc4411fb38d0e628c06fd/Content.Server/Body/Systems/RespiratorSystem.cs#L87) handle skipping dead mobs:
Check `MobStateSystem.IsDead()` and skip the dead mob entity in `ThermalRegulatorSystem.Update()`

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Prepare cryogenics with very low temperature
2. Place alive/dead mob into cryo pod
3. Observe patient temperature change and stabilize differently 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
|Alive|Dead \| Before|Dead \| After|
|---|---|---|
|<img width="553" height="203" alt="스크린샷 2026-07-17 174623" src="https://github.com/user-attachments/assets/b9a86f37-957c-4d19-ac51-3bf114f7c445" />|<img width="555" height="189" alt="image" src="https://github.com/user-attachments/assets/bedc1ea6-3e98-4391-bd62-95e90474cddb" />|<img width="550" height="186" alt="image" src="https://github.com/user-attachments/assets/b6b5eb21-cd27-41e2-b485-b1b927f59ca1" />|
|Alive Tropico can not be chilled enough for cryogenics as it regulating body temperature really well|Dead Tropico is somehow still regulating its own body temperature|Dead Tropico can no longer regulate its own body temperature and has been chilled enough|

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Dead mobs do not regulate body termperature anymore.
