### PR TITLE
Revert "WYA to Where you at (#42350)"

### DIFF
--- a/Resources/Locale/en-US/speech/speech-chatsan.ftl
+++ b/Resources/Locale/en-US/speech/speech-chatsan.ftl
@@ -192,6 +192,3 @@ chatsan-replacement-67 = all good
 
 chatsan-word-68 = idk
 chatsan-replacement-68 = i don't know
-
-chatsan-word-69 = wya
-chatsan-replacement-69 = where you at

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -306,7 +306,6 @@
     chatsan-word-66: chatsan-replacement-66
     chatsan-word-67: chatsan-replacement-67
     chatsan-word-68: chatsan-replacement-68
-    chatsan-word-69: chatsan-replacement-69 # :godo:
 
 - type: accent
   id: liar


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Stops transforming a misstyping of "way" as "wya" being converted to "where you at".
Fixes #44744

## Why / Balance
Too easily miss typed out. No more "By the where you at?" 

## Technical details
Reverts #42350

## Test plan
Say "wya" in chat.
No more changed text.

## Media
<img width="183" height="236" alt="image" src="https://github.com/user-attachments/assets/04a881d6-cb9e-46ba-ba64-43dd22749550" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
No CL needed
