### PR TITLE
fix name highlighting in deadchat

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -123,7 +123,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
             // Make sure the character's name is highlighted only when mentioned directly (eg. it's said by someone),
             // for example in 'Name Surname says, "..."' 'Name Surname' won't be highlighted.
             keyword = StartAtSign.Replace(keyword,
-                $"(?<=(?<=^.?OOC:.*:.*)|(?<=,.*{_chatSpeechDoubleQuoteBegin}.*)|(?<=\\n.*))");
+                $"(?<=(?<=^.?OOC:.*:.*)|(?<=,.*{_chatSpeechDoubleQuoteBegin}.*)|(?<=\\n.*)|(?<=:.*))");
 
             _highlights.Add(keyword);
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
fix "@name" highlights not working in deadchat

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bug fix. if someone says our name in deadchat, we probably wanna hear it.

## Technical details
<!-- Summary of code changes for easier review. -->
The regex being added to "@name" highlights didnt account for dead chat. I add so that it now finds the `: ` in `(Dead) John Doe: hi` and highlights name words after it.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. ghost
2. say your name (one that is in highlights with an "@")
3. it highlights (it didnt previously)


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="625" height="366" alt="2026-07-19-17h51m13s_Content Client" src="https://github.com/user-attachments/assets/85646ec0-ed52-4a26-b1e3-b209a012ac12" />
