### PR TITLE
Hotfix: Check recipient lifecycle in StackSystem.TryMergeStacks

### DIFF
--- a/Content.Shared/Stacks/SharedStackSystem.API.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.API.cs
@@ -121,6 +121,11 @@ public abstract partial class SharedStackSystem
         if (donor == recipient)
             return false;
 
+        // Recipient is being torn down, don't give it anything.
+        if (TerminatingOrDeleted(recipient)
+            || EntityManager.IsQueuedForDeletion(recipient))
+            return false;
+
         // Check they're stacks of the same type
         if (!_stackQuery.Resolve(recipient, ref recipient.Comp, false)
             || !_stackQuery.Resolve(donor, ref donor.Comp, false)


### PR DESCRIPTION
## About the PR

Hotfix: check the lifecycle of recipient entities when transferring between stacks.

## Why / Balance

Regression from #44496.

Fixes #44740.

## Technical details

Check originally in TryMergeToContacts at https://github.com/space-wizards/space-station-14/pull/44496/changes#diff-e0c3beafe52e97adb1f369d3fb3a10c483a879f2d2cdf7c05cc554c176fd7fd5L129

Check moved into TryMergeStack, which is called by TryMergeToContacts.

## Test plan
Spawn diamonds, an ore processor, and an industrial ore processor.

Refine the diamonds.  You should get thirty in the ore processor, and about 40 in the industrial ore processor.

## Media
Before refinement: two full stacks of diamond ore
<img width="1282" height="759" alt="image" src="https://github.com/user-attachments/assets/0807537b-7c5b-4d27-95e8-739d50a99295" />

After refinement: one stack of 30 from the ore processor, and 40 from the industrial ore processor.
<img width="1282" height="759" alt="image" src="https://github.com/user-attachments/assets/ee89b6c7-6915-4b35-b5b4-7b9f0ac7671c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The ore processor produces the correct amount of refined material when smelting in batches.
