### PR TITLE
Tweak/add Salvage debris ambience

### DIFF
--- a/Content.Shared/EntityConditions/Conditions/Generic/NearPlayerConditionSystem.cs
+++ b/Content.Shared/EntityConditions/Conditions/Generic/NearPlayerConditionSystem.cs
@@ -1,0 +1,61 @@
+using Content.Shared.Ghost;
+using Content.Shared.Mind.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.EntityConditions.Conditions.Generic;
+
+/// <summary>
+/// Checks if the entity is near a player
+/// </summary>
+public sealed partial class NearPlayerConditionSystem : EntityConditionSystem<TransformComponent, NearPlayerCondition>
+{
+    [Dependency] private EntityLookupSystem _lookup = default!;
+
+    protected override void Condition(Entity<TransformComponent> entity, ref EntityConditionEvent<NearPlayerCondition> args)
+    {
+        var entities = _lookup.GetEntitiesInRange<MindExaminableComponent>(entity.Comp.Coordinates, args.Condition.Range, LookupFlags.Uncontained);
+        var count = 0;
+
+        foreach (var foundEnt in entities)
+        {
+            if (foundEnt.Owner == entity.Owner)
+                continue;
+
+            if (foundEnt.Comp.State != args.Condition.State)
+                continue;
+
+            count++;
+
+            if (count >= args.Condition.Count)
+            {
+                args.Result = true;
+                return;
+            }
+        }
+    }
+}
+
+
+/// <inheritdoc cref="EntityCondition"/>
+public sealed partial class NearPlayerCondition : EntityConditionBase<NearPlayerCondition>
+{
+    /// <summary>
+    /// Desired mindstate to check for
+    /// </summary>
+    [DataField]
+    public MindState State = MindState.None;
+
+    /// <summary>
+    /// Range around entity to check
+    /// </summary>
+    [DataField]
+    public float Range = 10f;
+
+    /// <summary>
+    /// Amount of players that need to be nearby.
+    /// </summary>
+    [DataField]
+    public int Count = 1;
+
+    public override string EntityConditionGuidebookText(IPrototypeManager prototype) => String.Empty;
+}

--- a/Content.Shared/EntityConditions/Conditions/Generic/OnStationGridConditionSystem.cs
+++ b/Content.Shared/EntityConditions/Conditions/Generic/OnStationGridConditionSystem.cs
@@ -1,0 +1,22 @@
+using Content.Shared.Station.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.EntityConditions.Conditions.Generic;
+
+/// <summary>
+/// Returns true if entity is on a station grid
+/// </summary>
+public sealed class OnStationGridConditionSystem : EntityConditionSystem<TransformComponent, OnStationGridCondition>
+{
+    protected override void Condition(Entity<TransformComponent> entity, ref EntityConditionEvent<OnStationGridCondition> args)
+    {
+        args.Result = HasComp<StationMemberComponent>(entity.Comp.GridUid);
+    }
+}
+
+
+/// <inheritdoc cref="EntityCondition"/>
+public sealed partial class OnStationGridCondition : EntityConditionBase<OnStationGridCondition>
+{
+    public override string EntityConditionGuidebookText(IPrototypeManager prototype) => String.Empty;
+}

--- a/Resources/Prototypes/AmbientMusic/areas.yml
+++ b/Resources/Prototypes/AmbientMusic/areas.yml
@@ -53,6 +53,31 @@
     collection: AmbienceMining
   fadeIn: true
   interruptable: true
-  priority: 1
+  priority: 4
   conditions:
   - !type:OnMapGridCondition
+
+- type: ambientMusic
+  id: Salvage
+  sound:
+    params:
+      volume: -12
+    collection: AmbienceRuins
+  fadeIn: true
+  interruptable: true
+  priority: 4
+  conditions:
+  - !type:GridInRangeCondition # make sure we're on or near a grid
+    range: 4
+  - !type:OnStationGridCondition # make sure that grid isn't the station
+    inverted: true
+  - !type:NearPlayerCondition # only want the spooky sounds to play when the player is somewhat isolated
+    inverted: true
+    count: 2
+    range: 10
+  - !type:NearbyComponentsCondition # make sure we aren't on a shuttle
+    anchored: true
+    count: 1
+    components:
+    - type: Thruster
+    range: 10

--- a/Resources/Prototypes/AmbientMusic/collections.yml
+++ b/Resources/Prototypes/AmbientMusic/collections.yml
@@ -85,7 +85,6 @@
   id: AmbienceRuins
   files:
     - /Audio/Ambience/ambicave.ogg
-    - /Audio/Ambience/ambidanger.ogg
     - /Audio/Ambience/ambidanger2.ogg
     - /Audio/Ambience/ambimaint1.ogg
     - /Audio/Ambience/ambimine.ogg
@@ -97,6 +96,8 @@
     - /Audio/Ambience/ambiruin5.ogg
     - /Audio/Ambience/ambiruin6.ogg
     - /Audio/Ambience/ambiruin7.ogg
+    - /Audio/Ambience/ambireebe1.ogg
+    - /Audio/Ambience/ambireebe3.ogg
 
 - type: soundCollection
   id: AmbienceSpace

--- a/Resources/Prototypes/AmbientMusic/generic.yml
+++ b/Resources/Prototypes/AmbientMusic/generic.yml
@@ -49,4 +49,3 @@
     tiles:
     - TrainLattice
     range: 4
-


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Ambient music should now play when you are on salvage wrecks or debris or magnet pulls. A sound collection existed but I guess was never setup to work.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Ambient music will add to the atmosphere, should be better than the default maintenance ambience playing on debris.

## Technical details
<!-- Summary of code changes for easier review. -->
`NearPlayerCondition` which will check if there is a nearby _player_ (not mob) 
`OnStationGridCondition` which checks if the given entity is on a station grid or not.

also tweaked the ambienceruins collection a bit 

also tweaked the priority of the salvage expedition ambience, it would literally never play before.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. `sudo cvar shuttle.grid_fill true`
2. go to some debris in space
3. listen and make sure the proper ambience plays

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
