### PR TITLE
Add AppearanceComponent to BaseFoldable, remove from simple inheritors

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/base_clothingeyes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/base_clothingeyes.yml
@@ -16,7 +16,6 @@
   id: ClothingHeadEyeBaseFlippable
   abstract: true
   components:
-  - type: Appearance
   - type: FlippableClothingVisuals
   - type: Foldable
     canFoldInsideContainer: true

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -552,7 +552,6 @@
   components:
   - type: Clothing
     sprite: Clothing/Head/Hats/santahat.rsi
-  - type: Appearance
   - type: HideLayerClothing
     layers:
       Hair: HEAD
@@ -677,7 +676,6 @@
   components:
   - type: Clothing
     sprite: Clothing/Head/Hats/ushanka.rsi
-  - type: Appearance
   - type: RussianAccent
     relayAccent: true
   - type: Foldable

--- a/Resources/Prototypes/Entities/Clothing/Head/soft.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/soft.yml
@@ -3,7 +3,6 @@
   id: ClothingHeadHeadHatBaseFlippable
   abstract: true
   components:
-  - type: Appearance
   - type: Foldable
     canFoldInsideContainer: true
     unfoldVerbText: fold-flip-verb

--- a/Resources/Prototypes/Entities/Clothing/Masks/bandanas.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/bandanas.yml
@@ -3,7 +3,6 @@
   id: ClothingMaskBandanaBase
   abstract: true
   components:
-  - type: Appearance
   - type: Foldable
     canFoldInsideContainer: true
   - type: FoldableClothing

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -66,7 +66,6 @@
   parent: [ClothingOuterStorageBase, BaseFoldable]
   id: ClothingOuterStorageFoldableBase
   components:
-  - type: Appearance
   - type: Foldable
     canFoldInsideContainer: true
     unfoldVerbText: fold-zip-verb

--- a/Resources/Prototypes/Entities/Objects/Tools/decoys.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/decoys.yml
@@ -25,7 +25,6 @@
       - !type:PlaySoundBehavior
         sound:
           path: /Audio/Effects/pop_high.ogg
-  - type: Appearance
   - type: Item
     size: Normal
   - type: RandomMetadata # No metagaming these, jimbo.

--- a/Resources/Prototypes/Entities/Objects/Tools/fulton.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/fulton.yml
@@ -38,20 +38,16 @@
     - type: Clickable
     - type: InteractionOutline
     - type: FultonBeacon
-    - type: Appearance
-    - type: GenericVisualizer
-      visuals:
-        enum.FoldedVisuals.State:
-          foldedLayer:
-            True: { state: folded_extraction }
-            False: { state: extraction_point }
     - type: Sprite
       sprite: Objects/Tools/fulton.rsi
       drawdepth: SmallObjects
       noRot: true
       layers:
         - state: extraction_point
-          map: [ "foldedLayer" ]
+          map: ["unfoldedLayer"]
+          visible: false
+        - state: folded_extraction
+          map: ["foldedLayer"]
 
 - type: entity
   id: Fulton

--- a/Resources/Prototypes/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/vehicles.yml
@@ -51,7 +51,6 @@
     - state: wheelchair_folded
       map: ["foldedLayer"]
       visible: false
-  - type: Appearance
   - type: Item
     size: Ginormous
   - type: Damageable

--- a/Resources/Prototypes/Entities/Objects/base_foldable.yml
+++ b/Resources/Prototypes/Entities/Objects/base_foldable.yml
@@ -1,7 +1,6 @@
 - type: entity
-  id: BaseFoldable
-  name: "foldable"
   abstract: true
+  id: BaseFoldable
   components:
   - type: Foldable
   - type: Appearance
@@ -19,6 +18,5 @@
   abstract: true
   parent: BaseFoldable
   id: BaseDeployFoldable
-  name: "deploy foldable"
   components:
   - type: DeployFoldable

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -335,7 +335,6 @@
       visible: false
   - type: Item
     size: Huge
-  - type: Appearance
   - type: MeleeWeapon
     damage:
       types:

--- a/Resources/Prototypes/Entities/foldable.yml
+++ b/Resources/Prototypes/Entities/foldable.yml
@@ -4,6 +4,7 @@
   abstract: true
   components:
   - type: Foldable
+  - type: Appearance
   - type: GenericVisualizer
     visuals:
       enum.FoldedVisuals.State:


### PR DESCRIPTION
## About the PR
Adds the AppearanceComponent to BaseFoldable (which has a GenericVisualizer, but is missing Appearance).

Removes AppearanceComponent from entities that inherit from BaseFoldable without defining other appearance data.

## Why / Balance
BaseFoldable: good inheritance.

Redundant Appearance cleanup: handy cleanup, reinforces that Appearance should be used with Visualizers.

foldable.yml moved to Entities/Objects (renamed as base_foldable.yml) to resolve #13977.

## Technical details
YAML

## Test plan
Spawn some bandanas.  Flip 'em.  Put 'em on, should work fine.
Spawn a fulton beacon, deploy it, pack it back up, should work fine.
Spawn a wheelchair, deploy it, pack it back up.
Spawn a beer HUD eyeback, flip it and back.
Spawn a folding chair, fold and unfold it.

## Media

A collection of foldable items in various states.
<img width="1282" height="759" alt="image" src="https://github.com/user-attachments/assets/609aa1e2-c6b9-4fcd-943f-c65b5e89d8a5" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

`Resources/Properties/Entities/foldable.yml` has been moved to `Resources/Properties/Entities/Objects/base_foldable.yml`

## Changelog
honk