### PR TITLE
Remove hardcoding from various GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    if: github.event.pull_request.draft == false
+    if: ${{ github.actor != vars.REPO_BOT_NAME && github.event.pull_request.draft == false }}
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -2,7 +2,7 @@
 
 on:
   push:
-    branches: [ master, main, develop, staging, stable ]
+    branches: [ master, main, develop, dev, staging, stable ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]

--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -2,7 +2,7 @@
 
 on:
   push:
-    branches: [ master, staging, stable ]
+    branches: [ master, main, develop, staging, stable ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    if: github.actor != 'PJBot' && github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -2,11 +2,11 @@ name: Build & Test Debug
 
 on:
   push:
-    branches: [ master, main, develop, staging, stable ]
+    branches: [ master, main, develop, dev, staging, stable ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
-    branches: [ master, main, develop, staging, stable ]
+    branches: [ master, main, develop, dev, staging, stable ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -2,11 +2,11 @@ name: Build & Test Debug
 
 on:
   push:
-    branches: [ master, staging, stable ]
+    branches: [ master, main, develop, staging, stable ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
-    branches: [ master, staging, stable ]
+    branches: [ master, main, develop, staging, stable ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    if: github.actor != 'PJBot' && github.event.pull_request.draft == false
+    if: ${{ github.actor != vars.REPO_BOT_NAME && github.event.pull_request.draft == false }}
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/heisendetector.yml
+++ b/.github/workflows/heisendetector.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   hunt:
+    if: ${{ github.repository == vars.UPSTREAM_REPO_NAME }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.get_fails.outputs.matrix }}

--- a/.github/workflows/labeler-conflict.yml
+++ b/.github/workflows/labeler-conflict.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   Label:
-    if: ( github.event.pull_request.draft == false ) && ( github.actor != 'PJBot' )
+    if: ${{ github.actor != vars.REPO_BOT_NAME && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Check for Merge Conflicts

--- a/.github/workflows/labeler-pr.yml
+++ b/.github/workflows/labeler-pr.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   labeler:
-    if: github.actor != 'PJBot'
+    if: ${{ github.actor != vars.REPO_BOT_NAME }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/labeler-review.yml
+++ b/.github/workflows/labeler-review.yml
@@ -4,8 +4,7 @@ on:
     types: [submitted]
 jobs:
   add_label:
-    # Change the repository name after you've made sure the team name is correct for your fork!
-    if: ${{ (github.repository == 'space-wizards/space-station-14') && (github.event.review.state == 'APPROVED') }}
+    if: ${{ (github.repository == vars.UPSTREAM_REPO_NAME) && (github.event.review.state == 'APPROVED') }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/no-submodule-update.yml
+++ b/.github/workflows/no-submodule-update.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   this_aint_right:
     name: Submodule update in pr found
-    if: github.actor != 'PJBot' && github.event.pull_request.draft == false
+    if: ${{ github.actor != vars.REPO_BOT_NAME && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == vars.UPSTREAM_REPO_NAME && vars.PUBLISH_TESTING_FORK_ID != '' }}
 
     steps:
     - uses: actions/checkout@v7
@@ -43,7 +44,7 @@ jobs:
       run: dotnet run --project Content.Packaging client --no-wipe-release
 
     - name: Publish version
-      run: Tools/publish_multi_request.py --fork-id wizards-testing
+      run: Tools/publish_multi_request.py --fork-id ${{ vars.PUBLISH_TESTING_FORK_ID }}
       env:
         PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
         GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == vars.UPSTREAM_REPO_NAME && vars.PUBLISH_FORK_ID != '' && vars.CDN_URL != '' }}
 
     steps:
     - name: Fail if we are attempting to run on the master branch
-      if: ${{GITHUB.REF_NAME == 'master' && github.repository == 'space-wizards/space-station-14'}}
+      if: ${{GITHUB.REF_NAME == 'master' && github.repository == vars.UPSTREAM_REPO_NAME}}
       run: exit 1
 
     - name: Install dependencies
@@ -47,7 +48,7 @@ jobs:
       run: dotnet run --project Content.Packaging client --no-wipe-release
 
     - name: Publish version
-      run: Tools/publish_multi_request.py
+      run: Tools/publish_multi_request.py --fork-id ${{ vars.PUBLISH_FORK_ID }} --cdn_url ${{ vars.CDN_URL }}
       env:
         PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
         GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }}

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -2,7 +2,7 @@
 
 on:
   push:
-    branches: [ master, main, develop, staging, stable ]
+    branches: [ master, main, develop, dev, staging, stable ]
     paths:
       - '**.cs'
       - '**.csproj'
@@ -16,7 +16,7 @@ on:
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
-    branches: [ master, main, develop, staging, stable ]
+    branches: [ master, main, develop, dev, staging, stable ]
     paths:
       - '**.cs'
       - '**.csproj'

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -2,7 +2,7 @@
 
 on:
   push:
-    branches: [ master, staging, stable ]
+    branches: [ master, main, develop, staging, stable ]
     paths:
       - '**.cs'
       - '**.csproj'
@@ -16,7 +16,7 @@ on:
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
-    branches: [ master, staging, stable ]
+    branches: [ master, main, develop, staging, stable ]
     paths:
       - '**.cs'
       - '**.csproj'
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   build:
     name: Test Packaging
-    if: github.actor != 'PJBot' && github.event.pull_request.draft == false
+    if: ${{ github.actor != vars.REPO_BOT_NAME && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update-credits.yml
+++ b/.github/workflows/update-credits.yml
@@ -8,9 +8,7 @@ on:
 jobs:
   get_credits:
     runs-on: ubuntu-latest
-    # Hey there fork dev! If you like to include your own contributors in this then you can probably just change this to your own repo
-    # Do this in dump_github_contributors.ps1 too into your own repo
-    if: github.repository == 'space-wizards/space-station-14'
+    if: ${{ github.repository == vars.UPSTREAM_REPO_NAME }}
 
     steps:
       - uses: actions/checkout@v7
@@ -38,7 +36,7 @@ jobs:
       #  uses: stefanzweifel/git-auto-commit-action@v4
       #  with:
       #    commit_message: Update Credits
-      #    commit_author: PJBot <pieterjan.briers+bot@gmail.com>
+      #    commit_author: ${{ vars.CREDITS_COMMIT_AUTHOR_NAME }} <${{ vars.CREDITS_COMMIT_AUTHOR_EMAIL }}>
 
       # This will make a PR
       - name: Set current date as env variable
@@ -47,8 +45,8 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: Update Credits
-          title: Update Credits
-          body: This is an automated Pull Request. This PR updates the github contributors in the credits section.
-          author: PJBot <pieterjan.briers+bot@gmail.com>
-          branch: automated/credits-${{env.NOW}}
+          commit-message: Update the in-game credits at time time ${{ github.event.repository.updated_at}}
+          title: Update in-game credits at time ${{ github.event.repository.updated_at}}
+          body: This is an automated Pull Request. This PR adds new GitHub contributors to the in-game credits section.
+          author: ${{ vars.CREDITS_COMMIT_AUTHOR_NAME }} <${{ vars.CREDITS_COMMIT_AUTHOR_EMAIL }}>
+          branch: automated/credits-${{ github.event.repository.updated_at}}

--- a/.github/workflows/update-credits.yml
+++ b/.github/workflows/update-credits.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: Update the in-game credits at time time ${{ github.event.repository.updated_at}}
+          commit-message: Update the in-game credits at time ${{ github.event.repository.updated_at}}
           title: Update in-game credits at time ${{ github.event.repository.updated_at}}
           body: This is an automated Pull Request. This PR adds new GitHub contributors to the in-game credits section.
           author: ${{ vars.CREDITS_COMMIT_AUTHOR_NAME }} <${{ vars.CREDITS_COMMIT_AUTHOR_EMAIL }}>

--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -1,7 +1,7 @@
 name: RGA schema validator
 on:
   push:
-    branches: [ master, staging, stable ]
+    branches: [ master, main, develop, staging, stable ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   yaml-schema-validation:
     name: YAML RGA schema validator
-    if: github.actor != 'PJBot' && github.event.pull_request.draft == false
+    if: ${{ github.actor != vars.REPO_BOT_NAME && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -1,7 +1,7 @@
 name: RGA schema validator
 on:
   push:
-    branches: [ master, main, develop, staging, stable ]
+    branches: [ master, main, develop, dev, staging, stable ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]

--- a/.github/workflows/validate-rsis.yml
+++ b/.github/workflows/validate-rsis.yml
@@ -2,7 +2,7 @@ name: RSI Validator
 
 on:
   push:
-    branches: [ master, staging, stable ]
+    branches: [ master, main, develop, staging, stable ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   validate_rsis:
     name: Validate RSIs
-    if: github.actor != 'PJBot' && github.event.pull_request.draft == false
+    if: ${{ github.actor != vars.REPO_BOT_NAME && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/validate-rsis.yml
+++ b/.github/workflows/validate-rsis.yml
@@ -2,7 +2,7 @@ name: RSI Validator
 
 on:
   push:
-    branches: [ master, main, develop, staging, stable ]
+    branches: [ master, main, develop, dev, staging, stable ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]

--- a/.github/workflows/validate_mapfiles.yml
+++ b/.github/workflows/validate_mapfiles.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   yaml-schema-validation:
     name: YAML map schema validator
-    if: github.actor != 'PJBot' && github.event.pull_request.draft == false
+    if: ${{ github.actor != vars.REPO_BOT_NAME && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: YAML Linter
-    if: github.actor != 'PJBot' && github.event.pull_request.draft == false
+    if: ${{ github.actor != vars.REPO_BOT_NAME && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/Tools/publish_github_artifact.py
+++ b/Tools/publish_github_artifact.py
@@ -11,13 +11,21 @@ GITHUB_REPOSITORY = os.environ["GITHUB_REPOSITORY"]
 VERSION = os.environ['GITHUB_SHA']
 
 #
-# CONFIGURATION PARAMETERS
-# Forks should change these to publish to their own infrastructure.
+# DEFAULT CONFIGURATION PARAMETERS
+# Forks can change these to point at their own infrastructure.
 #
 ROBUST_CDN_URL = "https://wizards.cdn.spacestation14.com/"
 FORK_ID = "wizards"
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fork-id", default=FORK_ID)
+    parser.add_argument("--cdn-url", default=ROBUST_CDN_URL)
+
+    args = parser.parse_args()
+    fork_id = args.fork_id
+    robust_cdn_url = args.cdn_url
+
     print("Fetching artifact URL from API...")
     artifact_url = get_artifact_url()
     print(f"Artifact URL is {artifact_url}, publishing to Robust.Cdn")
@@ -31,7 +39,7 @@ def main():
         "Authorization": f"Bearer {PUBLISH_TOKEN}",
         "Content-Type": "application/json"
     }
-    resp = requests.post(f"{ROBUST_CDN_URL}fork/{FORK_ID}/publish", json=data, headers=headers)
+    resp = requests.post(f"{robust_cdn_url}fork/{fork_id}/publish", json=data, headers=headers)
     resp.raise_for_status()
     print("Publish succeeded!")
 

--- a/Tools/publish_multi_request.py
+++ b/Tools/publish_multi_request.py
@@ -12,8 +12,8 @@ VERSION = os.environ["GITHUB_SHA"]
 RELEASE_DIR = "release"
 
 #
-# CONFIGURATION PARAMETERS
-# Forks should change these to publish to their own infrastructure.
+# DEFAULT CONFIGURATION PARAMETERS
+# Forks can change these to point at their own infrastructure.
 #
 ROBUST_CDN_URL = "https://wizards.cdn.spacestation14.com/"
 FORK_ID = "wizards"
@@ -21,9 +21,11 @@ FORK_ID = "wizards"
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--fork-id", default=FORK_ID)
+    parser.add_argument("--cdn-url", default=ROBUST_CDN_URL)
 
     args = parser.parse_args()
     fork_id = args.fork_id
+    robust_cdn_url = args.cdn_url
 
     session = requests.Session()
     session.headers = {
@@ -39,7 +41,7 @@ def main():
     headers = {
         "Content-Type": "application/json"
     }
-    resp = session.post(f"{ROBUST_CDN_URL}fork/{fork_id}/publish/start", json=data, headers=headers)
+    resp = session.post(f"{robust_cdn_url}fork/{fork_id}/publish/start", json=data, headers=headers)
     resp.raise_for_status()
     print("Publish successfully started, adding files...")
 
@@ -51,7 +53,7 @@ def main():
                 "Robust-Cdn-Publish-File": os.path.basename(file),
                 "Robust-Cdn-Publish-Version": VERSION
             }
-            resp = session.post(f"{ROBUST_CDN_URL}fork/{fork_id}/publish/file", data=f, headers=headers)
+            resp = session.post(f"{robust_cdn_url}fork/{fork_id}/publish/file", data=f, headers=headers)
 
         resp.raise_for_status()
 
@@ -63,7 +65,7 @@ def main():
     headers = {
         "Content-Type": "application/json"
     }
-    resp = session.post(f"{ROBUST_CDN_URL}fork/{fork_id}/publish/finish", json=data, headers=headers)
+    resp = session.post(f"{robust_cdn_url}fork/{fork_id}/publish/finish", json=data, headers=headers)
     resp.raise_for_status()
 
     print("SUCCESS!")


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
A five-minute "remove references to PJBot PR" evolved into a sweep of all Actions to remove Wizden-specific cruft, moving things that should be repo variables to being repo variables.

## Why / Balance
There's not really a good reason to force downstreams, forkers and people who do not want to receive weekly emails about how random CI failed because they didn't turn off Actions on their content fork to patch out random Wizden-specific CI.

## Technical details
* Shunted a lot of hard-coded strings to being variables.
* Protected all cron jobs from running unless a repository variable is set.
* Added `main`, `dev`, and `develop` to the list of protected branches on some CI commands, because those are common names for the main thread of a repo.
* Made sure that the two Python scripts used for publishing can pipe in custom CDN URLs. Piping in the fork ID was patched into one of the two scripts already, so it's just incomplete work that's been completed.
* Made the credits bot's commits slightly more descriptive.

Vars:
* `REPO_BOT_NAME`: The name of your repo's automated bot. It used to be `PJBot` here.
* `UPSTREAM_REPO_NAME`: The name of your fork's repo. For Wizden this is `space-wizards/space-station-14`. For a downstream server it'll be their fork's core codebase (e.g. `Goob-Station/Goob-Station`).
* `PUBLISH_TESTING_FORK_ID`: The name of your repo's testing fork. For Wizden this is `wizards-testing`. Used when publishing test builds.
* `PUBLISH_FORK_ID`: The ID of your fork on the CDN. For Wizden this is `wizards`.
* `CDN_URL`: The URL of your Robust CDN.
* `CREDITS_COMMIT_AUTHOR_NAME`: The name of the author of your automated credits commits. E.g. "Credits Bot".
* `CREDITS_COMMIT_AUTHOR_EMAIL`: The email of the author of your automated credits commits. E.g. "credits@myfancywebsite.io".

## Test plan
Merge this and see what CI breaks :godo:

Testing this needs organization admin permissions as you'll need to set the env vars. You'll then need to run the modified CI jobs to detect anything. But honestly given how awful Actions is, merge-and-hotfix seems pretty inevitable.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
Nah
