### PR TITLE
Allow wrapping nuke disk in parcel wrap

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.TradeStation.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.TradeStation.cs
@@ -167,15 +167,13 @@ public sealed partial class CargoSystem
                 // - anything already being sold
                 // - anything anchored (e.g. light fixtures)
                 // - anything blacklisted (e.g. players).
+                // - anything containing anything we should not sell
                 if (toSell.Contains(ent) ||
                     TryComp(ent, out TransformComponent? xform) &&
                     (xform.Anchored || !CanSell(ent)))
                 {
                     continue;
                 }
-
-                if (_cargoSellBlacklistQuery.HasComponent(ent))
-                    continue;
 
                 var price = _pricing.GetPrice(ent);
                 if (price == 0)
@@ -205,6 +203,11 @@ public sealed partial class CargoSystem
 
             if (!CanSell(child))
                 return false;
+        }
+
+        if (_cargoSellBlacklistQuery.HasComponent(uid))
+        {
+            return false;
         }
 
         return true;

--- a/Resources/Prototypes/Entities/Objects/Misc/parcel_wrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/parcel_wrap.yml
@@ -21,11 +21,9 @@
       - ParcelWrapOverride
     blacklist:
       components:
-      - NukeDisk # Don't try to hide the disk.
       - WrappedParcel # No wrapping wrapped things.
       tags:
       - ParcelWrapBlacklist
-      - FakeNukeDisk # So you can't tell if the nuke disk is real or fake depending on if it can be wrapped or not.
   - type: LimitedCharges
     maxCharges: 30
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
You can now wrap the nuke disk in parcel wrap. It was specifically blacklisted before.

fix https://github.com/space-wizards/space-station-14/issues/44603

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
You can already stuff the disk in plushies(!). Wrapping it in a parcel is even more funny (subjective) and it's **even easier to get it back** (don't even need a knife, you unwrap it with your hands). There is no reason to forbid wrapping it. 

Remember that it's very simple for someone with a pinpointer to pinpoint the disk exactly, even if wrapped, and unwrapping takes one second.