### PR TITLE
Feat: Ejected gun cartridges inertia retention

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -29,7 +29,10 @@ public sealed partial class GunSystem
         }
 
         if (ammoEnt != null)
-            EjectCartridge(ammoEnt.Value);
+        {
+            Containers.TryGetOuterContainer(ent, Transform(ent), out var container);
+            EjectCartridge(ammoEnt.Value, ent, container?.Owner);
+        }
 
         var cycledEvent = new GunCycledEvent();
         RaiseLocalEvent(ent, ref cycledEvent);

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -122,7 +122,10 @@ public sealed partial class GunSystem : SharedGunSystem
 
                     // Something like ballistic might want to leave it in the container still
                     if (!cartridge.DeleteOnSpawn && !Containers.IsEntityInContainer(ent!.Value))
-                        EjectCartridge(ent.Value, angle);
+                    {
+                        Containers.TryGetOuterContainer(gun, Transform(gun), out var container);
+                        EjectCartridge(ent.Value, gun, container?.Owner, angle);
+                    }
 
                     Dirty(ent!.Value, cartridge);
                     break;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -104,7 +104,8 @@ public abstract partial class SharedGunSystem
         {
             if (_netManager.IsServer)
             {
-                EjectCartridge(chamberEnt.Value);
+                Containers.TryGetOuterContainer(uid, Transform(uid), out var container);
+                EjectCartridge(chamberEnt.Value, uid, container?.Owner);
             }
             else
             {
@@ -174,7 +175,8 @@ public abstract partial class SharedGunSystem
             {
                 if (_netManager.IsServer)
                 {
-                    EjectCartridge(chambered.Value);
+                    Containers.TryGetOuterContainer(uid, Transform(uid), out var container);
+                    EjectCartridge(chambered.Value, uid, container?.Owner);
                 }
                 else
                 {

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Revolver.cs
@@ -285,6 +285,7 @@ public partial class SharedGunSystem
         var mapCoordinates = TransformSystem.GetMapCoordinates(ent);
         var anyEmpty = false;
 
+        Containers.TryGetOuterContainer(ent, Transform(ent), out var container);
         for (var i = 0; i < ent.Comp.Capacity; i++)
         {
             var chamber = ent.Comp.Chambers[i];
@@ -303,7 +304,7 @@ public partial class SharedGunSystem
                     if (TryComp<CartridgeAmmoComponent>(uid, out var cartridge))
                         SetCartridgeSpent(uid, cartridge, !(bool)chamber);
 
-                    EjectCartridge(uid);
+                    EjectCartridge(uid, ent, container?.Owner);
                 }
 
                 ent.Comp.Chambers[i] = null;
@@ -316,7 +317,7 @@ public partial class SharedGunSystem
                 ent.Comp.Chambers[i] = null;
 
                 if (!_netManager.IsClient)
-                    EjectCartridge(slot.Value);
+                    EjectCartridge(slot.Value, ent, container?.Owner);
 
                 anyEmpty = true;
             }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -86,6 +86,27 @@ public abstract partial class SharedGunSystem : EntitySystem
     private const float InteractNextFire = 0.3f;
     private const double SafetyNextFire = 0.5;
     private const float EjectOffset = 0.4f;
+
+    /// <summary>
+    /// Ejecting cartridge angle offset.
+    /// </summary>
+    private const float EjectAngleOffset = 3.7f; // 212 degrees; casings should eject slightly to the right and behind of a gun
+
+    /// <summary>
+    /// Ejecting cartridge velocity multiplier.
+    /// </summary>
+    private const float EjectVelocityMultiplier = 0.01f;
+
+    /// <summary>
+    /// Ejecting cartridge inertia vector multiplier.
+    /// </summary>
+    private const float InertiaMultiplier = 0.4f;
+
+    /// <summary>
+    /// Cartridge ejection speed.
+    /// </summary>
+    private const float EjectSpeed = 5f;
+
     protected const string AmmoExamineColor = "yellow";
     protected const string FireRateExamineColor = "yellow";
     public const string ModeExamineColor = "cyan";
@@ -488,6 +509,8 @@ public abstract partial class SharedGunSystem : EntitySystem
     /// </summary>
     protected void EjectCartridge(
         EntityUid entity,
+        EntityUid gun,
+        EntityUid? holder = null,
         Angle? angle = null,
         bool playSound = true)
     {
@@ -501,13 +524,17 @@ public abstract partial class SharedGunSystem : EntitySystem
         TransformSystem.SetLocalRotation(entity, Random.NextAngle(), xform);
         TransformSystem.SetCoordinates(entity, xform, coordinates);
 
-        // decides direction the casing ejects and only when not cycling
-        if (angle != null)
-        {
-            var ejectAngle = angle.Value;
-            ejectAngle += 3.7f; // 212 degrees; casings should eject slightly to the right and behind of a gun
-            ThrowingSystem.TryThrow(entity, ejectAngle.ToVec().Normalized() / 100, 5f);
-        }
+        var ejectAngle = Angle.Zero;
+        if (angle.HasValue)
+            ejectAngle += angle.Value + EjectAngleOffset;
+
+        // Try applying the holder or gun velocity
+        var inertia = Vector2.Zero;
+        if (TryComp<PhysicsComponent>(holder ?? gun, out var body))
+            inertia += body.LinearVelocity;
+
+        ThrowingSystem.TryThrow(entity, ejectAngle.ToVec().Normalized() * EjectVelocityMultiplier + inertia * InertiaMultiplier, EjectSpeed);
+
         if (playSound && TryComp<CartridgeAmmoComponent>(entity, out var cartridge))
         {
             Audio.PlayPvs(cartridge.EjectSound, entity, AudioParams.Default.WithVariation(SharedContentAudioSystem.DefaultVariation).WithVolume(-1f));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added inertia retention to the ejected gun cartridges.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #44725.

## Technical details
<!-- Summary of code changes for easier review. -->
- Added gun and holder parameters to the EjectCartridge method.
- Added 40% of velocity (from holder or gun) to the throw vector for ejected cartridge.
- Removed magical values moving them into constants.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1) Grab a loaded gun.
2) Cycle it or shoot it while moving.
3) Watch ejected cartridge flying away.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
### Before
https://github.com/user-attachments/assets/c1955681-1bb7-432a-a3ab-52aad34a6941

### After
https://github.com/user-attachments/assets/2008711d-9768-4edc-b223-1c23f27d82e3

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
``SharedGunSystem.EjectCartridge(EntityUid entity, Angle? angle = null, bool playSound = true)`` was changed to ``SharedGunSystem.EjectCartridge(EntityUid entity, EntityUid gun, EntityUid? holder = null, Angle? angle = null, bool playSound = true)``.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Now ejected gun cartridges retain inertia.