### PR TITLE
Custom DamageThreshold Serializer

### DIFF
--- a/Content.Server/Destructible/DamageThresholdsSerializer.cs
+++ b/Content.Server/Destructible/DamageThresholdsSerializer.cs
@@ -90,8 +90,6 @@ public sealed class DamageThresholdsSerializer : ITypeSerializer<List<DamageThre
     private bool IsEqual<T1, T2>(T1 a, T2 b) where T1 : IThresholdTrigger where T2 : IThresholdTrigger
     {
         // Ensure same type and same thresholds!
-        return a is T2 trigger &&
-               // TODO: TEST TO ENSURE THIS IS DIFFERENT FROM "==" !!!
-               trigger.Equals(b);
+        return a is T2 trigger && trigger.Equals(b);
     }
 }

--- a/Content.Server/Destructible/DamageThresholdsSerializer.cs
+++ b/Content.Server/Destructible/DamageThresholdsSerializer.cs
@@ -1,0 +1,97 @@
+﻿#nullable disable
+using System.Linq;
+using Content.Server.Destructible.Thresholds;
+using Content.Shared.Destructible.Thresholds.Triggers;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Sequence;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Content.Server.Destructible;
+
+public sealed class DamageThresholdsSerializer : ITypeSerializer<List<DamageThreshold>, SequenceDataNode>
+{
+    public ValidationNode Validate(ISerializationManager serializationManager,
+        SequenceDataNode node,
+        IDependencyCollection dependencies,
+        ISerializationContext context = null)
+    {
+        var list = new List<ValidationNode>();
+        foreach (var elem in node.Sequence)
+        {
+            list.Add(serializationManager.ValidateNode<DamageThreshold>(elem, context));
+        }
+
+        return new ValidatedSequenceNode(list);
+    }
+
+    public List<DamageThreshold> Read(ISerializationManager serializationManager,
+        SequenceDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext context = null,
+        ISerializationManager.InstantiationDelegate<List<DamageThreshold>> instanceProvider = null)
+    {
+        if (instanceProvider != null)
+        {
+            var sawmill = dependencies.Resolve<ILogManager>().GetSawmill("szr");
+            sawmill.Warning($"Provided value to a Read-call for a {nameof(List<DamageThreshold>)}. Ignoring...");
+        }
+
+        var list = new List<DamageThreshold>();
+
+        var ignore = new HashSet<int>(node.Sequence.Count);
+        for (var i = 0; i < node.Sequence.Count; i++)
+        {
+            if (ignore.Contains(i))
+                continue;
+
+            var item = serializationManager.Read<DamageThreshold>(node.Sequence[i], hookCtx, context);
+            for (var j = i + 1; j < node.Sequence.Count; j++)
+            {
+                var item2 = serializationManager.Read<DamageThreshold>(node.Sequence[j], hookCtx, context);
+                if (IsEqual(item, item2))
+                {
+                    item.Behaviors = item.Behaviors.Union(item2.Behaviors).ToList();
+                    ignore.Add(j);
+                }
+            }
+
+            list.Add(item);
+        }
+
+        list.Sort();
+        return list;
+    }
+
+    public DataNode Write(ISerializationManager serializationManager,
+        List<DamageThreshold> value,
+        IDependencyCollection dependencies,
+        bool alwaysWrite = false,
+        ISerializationContext context = null)
+    {
+        var sequence = new SequenceDataNode();
+
+        foreach (var elem in value)
+        {
+            sequence.Add(serializationManager.WriteValue(elem, alwaysWrite, context));
+        }
+
+        return sequence;
+    }
+
+    private bool IsEqual(DamageThreshold a, DamageThreshold b)
+    {
+        return IsEqual(a.Trigger, b.Trigger);
+    }
+
+    private bool IsEqual<T1, T2>(T1 a, T2 b) where T1 : IThresholdTrigger where T2 : IThresholdTrigger
+    {
+        // Ensure same type and same thresholds!
+        return a is T2 trigger &&
+               // TODO: TEST TO ENSURE THIS IS DIFFERENT FROM "==" !!!
+               trigger.Equals(b);
+    }
+}

--- a/Content.Server/Destructible/DestructibleComponent.cs
+++ b/Content.Server/Destructible/DestructibleComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class DestructibleComponent : Component
     /// A list of damage thresholds for the entity;
     /// includes their triggers and resultant behaviors.
     /// </summary>
-    [DataField]
+    [DataField(customTypeSerializer: typeof(DamageThresholdsSerializer))]
     public List<DamageThreshold> Thresholds = new();
 
     /// <summary>

--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -134,9 +134,6 @@ public sealed partial class DestructibleSystem : SharedDestructibleSystem
     /// </summary>
     public bool Triggered(DamageThreshold threshold, Entity<Shared.Damage.Components.DamageableComponent> owner)
     {
-        if (threshold.Trigger == null)
-            return false;
-
         if (threshold.Triggered && threshold.TriggersOnce)
             return false;
 

--- a/Content.Server/Destructible/Thresholds/DamageThreshold.cs
+++ b/Content.Server/Destructible/Thresholds/DamageThreshold.cs
@@ -4,7 +4,7 @@ using Content.Shared.Destructible.Thresholds.Triggers;
 namespace Content.Server.Destructible.Thresholds;
 
 [DataDefinition]
-public sealed partial class DamageThreshold
+public sealed partial class DamageThreshold : IComparable<DamageThreshold>
 {
     /// <summary>
     /// Whether or not this threshold was triggered in the previous call to
@@ -31,8 +31,8 @@ public sealed partial class DamageThreshold
     /// The condition that decides if this threshold has been reached.
     /// Gets evaluated each time the entity's damage changes.
     /// </summary>
-    [DataField]
-    public IThresholdTrigger? Trigger;
+    [DataField(required: true)]
+    public IThresholdTrigger Trigger;
 
     /// <summary>
     /// Behaviors to activate once this threshold is triggered.
@@ -40,4 +40,9 @@ public sealed partial class DamageThreshold
     /// </summary>
     [DataField]
     public List<IThresholdBehavior> Behaviors = new();
+
+    public int CompareTo(DamageThreshold? other)
+    {
+        return Trigger.CompareTo(other?.Trigger);
+    }
 }

--- a/Content.Shared/Destructible/Triggers/AndTrigger.cs
+++ b/Content.Shared/Destructible/Triggers/AndTrigger.cs
@@ -39,7 +39,7 @@ public sealed partial class AndTrigger : IThresholdTrigger
 
     public bool Equals(IThresholdTrigger? other)
     {
-        if (other is not OrTrigger trigger || trigger.Triggers.Count != Triggers.Count)
+        if (other is not AndTrigger trigger || trigger.Triggers.Count != Triggers.Count)
             return false;
 
         for (var i = 0; i < Triggers.Count; i++)

--- a/Content.Shared/Destructible/Triggers/AndTrigger.cs
+++ b/Content.Shared/Destructible/Triggers/AndTrigger.cs
@@ -25,4 +25,29 @@ public sealed partial class AndTrigger : IThresholdTrigger
 
         return true;
     }
+
+    public int CompareTo(IThresholdTrigger? other)
+    {
+        var comparison = 0;
+        foreach (var trigger in Triggers)
+        {
+            comparison += trigger.CompareTo(other);
+        }
+
+        return Math.Clamp(comparison, -1, 1);
+    }
+
+    public bool Equals(IThresholdTrigger? other)
+    {
+        if (other is not OrTrigger trigger || trigger.Triggers.Count != Triggers.Count)
+            return false;
+
+        for (var i = 0; i < Triggers.Count; i++)
+        {
+            if (!trigger.Triggers[i].Equals(Triggers[i]))
+                return false;
+        }
+
+        return true;
+    }
 }

--- a/Content.Shared/Destructible/Triggers/DamageGroupTrigger.cs
+++ b/Content.Shared/Destructible/Triggers/DamageGroupTrigger.cs
@@ -30,4 +30,20 @@ public sealed partial class DamageGroupTrigger : IThresholdTrigger
     {
         return system.Damageable.GetDamagePerGroup(damageable.Owner).GetValueOrDefault(DamageGroup) >= Damage;
     }
+
+    public int CompareTo(IThresholdTrigger? other)
+    {
+        if (other is DamageGroupTrigger trigger && trigger.DamageGroup == DamageGroup)
+        {
+            return Damage.CompareTo(trigger.Damage);
+        }
+
+        // Not comparable...
+        return 0;
+    }
+
+    public bool Equals(IThresholdTrigger? other)
+    {
+        return other is DamageGroupTrigger trigger && trigger.DamageGroup == DamageGroup && trigger.Damage == Damage;
+    }
 }

--- a/Content.Shared/Destructible/Triggers/DamageTrigger.cs
+++ b/Content.Shared/Destructible/Triggers/DamageTrigger.cs
@@ -22,4 +22,19 @@ public sealed partial class DamageTrigger : IThresholdTrigger
     {
         return system.Damageable.GetTotalDamage(damageable.AsNullable()) >= Damage;
     }
+
+    public int CompareTo(IThresholdTrigger? other)
+    {
+        if (other is DamageTrigger trigger)
+        {
+            return Damage.CompareTo(trigger.Damage);
+        }
+
+        return 0;
+    }
+
+    public bool Equals(IThresholdTrigger? other)
+    {
+        return other is DamageTrigger trigger && trigger.Damage == Damage;
+    }
 }

--- a/Content.Shared/Destructible/Triggers/DamageTypeTrigger.cs
+++ b/Content.Shared/Destructible/Triggers/DamageTypeTrigger.cs
@@ -31,4 +31,19 @@ public sealed partial class DamageTypeTrigger : IThresholdTrigger
         return system.Damageable.GetAllDamage(damageable.AsNullable()).DamageDict.TryGetValue(DamageType, out var damageReceived) &&
                damageReceived >= Damage;
     }
+
+    public int CompareTo(IThresholdTrigger? other)
+    {
+        if (other is DamageTypeTrigger trigger && trigger.DamageType == DamageType)
+        {
+            return Damage.CompareTo(trigger.Damage);
+        }
+
+        return 0;
+    }
+
+    public bool Equals(IThresholdTrigger? other)
+    {
+        return other is DamageTypeTrigger trigger && trigger.DamageType == DamageType && trigger.Damage == Damage;
+    }
 }

--- a/Content.Shared/Destructible/Triggers/IThresholdTrigger.cs
+++ b/Content.Shared/Destructible/Triggers/IThresholdTrigger.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.Destructible.Thresholds.Triggers;
 /// IThresholdTriggers on the other hand are directly checked in a foreach loop without raising events.
 /// And there are only few of these conditions, so there is only a minor amount of code duplication.
 /// </remarks>
-public interface IThresholdTrigger
+public interface IThresholdTrigger : IComparable<IThresholdTrigger>, IEquatable<IThresholdTrigger>
 {
     /// <summary>
     /// Checks if this trigger has been reached.

--- a/Content.Shared/Destructible/Triggers/OrTrigger.cs
+++ b/Content.Shared/Destructible/Triggers/OrTrigger.cs
@@ -25,4 +25,29 @@ public sealed partial class OrTrigger : IThresholdTrigger
 
         return false;
     }
+
+    public int CompareTo(IThresholdTrigger? other)
+    {
+        var comparison = 0;
+        foreach (var trigger in Triggers)
+        {
+            comparison += trigger.CompareTo(other);
+        }
+
+        return Math.Clamp(comparison, -1, 1);
+    }
+
+    public bool Equals(IThresholdTrigger? other)
+    {
+        if (other is not OrTrigger trigger || trigger.Triggers.Count != Triggers.Count)
+            return false;
+
+        for (var i = 0; i < Triggers.Count; i++)
+        {
+            if (!trigger.Triggers[i].Equals(Triggers[i]))
+                return false;
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title. Needed for #44644 
Makes it so Destructible Behaviors will combine if the Triggers are the same, and so we can give entities thresholds without having to rewrite a bunch of garbage when you want to add 1 additional behavior.
In addition forcibly organizes all Triggers that way you don't have to worry about them being disorganized and some bulldozing others because of YAML ordering. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Less YAML slop and this is much faster compared to reorganizing the list anytime we do MapInit. Does make Prototype loading slower but I'll take that for far more readable YAML

## Technical details
<!-- Summary of code changes for easier review. -->
New Serializer!!!
DamageThreshold and IThresholdTrigger now inherit from IComparable 
IThresholdTrigger now inherits from IEquatable

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Tests passed locally, add a second DamageThreshold with the same Trigger to an entity and ensure they combine properly. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`DamageThreshold` and `IThresholdTrigger` now inherit from `IComparable`
`IThresholdTrigger` now inherits from `IEquatable`
`DestructibleComponent` `Trigger` is no longer nullable and is required 

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
