### PR TITLE
Accents Relay Fix

### DIFF
--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -67,9 +67,9 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, BeforeEmoteEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, StoodEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, DownedEvent>(RelayInventoryEvent);
-        SubscribeLocalEvent<InventoryComponent, AccentGetEvent>(RefRelayInventoryEvent);
 
         // by-ref events
+        SubscribeLocalEvent<InventoryComponent, AccentGetEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshFrictionModifiersEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, BeforeStaminaDamageEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, GetExplosionResistanceEvent>(RefRelayInventoryEvent);

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -67,7 +67,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, BeforeEmoteEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, StoodEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, DownedEvent>(RelayInventoryEvent);
-        SubscribeLocalEvent<InventoryComponent, AccentGetEvent>(RelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, AccentGetEvent>(RefRelayInventoryEvent);
 
         // by-ref events
         SubscribeLocalEvent<InventoryComponent, RefreshFrictionModifiersEvent>(RefRelayInventoryEvent);

--- a/Content.Shared/Speech/EntitySystems/RelayAccentSystem.cs
+++ b/Content.Shared/Speech/EntitySystems/RelayAccentSystem.cs
@@ -34,13 +34,7 @@ public abstract class RelayAccentSystem<T> : EntitySystem where T : BaseAccentCo
     {
         SubscribeLocalEvent<T, AccentGetEvent>(OnAccent, before: AccentBefore, after: AccentAfter);
         SubscribeLocalEvent<T, InventoryRelayedEvent<AccentGetEvent>>(OnInventoryRelayAccent, before: RelayAccentBefore, after: RelayAccentAfter);
-        SubscribeLocalEvent<T, StatusEffectRelayedEvent<AccentGetEvent>>((e, c, ev) =>
-        {
-            var accentGetEvent = ev.Args;
-            OnAccent((e, c), ref accentGetEvent);
-        },
-        before: RelayAccentBefore,
-        after: RelayAccentAfter);
+        SubscribeLocalEvent<T, StatusEffectRelayedEvent<AccentGetEvent>>(OnStatusEffectRelayAccent, before: RelayAccentBefore, after: RelayAccentAfter);
     }
 
     protected virtual void OnInventoryRelayAccent(Entity<T> ent, ref InventoryRelayedEvent<AccentGetEvent> args)
@@ -49,6 +43,13 @@ public abstract class RelayAccentSystem<T> : EntitySystem where T : BaseAccentCo
             return;
 
         OnAccent(ent, ref args.Args);
+    }
+
+    protected virtual void OnStatusEffectRelayAccent(Entity<T> ent, ref StatusEffectRelayedEvent<AccentGetEvent> args)
+    {
+        var ev = args.Args;
+        OnAccent(ent, ref ev);
+        args.Args = ev;
     }
 
     protected virtual void OnAccent(Entity<T> ent, ref AccentGetEvent args)


### PR DESCRIPTION
Fixed an issue introduced during the review of #43008, where `EntityEventArgs` was removed from `AccentGetEvent`, which subsequently required a change to the Relay logic 

Status Effects
<img width="142" height="128" alt="image" src="https://github.com/user-attachments/assets/2ee02aa2-58d3-4004-8418-7daa843f304f" />

Inventory
<img width="135" height="133" alt="image" src="https://github.com/user-attachments/assets/4d808f1a-0a14-43f4-959a-41d2d2985e46" />
