### PR TITLE
Bugfix: Fix shuttle airlock construction parent

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -511,7 +511,7 @@
   targetNode: glassAirlock
 
 - type: construction
-  parent: BaseStructureFullTile
+  parent: BaseStructureFullTileDirectional
   id: AirlockShuttle
   graph: AirlockShuttle
   targetNode: airlock


### PR DESCRIPTION

## About the PR

Fixes an issue where shuttle airlocks couldn't be rotated.

## Why / Balance

I goofed.  Bug report at https://discord.com/channels/310555209753690112/1528606150277333082

## Technical details

YAML parent swap.

## Test plan

Construct a shuttle airlock and a glass shuttle airlock in non-south rotations.
Should build fine and show up as you expect.

## Media

<img width="1282" height="759" alt="image" src="https://github.com/user-attachments/assets/5722130e-9e3b-41b7-812f-5edd4f022fc1" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
no, sins
