### PR TITLE
Fix Some Astro-Tile Weather

### DIFF
--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -1360,6 +1360,7 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemMowedAstroGrass
+  weather: false
 
 - type: tile
   id: FloorJungleAstroGrass
@@ -1368,6 +1369,7 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemJungleAstroGrass
+  weather: false
 
 - type: tile
   parent: FloorGrassDark
@@ -1377,6 +1379,7 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemDarkAstroGrass
+  weather: false
 
 - type: tile
   parent: FloorGrassLight
@@ -1386,6 +1389,7 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemLightAstroGrass
+  weather: false
 
 # Ice
 - type: tile
@@ -1405,6 +1409,7 @@
   isSubfloor: false
   deconstructTools: [ Prying ]
   itemDrop: FloorTileItemAstroSnow
+  weather: false
 
 # Asteroid Sand
 - type: tile

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -24,6 +24,7 @@
   - FloorDirt
   - PlatingRCD
   - FloorHullReinforced
+  weather: false
 
 - type: tile
   id: FloorSteel
@@ -1360,7 +1361,6 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemMowedAstroGrass
-  weather: false
 
 - type: tile
   id: FloorJungleAstroGrass
@@ -1369,27 +1369,24 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemJungleAstroGrass
-  weather: false
 
 - type: tile
-  parent: FloorGrassDark
+  parent: [ BaseStationTile, FloorGrassDark ]
   id: FloorDarkAstroGrass
   name: tiles-dark-astro-grass
   baseTurf: Plating
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemDarkAstroGrass
-  weather: false
 
 - type: tile
-  parent: FloorGrassLight
+  parent: [ BaseStationTile, FloorGrassLight ]
   id: FloorLightAstroGrass
   name: tiles-light-astro-grass
   baseTurf: Plating
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemLightAstroGrass
-  weather: false
 
 # Ice
 - type: tile
@@ -1409,7 +1406,6 @@
   isSubfloor: false
   deconstructTools: [ Prying ]
   itemDrop: FloorTileItemAstroSnow
-  weather: false
 
 # Asteroid Sand
 - type: tile
@@ -1419,7 +1415,6 @@
   isSubfloor: false
   deconstructTools: [ Prying ]
   itemDrop: FloorTileItemAstroAsteroidSand
-  weather: false
 
 - type: tile
   id: FloorAstroAsteroidSandBorderless
@@ -1428,7 +1423,6 @@
   isSubfloor: false
   deconstructTools: [ Prying ]
   itemDrop: FloorTileItemAstroAsteroidSand
-  weather: false
 
 - type: tile
   parent: FloorDesert


### PR DESCRIPTION
## About the PR
Effectively disables weather on astro-snow, dark astro-grass, jungle astro-grass, light astro-grass, and mowed astro-grass tiles.

In actuality, changes the default station tile to not show weather and makes all the astro tiles properly inherit from the default station tile.

## Why / Balance
Astro-tiles are primarily used inside stations and having weather inside stations is weird.

## Test plan
Place the relevant tiles down and run `weatherset 1 WeatherAshfallHeavy`.

## Media
<img width="2075" height="782" alt="image" src="https://github.com/user-attachments/assets/ff201e32-d602-4011-be13-007e65b83fb2" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
- fix: Fixed certain astro-tiles being affected by weather.
