### PR TITLE
Entity Shapes system

### DIFF
--- a/Content.Shared/EntityShapes/Components/ExpandingShapeSpawnerComponent.cs
+++ b/Content.Shared/EntityShapes/Components/ExpandingShapeSpawnerComponent.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Shared.EntityShapes.Shapes;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.EntityShapes.Components;
@@ -9,12 +10,25 @@ namespace Content.Shared.EntityShapes.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ExpandingShapeSpawnerComponent : Component
 {
+    /// <summary>
+    /// If specified, changes the <see cref="EntityShape.Offset"/> on each trigger by its amount.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public Vector2? CounterOffset;
 
+    /// <summary>
+    /// If specified, changes the <see cref="EntityShape.Size"/> on each trigger by its amount.
+    /// </summary>
+    /// <remarks>
+    /// This is intentionally a float, so you can specify fractions
+    /// and make it grow only on each second, third, etc. activation.
+    /// </remarks>
     [DataField, AutoNetworkedField]
     public float? CounterSize;
 
+    /// <summary>
+    /// If specified, changes the <see cref="EntityShape.StepSize"/> on each trigger by its amount.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public float? CounterStepSize;
 }

--- a/Content.Shared/EntityShapes/Components/ExpandingShapeSpawnerComponent.cs
+++ b/Content.Shared/EntityShapes/Components/ExpandingShapeSpawnerComponent.cs
@@ -1,0 +1,20 @@
+using System.Numerics;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.EntityShapes.Components;
+
+/// <summary>
+/// Spawns an entity shape periodically or with a delay. Can be modified to expand, shrink, or move with time.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ExpandingShapeSpawnerComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Vector2? CounterOffset;
+
+    [DataField, AutoNetworkedField]
+    public float? CounterSize;
+
+    [DataField, AutoNetworkedField]
+    public float? CounterStepSize;
+}

--- a/Content.Shared/EntityShapes/Components/ShapeSpawnerComponent.cs
+++ b/Content.Shared/EntityShapes/Components/ShapeSpawnerComponent.cs
@@ -1,0 +1,26 @@
+using Content.Shared.EntityShapes.Shapes;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.EntityShapes.Components;
+
+/// <summary>
+/// Spawns an entity shape on MapInit.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ShapeSpawnerComponent : Component
+{
+    [DataField(required: true)]
+    public EntityShape Shape;
+
+    [DataField(required: true)]
+    public EntProtoId Spawn;
+
+    /// <summary>
+    /// If true, aligns center coordinates of a spawner to the nearest tile.
+    /// Used for tile patterns to be more stable when the origin
+    /// is located on the edge between 2 or more tiles.
+    /// </summary>
+    [DataField]
+    public bool AlignCoords;
+}

--- a/Content.Shared/EntityShapes/Components/ShapeSpawnerComponent.cs
+++ b/Content.Shared/EntityShapes/Components/ShapeSpawnerComponent.cs
@@ -1,6 +1,6 @@
 using Content.Shared.EntityShapes.Shapes;
+using Content.Shared.EntityTable.EntitySelectors;
 using Robust.Shared.GameStates;
-using Robust.Shared.Prototypes;
 
 namespace Content.Shared.EntityShapes.Components;
 
@@ -10,11 +10,17 @@ namespace Content.Shared.EntityShapes.Components;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class ShapeSpawnerComponent : Component
 {
+    /// <summary>
+    /// The shape to use to spawn the entities.
+    /// </summary>
     [DataField(required: true)]
     public EntityShape Shape;
 
+    /// <summary>
+    /// Table to spawn at each point of the shape.
+    /// </summary>
     [DataField(required: true)]
-    public EntProtoId Spawn;
+    public EntityTableSelector Spawn;
 
     /// <summary>
     /// If true, aligns center coordinates of a spawner to the nearest tile.
@@ -23,4 +29,10 @@ public sealed partial class ShapeSpawnerComponent : Component
     /// </summary>
     [DataField]
     public bool AlignCoords;
+
+    /// <summary>
+    /// Sets whether to delete the entity with this component after the spawner is finished.
+    /// </summary>
+    [DataField]
+    public bool DeleteSpawnerAfterSpawn = true;
 }

--- a/Content.Shared/EntityShapes/Components/ShapeSpawnerCounterComponent.cs
+++ b/Content.Shared/EntityShapes/Components/ShapeSpawnerCounterComponent.cs
@@ -8,15 +8,27 @@ namespace Content.Shared.EntityShapes.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ShapeSpawnerCounterComponent : Component
 {
+    /// <summary>
+    /// Prediod between each trigger.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public TimeSpan SpawnPeriod = TimeSpan.FromSeconds(1f);
 
+    /// <summary>
+    /// The max amount of triggers.
+    /// </summary>
     [DataField, AutoNetworkedField]
-    public int MaxCounter = 1;
+    public int MaxCounter = 2;
 
+    /// <summary>
+    /// Time when the next trigger will occur.
+    /// </summary>
     [ViewVariables, AutoNetworkedField]
     public TimeSpan NextSpawn;
 
+    /// <summary>
+    /// Amount of triggers.
+    /// </summary>
     [ViewVariables, AutoNetworkedField]
-    public int Counter = 1; // We spawn 1 shape not in a loop, so we have to start from 1.
+    public int Counter = 1; // We spawn 1 shape on map init already
 }

--- a/Content.Shared/EntityShapes/Components/ShapeSpawnerCounterComponent.cs
+++ b/Content.Shared/EntityShapes/Components/ShapeSpawnerCounterComponent.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.EntityShapes.Components;
+
+/// <summary>
+/// Used for different shape spawner components to count new steps for spawns.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ShapeSpawnerCounterComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan SpawnPeriod = TimeSpan.FromSeconds(1f);
+
+    [DataField, AutoNetworkedField]
+    public int MaxCounter = 1;
+
+    [ViewVariables, AutoNetworkedField]
+    public TimeSpan NextSpawn;
+
+    [ViewVariables, AutoNetworkedField]
+    public int Counter = 1; // We spawn 1 shape not in a loop, so we have to start from 1.
+}

--- a/Content.Shared/EntityShapes/EntityShapePrototype.cs
+++ b/Content.Shared/EntityShapes/EntityShapePrototype.cs
@@ -1,0 +1,18 @@
+using Content.Shared.EntityShapes.Shapes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.EntityShapes;
+
+/// <summary>
+/// Contains an EntityShape for common use.
+/// </summary>
+[Prototype]
+public sealed partial class EntityShapePrototype : IPrototype
+{
+    /// <inheritdoc/>
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    [DataField(required: true)]
+    public EntityShape Shape = default!;
+}

--- a/Content.Shared/EntityShapes/EntityShapeSystem.Visitor.cs
+++ b/Content.Shared/EntityShapes/EntityShapeSystem.Visitor.cs
@@ -2,6 +2,7 @@
 using System.Numerics;
 using Content.Shared.EntityShapes.Shapes;
 using Content.Shared.Random.Helpers;
+using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -15,6 +16,7 @@ public sealed partial class EntityShapeSystem
     /// <param name="shape">The shape to calculate.</param>
     /// <param name="center">Amount to offset the final result.</param>
     /// <param name="rand">The randomizer to use. <br/> Defaults to the instance <see cref="IoCManager"/> provides.</param>
+    [PublicAPI]
     public IEnumerable<Vector2> GetShape(
         EntityShape? shape,
         Vector2? center = null,
@@ -27,7 +29,7 @@ public sealed partial class EntityShapeSystem
         center ??= Vector2.Zero;
         return shape.Accept(
             GetEntityShapeVisitor.Instance,
-            new GetEntityShapeVisitor.Args(ProtoMan, rand, center)
+            new GetEntityShapeVisitor.Args(ProtoMan, rand, center.Value)
         );
     }
 }
@@ -41,7 +43,8 @@ sealed file class GetEntityShapeVisitor :
     public record struct Args(
         IPrototypeManager ProtoMan,
         IRobustRandom Rand,
-        Vector2? Center = null,
+        Vector2 Center,
+        Vector2? Offset = null,
         int? Size = null,
         float? StepSize = null
     );
@@ -52,7 +55,7 @@ sealed file class GetEntityShapeVisitor :
         // 1. YAML DataFields
         // 2. Arguments passed from the parent
         // 3. Default value.
-        shape.Offset = shape.DefaultOffset ?? args.Center ?? shape.Offset;
+        shape.Offset = (shape.DefaultOffset ?? args.Offset ?? Vector2.Zero) + args.Center;
         shape.Size = shape.DefaultSize ?? args.Size ?? shape.Size;
         shape.StepSize = shape.DefaultStepSize  ?? args.StepSize ?? shape.StepSize;
     }
@@ -77,11 +80,11 @@ sealed file class GetEntityShapeVisitor :
                 stepSize = options.GroupStepSize;
             }
 
-            var newArgs = args with { Center = offset, Size = size, StepSize = stepSize };
+            var newArgs = args with { Offset = offset, Size = size, StepSize = stepSize };
             result.AddRange(child.Accept(this, newArgs));
         }
 
-        return result.Distinct().ToList();
+        return result;
     }
 
     public IEnumerable<Vector2> VisitGroupShape(GroupEntityShape shape, Args args)
@@ -96,14 +99,14 @@ sealed file class GetEntityShapeVisitor :
             return Enumerable.Empty<Vector2>();
 
         var child = SharedRandomExtensions.Pick(validWeightedChildren, args.Rand);
-        var newArgs = args with { Center = shape.Offset, Size = shape.Size, StepSize = shape.StepSize };
+        var newArgs = args with { Offset = shape.Offset, Size = shape.Size, StepSize = shape.StepSize };
         return child.Accept(this, newArgs);
     }
 
     public IEnumerable<Vector2> VisitNestedShape(NestedEntityShape shape, Args args)
     {
         ApplyOverrides(shape, args);
-        var newArgs = args with { Center = shape.Offset, Size = shape.Size, StepSize = shape.StepSize };
+        var newArgs = args with { Offset = shape.Offset, Size = shape.Size, StepSize = shape.StepSize };
         return args.ProtoMan.Index(shape.Id).Shape.Accept(this, newArgs);
     }
 
@@ -122,7 +125,7 @@ sealed file class GetEntityShapeVisitor :
     {
         ApplyOverrides(shape, args);
 
-        var newArgs = args with { Center = shape.Offset, Size = shape.Size, StepSize = shape.StepSize };
+        var newArgs = args with { Offset = shape.Offset, Size = shape.Size, StepSize = shape.StepSize };
         var shapeRefs = shape.Accept(this, newArgs).ToList();
 
         if (shape.FilledChance != null)
@@ -200,28 +203,25 @@ sealed file class GetEntityShapeVisitor :
         var topRight = center - new Vector2(-range, -range);
         var bottomRight = center - new Vector2(-range, range);
 
-        // for example 0.999 should be considered as 1 so the loop works correctly
-        var side = (int) MathF.Round(range, 2);
-
         // Left side
-        for (var i = 0f; i < side; i += stepSize)
+        for (var i = 0f; i < range; i++)
         {
-            yield return bottomLeft + Vector2.UnitY * i;
+            yield return bottomLeft + Vector2.UnitY * stepSize;
         }
         // Top side
-        for (var i = 0f; i < side; i += stepSize)
+        for (var i = 0f; i < range; i++)
         {
-            yield return topLeft + Vector2.UnitX * i;
+            yield return topLeft + Vector2.UnitX * stepSize;
         }
         // Right side
-        for (var i = 0f; i < side; i += stepSize)
+        for (var i = 0f; i < range; i++)
         {
-            yield return topRight + -Vector2.UnitY * i;
+            yield return topRight + -Vector2.UnitY * stepSize;
         }
         // Bottom side
-        for (var i = 0f; i < side; i += stepSize)
+        for (var i = 0f; i < range; i++)
         {
-            yield return bottomRight + -Vector2.UnitX * i;
+            yield return bottomRight + -Vector2.UnitX * stepSize;
         }
     }
 

--- a/Content.Shared/EntityShapes/EntityShapeSystem.Visitor.cs
+++ b/Content.Shared/EntityShapes/EntityShapeSystem.Visitor.cs
@@ -1,0 +1,280 @@
+﻿using System.Linq;
+using System.Numerics;
+using Content.Shared.EntityShapes.Shapes;
+using Content.Shared.Random.Helpers;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Shared.EntityShapes;
+
+public sealed partial class EntityShapeSystem
+{
+    /// <summary>
+    /// Gets positions of an <see cref="EntityShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to calculate.</param>
+    /// <param name="center">Amount to offset the final result.</param>
+    /// <param name="rand">The randomizer to use. <br/> Defaults to the instance <see cref="IoCManager"/> provides.</param>
+    public IEnumerable<Vector2> GetShape(
+        EntityShape? shape,
+        Vector2? center = null,
+        IRobustRandom? rand = null)
+    {
+        if (shape == null)
+            return Enumerable.Empty<Vector2>();
+
+        rand ??= _random;
+        center ??= Vector2.Zero;
+        return shape.Accept(
+            GetEntityShapeVisitor.Instance,
+            new GetEntityShapeVisitor.Args(ProtoMan, rand, center)
+        );
+    }
+}
+
+sealed file class GetEntityShapeVisitor :
+    IEntityShapeVisitor<GetEntityShapeVisitor.Args, IEnumerable<Vector2>>
+{
+    private GetEntityShapeVisitor() { }
+    public static readonly GetEntityShapeVisitor Instance = new();
+
+    public record struct Args(
+        IPrototypeManager ProtoMan,
+        IRobustRandom Rand,
+        Vector2? Center = null,
+        int? Size = null,
+        float? StepSize = null
+    );
+
+    private static void ApplyOverrides(EntityShape shape, Args args)
+    {
+        // We take values by these priorities:
+        // 1. YAML DataFields
+        // 2. Arguments passed from the parent
+        // 3. Default value.
+        shape.Offset = shape.DefaultOffset ?? args.Center ?? shape.Offset;
+        shape.Size = shape.DefaultSize ?? args.Size ?? shape.Size;
+        shape.StepSize = shape.DefaultStepSize  ?? args.StepSize ?? shape.StepSize;
+    }
+
+    public IEnumerable<Vector2> VisitAllShape(AllEntityShape shape, Args args)
+    {
+        ApplyOverrides(shape, args);
+
+        var result = new List<Vector2>();
+        foreach (var child in shape.Children)
+        {
+            Vector2? offset = shape.Offset;
+            int? size = shape.Size;
+            float? stepSize = shape.StepSize;
+
+            if (shape.Options != null
+                && child.OverrideGroup != null
+                && shape.Options.TryGetValue(child.OverrideGroup, out var options))
+            {
+                offset = options.Offset;
+                size = options.GroupSize;
+                stepSize = options.GroupStepSize;
+            }
+
+            var newArgs = args with { Center = offset, Size = size, StepSize = stepSize };
+            result.AddRange(child.Accept(this, newArgs));
+        }
+
+        return result.Distinct().ToList();
+    }
+
+    public IEnumerable<Vector2> VisitGroupShape(GroupEntityShape shape, Args args)
+    {
+        ApplyOverrides(shape, args);
+
+        var validWeightedChildren = shape.Children
+            .Where(child => child.Weight >= float.Epsilon)
+            .ToDictionary(child => child, child => child.Weight);
+
+        if (validWeightedChildren.Count == 0)
+            return Enumerable.Empty<Vector2>();
+
+        var child = SharedRandomExtensions.Pick(validWeightedChildren, args.Rand);
+        var newArgs = args with { Center = shape.Offset, Size = shape.Size, StepSize = shape.StepSize };
+        return child.Accept(this, newArgs);
+    }
+
+    public IEnumerable<Vector2> VisitNestedShape(NestedEntityShape shape, Args args)
+    {
+        ApplyOverrides(shape, args);
+        var newArgs = args with { Center = shape.Offset, Size = shape.Size, StepSize = shape.StepSize };
+        return args.ProtoMan.Index(shape.Id).Shape.Accept(this, newArgs);
+    }
+
+    public IEnumerable<Vector2> VisitNoneShape(NoneEntityShape shape, Args args)
+    {
+        return Enumerable.Empty<Vector2>();
+    }
+
+    public IEnumerable<Vector2> VisitSingleShape(SingleEntityShape shape, Args args)
+    {
+        ApplyOverrides(shape, args);
+        return new List<Vector2> { shape.Offset };
+    }
+
+    public IEnumerable<Vector2> VisitRandomShape(RandomEntityShape shape, Args args)
+    {
+        ApplyOverrides(shape, args);
+
+        var newArgs = args with { Center = shape.Offset, Size = shape.Size, StepSize = shape.StepSize };
+        var shapeRefs = shape.Accept(this, newArgs).ToList();
+
+        if (shape.FilledChance != null)
+        {
+            var temp = new List<Vector2>(shapeRefs);
+            foreach (var pos in temp)
+            {
+                if (!args.Rand.Prob(shape.FilledChance.Value))
+                    shapeRefs.Remove(pos);
+            }
+        }
+
+        if (shape.Amount != null)
+        {
+            var temp = new List<Vector2>(shape.Amount.Value);
+            for (int i = 0; i < shape.Amount.Value; i++)
+            {
+                temp.Add(args.Rand.Pick(temp));
+            }
+            shapeRefs = temp;
+        }
+
+        return shapeRefs;
+    }
+
+    public IEnumerable<Vector2> VisitBoxShape(BoxEntityShape shape, Args args)
+    {
+        ApplyOverrides(shape, args);
+
+        return shape.Hollow ? MakeBoxHollow(shape.Offset, shape.Size, shape.StepSize) : MakeBoxFilled(shape.Offset, shape.Size, shape.StepSize);
+    }
+
+    private static IEnumerable<Vector2> MakeBoxFilled(Vector2 center, int range, float stepSize = 1)
+    {
+        if (range <= 0)
+            yield break;
+
+        if (stepSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(stepSize), "stepSize must be greater than zero.");
+
+        if (range == 1)
+        {
+            yield return center;
+            yield break;
+        }
+
+        var half = (range - 1) / 2f;
+        var startPoint = center - new Vector2(half, half);
+
+        for (var y = 0f; y < range; y += stepSize)
+        {
+            for (var x = 0f; x < range; x += stepSize)
+            {
+                yield return startPoint + new Vector2(x, y);
+            }
+        }
+    }
+
+    private static IEnumerable<Vector2> MakeBoxHollow(Vector2 center, int range, float stepSize = 1)
+    {
+        if (range <= 0)
+            yield break;
+
+        if (stepSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(stepSize), "stepSize must be greater than zero.");
+
+        if (range == 1)
+        {
+            yield return center;
+            yield break;
+        }
+
+        var bottomLeft = center - new Vector2(range, range);
+        var topLeft = center - new Vector2(range, -range);
+        var topRight = center - new Vector2(-range, -range);
+        var bottomRight = center - new Vector2(-range, range);
+
+        // for example 0.999 should be considered as 1 so the loop works correctly
+        var side = (int) MathF.Round(range, 2);
+
+        // Left side
+        for (var i = 0f; i < side; i += stepSize)
+        {
+            yield return bottomLeft + Vector2.UnitY * i;
+        }
+        // Top side
+        for (var i = 0f; i < side; i += stepSize)
+        {
+            yield return topLeft + Vector2.UnitX * i;
+        }
+        // Right side
+        for (var i = 0f; i < side; i += stepSize)
+        {
+            yield return topRight + -Vector2.UnitY * i;
+        }
+        // Bottom side
+        for (var i = 0f; i < side; i += stepSize)
+        {
+            yield return bottomRight + -Vector2.UnitX * i;
+        }
+    }
+
+    public IEnumerable<Vector2> VisitLineShape(LineEntityShape shape, Args args)
+    {
+        ApplyOverrides(shape, args);
+
+        yield return shape.Offset;
+
+        if (shape.Direction == Vector2.Zero)
+            yield break;
+
+        var curStep = shape.Offset;
+        for (int i = 0; i < shape.Size; i++)
+        {
+            curStep += shape.Direction;
+            yield return curStep;
+        }
+    }
+
+    public IEnumerable<Vector2> VisitCrossShape(CrossEntityShape shape, Args args)
+    {
+        ApplyOverrides(shape, args);
+
+        yield return shape.Offset;
+
+        if (shape.Size <= 0)
+            yield break;
+
+        for (var i = 1f; i < shape.Size; i += shape.StepSize)
+        {
+            yield return shape.Offset with { X = shape.Offset.X + i };
+            yield return shape.Offset with { Y = shape.Offset.Y + i };
+            yield return shape.Offset with { X = shape.Offset.X - i };
+            yield return shape.Offset with { Y = shape.Offset.Y - i };
+        }
+    }
+
+    public IEnumerable<Vector2> VisitDiagonalCrossShape(DiagonalCrossEntityShape shape, Args args)
+    {
+        ApplyOverrides(shape, args);
+
+        yield return shape.Offset;
+
+        if (shape.Size <= 0)
+            yield break;
+
+        for (var i = 1f; i < shape.Size; i += shape.StepSize)
+        {
+            yield return new Vector2(shape.Offset.X + i, shape.Offset.Y + i);
+            yield return new Vector2(shape.Offset.X + i, shape.Offset.Y - i);
+            yield return new Vector2(shape.Offset.X - i, shape.Offset.Y + i);
+            yield return new Vector2(shape.Offset.X - i, shape.Offset.Y - i);
+        }
+    }
+}

--- a/Content.Shared/EntityShapes/EntityShapeSystem.cs
+++ b/Content.Shared/EntityShapes/EntityShapeSystem.cs
@@ -1,6 +1,9 @@
 using Content.Shared.EntityShapes.Components;
 using Content.Shared.EntityShapes.Shapes;
+using Content.Shared.EntityTable;
+using Content.Shared.EntityTable.EntitySelectors;
 using Content.Shared.Random.Helpers;
+using JetBrains.Annotations;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -12,7 +15,10 @@ public sealed partial class EntityShapeSystem : EntitySystem
 {
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private EntityTableSystem _entityTable = default!;
+
     [Dependency] private EntityQuery<ShapeSpawnerComponent> _spawnerQuery = default!;
+    [Dependency] private EntityQuery<ShapeSpawnerCounterComponent> _counterQuery = default!;
 
     public override void Initialize()
     {
@@ -28,15 +34,17 @@ public sealed partial class EntityShapeSystem : EntitySystem
         base.Update(frameTime);
 
         var curTime = _timing.CurTime;
-        var query = EntityQueryEnumerator<ShapeSpawnerCounterComponent>();
-        while (query.MoveNext(out var uid, out var counterComp))
+        var query = EntityQueryEnumerator<ShapeSpawnerComponent, ShapeSpawnerCounterComponent>();
+        while (query.MoveNext(out var uid, out var spawnerComp, out var counterComp))
         {
             if (counterComp.NextSpawn > curTime)
                 continue;
 
             if (counterComp.Counter == counterComp.MaxCounter)
             {
-                PredictedQueueDel(uid);
+                if (spawnerComp.DeleteSpawnerAfterSpawn)
+                    PredictedQueueDel(uid);
+
                 continue;
             }
 
@@ -49,6 +57,7 @@ public sealed partial class EntityShapeSystem : EntitySystem
     }
 
     /// <inheritdoc cref="SpawnEntityShape(EntityShape?, EntityCoordinates, EntProtoId, out List{EntityUid})"/>
+    [PublicAPI]
     public void SpawnEntityShape(EntityShape shape, EntityUid target, EntProtoId spawnId, out List<EntityUid> spawned, bool alignTile = false)
     {
         var coords = alignTile
@@ -70,6 +79,7 @@ public sealed partial class EntityShapeSystem : EntitySystem
     /// otherwise it's better to spawn an entity with ShapeSpawnerComponent,
     /// since it allows for more functionality.
     /// </remarks>
+    [PublicAPI]
     public void SpawnEntityShape(EntityShape? shape, EntityCoordinates coords, EntProtoId spawnId, out List<EntityUid> spawned)
     {
         spawned = new List<EntityUid>();
@@ -91,9 +101,62 @@ public sealed partial class EntityShapeSystem : EntitySystem
         }
     }
 
+    /// <inheritdoc cref="SpawnEntityShape(EntityShape?, EntityCoordinates, EntityTableSelector, out List{EntityUid})"/>
+    [PublicAPI]
+    public void SpawnEntityShape(EntityShape shape, EntityUid target, EntityTableSelector table, out List<EntityUid> spawned, bool alignTile = false)
+    {
+        var coords = alignTile
+            ? Transform(target).Coordinates.AlignWithClosestGridTile(1.5f, EntityManager)
+            : Transform(target).Coordinates;
+
+        SpawnEntityShape(shape, coords, table, out spawned);
+    }
+
+    /// <summary>
+    /// Calculates all positions of an <see cref="EntityShape"/> and spawns <see cref="EntProtoId"/> on them.
+    /// </summary>
+    /// <param name="shape">The shape to calculate the positions.</param>
+    /// <param name="coords">Coordinates of the center of the shape.</param>
+    /// <param name="table">The table to spawn at each point.</param>
+    /// <param name="spawned">List of all spawned entities.</param>
+    /// <remarks>
+    /// Use this only if you need to get all spawned entities by this shape,
+    /// otherwise it's better to spawn an entity with ShapeSpawnerComponent,
+    /// since it allows for more functionality.
+    /// </remarks>
+    [PublicAPI]
+    public void SpawnEntityShape(EntityShape? shape, EntityCoordinates coords, EntityTableSelector table, out List<EntityUid> spawned)
+    {
+        spawned = new List<EntityUid>();
+
+        // Prevents the spawn menu from exploding
+        if (!coords.IsValid(EntityManager))
+            return;
+
+        if (shape == null)
+            return;
+
+        var random = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(coords.EntityId));
+        var result = GetShape(shape, coords.Position, random);
+        foreach (var pos in result)
+        {
+            var coord = new EntityCoordinates(coords.EntityId, pos);
+            var spawns = _entityTable.GetSpawns(table, random);
+            foreach (var spawn in spawns)
+            {
+                var ent = PredictedSpawnAtPosition(spawn, coord);
+                spawned.Add(ent);
+            }
+        }
+    }
+
     private void OnSpawnerInit(Entity<ShapeSpawnerComponent> ent, ref MapInitEvent args)
     {
         SpawnEntityShape(ent.Comp.Shape, ent.Owner, ent.Comp.Spawn, out _, ent.Comp.AlignCoords);
+
+        if (!_counterQuery.HasComp(ent.Owner) // Deletion handled after the spawner loop is done
+            && ent.Comp.DeleteSpawnerAfterSpawn)
+            PredictedQueueDel(ent.Owner);
     }
 
     private void OnCounterInit(Entity<ShapeSpawnerCounterComponent> ent, ref MapInitEvent args)

--- a/Content.Shared/EntityShapes/EntityShapeSystem.cs
+++ b/Content.Shared/EntityShapes/EntityShapeSystem.cs
@@ -1,0 +1,123 @@
+using Content.Shared.EntityShapes.Components;
+using Content.Shared.EntityShapes.Shapes;
+using Content.Shared.Random.Helpers;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.EntityShapes;
+
+public sealed partial class EntityShapeSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private EntityQuery<ShapeSpawnerComponent> _spawnerQuery = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ShapeSpawnerComponent, MapInitEvent>(OnSpawnerInit);
+        SubscribeLocalEvent<ShapeSpawnerCounterComponent, MapInitEvent>(OnCounterInit);
+        SubscribeLocalEvent<ExpandingShapeSpawnerComponent, SpawnCounterEntityShapeEvent>(OnExpandingShapeTrigger);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        var query = EntityQueryEnumerator<ShapeSpawnerCounterComponent>();
+        while (query.MoveNext(out var uid, out var counterComp))
+        {
+            if (counterComp.NextSpawn > curTime)
+                continue;
+
+            if (counterComp.Counter == counterComp.MaxCounter)
+            {
+                PredictedQueueDel(uid);
+                continue;
+            }
+
+            counterComp.NextSpawn = curTime + counterComp.SpawnPeriod;
+            counterComp.Counter++;
+
+            var ev = new SpawnCounterEntityShapeEvent(counterComp.Counter);
+            RaiseLocalEvent(uid, ref ev);
+        }
+    }
+
+    /// <inheritdoc cref="SpawnEntityShape(EntityShape?, EntityCoordinates, EntProtoId, out List{EntityUid})"/>
+    public void SpawnEntityShape(EntityShape shape, EntityUid target, EntProtoId spawnId, out List<EntityUid> spawned, bool alignTile = false)
+    {
+        var coords = alignTile
+            ? Transform(target).Coordinates.AlignWithClosestGridTile(1.5f, EntityManager)
+            : Transform(target).Coordinates;
+
+        SpawnEntityShape(shape, coords, spawnId, out spawned);
+    }
+
+    /// <summary>
+    /// Calculates all positions of an <see cref="EntityShape"/> and spawns <see cref="EntProtoId"/> on them.
+    /// </summary>
+    /// <param name="shape">The shape to calculate the positions.</param>
+    /// <param name="coords">Coordinates of the center of the shape.</param>
+    /// <param name="spawnId">A proto ID of the entities.</param>
+    /// <param name="spawned">List of all spawned entities.</param>
+    /// <remarks>
+    /// Use this only if you need to get all spawned entities by this shape,
+    /// otherwise it's better to spawn an entity with ShapeSpawnerComponent,
+    /// since it allows for more functionality.
+    /// </remarks>
+    public void SpawnEntityShape(EntityShape? shape, EntityCoordinates coords, EntProtoId spawnId, out List<EntityUid> spawned)
+    {
+        spawned = new List<EntityUid>();
+
+        // Prevents the spawn menu from exploding
+        if (!coords.IsValid(EntityManager))
+            return;
+
+        if (shape == null)
+            return;
+
+        var random = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(coords.EntityId));
+        var result = GetShape(shape, coords.Position, random);
+        foreach (var pos in result)
+        {
+            var coord = new EntityCoordinates(coords.EntityId, pos);
+            var ent = PredictedSpawnAtPosition(spawnId, coord);
+            spawned.Add(ent);
+        }
+    }
+
+    private void OnSpawnerInit(Entity<ShapeSpawnerComponent> ent, ref MapInitEvent args)
+    {
+        SpawnEntityShape(ent.Comp.Shape, ent.Owner, ent.Comp.Spawn, out _, ent.Comp.AlignCoords);
+    }
+
+    private void OnCounterInit(Entity<ShapeSpawnerCounterComponent> ent, ref MapInitEvent args)
+    {
+        // First shape is spawned by an event anyway, so delay the counter one to be later
+        ent.Comp.NextSpawn = _timing.CurTime + ent.Comp.SpawnPeriod;
+    }
+
+    private void OnExpandingShapeTrigger(Entity<ExpandingShapeSpawnerComponent> ent, ref SpawnCounterEntityShapeEvent args)
+    {
+        var (uid, comp) = ent;
+
+        if (!_spawnerQuery.TryComp(uid, out var spawner))
+            return;
+
+        if (comp.CounterOffset != null)
+            spawner.Shape.DefaultOffset = comp.CounterOffset.Value * args.Counter;
+
+        if (comp.CounterSize != null)
+            spawner.Shape.DefaultSize = (int) Math.Round(comp.CounterSize.Value * args.Counter);
+
+        if (comp.CounterStepSize != null)
+            spawner.Shape.DefaultStepSize = (int) Math.Round(comp.CounterStepSize.Value * args.Counter);
+
+        SpawnEntityShape(spawner.Shape, uid, spawner.Spawn, out _, spawner.AlignCoords);
+    }
+}

--- a/Content.Shared/EntityShapes/EntityShapeTypeSerializer.cs
+++ b/Content.Shared/EntityShapes/EntityShapeTypeSerializer.cs
@@ -1,0 +1,40 @@
+using Content.Shared.EntityShapes.Shapes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Content.Shared.EntityShapes;
+
+[TypeSerializer]
+public sealed class EntityShapeTypeSerializer :
+    ITypeReader<EntityShape, MappingDataNode>
+{
+    public ValidationNode Validate(
+        ISerializationManager serializationManager,
+        MappingDataNode node,
+        IDependencyCollection dependencies,
+        ISerializationContext? context = null)
+    {
+        if (node.Has(NestedEntityShape.IdDataFieldTag))
+            return serializationManager.ValidateNode<NestedEntityShape>(node, context);
+
+        return new ErrorNode(node, "Custom validation not supported! Please specify the type manually!");
+    }
+
+    public EntityShape Read(
+        ISerializationManager serializationManager,
+        MappingDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<EntityShape>? instanceProvider = null)
+    {
+        var type = typeof(EntityShape);
+        if (node.Has(NestedEntityShape.IdDataFieldTag))
+            type = typeof(NestedEntityShape);
+
+        return (EntityShape) serializationManager.Read(type, node, context)!;
+    }
+}

--- a/Content.Shared/EntityShapes/IEntityShapeVisitor.cs
+++ b/Content.Shared/EntityShapes/IEntityShapeVisitor.cs
@@ -1,0 +1,79 @@
+﻿using Content.Shared.EntityShapes.Shapes;
+using JetBrains.Annotations;
+
+namespace Content.Shared.EntityShapes;
+
+/// <summary>
+/// <a href="https://en.wikipedia.org/wiki/Visitor_pattern">Visitor</a> for <see cref="EntityShape"/>s.
+/// </summary>
+/// <typeparam name="TArgs">The type of arguments passed to visitation.</typeparam>
+/// <typeparam name="TResult">The type of the visitation result.</typeparam>
+[PublicAPI]
+public interface IEntityShapeVisitor<in TArgs, out TResult>
+{
+    /// <summary>
+    /// Alias of <see cref="EntityShape.Accept{TContext, TResult}(IEntityShapeVisitor{TContext, TResult}, TContext)"/>.
+    /// </summary>
+    [PublicAPI]
+    TResult Visit(EntityShape selector, TArgs args) => selector.Accept(this, args);
+
+    /// <summary>
+    /// Visit an <see cref="AllEntityShape"/>.
+    /// </summary>
+    [PublicAPI]
+    TResult VisitAllShape(AllEntityShape shape, TArgs args);
+
+    /// <summary>
+    /// Visit a <see cref="GroupEntityShape"/>.
+    /// </summary>
+    [PublicAPI]
+    TResult VisitGroupShape(GroupEntityShape shape, TArgs args);
+
+    /// <summary>
+    /// Visit a <see cref="NestedEntityShape"/>.
+    /// </summary>
+    [PublicAPI]
+    TResult VisitNestedShape(NestedEntityShape shape, TArgs args);
+
+    /// <summary>
+    /// Visit a <see cref="NoneEntityShape"/>.
+    /// </summary>
+    [PublicAPI]
+    TResult VisitNoneShape(NoneEntityShape shape, TArgs args);
+
+    /// <summary>
+    /// Visit an <see cref="SingleEntityShape"/>.
+    /// </summary>
+    [PublicAPI]
+    TResult VisitSingleShape(SingleEntityShape shape, TArgs args);
+
+    /// <summary>
+    /// Visit an <see cref="RandomEntityShape"/>.
+    /// </summary>
+    [PublicAPI]
+    TResult VisitRandomShape(RandomEntityShape shape, TArgs args);
+
+    /// <summary>
+    /// Visit an <see cref="BoxEntityShape"/>.
+    /// </summary>
+    [PublicAPI]
+    TResult VisitBoxShape(BoxEntityShape shape, TArgs args);
+
+    /// <summary>
+    /// Visit a <see cref="LineEntityShape"/>.
+    /// </summary>
+    [PublicAPI]
+    TResult VisitLineShape(LineEntityShape shape, TArgs args);
+
+    /// <summary>
+    /// Visit a <see cref="CrossEntityShape"/>.
+    /// </summary>
+    [PublicAPI]
+    TResult VisitCrossShape(CrossEntityShape shape, TArgs args);
+
+    /// <summary>
+    /// Visit a <see cref="DiagonalCrossEntityShape"/>.
+    /// </summary>
+    [PublicAPI]
+    TResult VisitDiagonalCrossShape(DiagonalCrossEntityShape shape, TArgs args);
+}

--- a/Content.Shared/EntityShapes/ShapeSpawnerEvents.cs
+++ b/Content.Shared/EntityShapes/ShapeSpawnerEvents.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared.EntityShapes;
+
+[ByRefEvent]
+public readonly record struct SpawnCounterEntityShapeEvent(int Counter);

--- a/Content.Shared/EntityShapes/Shapes/AllEntityShape.cs
+++ b/Content.Shared/EntityShapes/Shapes/AllEntityShape.cs
@@ -1,0 +1,31 @@
+using System.Numerics;
+
+namespace Content.Shared.EntityShapes.Shapes;
+
+/// <summary>
+/// Tile shape that is made of multiple other shapes.
+/// </summary>
+public sealed partial class AllEntityShape : EntityShape
+{
+    [DataField(required: true)]
+    public List<EntityShape> Children = new();
+
+    [DataField]
+    public Dictionary<string, GroupEntityShapeOptions>? Options;
+
+    public override TResult Accept<TArgs, TResult>(IEntityShapeVisitor<TArgs, TResult> visitor, TArgs args)
+        => visitor.VisitAllShape(this, args);
+}
+
+[DataDefinition]
+public partial record struct GroupEntityShapeOptions
+{
+    [DataField]
+    public Vector2? Offset;
+
+    [DataField]
+    public int? GroupSize;
+
+    [DataField]
+    public int? GroupStepSize;
+}

--- a/Content.Shared/EntityShapes/Shapes/BoxEntityShape.cs
+++ b/Content.Shared/EntityShapes/Shapes/BoxEntityShape.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.EntityShapes.Shapes;
+
+public sealed partial class BoxEntityShape : EntityShape
+{
+    [DataField]
+    public bool Hollow;
+
+    public override TResult Accept<TArgs, TResult>(IEntityShapeVisitor<TArgs, TResult> visitor, TArgs args)
+        => visitor.VisitBoxShape(this, args);
+}

--- a/Content.Shared/EntityShapes/Shapes/CrossEntityShape.cs
+++ b/Content.Shared/EntityShapes/Shapes/CrossEntityShape.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.EntityShapes.Shapes;
+
+/// <summary>
+/// Represents a simple shape out of one horizontal and one vertical line combined.
+/// </summary>
+public sealed partial class CrossEntityShape : EntityShape
+{
+    public override TResult Accept<TArgs, TResult>(IEntityShapeVisitor<TArgs, TResult> visitor, TArgs args)
+        => visitor.VisitCrossShape(this, args);
+}

--- a/Content.Shared/EntityShapes/Shapes/DiagonalCrossEntityShape.cs
+++ b/Content.Shared/EntityShapes/Shapes/DiagonalCrossEntityShape.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.EntityShapes.Shapes;
+
+/// <summary>
+/// Represents a simple shape out of two diagonal lines combined.
+/// </summary>
+public sealed partial class DiagonalCrossEntityShape : EntityShape
+{
+    public override TResult Accept<TArgs, TResult>(IEntityShapeVisitor<TArgs, TResult> visitor, TArgs args)
+        => visitor.VisitDiagonalCrossShape(this, args);
+}

--- a/Content.Shared/EntityShapes/Shapes/EntityShape.cs
+++ b/Content.Shared/EntityShapes/Shapes/EntityShape.cs
@@ -1,0 +1,55 @@
+using System.Numerics;
+using JetBrains.Annotations;
+
+namespace Content.Shared.EntityShapes.Shapes;
+
+/// <summary>
+/// Represents a list of points that entities can be then spawned on.
+/// </summary>
+[ImplicitDataDefinitionForInheritors, UsedImplicitly(ImplicitUseTargetFlags.WithInheritors)]
+public abstract partial class EntityShape
+{
+    /// <summary>
+    /// A weight used to pick between shapes.
+    /// </summary>
+    [DataField]
+    public float Weight = 1;
+
+    /// <summary>
+    /// If specified, will add this shape into a shapes group,
+    /// that can be customized via <see cref="AllEntityShape"/>.
+    /// That way you can change size or offset for groups of tiles
+    /// instead of individually changing values.
+    /// </summary>
+    [DataField("group")]
+    public string? OverrideGroup;
+
+    // All "DefaultX" are values that are specified in prototypes
+
+    [DataField("offset")]
+    public Vector2? DefaultOffset;
+
+    [DataField("size")]
+    public int? DefaultSize;
+
+    [DataField("step")]
+    public float? DefaultStepSize;
+
+    [ViewVariables]
+    public Vector2 Offset = Vector2.Zero;
+
+    [ViewVariables]
+    public int Size = 1;
+
+    [ViewVariables]
+    public float StepSize = 1;
+
+    /// <summary>
+    /// Accepts <paramref name="visitor"/>, passing <paramref name="args"/> to it, and returning the result. Basically
+    /// an alias for invoking <c>visitor.Visit(this, args)</c>.
+    /// <br/>
+    /// </summary>
+    /// <seealso cref="IEntityShapeVisitor{TArgs, TResult}"/>
+    [Access(Other = AccessPermissions.Execute)]
+    public abstract TResult Accept<TArgs, TResult>(IEntityShapeVisitor<TArgs, TResult> visitor, TArgs args);
+}

--- a/Content.Shared/EntityShapes/Shapes/GroupEntityShape.cs
+++ b/Content.Shared/EntityShapes/Shapes/GroupEntityShape.cs
@@ -1,0 +1,13 @@
+namespace Content.Shared.EntityShapes.Shapes;
+
+/// <summary>
+/// Picks one shape out of a list of children using weights to randomize between them.
+/// </summary>
+public sealed partial class GroupEntityShape : EntityShape
+{
+    [DataField(required: true)]
+    public List<EntityShape> Children = new();
+
+    public override TResult Accept<TArgs, TResult>(IEntityShapeVisitor<TArgs, TResult> visitor, TArgs args)
+        => visitor.VisitGroupShape(this, args);
+}

--- a/Content.Shared/EntityShapes/Shapes/LineEntityShape.cs
+++ b/Content.Shared/EntityShapes/Shapes/LineEntityShape.cs
@@ -1,0 +1,16 @@
+using System.Numerics;
+
+namespace Content.Shared.EntityShapes.Shapes;
+
+/// <summary>
+/// Represents a simple line with length of Size
+/// made in some specified direction.
+/// </summary>
+public sealed partial class LineEntityShape : EntityShape
+{
+    [DataField]
+    public Vector2 Direction = Vector2.UnitX;
+
+    public override TResult Accept<TArgs, TResult>(IEntityShapeVisitor<TArgs, TResult> visitor, TArgs args)
+        => visitor.VisitLineShape(this, args);
+}

--- a/Content.Shared/EntityShapes/Shapes/NestedEntityShape.cs
+++ b/Content.Shared/EntityShapes/Shapes/NestedEntityShape.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.EntityShapes.Shapes;
+
+/// <summary>
+/// Shape that references a ProtoId containing some other shape.
+/// </summary>
+public sealed partial class NestedEntityShape : EntityShape
+{
+    public const string IdDataFieldTag = "id";
+
+    [DataField(IdDataFieldTag, required: true)]
+    public ProtoId<EntityShapePrototype> Id;
+
+    public override TResult Accept<TArgs, TResult>(IEntityShapeVisitor<TArgs, TResult> visitor, TArgs args)
+        => visitor.VisitNestedShape(this, args);
+}

--- a/Content.Shared/EntityShapes/Shapes/NoneEntityShape.cs
+++ b/Content.Shared/EntityShapes/Shapes/NoneEntityShape.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.EntityShapes.Shapes;
+
+/// <summary>
+/// Shape that references a ProtoId containing some other shape.
+/// </summary>
+public sealed partial class NoneEntityShape : EntityShape
+{
+    public override TResult Accept<TArgs, TResult>(IEntityShapeVisitor<TArgs, TResult> visitor, TArgs args)
+        => visitor.VisitNoneShape(this, args);
+}

--- a/Content.Shared/EntityShapes/Shapes/RandomEntityShape.cs
+++ b/Content.Shared/EntityShapes/Shapes/RandomEntityShape.cs
@@ -1,0 +1,26 @@
+namespace Content.Shared.EntityShapes.Shapes;
+
+/// <summary>
+/// Picks tiles from another shape as a fixed amount or with some percentage chance.
+/// </summary>
+public sealed partial class RandomEntityShape : EntityShape
+{
+    [DataField(required: true)]
+    public EntityShape Shape;
+
+    /// <summary>
+    /// The chance for a tile to be filled in a shape.
+    /// Always overrides <see cref="Amount"/>.
+    /// </summary>
+    [DataField]
+    public float? FilledChance;
+
+    /// <summary>
+    /// How many tiles we should randomly include from a shape.
+    /// </summary>
+    [DataField]
+    public int? Amount;
+
+    public override TResult Accept<TArgs, TResult>(IEntityShapeVisitor<TArgs, TResult> visitor, TArgs args)
+        => visitor.VisitRandomShape(this, args);
+}

--- a/Content.Shared/EntityShapes/Shapes/SingleEntityShape.cs
+++ b/Content.Shared/EntityShapes/Shapes/SingleEntityShape.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.EntityShapes.Shapes;
+
+/// <summary>
+/// Returns a singe tile at the specified position.
+/// </summary>
+public sealed partial class SingleEntityShape : EntityShape
+{
+    public override TResult Accept<TArgs, TResult>(IEntityShapeVisitor<TArgs, TResult> visitor, TArgs args)
+        => visitor.VisitSingleShape(this, args);
+}

--- a/Resources/Prototypes/Entities/Markers/Spawners/Shapes/lava.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Shapes/lava.yml
@@ -1,0 +1,63 @@
+﻿- type: entity
+  parent: MarkerBase
+  id: SpawnerShapeLavaCross
+  name: Lava Spawner
+  suffix: Cross, Size 5
+  categories: [ Debug ]
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+  - type: ShapeSpawner
+    spawn: FloorLavaEntity
+    shape:
+      id: Cross
+      size: 5
+
+- type: entity
+  parent: MarkerBase
+  id: SpawnerShapeLavaCrossDiagonal
+  name: Lava Spawner
+  suffix: Cross, Size 5
+  categories: [ Debug ]
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+  - type: ShapeSpawner
+    spawn: FloorLavaEntity
+    shape:
+      id: DiagonalCross
+      size: 5
+
+- type: entity
+  parent: MarkerBase
+  id: SpawnerShapeLavaCrossCombined
+  name: Lava Spawner
+  suffix: Combined cross, Size 4
+  categories: [ Debug ]
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+  - type: ShapeSpawner
+    spawn: FloorLavaEntity
+    shape:
+      id: BothCross
+      size: 4
+
+- type: entity
+  parent: MarkerBase
+  id: SpawnerShapeLavaComplex
+  name: Lava Spawner
+  suffix: Box
+  categories: [ Debug ]
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+  - type: ShapeSpawner
+    spawn: FloorLavaEntity
+    shape:
+      id: BoxFilled
+      size: 5

--- a/Resources/Prototypes/Entities/Markers/Spawners/Shapes/lava.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Shapes/lava.yml
@@ -1,15 +1,16 @@
 ﻿- type: entity
   parent: MarkerBase
   id: SpawnerShapeLavaCross
-  name: Lava Spawner
+  name: lava shape spawner
   suffix: Cross, Size 5
-  categories: [ Debug ]
+  categories: [ Debug, Spawner ]
   components:
   - type: Sprite
     layers:
     - state: green
   - type: ShapeSpawner
-    spawn: FloorLavaEntity
+    spawn:
+      id: FloorLavaEntity
     shape:
       id: Cross
       size: 5
@@ -17,15 +18,16 @@
 - type: entity
   parent: MarkerBase
   id: SpawnerShapeLavaCrossDiagonal
-  name: Lava Spawner
+  name: lava shape spawner
   suffix: Cross, Size 5
-  categories: [ Debug ]
+  categories: [ Debug, Spawner ]
   components:
   - type: Sprite
     layers:
     - state: green
   - type: ShapeSpawner
-    spawn: FloorLavaEntity
+    spawn:
+      id: FloorLavaEntity
     shape:
       id: DiagonalCross
       size: 5
@@ -33,15 +35,16 @@
 - type: entity
   parent: MarkerBase
   id: SpawnerShapeLavaCrossCombined
-  name: Lava Spawner
+  name: lava shape spawner
   suffix: Combined cross, Size 4
-  categories: [ Debug ]
+  categories: [ Debug, Spawner ]
   components:
   - type: Sprite
     layers:
     - state: green
   - type: ShapeSpawner
-    spawn: FloorLavaEntity
+    spawn:
+      id: FloorLavaEntity
     shape:
       id: BothCross
       size: 4
@@ -49,15 +52,16 @@
 - type: entity
   parent: MarkerBase
   id: SpawnerShapeLavaComplex
-  name: Lava Spawner
+  name: lava shape spawner
   suffix: Box
-  categories: [ Debug ]
+  categories: [ Debug, Spawner ]
   components:
   - type: Sprite
     layers:
     - state: green
   - type: ShapeSpawner
-    spawn: FloorLavaEntity
+    spawn:
+      id: FloorLavaEntity
     shape:
       id: BoxFilled
       size: 5

--- a/Resources/Prototypes/EntityShapes/base.yml
+++ b/Resources/Prototypes/EntityShapes/base.yml
@@ -1,0 +1,24 @@
+# Basic shapes prototyped for convenience
+- type: entityShape
+  id: BoxFilled
+  shape: !type:BoxEntityShape
+
+- type: entityShape
+  id: BoxHollow
+  shape: !type:BoxEntityShape
+    hollow: true
+
+- type: entityShape
+  id: Cross
+  shape: !type:CrossEntityShape
+
+- type: entityShape
+  id: DiagonalCross
+  shape: !type:DiagonalCrossEntityShape
+
+- type: entityShape
+  id: BothCross
+  shape: !type:AllEntityShape
+    children:
+    - id: Cross
+    - id: DiagonalCross


### PR DESCRIPTION
## About the PR
Added `EntityShape`s - a way to spawn entities in certain shapes.

Ported from Goobstation (https://github.com/Goob-Station/Goob-Station/pull/3269), originally made by me, and I allow it under the MIT license now

## Why / Balance
Entity shapes are useful for spawning lots of entities at once in a predictable shape. This can be used for visual effects, repeating patterns, or other general cases.

## Technical details
`EntityShape`s return a collection of `Vector2` positions (meaning they can be used for more than just entities, for example tiles or decals).
All shapes have 3 main parameters that determine how the result will look like:
1. `Offset` - The center point of the shape
2. `Size` - determines the amount of steps that the shape will take. This applies differently to all shapes, but in general by increasing the size by 1, the shape increases its amount of points by some specific proportion (crosses have 4 more points, boxes get 1 more to their width and height, etc.)
3. `StepSize` - determines the size of a single step, basically distance between each spawn point (1 tile by default)

In its core `EntityShape`s are very similar to `EntityTableSelector`s. This PR also uses the Visitors approach to centralize all code in one place and do other cool stuff (see #44424)

Right now only the very basic shapes are implemented: crosses, boxes, and lines.

`EntityShapeSystem` has API to spawn entities and then get them, but if you don't need the outputs you should make a new spawner instead and just spawn it.
Shape spawners can not only spawn a shape on map init, but also spawn it on a timer a few more times, and even tweak the size of the resulting shape on each spawn cycle. This is extremely useful for animated effects or animated spawns.

## Test plan
- Open spawn menu
- Type `shape spawner` into the menu and place each type
- Lots of entitites in cool shapes appear

## Media
There's not much to show, it just spawns entities in crosses, boxes, hollow boxes, lines, and stuff like that

## Breaking Changes
*This is mostly a fork-facing PR, so the breaking changes are recommended but not necessary*

Added `EntityShape`s - selectors for positions to spawn entities or other game objects.
If you just want to spawn the same entity prototype in a specific shape, create a new spawner entity that has a `ShapeSpawnerComponent` and spawn it.
If you need the output entities that were spawned by a shape, use `EntityShapeSystem`s `SpawnEntityShape` API method.

## Changelog
not player facing, this is just API
