### PR TITLE
Add new changelog project, update changelogs on test publish

### DIFF
--- a/.github/workflows/changelog-test.yml
+++ b/.github/workflows/changelog-test.yml
@@ -1,0 +1,32 @@
+name: Test Changelog
+
+on:
+  push:
+    paths:
+      - Changelog
+      - Changelog.Tests
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - name: Checkout Master
+      uses: actions/checkout@v7
+
+    - name: Setup Submodule
+      run: |
+        git submodule update --init --recursive
+
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Install dependencies
+      run: dotnet restore
+
+    - name: Run Changelog.Tests
+      shell: pwsh
+      run: dotnet test Changelog.Tests

--- a/.github/workflows/changelog-test.yml
+++ b/.github/workflows/changelog-test.yml
@@ -7,7 +7,7 @@ on:
       - 'Changelog.Tests/**'
 
 jobs:
-  build:
+  test-changelog:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/changelog-test.yml
+++ b/.github/workflows/changelog-test.yml
@@ -3,8 +3,8 @@ name: Test Changelog
 on:
   push:
     paths:
-      - Changelog
-      - Changelog.Tests
+      - 'Changelog/**'
+      - 'Changelog.Tests/**'
 
 jobs:
   build:

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        sparse-checkout: >
+        sparse-checkout: |
           Resources/Changelog
           Changelog
     - name: Setup .NET Core

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        sparse-checkout: 'Resources/Changelog'
+        sparse-checkout: 'Resources/Changelog/*'
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -72,14 +72,14 @@ jobs:
     - name: Package client
       run: dotnet run --project Content.Packaging client --no-wipe-release
 
-    - name: Publish version
-      run: Tools/publish_multi_request.py --fork-id wizards-testing
-      env:
-        PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-        GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }}
-
-    - name: Publish changelog (RSS)
-      continue-on-error: true
-      run: Tools/actions_changelog_rss.py
-      env:
-        CHANGELOG_RSS_KEY: ${{ secrets.CHANGELOG_RSS_KEY }}
+#    - name: Publish version
+#      run: Tools/publish_multi_request.py --fork-id wizards-testing
+#      env:
+#        PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+#        GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }}
+#
+#    - name: Publish changelog (RSS)
+#      continue-on-error: true
+#      run: Tools/actions_changelog_rss.py
+#      env:
+#        CHANGELOG_RSS_KEY: ${{ secrets.CHANGELOG_RSS_KEY }}

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
+      with:
+        submodules: 'recursive'
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -37,7 +37,7 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         file_pattern: 'Resources/Changelog/*.yml'
-        commit_author: 'CentComm'
+        commit_author: 'CentComm <CentComm@users.noreply.github.com>'
         commit_user_name: 'CentComm'
         commit_message: Automated changelog update [skip ci]
 

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -30,7 +30,6 @@ jobs:
       env:
         REPO: space-wizards/space-station-14
         BRANCH: master
-        GITHUB_TOKEN: {{ secrets.GITHUB_TOKEN }}
 
     - name: Commit changelog update
       uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -18,8 +18,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-      with:
-        sparse-checkout: 'Resources/Changelog/*'
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -30,6 +30,7 @@ jobs:
       env:
         REPO: space-wizards/space-station-14
         BRANCH: master
+        EXTRA_CATEGORIES: Admin,Maps,Rules
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Commit changelog update

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -33,6 +33,13 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
 
+    - name: Update changelog YML
+      run: dotnet run --project Changelog update -d Resources/Changelog
+      env:
+        REPO: space-wizards/space-station-14
+        BRANCH: master
+        GITHUB_TOKEN: {{ secrets.GITHUB_TOKEN }}
+
     - name: Build Packaging
       run: dotnet build Content.Packaging --configuration Release --no-restore /m
 

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -19,9 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        sparse-checkout: |
-          Resources/Changelog
-          Changelog
+        submodules: 'recursive'
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -30,6 +30,7 @@ jobs:
       env:
         REPO: space-wizards/space-station-14
         BRANCH: master
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Commit changelog update
       uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -19,7 +19,9 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        submodules: 'recursive'
+        sparse-checkout: >
+          Resources/Changelog
+          Changelog
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -36,7 +36,7 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         file_pattern: 'Resources/Changelog/*.yml'
-        commit_message: Automated changelog update
+        commit_message: Automated changelog update [skip ci]
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -37,6 +37,8 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         file_pattern: 'Resources/Changelog/*.yml'
+        commit_author: 'CentComm'
+        commit_user_name: 'CentComm'
         commit_message: Automated changelog update [skip ci]
 
   build:

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -72,14 +72,14 @@ jobs:
     - name: Package client
       run: dotnet run --project Content.Packaging client --no-wipe-release
 
-#    - name: Publish version
-#      run: Tools/publish_multi_request.py --fork-id wizards-testing
-#      env:
-#        PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-#        GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }}
-#
-#    - name: Publish changelog (RSS)
-#      continue-on-error: true
-#      run: Tools/actions_changelog_rss.py
-#      env:
-#        CHANGELOG_RSS_KEY: ${{ secrets.CHANGELOG_RSS_KEY }}
+    - name: Publish version
+      run: Tools/publish_multi_request.py --fork-id wizards-testing
+      env:
+        PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+        GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }}
+
+    - name: Publish changelog (RSS)
+      continue-on-error: true
+      run: Tools/actions_changelog_rss.py
+      env:
+        CHANGELOG_RSS_KEY: ${{ secrets.CHANGELOG_RSS_KEY }}

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -10,8 +10,38 @@ on:
   - cron: '0 10 * * *'
 
 jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        sparse-checkout: 'Resources/Changelog'
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Update changelog YML
+      run: dotnet run --project Changelog update -d Resources/Changelog
+      env:
+        REPO: space-wizards/space-station-14
+        BRANCH: master
+        GITHUB_TOKEN: {{ secrets.GITHUB_TOKEN }}
+
+    - name: Commit changelog update
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        file_pattern: 'Resources/Changelog/*.yml'
+        commit_message: Automated changelog update
+
   build:
     runs-on: ubuntu-latest
+
+    needs: update-changelog
 
     steps:
     - uses: actions/checkout@v7
@@ -32,13 +62,6 @@ jobs:
 
     - name: Install dependencies
       run: dotnet restore
-
-    - name: Update changelog YML
-      run: dotnet run --project Changelog update -d Resources/Changelog
-      env:
-        REPO: space-wizards/space-station-14
-        BRANCH: master
-        GITHUB_TOKEN: {{ secrets.GITHUB_TOKEN }}
 
     - name: Build Packaging
       run: dotnet build Content.Packaging --configuration Release --no-restore /m

--- a/Changelog.Tests/Changelog.Tests.csproj
+++ b/Changelog.Tests/Changelog.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+
+        <RootNamespace>SS14.Changelog.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="NUnit" Version="4.0.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Changelog\Changelog.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Changelog.Tests/ChangelogParseTest.cs
+++ b/Changelog.Tests/ChangelogParseTest.cs
@@ -1,0 +1,275 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework;
+using Changelog;
+
+namespace SS14.Changelog.Tests
+{
+    [Parallelizable(ParallelScope.All)]
+    [TestFixture]
+    // NUnit assertion is bugged.
+    [SuppressMessage("Assertion", "NUnit2022:Missing property required for constraint")]
+    public class ChangelogParseTest
+    {
+        [Test]
+        public void Test()
+        {
+            const string text = """
+                Did stuff!
+
+                :cl: Ev1__l P-JB2323
+                - add: Did the thing
+                - remove: Removed the thing
+                - fix: A
+                - bugfix: B
+                - bug: C
+
+                """;
+
+            var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
+            var pr = new GHPullRequest(true, text, new GHUser("PJB"), time, new GHPullRequestBase("master"), 123,
+                "https://www.example.com");
+            var parsed = PR.ParsePRBody(pr, []);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(parsed, Is.Not.Null);
+                Assert.That(parsed.Author, Is.EqualTo("Ev1__l P-JB2323"));
+                Assert.That(parsed.Time, Is.EqualTo(time));
+                Assert.That(parsed.HtmlUrl, Is.EqualTo("https://www.example.com"));
+                Assert.That(parsed.Categories, Has.Length.EqualTo(1));
+                Assert.That(parsed.Categories, Has.One
+                    .Property(nameof(ChangelogData.CategoryData.Category)).EqualTo(ChangelogData.MainCategory)
+                    .And.Property(nameof(ChangelogData.CategoryData.Changes)).EquivalentTo(new ChangelogData.Change[]
+                    {
+                        new(ChangelogData.ChangeType.Add, "Did the thing"),
+                        new(ChangelogData.ChangeType.Remove, "Removed the thing"),
+                        new(ChangelogData.ChangeType.Fix, "A"),
+                        new(ChangelogData.ChangeType.Fix, "B"),
+                        new(ChangelogData.ChangeType.Fix, "C"),
+                    }));
+            });
+        }
+
+        [Test]
+        public void TestWithoutName()
+        {
+            const string text = """
+
+                Did stuff!
+
+                :cl:
+                - add: Did the thing
+                - remove: Removed the thing
+
+                """;
+
+            var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
+            var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
+                "https://www.example.com");
+            var parsed = PR.ParsePRBody(pr, []);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(parsed, Is.Not.Null);
+                Assert.That(parsed.Author, Is.EqualTo("Swept"));
+                Assert.That(parsed.Time, Is.EqualTo(time));
+                Assert.That(parsed.HtmlUrl, Is.EqualTo("https://www.example.com"));
+                Assert.That(parsed.Categories, Has.Length.EqualTo(1));
+                Assert.That(parsed.Categories, Has.One
+                    .Property(nameof(ChangelogData.CategoryData.Category)).EqualTo(ChangelogData.MainCategory)
+                    .And.Property(nameof(ChangelogData.CategoryData.Changes)).EquivalentTo(new ChangelogData.Change[]
+                    {
+                        new(ChangelogData.ChangeType.Add, "Did the thing"),
+                        new(ChangelogData.ChangeType.Remove, "Removed the thing"),
+                    }));
+            });
+        }
+
+        [Test]
+        public void TestComment()
+        {
+            const string text = """
+
+                Did stuff!
+
+                <!-- The :cl: symbol
+                -->
+
+                :cl:
+                - add: Did the thing
+                - remove: Removed the thing
+
+                """;
+
+            var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
+            var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
+                "https://www.example.com");
+            var parsed = PR.ParsePRBody(pr, []);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(parsed, Is.Not.Null);
+                Assert.That(parsed.Author, Is.EqualTo("Swept"));
+                Assert.That(parsed.Time, Is.EqualTo(time));
+                Assert.That(parsed.HtmlUrl, Is.EqualTo("https://www.example.com"));
+                Assert.That(parsed.Categories, Has.Length.EqualTo(1));
+                Assert.That(parsed.Categories, Has.One
+                    .Property(nameof(ChangelogData.CategoryData.Category)).EqualTo(ChangelogData.MainCategory)
+                    .And.Property(nameof(ChangelogData.CategoryData.Changes)).EquivalentTo(new ChangelogData.Change[]
+                    {
+                        new(ChangelogData.ChangeType.Add, "Did the thing"),
+                        new(ChangelogData.ChangeType.Remove, "Removed the thing"),
+                    }));
+            });
+        }
+
+        [Test]
+        public void TestBroke()
+        {
+            const string text =
+                "Makes it possible to repair things with a welder.\r\n\r\n**Changelog**\r\n:cl: AJCM\r\n- add: Makes gravity generator and windows repairable with a lit welding tool \r\n\r\n";
+
+            var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
+            var pr = new GHPullRequest(true, text, new GHUser("AJCM-Git"), time, new GHPullRequestBase("master"), 123,
+                "https://www.example.com");
+            var parsed = PR.ParsePRBody(pr, []);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(parsed, Is.Not.Null);
+                Assert.That(parsed.Author, Is.EqualTo("AJCM"));
+                Assert.That(parsed.Time, Is.EqualTo(time));
+                Assert.That(parsed.HtmlUrl, Is.EqualTo("https://www.example.com"));
+                Assert.That(parsed.Categories, Has.Length.EqualTo(1));
+                Assert.That(parsed.Categories, Has.One
+                    .Property(nameof(ChangelogData.CategoryData.Category)).EqualTo(ChangelogData.MainCategory)
+                    .And.Property(nameof(ChangelogData.CategoryData.Changes)).EquivalentTo(new ChangelogData.Change[]
+                    {
+                        new(ChangelogData.ChangeType.Add, "Makes gravity generator and windows repairable with a lit welding tool"),
+                    }));
+            });
+        }
+
+        [Test]
+        public void TestCategory()
+        {
+            const string text = """
+
+                Did stuff!
+
+                :cl:
+                ADMIN:
+                - add: Did the thing
+                - remove: Removed the thing
+
+                """;
+
+            var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
+            var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
+                "https://www.example.com");
+            var parsed = PR.ParsePRBody(pr, []);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(parsed, Is.Not.Null);
+                Assert.That(parsed.Author, Is.EqualTo("Swept"));
+                Assert.That(parsed.Time, Is.EqualTo(time));
+                Assert.That(parsed.HtmlUrl, Is.EqualTo("https://www.example.com"));
+                Assert.That(parsed.Categories, Has.Length.EqualTo(1));
+                Assert.That(parsed.Categories, Has.One
+                    .Property(nameof(ChangelogData.CategoryData.Category)).EqualTo(ChangelogData.MainCategory)
+                    .And.Property(nameof(ChangelogData.CategoryData.Changes)).EquivalentTo(new ChangelogData.Change[]
+                    {
+                        new(ChangelogData.ChangeType.Add, "Did the thing"),
+                        new(ChangelogData.ChangeType.Remove, "Removed the thing"),
+                    }));
+            });
+        }
+
+        [Test]
+        public void TestCategoryMulti()
+        {
+            const string text = """
+
+                Did stuff!
+
+                :cl:
+                ADMIN:
+                - add: Did the thing
+                - remove: Removed the thing
+                MAIN:
+                - add: Did more thing
+                - remove: Removed more thing
+                ADMIN:
+                - fix: Fix the thing
+                """;
+
+            var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
+            var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
+                "https://www.example.com");
+            var parsed = PR.ParsePRBody(pr, ["Admin"]);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(parsed, Is.Not.Null);
+                Assert.That(parsed.Author, Is.EqualTo("Swept"));
+                Assert.That(parsed.Time, Is.EqualTo(time));
+                Assert.That(parsed.HtmlUrl, Is.EqualTo("https://www.example.com"));
+                Assert.That(parsed.Categories, Has.Length.EqualTo(2));
+                Assert.That(parsed.Categories, Has.One
+                    .Property(nameof(ChangelogData.CategoryData.Category)).EqualTo("Admin")
+                    .And.Property(nameof(ChangelogData.CategoryData.Changes)).EquivalentTo(new ChangelogData.Change[]
+                    {
+                        new(ChangelogData.ChangeType.Add, "Did the thing"),
+                        new(ChangelogData.ChangeType.Remove, "Removed the thing"),
+                        new(ChangelogData.ChangeType.Fix, "Fix the thing"),
+                    }));
+                Assert.That(parsed.Categories, Has.One
+                    .Property(nameof(ChangelogData.CategoryData.Category)).EqualTo(ChangelogData.MainCategory)
+                    .And.Property(nameof(ChangelogData.CategoryData.Changes)).EquivalentTo(new ChangelogData.Change[]
+                    {
+                        new(ChangelogData.ChangeType.Add, "Did more thing"),
+                        new(ChangelogData.ChangeType.Remove, "Removed more thing"),
+                    }));
+            });
+        }
+
+        [Test]
+        public void TestCategoryInvalid()
+        {
+            const string text = """
+
+                Did stuff!
+
+                :cl:
+                - add: Did the thing
+                - remove: Removed the thing
+                NOTACATEGORY:
+                - add: WOW
+                """;
+
+            var time = new DateTimeOffset(2021, 1, 1, 1, 1, 1, TimeSpan.Zero);
+            var pr = new GHPullRequest(true, text, new GHUser("Swept"), time, new GHPullRequestBase("master"), 123,
+                "https://www.example.com");
+            var parsed = PR.ParsePRBody(pr, ["Admin"]);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(parsed, Is.Not.Null);
+                Assert.That(parsed.Author, Is.EqualTo("Swept"));
+                Assert.That(parsed.Time, Is.EqualTo(time));
+                Assert.That(parsed.HtmlUrl, Is.EqualTo("https://www.example.com"));
+                Assert.That(parsed.Categories, Has.Length.EqualTo(1));
+                Assert.That(parsed.Categories, Has.One
+                    .Property(nameof(ChangelogData.CategoryData.Category)).EqualTo(ChangelogData.MainCategory)
+                    .And.Property(nameof(ChangelogData.CategoryData.Changes)).EquivalentTo(new ChangelogData.Change[]
+                    {
+                        new(ChangelogData.ChangeType.Add, "Did the thing"),
+                        new(ChangelogData.ChangeType.Remove, "Removed the thing"),
+                        new(ChangelogData.ChangeType.Add, "WOW"),
+                    }));
+            });
+        }
+    }
+}

--- a/Changelog.Tests/ChangelogParseTest.cs
+++ b/Changelog.Tests/ChangelogParseTest.cs
@@ -271,5 +271,11 @@ namespace SS14.Changelog.Tests
                     }));
             });
         }
+
+        [Test]
+        public void TestFail()
+        {
+            Assert.That(false);
+        }
     }
 }

--- a/Changelog.Tests/ChangelogParseTest.cs
+++ b/Changelog.Tests/ChangelogParseTest.cs
@@ -271,11 +271,5 @@ namespace SS14.Changelog.Tests
                     }));
             });
         }
-
-        [Test]
-        public void TestFail()
-        {
-            Assert.That(false);
-        }
     }
 }

--- a/Changelog/.env.example
+++ b/Changelog/.env.example
@@ -2,6 +2,6 @@ REPO=space-wizards/space-station-14
 BRANCH=master
 CHANGELOG_REPO_PATH=Resources/Changelog
 EXTRA_CATEGORIES=Admin,Maps,Rules
-#GITHUB_TOKEN=optional
+GITHUB_TOKEN=in workflows this will be secrets.GITHUB_TOKEN
 DISCORD_WEBHOOK=url to discord webhook for posting changelogs to a channel
 MAX_GRAPQHL_PAGES=50 # how many pages of graphql results to go through. If you hit this wtf are you doing

--- a/Changelog/.env.example
+++ b/Changelog/.env.example
@@ -1,0 +1,7 @@
+REPO=space-wizards/space-station-14
+BRANCH=master
+CHANGELOG_REPO_PATH=Resources/Changelog
+EXTRA_CATEGORIES=Admin,Maps,Rules
+#GITHUB_TOKEN=optional
+DISCORD_WEBHOOK=url to discord webhook for posting changelogs to a channel
+MAX_GRAPQHL_PAGES=50 # how many pages of graphql results to go through. If you hit this wtf are you doing

--- a/Changelog/Changelog.csproj
+++ b/Changelog/Changelog.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Dotenv.Extensions.Microsoft.Configuration" Version="3.1.1" />
+      <PackageReference Include="GraphQL.Client" Version="6.1.0" />
+      <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.1.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="11.0.0-preview.6.26359.118" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="11.0.0-preview.6.26359.118" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="11.0.0-preview.6.26359.118" />
+      <PackageReference Include="System.CommandLine" Version="3.0.0-preview.6.26359.118" />
+      <PackageReference Include="YamlDotNet.NetCore" Version="1.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/Changelog/ChangelogData.cs
+++ b/Changelog/ChangelogData.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Immutable;
+
+namespace Changelog
+{
+    public sealed record ChangelogData
+    {
+        public const string MainCategory = "Main";
+
+        public ChangelogData(string author, ImmutableArray<CategoryData> categories, DateTimeOffset time)
+        {
+            Author = author;
+            Categories = categories;
+            Time = time;
+        }
+
+        public string Author { get; }
+        public ImmutableArray<CategoryData> Categories { get; }
+        public DateTimeOffset Time { get; }
+        public int Number { get; init; }
+        public required string HtmlUrl { get; init; }
+
+        public sealed record CategoryData(string Category, ImmutableArray<Change> Changes);
+
+        public record struct Change(ChangeType Type, string Message);
+
+        public enum ChangeType
+        {
+            Add,
+            Remove,
+            Fix,
+            Tweak
+        }
+    }
+}

--- a/Changelog/ChangelogData.cs
+++ b/Changelog/ChangelogData.cs
@@ -2,6 +2,10 @@
 
 namespace Changelog
 {
+    /// <summary>
+    /// Contains the changelog data relevant for our changelog .ymls
+    /// This is taken from https://github.com/space-wizards/SS14.Changelog/blob/master/SS14.Changelog/ChangelogData.cs
+    /// </summary>
     public sealed record ChangelogData
     {
         public const string MainCategory = "Main";

--- a/Changelog/Config.cs
+++ b/Changelog/Config.cs
@@ -2,6 +2,9 @@ using Microsoft.Extensions.Configuration;
 
 namespace Changelog;
 
+/// <summary>
+/// Class containing configuration. This is taken from the env variables or a .env file in the working directory
+/// </summary>
 public sealed class Config
 {
     public static Config Instance = new();

--- a/Changelog/Config.cs
+++ b/Changelog/Config.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Changelog;
+
+public sealed class Config
+{
+    public static Config Instance = new();
+
+    [ConfigurationKeyName("REPO")]
+    public string? Repo { get; set; }
+    [ConfigurationKeyName("BRANCH")]
+    public string? Branch { get; set; }
+    [ConfigurationKeyName("CHANGELOG_REPO_PATH")]
+    public string? ChangelogRepoPath { get; set; }
+    [ConfigurationKeyName("EXTRA_CATEGORIES")]
+    public string? ExtraCategories { get; set; }
+    [ConfigurationKeyName("GITHUB_TOKEN")]
+    public string? GithubToken { get; set; }
+    [ConfigurationKeyName("DISCORD_WEBHOOK")]
+    public string? DiscordWebHook { get; set; }
+    [ConfigurationKeyName("MAX_GRAPQHL_PAGES")]
+    public int MaxPages { get; set; } = 50;
+
+    public Config()
+    {
+        new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .AddEnvFile(".env", optional: true)
+            .Build()
+            .Bind(this);
+    }
+}

--- a/Changelog/Config.cs
+++ b/Changelog/Config.cs
@@ -9,18 +9,46 @@ public sealed class Config
 {
     public static Config Instance = new();
 
+    /// <summary>
+    /// The repository to use
+    /// </summary>
     [ConfigurationKeyName("REPO")]
     public string? Repo { get; set; }
+
+    /// <summary>
+    /// The branch to use as a base when gathering PRs. should probably be master or stable
+    /// </summary>
     [ConfigurationKeyName("BRANCH")]
     public string? Branch { get; set; }
+
+    /// <summary>
+    /// the relative path to the changelog directory. should probably be Resources/Changelog
+    /// </summary>
     [ConfigurationKeyName("CHANGELOG_REPO_PATH")]
     public string? ChangelogRepoPath { get; set; }
+
+    /// <summary>
+    /// The extra categories to scan. E.g. for wizden there is Admin, Maps and Rules
+    /// </summary>
     [ConfigurationKeyName("EXTRA_CATEGORIES")]
     public string? ExtraCategories { get; set; }
+
+    /// <summary>
+    /// The github PAT to use. Should have content.read
+    /// </summary>
     [ConfigurationKeyName("GITHUB_TOKEN")]
     public string? GithubToken { get; set; }
+
+    /// <summary>
+    /// The discord webhook to use in sending changelog diffs
+    /// </summary>
     [ConfigurationKeyName("DISCORD_WEBHOOK")]
     public string? DiscordWebHook { get; set; }
+
+    /// <summary>
+    /// Maximum number of pages to go through in the graphQL. if you exceed this it means you have not updated the
+    /// changelog in months.
+    /// </summary>
     [ConfigurationKeyName("MAX_GRAPQHL_PAGES")]
     public int MaxPages { get; set; } = 50;
 

--- a/Changelog/DiscordWebhook.cs
+++ b/Changelog/DiscordWebhook.cs
@@ -32,15 +32,18 @@ public static class DiscordWebhook
             if (nextLine is null)
                 break;
 
+            // if we not going to exceed the discord limit with the next message, continue adding lines
             if (sb.Length + nextLine.Length < DiscordWebhookCharacterLimit)
                 continue;
 
+            // otherwise send the part
             if (!SendPart(webhookUrl, sb.ToString()))
                 return false;
 
             sb.Clear();
         }
 
+        // send the leftover part after breaking out of the while loop
         if (sb.Length > 0)
             return SendPart(webhookUrl, sb.ToString());
 
@@ -55,6 +58,7 @@ public static class DiscordWebhook
     /// <returns></returns>
     public static bool SendPart(string webhookUrl, string contentPart)
     {
+        // specific body for the webhook request. "content" contains the actual content of the discord message
         var discordWebhookBody = new Dictionary<string, object>()
         {
             { "content", contentPart },
@@ -65,10 +69,6 @@ public static class DiscordWebhook
         };
 
         var jsonContent = JsonSerializer.Serialize(discordWebhookBody);
-
-        Console.WriteLine("Sending JSON:");
-        Console.Write(jsonContent);
-        Console.WriteLine();
 
 
         var attempts = 0;
@@ -83,8 +83,6 @@ public static class DiscordWebhook
 
             var response = Client.Send(request);
 
-            Console.WriteLine($"Status: {response.StatusCode}, message: {response.Content.ReadAsStringAsync().Result}");
-
             if (!response.IsSuccessStatusCode)
             {
                 switch (response.StatusCode)
@@ -97,6 +95,8 @@ public static class DiscordWebhook
                         Console.WriteLine("Rate limiting...");
                         // it's actually like 300ms or so but this is fine whatever sue me
                         // I'd have to parse the json here to check what number they give me and I DON'T WANT TO
+                        // if you do run into a rate limit because you're sending 20 discord changelog updates and your
+                        // wait time is over 1 full second somehow (wtf are you doing?) then implement this properly
                         Thread.Sleep(1000);
                         break;
                     default:

--- a/Changelog/DiscordWebhook.cs
+++ b/Changelog/DiscordWebhook.cs
@@ -39,7 +39,6 @@ public static class DiscordWebhook
                 return false;
 
             sb.Clear();
-            sb.Append(nextLine + "\n");
         }
 
         if (sb.Length > 0)

--- a/Changelog/DiscordWebhook.cs
+++ b/Changelog/DiscordWebhook.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Changelog;
+
+public static class DiscordWebhook
+{
+    private static readonly HttpClient Client = new();
+
+    public const int DiscordWebhookCharacterLimit = 2000;
+
+    /// <summary>
+    /// Cuts up content from a streamreader into discord friendly chunks and sends them onwards
+    /// </summary>
+    /// <param name="webhookUrl">discord webhook url to send to</param>
+    /// <param name="contentStreamReader">stream reader from which to read content from</param>
+    /// <returns></returns>
+    public static bool SendDiffInParts(string webhookUrl, StreamReader contentStreamReader)
+    {
+        var sb = new StringBuilder(DiscordWebhookCharacterLimit);
+
+        var nextLine = contentStreamReader.ReadLine();
+
+        while (nextLine is not null)
+        {
+            sb.Append(nextLine + "\n");
+
+            nextLine = contentStreamReader.ReadLine();
+
+            if (nextLine is null)
+                break;
+
+            if (sb.Length + nextLine.Length < DiscordWebhookCharacterLimit)
+                continue;
+
+            if (!SendPart(webhookUrl, sb.ToString()))
+                return false;
+
+            sb.Clear();
+            sb.Append(nextLine + "\n");
+        }
+
+        if (sb.Length > 0)
+            return SendPart(webhookUrl, sb.ToString());
+
+        return true;
+    }
+
+    /// <summary>
+    /// Does the actual sending of content to a discord webhook
+    /// </summary>
+    /// <param name="webhookUrl"></param>
+    /// <param name="contentPart"></param>
+    /// <returns></returns>
+    public static bool SendPart(string webhookUrl, string contentPart)
+    {
+        var discordWebhookBody = new Dictionary<string, object>()
+        {
+            { "content", contentPart },
+            // disallow mentions
+            { "allowed_mentions", new Dictionary<string, List<string>>(){ { "parse", [] } } },
+            // disable embeds
+            { "flags", 1 << 2 },
+        };
+
+        var jsonContent = JsonSerializer.Serialize(discordWebhookBody);
+
+        Console.WriteLine("Sending JSON:");
+        Console.Write(jsonContent);
+        Console.WriteLine();
+
+
+        var attempts = 0;
+        while (attempts < 20)
+        {
+            attempts++;
+
+            var request = new HttpRequestMessage(HttpMethod.Post, webhookUrl + "?wait=true");
+
+            request.Content = new StringContent(jsonContent);
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            var response = Client.Send(request);
+
+            Console.WriteLine($"Status: {response.StatusCode}, message: {response.Content.ReadAsStringAsync().Result}");
+
+            if (!response.IsSuccessStatusCode)
+            {
+                switch (response.StatusCode)
+                {
+                    case HttpStatusCode.BadRequest:
+                        Console.WriteLine("Bad request response received, cancelling:");
+                        Console.WriteLine(response.Content.ReadAsStringAsync().Result);
+                        return false;
+                    case HttpStatusCode.TooManyRequests:
+                        Console.WriteLine("Rate limiting...");
+                        // it's actually like 300ms or so but this is fine whatever sue me
+                        // I'd have to parse the json here to check what number they give me and I DON'T WANT TO
+                        Thread.Sleep(1000);
+                        break;
+                    default:
+                        Console.WriteLine($"Received unexpected response status code ({response.StatusCode}), cancelling:");
+                        Console.WriteLine(response.Content.ReadAsStringAsync().Result);
+                        return false;
+                }
+
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Changelog/GitHubData.cs
+++ b/Changelog/GitHubData.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+
+// this is largely taken from the old code here 
+// https://github.com/space-wizards/SS14.Changelog/blob/83831f3cf8d1b6e49432b4a45f5aa3c6e3f5fc2c/SS14.Changelog/GitHubData.cs
+namespace Changelog
+{
+    public sealed record GraphQLResponse(GrapQLSearchResponse Search);
+
+    public sealed record GrapQLSearchResponse(List<GraphQLEdge> Edges, GraphQLPageInfo PageInfo);
+
+    public sealed record GraphQLPageInfo(bool HasNextPage, string EndCursor);
+
+    public sealed record GraphQLEdge(GHPullRequest Node);
+    
+    public sealed record GHPullRequest(
+        bool Merged,
+        string Body,
+        GHUser User,
+        DateTimeOffset? MergedAt,
+        GHPullRequestBase Base,
+        int Number,
+        string Html_url);
+
+    public sealed record GHPullRequestBase(string Ref);
+
+    public sealed record GHUser(string Login);
+
+    public sealed record GHPushEvent(ImmutableArray<GHPushedCommit> Commits, string Ref);
+
+    public sealed record GHPushedCommit(ImmutableArray<string> Added, ImmutableArray<string> Modified);
+}

--- a/Changelog/IO.cs
+++ b/Changelog/IO.cs
@@ -1,0 +1,158 @@
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+
+namespace Changelog;
+
+/// <summary>
+/// File IO for yml and markdown stuff
+/// </summary>
+public static class IO
+{
+    /// <summary>
+    /// How many changelog entries should be in a yaml. older ones are pruned
+    /// </summary>
+    public static int MaxChangelogEntries = 500;
+    
+    /// <summary>
+    /// Emojis associated with a change type
+    /// </summary>
+    public static Dictionary<ChangelogData.ChangeType, string> Emojis = new()
+    {
+        { ChangelogData.ChangeType.Add, "🆕" },
+        { ChangelogData.ChangeType.Fix, "🐛" },
+        { ChangelogData.ChangeType.Remove, "❌" },
+        { ChangelogData.ChangeType.Tweak, "⚒️" },
+    };
+
+    /// <summary>
+    /// Convert a yaml scalar (text) node to a single-quoted string
+    /// </summary>
+    private static YamlScalarNode SingleQuoted(string content)
+    {
+        return new YamlScalarNode(content) { Style = ScalarStyle.SingleQuoted };
+    }
+
+    /// <summary>
+    /// Convert a yaml scalar (text) node to a double-quoted string
+    /// </summary>
+    private static YamlScalarNode DoubleQuoted(string content)
+    {
+        return new YamlScalarNode(content) { Style = ScalarStyle.DoubleQuoted };
+    }
+
+    /// <summary>
+    /// Dumps a changelog to markdown. This only sends "main" category changelogs, so no admin or map or whatever.
+    /// </summary>
+    /// <param name="changelogMarkdownPath">Path of the markdown file</param>
+    /// <param name="changelogParts">Changelog parts to include</param>
+    public static void DumpChangelogToMarkdown(string changelogMarkdownPath, IEnumerable<ChangelogData> changelogParts)
+    {
+        using var writer = new StreamWriter(changelogMarkdownPath);
+
+        foreach (var changelogPart in changelogParts)
+        {
+            foreach (var category in changelogPart.Categories)
+            {
+                // we will only send main ones
+                if (category.Category != PR.MainCategory)
+                    continue;
+
+                writer.WriteLine($"**{changelogPart.Author}** updated:");
+                foreach (var change in category.Changes)
+                {
+                    var emoji = Emojis[change.Type];
+                    writer.WriteLine($"{emoji} - {change.Message} ([#{changelogPart.Number}]({changelogPart.HtmlUrl})");
+                }
+
+                writer.WriteLine();
+            }
+        }
+    }
+
+
+    /// <summary>
+    /// Update the YML changelogs from a changelog part.
+    /// A changelog part may include multiple categories
+    /// </summary>
+    private static void UpdateChangelogFromPart(ChangelogData changelogPart, string changelogDir)
+    {
+        foreach (var category in changelogPart.Categories)
+        {
+            var categoryFile = category.Category == PR.MainCategory ? "Changelog" : category.Category;
+
+            var changelogYmlPath = Path.Combine(
+                changelogDir,
+                $"{categoryFile}.yml"
+            );
+
+            Console.WriteLine($"Writing changelog part {changelogYmlPath}");
+
+            // load the entire yaml
+            var yamlStream = new YamlStream();
+
+            using var reader = new StreamReader(changelogYmlPath);
+            yamlStream.Load(reader);
+
+            var changelog = (YamlMappingNode)yamlStream.Documents[0].RootNode;
+
+            var entries = (YamlSequenceNode)changelog.Children[new YamlScalarNode("Entries")];
+
+            // now we have our full set of entries. get the last ID so we can increment it on the next one
+
+            var lastEntry = (YamlMappingNode)entries.Last();
+            var lastEntryId = int.Parse((string)lastEntry.Children[new YamlScalarNode("id")]);
+
+            // now make a new entry with the incremented ID
+
+            var yamlMapping = new YamlMappingNode
+            {
+                {"author", changelogPart.Author},
+                {"time", SingleQuoted(changelogPart.Time.ToString("O"))},
+                {"url", changelogPart.HtmlUrl},
+                {
+                    "changes",
+                    new YamlSequenceNode(
+                        category.Changes.Select(c => new YamlMappingNode
+                        {
+                            {"type", c.Type.ToString()},
+                            {"message", c.Message},
+                        }))
+                },
+                {"id", (lastEntryId + 1).ToString() },
+            };
+
+            if (category.Category != ChangelogData.MainCategory)
+                yamlMapping.Add("category", category.Category);
+
+
+            entries.Add(yamlMapping);
+
+            // if you think the above stinks, so do I. this is the way it is because I cannot nicely serialize and
+            // deserialize between yaml and C# objects. if you know how to do it replace this and god help me
+            
+            // trim old entries. yes this also stinks
+            if (entries.Count() > MaxChangelogEntries)
+            {
+                while (entries.Count() - MaxChangelogEntries > 0)
+                {
+                    entries.Children.RemoveAt(0);
+                }   
+            }
+            
+            // done pruning old entries, write everything.
+            using var writer = new StreamWriter(changelogYmlPath);
+            yamlStream.Save(writer);
+        }
+    }
+
+    /// <summary>
+    /// Helper function to update YML changelogs from a list of changelog parts.
+    /// </summary>
+    public static void UpdateChangelogs(IEnumerable<ChangelogData> changelogParts, string changelogDir)
+    {
+        foreach (var changelogPart in changelogParts)
+        {
+            UpdateChangelogFromPart(changelogPart, changelogDir);
+        }
+    }
+}

--- a/Changelog/IO.cs
+++ b/Changelog/IO.cs
@@ -12,7 +12,7 @@ public static class IO
     /// How many changelog entries should be in a yaml. older ones are pruned
     /// </summary>
     public static int MaxChangelogEntries = 500;
-    
+
     /// <summary>
     /// Emojis associated with a change type
     /// </summary>
@@ -61,7 +61,7 @@ public static class IO
                 foreach (var change in category.Changes)
                 {
                     var emoji = Emojis[change.Type];
-                    writer.WriteLine($"{emoji} - {change.Message} ([#{changelogPart.Number}]({changelogPart.HtmlUrl})");
+                    writer.WriteLine($"{emoji} - {change.Message} ([#{changelogPart.Number}]({changelogPart.HtmlUrl}))");
                 }
 
                 writer.WriteLine();
@@ -129,16 +129,16 @@ public static class IO
 
             // if you think the above stinks, so do I. this is the way it is because I cannot nicely serialize and
             // deserialize between yaml and C# objects. if you know how to do it replace this and god help me
-            
+
             // trim old entries. yes this also stinks
             if (entries.Count() > MaxChangelogEntries)
             {
                 while (entries.Count() - MaxChangelogEntries > 0)
                 {
                     entries.Children.RemoveAt(0);
-                }   
+                }
             }
-            
+
             // done pruning old entries, write everything.
             using var writer = new StreamWriter(changelogYmlPath);
             yamlStream.Save(writer);

--- a/Changelog/IO.cs
+++ b/Changelog/IO.cs
@@ -49,11 +49,14 @@ public static class IO
     {
         using var writer = new StreamWriter(changelogMarkdownPath);
 
+        // each changelog part corresponds to a PR with a valid changelog body
         foreach (var changelogPart in changelogParts)
         {
+            // each category corresponds to a category in a PR which may have multiple changes to that category
             foreach (var category in changelogPart.Categories)
             {
-                // we will only send main ones
+                // we will only send main category ones though. the reason the other ones are included here is because
+                // the code that gets the last change needs all of them. don't worry about it
                 if (category.Category != PR.MainCategory)
                     continue;
 
@@ -76,8 +79,10 @@ public static class IO
     /// </summary>
     private static void UpdateChangelogFromPart(ChangelogData changelogPart, string changelogDir)
     {
+        // go through all the categories. these contain the actual changes
         foreach (var category in changelogPart.Categories)
         {
+            // grab the correct category file
             var categoryFile = category.Category == PR.MainCategory ? "Changelog" : category.Category;
 
             var changelogYmlPath = Path.Combine(
@@ -93,8 +98,12 @@ public static class IO
             using var reader = new StreamReader(changelogYmlPath);
             yamlStream.Load(reader);
 
+            // this is just yamldotnet shenanigans. I can't figure out how to deserialize this into an object properly
+            // using yamldotnet so we are doing it this way.
+            // here's the root node
             var changelog = (YamlMappingNode)yamlStream.Documents[0].RootNode;
 
+            // the entries node contains all the actual changelog entries
             var entries = (YamlSequenceNode)changelog.Children[new YamlScalarNode("Entries")];
 
             // now we have our full set of entries. get the last ID so we can increment it on the next one

--- a/Changelog/PR.cs
+++ b/Changelog/PR.cs
@@ -267,6 +267,7 @@ public static class PR
     /// <returns></returns>
     public static ChangelogData? ParsePRBody(GHPullRequest pr, List<string> extraCategories)
     {
+        // get all categories we could match
         var allCategories = new HashSet<string>
         {
             MainCategory,
@@ -274,19 +275,26 @@ public static class PR
         allCategories.UnionWith(extraCategories);
 
         var body = CommentRegex.Replace(pr.Body!, "");
+
+        // match the :[cl]: part to make sure we have an actual changelog
         var match = ChangelogHeaderRegex.Match(body);
         if (!match.Success)
             return null;
 
+        // get the author. this defaults to the PR username if it is not set
         var author = match.Groups[1].Success ? match.Groups[1].Value.Trim() : pr.User.Login;
         var changelogBody = body.Substring(match.Index + match.Length);
 
+        // default to main category
         var currentCategory = MainCategory;
+
         var entries = new List<(string, ChangelogData.Change)>();
 
+        // now traverse through the rest of the changelog after the :[cl]: [name] header
         var reader = new StringReader(changelogBody);
         while (reader.ReadLine() is { } line)
         {
+            // find a category to match
             var categoryMatch = ChangelogCategoryRegex.Match(line);
             if (categoryMatch.Success)
             {
@@ -294,6 +302,8 @@ public static class PR
                 // Check if it's actually a defined category, skip it otherwise.
                 var categoryName = categoryMatch.Groups[1].Value;
 
+                // the changelog convention is all uppercase letters for the category. this should probably be changed
+                // to be less strict. convert this into the name we use for the file either way
                 var correctedName = categoryName.ToUpperInvariant() switch
                 {
                     "ADMIN" => "Admin",
@@ -308,10 +318,15 @@ public static class PR
                 continue;
             }
 
+            // if the above condition succeeded, we have a currentCategory that corresponds to something like Main, Admin,
+            // Rules or Maps. Otherwise, we use whatever the last category was
+
+            // get the type of change and the message (e.g. fix: message)
             var entryMatch = ChangelogEntryRegex.Match(line);
             if (!entryMatch.Success)
                 continue;
 
+            // convert the found type of change into an enum. this is more permissive than the category
             var type = entryMatch.Groups[1].Value.ToLowerInvariant() switch
             {
                 "add" => ChangelogData.ChangeType.Add,
@@ -323,10 +338,12 @@ public static class PR
 
             var message = entryMatch.Groups[2].Value.Trim();
 
+            // if all went well, add this change to the changelog entry
             if (type is { } t)
                 entries.Add((currentCategory, new ChangelogData.Change(t, message)));
         }
 
+        // assemble the changelogData from the list of changes we assembled
         var finalCategories = entries
             .GroupBy(e => e.Item1)
             .Select(g => new ChangelogData.CategoryData(g.Key, g.Select(e => e.Item2).ToImmutableArray()))
@@ -339,6 +356,9 @@ public static class PR
         };
     }
 
+    /// <summary>
+    /// Helper function to parse all PR bodies that are given in an enumerator
+    /// </summary>
     public static List<ChangelogData> ParseAllPRBodies(IEnumerable<GHPullRequest> pullRequests, List<string>? extraCategories = null)
     {
         List<ChangelogData> changelog = [];

--- a/Changelog/PR.cs
+++ b/Changelog/PR.cs
@@ -1,0 +1,368 @@
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+using GraphQL;
+using GraphQL.Client.Http;
+using GraphQL.Client.Serializer.SystemTextJson;
+using YamlDotNet.RepresentationModel;
+
+namespace Changelog;
+
+/// <summary>
+/// PR helper functions. seeks out last merges, collects PRs, generates changelog objects
+/// </summary>
+public static class PR
+{
+    // Regexes are all copied from the old code
+    // https://github.com/space-wizards/SS14.Changelog/blob/83831f3cf8d1b6e49432b4a45f5aa3c6e3f5fc2c/SS14.Changelog/Controllers/WebhookController.cs#L23
+    private static readonly Regex IsChangelogFileRegex = new Regex(@"^Resources/Changelog/Parts/.*\.yml$");
+
+    private static readonly Regex ChangelogHeaderRegex =
+        new Regex(@"^\s*(?::cl:|🆑) *([a-z0-9_\- ,&]+)?\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+
+    private static readonly Regex ChangelogEntryRegex =
+        new Regex(@"^ *[*-]? *(add|remove|tweak|fix|bug|bugfix): *([^\n\r]+)\r?$", RegexOptions.IgnoreCase);
+
+    private static readonly Regex ChangelogCategoryRegex =
+        new Regex(@"^\s*([a-z]+):\s*$", RegexOptions.IgnoreCase);
+
+    private static readonly Regex CommentRegex = new(@"(?<!\\)<!--([^>]+)(?<!\\)-->");
+
+    private static readonly HttpClient Client = new();
+
+    public const string MainCategory = "Main";
+
+    private const string GithubGraphQLApiBase = "https://api.github.com/graphql";
+    private const string GithubRawDownloadBase = "https://raw.githubusercontent.com";
+
+    /// <summary>
+    /// Get the last merge time in a changelog yaml mapping node
+    /// </summary>
+    /// <param name="changelog">YAML mapping node containing changelog entries</param>
+    /// <returns>Time of last PR with a changelog that was merged</returns>
+    private static DateTimeOffset GetLastMergedChangelogEntry(YamlMappingNode changelog)
+    {
+        var lastMergeTime = DateTimeOffset.MinValue;
+        
+        var entries = (YamlSequenceNode)changelog.Children[new YamlScalarNode("Entries")];
+        foreach (var entry in entries)
+        {
+            if (entry is not YamlMappingNode mappingNode)
+                continue;
+
+            var id = int.Parse((string)mappingNode.Children[new YamlScalarNode("id")]);
+            var timeNodeKey = new YamlScalarNode("time");
+
+            if (!mappingNode.Children.TryGetValue(timeNodeKey, out var timeValue))
+                continue;
+
+            var timeString = (string)timeValue;
+
+            var prMergeTime = DateTimeOffset.Parse(timeString);
+
+            if (prMergeTime <= lastMergeTime)
+                continue;
+
+            lastMergeTime = prMergeTime;
+        }
+
+        return lastMergeTime;
+    }
+
+    /// <summary>
+    /// Get the time at which the last PR was merged in the given changelogs under the changelogDir
+    /// </summary>
+    /// <param name="changelogDir">Directory that contains the Changelog.yml and specific changelog files</param>
+    /// <param name="extraCategories">Names of extra categories to parse, e.g. Admin, Maps, Rules</param>
+    /// <returns></returns>
+    public static DateTimeOffset GetLastMergedTimeFromChangelogs(string changelogDir, List<string>? extraCategories = null)
+    {
+        // parse the current yamls
+        var allCategories = new HashSet<string>
+        {
+            "Changelog",
+        };
+        
+        if (extraCategories is not null)
+            allCategories.UnionWith(extraCategories);
+        
+        var lastMergedTime = DateTimeOffset.MinValue;
+
+        foreach (var category in allCategories)
+        {
+            var fileName = Path.Combine(
+                changelogDir,
+                $"{category}.yml"
+            );
+
+            // Yamldotnet's deserialization is, for lack of a better term, pure ass.
+            // I suspect this is the reason why part of the changelog generation stuff was in python
+            // because python's libraries actually do work.
+            // If I try to deserialize the yaml stream in any way into a proper object,
+            // it simply refuses to work. I'll make a class like
+            // public class Root {
+            //     public string Fuck;
+            // }
+            // and deserialize the following yml:
+            // Fuck: shit
+            // and Yamldotnet, in its infinite wisdom, will insist that
+            // System.Runtime.Serialization.SerializationException: Property 'Fuck' not found on type 'Root'.
+            // complete garbage.
+
+            // so instead we do a bunch of bullshit
+
+            using var reader = new StreamReader(fileName);
+            var yamlStream = new YamlStream();
+            yamlStream.Load(reader);
+
+            var changelog = (YamlMappingNode)yamlStream.Documents[0].RootNode;
+
+            var categoryLastMergedTime = GetLastMergedChangelogEntry(changelog);
+
+            if (lastMergedTime < categoryLastMergedTime)
+            {
+                lastMergedTime = categoryLastMergedTime;
+            }
+        }
+
+        Console.WriteLine($"Last PR time: {lastMergedTime}");
+
+        return lastMergedTime;
+    }
+
+
+    /// <summary>
+    /// Get the time at which the last PR with a changelog was merged from a specific git reference
+    /// </summary>
+    /// <param name="sinceRefSha"></param>
+    /// <param name="extraCategories"></param>
+    /// <returns></returns>
+    /// <exception cref="Exception"></exception>
+    public static DateTimeOffset GetLastMergedFromRef(string sinceRefSha, List<string> extraCategories)
+    {
+        var lastMergedTime = DateTimeOffset.MinValue;
+
+        List<string> allCategories = ["Changelog"];
+        allCategories.AddRange(extraCategories);
+
+        foreach (var category in allCategories)
+        {
+            // get the category's YAML at a specific ref
+            var refChangelogUrl =
+                $"{GithubRawDownloadBase}/{Config.Instance.Repo}/{sinceRefSha}/{Config.Instance.ChangelogRepoPath}/{category}.yml";
+
+            HttpRequestMessage request = new(HttpMethod.Get, refChangelogUrl);
+            
+            if (Config.Instance.GithubToken is not null)
+                request.Headers.Add("Authorization", $"Bearer {Config.Instance.GithubToken}");
+
+            var response = Client.Send(request);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new Exception("Could not get changelog content: " + response.Content.ReadAsStringAsync().Result);
+            }
+            
+            // read the file YML
+            using var reader = new StreamReader(response.Content.ReadAsStream());
+            var yamlStream = new YamlStream();
+            yamlStream.Load(reader);
+
+            var changelog = (YamlMappingNode)yamlStream.Documents[0].RootNode;
+            
+            // Get the last merged time found in this file
+            var categoryLastMergedTime = GetLastMergedChangelogEntry(changelog);
+
+            if (lastMergedTime < categoryLastMergedTime)
+            {
+                lastMergedTime = categoryLastMergedTime;
+            }
+        }
+    
+        return lastMergedTime;
+    }
+
+    /// <summary>
+    /// Returns a list of github pull request objects that have a body and were merged into `<paramref name="branch"/>` after `<paramref name="lastMergeTime"/>`
+    /// </summary>
+    /// <param name="lastMergeTime">The last merged PR. this will NOT be included in the diff</param>
+    /// <param name="repo">The repository to look at</param>
+    /// <param name="branch">The branch serving as a base on which PRs were merged. Probably should be mastger</param>
+    /// <param name="authToken">Optional auth token if you don't want to get rate limited. This should probably not be optional</param>
+    /// <returns></returns>
+    public static List<GHPullRequest> GetDiff(DateTimeOffset lastMergeTime, string repo, string branch, string? authToken)
+    {
+        List<GHPullRequest> pullRequests = [];
+        
+        
+        // Github allows you to filter by merged after a certain date, but it only accepts the date part
+        var date = lastMergeTime.ToString("yyyy-MM-dd");
+
+        var page = 0;
+        string? afterCursor = null;
+
+        while (page < Config.Instance.MaxPages) {
+            // yes I know graphql-dotnet has variables and placeholders. no they aren't documented correctly or very well
+            // no I am not going to spend more time trying to guess how they should be used. it can go kick rocks.
+            // string interpolation it is
+            var query = $$"""
+                          {
+                            search(first: 50, query: "is:pr repo:{{repo}} base:{{branch}} is:merged merged:>={{date}}", type: ISSUE, after: {{ '"' + afterCursor + '"' ?? "null"}}) {
+                              edges {
+                                node {
+                                  ... on PullRequest {
+                                    merged
+                                    body
+                                    user: author {
+                                      login
+                                    }
+                                    mergedAt
+                                    base: baseRef {
+                                      ref: name
+                                    }
+                                    number
+                                    html_url: url
+                                  }
+                                }
+                              }
+                              pageInfo {
+                                hasNextPage
+                                endCursor
+                              }
+                            }
+                          }
+                          """;
+
+
+            var graphQL = new GraphQLHttpClient(
+                GithubGraphQLApiBase,
+                new SystemTextJsonSerializer()
+            );
+
+
+            if (authToken is not null)
+                graphQL.HttpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {authToken}");
+
+            var graphQLRequest = new GraphQLRequest(query);
+
+            var response = graphQL.SendQueryAsync<GraphQLResponse>(graphQLRequest).Result;
+
+            foreach (var edge in response.Data.Search.Edges)
+            {
+                if (edge.Node.MergedAt <= lastMergeTime)
+                    continue;
+
+                pullRequests.Add(edge.Node);
+            }
+
+            if (!response.Data.Search.PageInfo.HasNextPage)
+                break;
+
+            afterCursor = response.Data.Search.PageInfo.EndCursor;
+        }
+        
+        // at the end of this we have a collection of PRs with bodies
+        
+        // order PRs by time ascending
+        pullRequests = pullRequests.OrderBy(item => item.MergedAt!.Value).ToList();
+        
+        return pullRequests;
+    }
+
+    /// <summary>
+    /// Parse a PR body as returned by github and return a more terse changelog data
+    /// This function was copied pretty much entirely from here:
+    /// https://github.com/space-wizards/SS14.Changelog/blob/83831f3cf8d1b6e49432b4a45f5aa3c6e3f5fc2c/SS14.Changelog/Controllers/WebhookController.cs#L161
+    /// </summary>
+    /// <param name="pr"></param>
+    /// <param name="extraCategories"></param>
+    /// <returns></returns>
+    public static ChangelogData? ParsePRBody(GHPullRequest pr, List<string> extraCategories)
+    {
+        var allCategories = new HashSet<string>
+        {
+            MainCategory,
+        };
+        allCategories.UnionWith(extraCategories);
+
+        var body = CommentRegex.Replace(pr.Body!, "");
+        var match = ChangelogHeaderRegex.Match(body);
+        if (!match.Success)
+            return null;
+
+        var author = match.Groups[1].Success ? match.Groups[1].Value.Trim() : pr.User.Login;
+        var changelogBody = body.Substring(match.Index + match.Length);
+
+        var currentCategory = MainCategory;
+        var entries = new List<(string, ChangelogData.Change)>();
+
+        var reader = new StringReader(changelogBody);
+        while (reader.ReadLine() is { } line)
+        {
+            var categoryMatch = ChangelogCategoryRegex.Match(line);
+            if (categoryMatch.Success)
+            {
+                // Changelog category directive.
+                // Check if it's actually a defined category, skip it otherwise.
+                var categoryName = categoryMatch.Groups[1].Value;
+
+                var correctedName = categoryName.ToUpperInvariant() switch
+                {
+                    "ADMIN" => "Admin",
+                    "MAPS" => "Maps",
+                    "RULES" => "Rules",
+                    _ => MainCategory,
+                };
+
+                if (allCategories.TryGetValue(correctedName, out var matchedCategory))
+                    currentCategory = matchedCategory;
+
+                continue;
+            }
+
+            var entryMatch = ChangelogEntryRegex.Match(line);
+            if (!entryMatch.Success)
+                continue;
+
+            var type = entryMatch.Groups[1].Value.ToLowerInvariant() switch
+            {
+                "add" => ChangelogData.ChangeType.Add,
+                "remove" => ChangelogData.ChangeType.Remove,
+                "fix" or "bugfix" or "bug" => ChangelogData.ChangeType.Fix,
+                "tweak" => ChangelogData.ChangeType.Tweak,
+                _ => (ChangelogData.ChangeType?) null,
+            };
+
+            var message = entryMatch.Groups[2].Value.Trim();
+
+            if (type is { } t)
+                entries.Add((currentCategory, new ChangelogData.Change(t, message)));
+        }
+
+        var finalCategories = entries
+            .GroupBy(e => e.Item1)
+            .Select(g => new ChangelogData.CategoryData(g.Key, g.Select(e => e.Item2).ToImmutableArray()))
+            .ToImmutableArray();
+
+        return new ChangelogData(author, finalCategories, pr.MergedAt ?? DateTimeOffset.Now)
+        {
+            Number = pr.Number,
+            HtmlUrl = pr.Html_url
+        };
+    }
+
+    public static List<ChangelogData> ParseAllPRBodies(IEnumerable<GHPullRequest> pullRequests, List<string>? extraCategories = null)
+    {
+        List<ChangelogData> changelog = [];
+        foreach (var pullRequest in pullRequests)
+        {
+            var changelogData = ParsePRBody(pullRequest, extraCategories ?? []);
+
+            if (changelogData is null)
+                continue;
+
+            changelog.Add(changelogData);
+        }
+
+        return changelog;
+    }
+}

--- a/Changelog/PR.cs
+++ b/Changelog/PR.cs
@@ -42,7 +42,7 @@ public static class PR
     private static DateTimeOffset GetLastMergedChangelogEntry(YamlMappingNode changelog)
     {
         var lastMergeTime = DateTimeOffset.MinValue;
-        
+
         var entries = (YamlSequenceNode)changelog.Children[new YamlScalarNode("Entries")];
         foreach (var entry in entries)
         {
@@ -81,10 +81,10 @@ public static class PR
         {
             "Changelog",
         };
-        
+
         if (extraCategories is not null)
             allCategories.UnionWith(extraCategories);
-        
+
         var lastMergedTime = DateTimeOffset.MinValue;
 
         foreach (var category in allCategories)
@@ -94,21 +94,9 @@ public static class PR
                 $"{category}.yml"
             );
 
-            // Yamldotnet's deserialization is, for lack of a better term, pure ass.
-            // I suspect this is the reason why part of the changelog generation stuff was in python
-            // because python's libraries actually do work.
-            // If I try to deserialize the yaml stream in any way into a proper object,
-            // it simply refuses to work. I'll make a class like
-            // public class Root {
-            //     public string Fuck;
-            // }
-            // and deserialize the following yml:
-            // Fuck: shit
-            // and Yamldotnet, in its infinite wisdom, will insist that
-            // System.Runtime.Serialization.SerializationException: Property 'Fuck' not found on type 'Root'.
-            // complete garbage.
-
-            // so instead we do a bunch of bullshit
+            // I couldn't figure out a proper way of doing deserialization into objects with yamldotnet, and it was not
+            // very helpful in telling me what I was doing wrong. If you have more experience with this and want to
+            // rewrite this and the UpdateChangelogFromPart function in IO.cs please do
 
             using var reader = new StreamReader(fileName);
             var yamlStream = new YamlStream();
@@ -151,7 +139,7 @@ public static class PR
                 $"{GithubRawDownloadBase}/{Config.Instance.Repo}/{sinceRefSha}/{Config.Instance.ChangelogRepoPath}/{category}.yml";
 
             HttpRequestMessage request = new(HttpMethod.Get, refChangelogUrl);
-            
+
             if (Config.Instance.GithubToken is not null)
                 request.Headers.Add("Authorization", $"Bearer {Config.Instance.GithubToken}");
 
@@ -161,14 +149,14 @@ public static class PR
             {
                 throw new Exception("Could not get changelog content: " + response.Content.ReadAsStringAsync().Result);
             }
-            
+
             // read the file YML
             using var reader = new StreamReader(response.Content.ReadAsStream());
             var yamlStream = new YamlStream();
             yamlStream.Load(reader);
 
             var changelog = (YamlMappingNode)yamlStream.Documents[0].RootNode;
-            
+
             // Get the last merged time found in this file
             var categoryLastMergedTime = GetLastMergedChangelogEntry(changelog);
 
@@ -177,30 +165,32 @@ public static class PR
                 lastMergedTime = categoryLastMergedTime;
             }
         }
-    
+
         return lastMergedTime;
     }
 
     /// <summary>
     /// Returns a list of github pull request objects that have a body and were merged into `<paramref name="branch"/>` after `<paramref name="lastMergeTime"/>`
+    /// This uses github's graphql API to get only the PRs after a certain date, and should be pretty robust.
+    /// You really should not be hitting the maxpages limit unless changelogs have not been generated for like 6 months
     /// </summary>
     /// <param name="lastMergeTime">The last merged PR. this will NOT be included in the diff</param>
     /// <param name="repo">The repository to look at</param>
     /// <param name="branch">The branch serving as a base on which PRs were merged. Probably should be mastger</param>
-    /// <param name="authToken">Optional auth token if you don't want to get rate limited. This should probably not be optional</param>
+    /// <param name="authToken">Github PAT with content.read permissions or something. You NEED this or Github will get MAD</param>
     /// <returns></returns>
-    public static List<GHPullRequest> GetDiff(DateTimeOffset lastMergeTime, string repo, string branch, string? authToken)
+    public static List<GHPullRequest> GetDiff(DateTimeOffset lastMergeTime, string repo, string branch, string authToken)
     {
         List<GHPullRequest> pullRequests = [];
-        
-        
+
         // Github allows you to filter by merged after a certain date, but it only accepts the date part
         var date = lastMergeTime.ToString("yyyy-MM-dd");
 
         var page = 0;
         string? afterCursor = null;
 
-        while (page < Config.Instance.MaxPages) {
+        while (page < Config.Instance.MaxPages)
+        {
             // yes I know graphql-dotnet has variables and placeholders. no they aren't documented correctly or very well
             // no I am not going to spend more time trying to guess how they should be used. it can go kick rocks.
             // string interpolation it is
@@ -238,9 +228,8 @@ public static class PR
                 new SystemTextJsonSerializer()
             );
 
-
-            if (authToken is not null)
-                graphQL.HttpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {authToken}");
+            // github will actually not allow you to make graphQL api calls without an auth token
+            graphQL.HttpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {authToken}");
 
             var graphQLRequest = new GraphQLRequest(query);
 
@@ -259,12 +248,12 @@ public static class PR
 
             afterCursor = response.Data.Search.PageInfo.EndCursor;
         }
-        
+
         // at the end of this we have a collection of PRs with bodies
-        
+
         // order PRs by time ascending
         pullRequests = pullRequests.OrderBy(item => item.MergedAt!.Value).ToList();
-        
+
         return pullRequests;
     }
 

--- a/Changelog/PR.cs
+++ b/Changelog/PR.cs
@@ -14,8 +14,6 @@ public static class PR
 {
     // Regexes are all copied from the old code
     // https://github.com/space-wizards/SS14.Changelog/blob/83831f3cf8d1b6e49432b4a45f5aa3c6e3f5fc2c/SS14.Changelog/Controllers/WebhookController.cs#L23
-    private static readonly Regex IsChangelogFileRegex = new Regex(@"^Resources/Changelog/Parts/.*\.yml$");
-
     private static readonly Regex ChangelogHeaderRegex =
         new Regex(@"^\s*(?::cl:|🆑) *([a-z0-9_\- ,&]+)?\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline);
 
@@ -189,14 +187,26 @@ public static class PR
         var page = 0;
         string? afterCursor = null;
 
-        while (page < Config.Instance.MaxPages)
+        while (page <= Config.Instance.MaxPages)
         {
+            page++;
+
+            string afterCursorString;
+            if (afterCursor is null)
+            {
+                afterCursorString = "null";
+            }
+            else
+            {
+                afterCursorString = $"\"{afterCursor}\"";
+            }
+
             // yes I know graphql-dotnet has variables and placeholders. no they aren't documented correctly or very well
             // no I am not going to spend more time trying to guess how they should be used. it can go kick rocks.
             // string interpolation it is
             var query = $$"""
                           {
-                            search(first: 50, query: "is:pr repo:{{repo}} base:{{branch}} is:merged merged:>={{date}}", type: ISSUE, after: {{ '"' + afterCursor + '"' ?? "null"}}) {
+                            search(first: 50, query: "is:pr repo:{{repo}} base:{{branch}} is:merged merged:>={{date}}", type: ISSUE, after: {{ afterCursorString }}) {
                               edges {
                                 node {
                                   ... on PullRequest {

--- a/Changelog/Program.cs
+++ b/Changelog/Program.cs
@@ -74,6 +74,7 @@ namespace Changelog
             string changelogDir
         )
         {
+            // mandatory configuration checks
             if (Config.Instance.Repo is null)
                 throw new Exception("Repository is not set in environment or could not be read from .env in working dir");
 

--- a/Changelog/Program.cs
+++ b/Changelog/Program.cs
@@ -12,13 +12,13 @@ namespace Changelog
                 Description = "Path to the changelog directory",
                 Required = true,
             };
-            
+
             Option<string> sinceRefShaOption = new("--sha", "-s")
             {
                 Description = "Specific ref sha to compare changes to. Good chance this should be the github.event.pull_request.base.sha workflow env",
                 Required = true,
             };
-            
+
             Option<string> discordWebhookUrlOption = new("--discord-webhook-url", "-u")
             {
                 Description = "URL for the discord webhook",
@@ -27,13 +27,13 @@ namespace Changelog
 
             Option<string> changelogMarkdownPathOption = new("--changelog-md-path", "-c")
             {
-                Description = "Path where the changelog markdown file is located. This will be sent to the discord webhook. Won't generate if not included.",
+                Description = "Path where the changelog markdown file is located. This will be sent to the discord webhook.",
                 Required = true,
             };
-            
-            
+
+
             RootCommand rootCommand = new("Changelog generator for SS14");
-            
+
             // Update changelog subcommand
             Command updateCommand = new("update", "Updates the changelog.yml files in resources");
 
@@ -96,7 +96,7 @@ namespace Changelog
 
             // Get the last merged PR time
             var lastMergedTime = PR.GetLastMergedTimeFromChangelogs(changelogDir, extraCategories);
-            
+
             Console.WriteLine($"Generating diff from {lastMergedTime}");
 
             // Get the list of PRs that were merged since last time.
@@ -112,7 +112,7 @@ namespace Changelog
                 Console.WriteLine("Nothing to do");
                 return 0;
             }
-            
+
             Console.WriteLine($"Generated {changelogs.Count} changelogs");
 
             // Add these parts to the actual changelog and trim older entries
@@ -141,14 +141,14 @@ namespace Changelog
 
             // Get the last merged PR time
             var lastMergedTime = PR.GetLastMergedFromRef(sinceRefSha, extraCategories);
-            
+
             Console.WriteLine($"Generating diff from {lastMergedTime}");
 
             // Get the list of PRs that were merged since last time.
             var diff = PR.GetDiff(lastMergedTime, Config.Instance.Repo, Config.Instance.Branch, Config.Instance.GithubToken);
 
             Console.WriteLine($"Collected {diff.Count} pull requests");
-            
+
             // Generate a new YMLfest out of this
             var changelogs = PR.ParseAllPRBodies(diff, extraCategories);
 
@@ -157,9 +157,9 @@ namespace Changelog
                 Console.WriteLine("Nothing to do");
                 return 0;
             }
-            
+
             Console.WriteLine($"Generated {changelogs.Count} changelogs");
-            
+
             IO.DumpChangelogToMarkdown(changelogMarkdownPath, changelogs);
 
             return 0;

--- a/Changelog/Program.cs
+++ b/Changelog/Program.cs
@@ -6,7 +6,7 @@ namespace Changelog
     {
         static int Main(string[] args)
         {
-            // options
+            // create options for the command line
             Option<string> changelogDirOption = new("--changelog-dir", "-d")
             {
                 Description = "Path to the changelog directory",
@@ -19,19 +19,14 @@ namespace Changelog
                 Required = true,
             };
 
-            Option<string> discordWebhookUrlOption = new("--discord-webhook-url", "-u")
-            {
-                Description = "URL for the discord webhook",
-                Required = true,
-            };
-
+            // changelogMarkdownPathOption will function both for dump-diff and discord-webhook, as output and input respectively
             Option<string> changelogMarkdownPathOption = new("--changelog-md-path", "-c")
             {
                 Description = "Path where the changelog markdown file is located. This will be sent to the discord webhook.",
                 Required = true,
             };
 
-
+            // Create the root command and subcommands for the command line
             RootCommand rootCommand = new("Changelog generator for SS14");
 
             // Update changelog subcommand
@@ -60,11 +55,9 @@ namespace Changelog
             Command sendWebhookCommand = new("send-webhook", "Send changelog markdown file to a discord webhook");
 
 
-            sendWebhookCommand.Options.Add(discordWebhookUrlOption);
             sendWebhookCommand.Options.Add(changelogMarkdownPathOption);
 
             sendWebhookCommand.SetAction(parseResult => SendDiscordWebhook(
-                parseResult.GetValue(discordWebhookUrlOption)!,
                 parseResult.GetValue(changelogMarkdownPathOption)!
             ));
 
@@ -165,17 +158,14 @@ namespace Changelog
             return 0;
         }
 
-        private static int SendDiscordWebhook(string discordWebhookUrl, string? changelogMarkdownPath)
+        private static int SendDiscordWebhook(string changelogMarkdownPath)
         {
-            if (changelogMarkdownPath is null)
-            {
-                Console.WriteLine();
-                return 1;
-            }
+            if (Config.Instance.DiscordWebHook is null)
+                throw new Exception("Discord webhook is not set in environment or could not be read from .env in working dir");
 
             using var reader = new StreamReader(changelogMarkdownPath);
 
-            if (!DiscordWebhook.SendDiffInParts(discordWebhookUrl, reader))
+            if (!DiscordWebhook.SendDiffInParts(Config.Instance.DiscordWebHook, reader))
                 return 1;
 
             return 0;

--- a/Changelog/Program.cs
+++ b/Changelog/Program.cs
@@ -1,0 +1,184 @@
+﻿using System.CommandLine;
+
+namespace Changelog
+{
+    internal static class Program
+    {
+        static int Main(string[] args)
+        {
+            // options
+            Option<string> changelogDirOption = new("--changelog-dir", "-d")
+            {
+                Description = "Path to the changelog directory",
+                Required = true,
+            };
+            
+            Option<string> sinceRefShaOption = new("--sha", "-s")
+            {
+                Description = "Specific ref sha to compare changes to. Good chance this should be the github.event.pull_request.base.sha workflow env",
+                Required = true,
+            };
+            
+            Option<string> discordWebhookUrlOption = new("--discord-webhook-url", "-u")
+            {
+                Description = "URL for the discord webhook",
+                Required = true,
+            };
+
+            Option<string> changelogMarkdownPathOption = new("--changelog-md-path", "-c")
+            {
+                Description = "Path where the changelog markdown file is located. This will be sent to the discord webhook. Won't generate if not included.",
+                Required = true,
+            };
+            
+            
+            RootCommand rootCommand = new("Changelog generator for SS14");
+            
+            // Update changelog subcommand
+            Command updateCommand = new("update", "Updates the changelog.yml files in resources");
+
+            updateCommand.Options.Add(changelogDirOption);
+
+            updateCommand.SetAction(parseResult => Generate(
+                parseResult.GetValue(changelogDirOption)!
+            ));
+            rootCommand.Subcommands.Add(updateCommand);
+
+            // generate diff subcommand
+            Command dumpCommand = new("dump-diff", "Dumps a diff to a markdown file, for later sending to discord or hosting on CDN");
+
+            dumpCommand.Options.Add(sinceRefShaOption);
+            dumpCommand.Options.Add(changelogMarkdownPathOption);
+
+            dumpCommand.SetAction(parseResult => DumpDiffToMarkdown(
+                parseResult.GetValue(sinceRefShaOption)!,
+                parseResult.GetValue(changelogMarkdownPathOption)!
+            ));
+            rootCommand.Subcommands.Add(dumpCommand);
+
+            // Send webhook subcommand
+            Command sendWebhookCommand = new("send-webhook", "Send changelog markdown file to a discord webhook");
+
+
+            sendWebhookCommand.Options.Add(discordWebhookUrlOption);
+            sendWebhookCommand.Options.Add(changelogMarkdownPathOption);
+
+            sendWebhookCommand.SetAction(parseResult => SendDiscordWebhook(
+                parseResult.GetValue(discordWebhookUrlOption)!,
+                parseResult.GetValue(changelogMarkdownPathOption)!
+            ));
+
+            rootCommand.Subcommands.Add(sendWebhookCommand);
+
+            return rootCommand.Parse(args).Invoke();
+        }
+
+        /// <summary>
+        /// Generates new changelogs
+        /// </summary>
+        /// <param name="changelogDir"></param>
+        private static int Generate(
+            string changelogDir
+        )
+        {
+            if (Config.Instance.Repo is null)
+                throw new Exception("Repository not set");
+
+            if (Config.Instance.Branch is null)
+                throw new Exception("Branch is not set");
+
+            if (Config.Instance.GithubToken is not null)
+                Console.WriteLine("Using github token");
+
+            List<string> extraCategories = [];
+            if (Config.Instance.ExtraCategories is not null)
+                extraCategories.AddRange(Config.Instance.ExtraCategories.Split(','));
+
+            // Get the last merged PR time
+            var lastMergedTime = PR.GetLastMergedTimeFromChangelogs(changelogDir, extraCategories);
+            
+            Console.WriteLine($"Generating diff from {lastMergedTime}");
+
+            // Get the list of PRs that were merged since last time.
+            var diff = PR.GetDiff(lastMergedTime, Config.Instance.Repo, Config.Instance.Branch, Config.Instance.GithubToken);
+
+            Console.WriteLine($"Collected {diff.Count} pull requests");
+
+            // Generate a new YMLfest out of this
+            var changelogs = PR.ParseAllPRBodies(diff, extraCategories);
+
+            if (changelogs.Count == 0)
+            {
+                Console.WriteLine("Nothing to do");
+                return 0;
+            }
+            
+            Console.WriteLine($"Generated {changelogs.Count} changelogs");
+
+            // Add these parts to the actual changelog and trim older entries
+            IO.UpdateChangelogs(changelogs, changelogDir);
+
+            return 0;
+        }
+
+        private static int DumpDiffToMarkdown(
+            string sinceRefSha,
+            string changelogMarkdownPath
+        )
+        {
+            if (Config.Instance.Repo is null)
+                throw new Exception("Repository not set");
+
+            if (Config.Instance.Branch is null)
+                throw new Exception("Branch is not set");
+
+            if (Config.Instance.GithubToken is not null)
+                Console.WriteLine("Using github token");
+
+            List<string> extraCategories = [];
+            if (Config.Instance.ExtraCategories is not null)
+                extraCategories.AddRange(Config.Instance.ExtraCategories.Split(','));
+
+            // Get the last merged PR time
+            var lastMergedTime = PR.GetLastMergedFromRef(sinceRefSha, extraCategories);
+            
+            Console.WriteLine($"Generating diff from {lastMergedTime}");
+
+            // Get the list of PRs that were merged since last time.
+            var diff = PR.GetDiff(lastMergedTime, Config.Instance.Repo, Config.Instance.Branch, Config.Instance.GithubToken);
+
+            Console.WriteLine($"Collected {diff.Count} pull requests");
+            
+            // Generate a new YMLfest out of this
+            var changelogs = PR.ParseAllPRBodies(diff, extraCategories);
+
+            if (changelogs.Count == 0)
+            {
+                Console.WriteLine("Nothing to do");
+                return 0;
+            }
+            
+            Console.WriteLine($"Generated {changelogs.Count} changelogs");
+            
+            IO.DumpChangelogToMarkdown(changelogMarkdownPath, changelogs);
+
+            return 0;
+        }
+
+        private static int SendDiscordWebhook(string discordWebhookUrl, string? changelogMarkdownPath)
+        {
+            if (changelogMarkdownPath is null)
+            {
+                Console.WriteLine();
+                return 1;
+            }
+
+            using var reader = new StreamReader(changelogMarkdownPath);
+
+            if (!DiscordWebhook.SendDiffInParts(discordWebhookUrl, reader))
+                return 1;
+
+            return 0;
+        }
+    }
+}

--- a/Changelog/Program.cs
+++ b/Changelog/Program.cs
@@ -82,13 +82,13 @@ namespace Changelog
         )
         {
             if (Config.Instance.Repo is null)
-                throw new Exception("Repository not set");
+                throw new Exception("Repository is not set in environment or could not be read from .env in working dir");
 
             if (Config.Instance.Branch is null)
-                throw new Exception("Branch is not set");
+                throw new Exception("Branch is not set in environment or could not be read from .env in working dir");
 
-            if (Config.Instance.GithubToken is not null)
-                Console.WriteLine("Using github token");
+            if (Config.Instance.GithubToken is null)
+                throw new Exception("Github token is not set in environment or could not be read from .env in working dir");
 
             List<string> extraCategories = [];
             if (Config.Instance.ExtraCategories is not null)
@@ -127,13 +127,13 @@ namespace Changelog
         )
         {
             if (Config.Instance.Repo is null)
-                throw new Exception("Repository not set");
+                throw new Exception("Repository is not set in environment or could not be read from .env in working dir");
 
             if (Config.Instance.Branch is null)
-                throw new Exception("Branch is not set");
+                throw new Exception("Branch is is not set in environment or could not be read from .env in working dir");
 
-            if (Config.Instance.GithubToken is not null)
-                Console.WriteLine("Using github token");
+            if (Config.Instance.GithubToken is null)
+                throw new Exception("Github token is not set in environment or could not be read from .env in working dir");
 
             List<string> extraCategories = [];
             if (Config.Instance.ExtraCategories is not null)

--- a/Changelog/README.md
+++ b/Changelog/README.md
@@ -23,7 +23,7 @@ It does the following:
 ### Update the changelog YMLs
 
 ```
-Description:                                                                                                                                                                                                                                                                                                                                                    
+Description:
   Updates the changelog.yml files in resources
 
 Usage:
@@ -42,7 +42,7 @@ This is intended for the master branch whenever a test publish is triggered but 
 ### Generate a diff markdown file
 
 ```
-Description:                                                                                                                                                                                                                                                                                                                                                    
+Description:
   Dumps a diff to a markdown file, for later sending to discord or hosting on CDN
 
 Usage:
@@ -65,7 +65,7 @@ This can be used to send it to a discord webhook or upload to a cdn or whatever
 ### Send the contents of a diff markdown to a discord webhook
 
 ```
-Description:                                                                                                                                                                                                                                                                                                                                                    
+Description:
   Send changelog markdown file to a discord webhook
 
 Usage:
@@ -77,16 +77,16 @@ Options:
 ```
 
 Reads the content of the input `--changelog-md-path` and sends the parts of it (split by discords max character limit of 2000)
-to the webhook specified by `--discord-webhook-url` 
+to the webhook specified by `--discord-webhook-url`
 
 
 # how this should be used probably
 
-### During publish testing: 
+### During publish testing:
 
-Workflow: checkout code -> `changelog update -d /path/to/Resources/Changelog` -> commit -> build -> publish testing build
+Workflow: checkout code -> `dotnet run --project Changelog -- update -d /path/to/Resources/Changelog` -> commit -> build -> publish testing build
 
 ### During publish stable
 
-Workflow: get last publish ref -> run `changelog dump-diff -s [ref] -c diff.md` -> build -> publish -> if all goes well, `changelog send-webhook -c diff.md`
+Workflow: get last publish ref -> run `dotnet run --project Changelog -- dump-diff -s [ref] -c diff.md` -> build -> publish -> if all goes well, `dotnet run --project Changelog -- send-webhook -c diff.md`
 

--- a/Changelog/README.md
+++ b/Changelog/README.md
@@ -1,0 +1,92 @@
+# SS14 changelog
+
+This is a program that generates changelogs for SS14. Parts of it were copied from the old one:
+
+https://github.com/space-wizards/SS14.Changelog
+
+## Setup
+
+Configure this by setting env variables or having a .env file in whatever place you run this in.
+
+```
+REPO=space-wizards/space-station-14
+BRANCH=master
+CHANGELOG_REPO_PATH=Resources/Changelog
+EXTRA_CATEGORIES=Admin,Maps,Rules
+#GITHUB_TOKEN=optional sort of but you should really be using this. you can probably use the workflow token at GITHUB_TOKEN or whatever
+DISCORD_WEBHOOK=url to discord webhook for posting changelogs to a channel
+```
+
+
+It does the following:
+
+### Update the changelog YMLs
+
+```
+Description:                                                                                                                                                                                                                                                                                                                                                    
+  Updates the changelog.yml files in resources
+
+Usage:
+  Changelog update [options]
+
+Options:
+  -d, --changelog-dir <changelog-dir> (REQUIRED)  Path to the changelog directory
+  -?, -h, --help                                  Show help and usage information
+```
+
+Takes the last date it can find in the changelog .yml files, then crawls the repository and branch specified in the
+config for merged PRs. It then works these into the changelog .yml files.
+
+This is intended for the master branch whenever a test publish is triggered but before the build is done and published
+
+### Generate a diff markdown file
+
+```
+Description:                                                                                                                                                                                                                                                                                                                                                    
+  Dumps a diff to a markdown file, for later sending to discord or hosting on CDN
+
+Usage:
+  Changelog dump-diff [options]
+
+Options:
+  -s, --sha <sha> (REQUIRED)                              Specific ref sha to compare changes to. Good chance this should be the github.event.pull_request.base.sha workflow env
+  -c, --changelog-md-path <changelog-md-path> (REQUIRED)  Path where the changelog markdown file is located. This will be sent to the discord webhook. Won't generate if not included.
+  -?, -h, --help                                          Show help and usage information
+```
+
+Takes the last date it can find in the changelog .yml files **at the specified `--sha` ref**, then crawls the repository
+and branch specified in the config for merged PRs. It then works these into a human readable markdown file that is meant
+for people eyes specified at `--changelog-md-path`
+
+the ref should probably be the commit of the last stable publish
+
+This can be used to send it to a discord webhook or upload to a cdn or whatever
+
+### Send the contents of a diff markdown to a discord webhook
+
+```
+Description:                                                                                                                                                                                                                                                                                                                                                    
+  Send changelog markdown file to a discord webhook
+
+Usage:
+  Changelog send-webhook [options]
+
+Options:
+  -c, --changelog-md-path <changelog-md-path> (REQUIRED)      Path where the changelog markdown file is located. This will be sent to the discord webhook. Won't generate if not included.
+  -?, -h, --help                                              Show help and usage information
+```
+
+Reads the content of the input `--changelog-md-path` and sends the parts of it (split by discords max character limit of 2000)
+to the webhook specified by `--discord-webhook-url` 
+
+
+# how this should be used probably
+
+### During publish testing: 
+
+Workflow: checkout code -> `changelog update -d /path/to/Resources/Changelog` -> commit -> build -> publish testing build
+
+### During publish stable
+
+Workflow: get last publish ref -> run `changelog dump-diff -s [ref] -c diff.md` -> build -> publish -> if all goes well, `changelog send-webhook -c diff.md`
+

--- a/SpaceStation14.slnx
+++ b/SpaceStation14.slnx
@@ -23,6 +23,8 @@
     <File Path="Directory.Packages.props" />
     <File Path="README.md" />
   </Folder>
+  <Project Path="Changelog.Tests/Changelog.Tests.csproj" />
+  <Project Path="Changelog/Changelog.csproj" />
   <Project Path="Content.Benchmarks/Content.Benchmarks.csproj" />
   <Project Path="Content.Client/Content.Client.csproj" />
   <Project Path="Content.IntegrationTests/Content.IntegrationTests.csproj" />


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

The code is based on the original project at https://github.com/space-wizards/SS14.Changelog.

Added a new project that manages the changelog changes, and updates the workflow to automatically update changelogs on test publish. Resolves #44397

This is the initial YAML changelog updating, meaning the workflows do not yet post the changelogs to discord. That'll appear in a second PR if this one is acceptable.

**Important note**: the previous workflow used python's pyaml library to export changelog yaml, which trimmed lines to be under some kind of line length limit (90 characters or so). C#'s yamldotnet is not as nice and doesn't really care at all. This means that all the changelogs do not have newlines in the messages, which changes previous changelogs. This **_shouldn't_** cause conflicts, but its good to be aware if anyone has messed around in the changelog files for some reason.

## Why
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The previous bit of infrastructure that managed the changelogs was a bit complicated, spread across 3 python scripts and a c# service, and required a dedicated host to work it.

This solution just works on workflows.

The code in this project is meant to be more structured and easier to follow. Let me know if that was successful.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds a two new projects:
- Changelog is the changelog project, partially based on [the old one](https://github.com/space-wizards/SS14.Changelog)
- Changelog.Tests contains tests that are directly copied from SS14.Changelog, and check if the regex parsing of changelog bodies works correctly.

See the readme for how to use this and how it is intended to be used, but in summary the new Changelog project can do the following:

1. Update yml files in Resources/Changelog to be up to date with the latest pull requests on a given branch/repo
2. Generate a formatted changelog by generating the changelog diff from a given commit SHA and dumping it to a markdown file
3. Send a markdown file to a discord webhook

Feature 1 is used in this PR through the publish testing workflow. 2 and 3 will appear in the next PR through the publish stable workflow.

This also edits the publish testing workflow to update the changelog first and commit the changes. If there are no changes, there will be no changelog update commit. The update changelog commit does not trigger more workflows.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
You'll have to test on a fork:

1. pull these changes into your fork's master
2. trigger the publish testing pipeline
3. Watch the workflow succeed on the "update changelog" job
4. see that a new commit to master was authored with you and github as the author and the message `[Automated changelog update [skip ci]]`

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
SS14.Changelog is being deprecated in favor of a solution that uses workflows. You should definitely not use both at the same time.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
who changelogs the changelog