### PR TITLE
Fix weapon targeting error spam for fixtureless entities

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -521,7 +521,7 @@ public sealed partial class GunSystem : SharedGunSystem
 
     private bool CheckFixtures(Entity<FixturesComponent?> entity)
     {
-        if (!Resolve(entity, ref entity.Comp))
+        if (!Resolve(entity, ref entity.Comp, false))
             return false;
 
         // TODO: Maybe also check that our cursor is intersecting a valid fixture?


### PR DESCRIPTION
## About the PR
Title.

Not all entities can have fixtures (such as stairs), and this is normal.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request ~and written instructions on how to test it~
- [X] I have added media to this PR or it does not require an in-game showcase.