### PR TITLE
Remove IPIntel 5-second delay

### DIFF
--- a/Content.Server/Connection/IPIntel/IPIntel.cs
+++ b/Content.Server/Connection/IPIntel/IPIntel.cs
@@ -1,6 +1,8 @@
 ﻿using System.Buffers.Binary;
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 using Content.Server.Chat.Managers;
 using Content.Server.Database;
@@ -22,6 +24,7 @@ public sealed class IPIntel
     private readonly IGameTiming _gameTiming;
 
     private readonly ISawmill _sawmill;
+    private readonly ConcurrentDictionary<IPAddress, Lazy<Task<IPIntelResult>>> _pendingLookups = new();
 
     public IPIntel(IIPIntelApi api,
         IServerDbManager db,
@@ -107,7 +110,7 @@ public sealed class IPIntel
             }
         }
 
-        var ip = e.IP.Address;
+        var ip = NormalizeAddress(e.IP.Address);
         var username = e.UserName;
 
         // Is this a local ip address?
@@ -138,11 +141,10 @@ public sealed class IPIntel
             return _rejectUnknown ? (true, Loc.GetString("generic-misconfigured")) : (false, string.Empty);
         }
 
-        var apiResult = await QueryIPIntelRateLimited(ip);
+        var apiResult = await QueryIPIntelSingle(ip);
         switch (apiResult.Code)
         {
             case IPIntelResultCode.Success:
-                await Task.Run(() => _db.UpsertIPIntelCache(DateTime.UtcNow, ip, apiResult.Score));
                 return ScoreCheck(apiResult.Score, username);
 
             case IPIntelResultCode.RateLimited:
@@ -158,6 +160,8 @@ public sealed class IPIntel
 
     public async Task<IPIntelResult> QueryIPIntelRateLimited(IPAddress ip)
     {
+        ip = NormalizeAddress(ip);
+
         IncrementAndTestRateLimit(ref _day, TimeSpan.FromDays(1), "daily");
         IncrementAndTestRateLimit(ref _minute, TimeSpan.FromMinutes(1), "minute");
 
@@ -196,6 +200,50 @@ public sealed class IPIntel
         }
 
         return new IPIntelResult(0, IPIntelResultCode.Errored);
+    }
+
+    private Task<IPIntelResult> QueryIPIntelSingle(IPAddress ip)
+    {
+        ip = NormalizeAddress(ip);
+
+        var lookup = _pendingLookups.GetOrAdd(
+            ip,
+            // Shitcode to stop it invoking the method, we mostly just need it to see if there's an existing one for this IP already.
+            static (address, self) => new Lazy<Task<IPIntelResult>>(
+                () => self.QueryAndCacheIPIntel(address),
+                LazyThreadSafetyMode.ExecutionAndPublication),
+            this);
+
+        return lookup.Value;
+    }
+
+    private async Task<IPIntelResult> QueryAndCacheIPIntel(IPAddress ip)
+    {
+        try
+        {
+            var result = await QueryIPIntelRateLimited(ip);
+
+            if (result.Code == IPIntelResultCode.Success)
+            {
+                await _db.UpsertIPIntelCache(
+                    DateTime.UtcNow,
+                    ip,
+                    result.Score);
+            }
+
+            return result;
+        }
+        finally
+        {
+            _pendingLookups.TryRemove(ip, out _);
+        }
+    }
+
+    private static IPAddress NormalizeAddress(IPAddress address)
+    {
+        return address.IsIPv4MappedToIPv6
+            ? address.MapToIPv4()
+            : address;
     }
 
     private bool CheckSuddenRateLimit()

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -1570,43 +1570,22 @@ INSERT INTO player_round (players_id, rounds_id) VALUES ({players[player]}, {id}
 
         public async Task<bool> UpsertIPIntelCache(DateTime time, IPAddress ip, float score)
         {
-            while (true)
-            {
-                try
-                {
-                    await using var db = await GetDb();
+            await using var db = await GetDb();
 
-                    var existing = await db.DbContext.IPIntelCache
-                        .Where(w => ip.Equals(w.Address))
-                        .SingleOrDefaultAsync();
+            await UpsertIPIntelCacheCore(
+                db.DbContext,
+                time,
+                ip,
+                score);
 
-                    if (existing == null)
-                    {
-                        var newCache = new IPIntelCache
-                        {
-                            Time = time,
-                            Address = ip,
-                            Score = score,
-                        };
-                        db.DbContext.IPIntelCache.Add(newCache);
-                    }
-                    else
-                    {
-                        existing.Time = time;
-                        existing.Score = score;
-                    }
-
-                    await Task.Delay(5000);
-
-                    await db.DbContext.SaveChangesAsync();
-                    return true;
-                }
-                catch (DbUpdateException)
-                {
-                    _opsLog.Warning("IPIntel UPSERT failed with a db exception... retrying.");
-                }
-            }
+            return true;
         }
+
+        protected abstract Task UpsertIPIntelCacheCore(
+            ServerDbContext db,
+            DateTime time,
+            IPAddress ip,
+            float score);
 
         public async Task<IPIntelCache?> GetIPIntelCache(IPAddress ip)
         {

--- a/Content.Server/Database/ServerDbPostgres.cs
+++ b/Content.Server/Database/ServerDbPostgres.cs
@@ -59,6 +59,22 @@ namespace Content.Server.Database
             InitNotificationListener(connectionString);
         }
 
+        protected override Task UpsertIPIntelCacheCore(
+            ServerDbContext db,
+            DateTime time,
+            IPAddress ip,
+            float score)
+        {
+            return db.Database.ExecuteSqlAsync($"""
+                INSERT INTO ipintel_cache (address, time, score)
+                VALUES ({ip}, {time}, {score})
+                ON CONFLICT (address) DO UPDATE
+                SET
+                    time = EXCLUDED.time,
+                    score = EXCLUDED.score;
+                """);
+        }
+
         #region Ban
         public override async Task<BanDef?> GetBanAsync(int id)
         {

--- a/Content.Server/Database/ServerDbSqlite.cs
+++ b/Content.Server/Database/ServerDbSqlite.cs
@@ -67,6 +67,24 @@ namespace Content.Server.Database
             cfg.OnValueChanged(CCVars.DatabaseSqliteDelay, v => _msDelay = v, true);
         }
 
+        protected override Task UpsertIPIntelCacheCore(
+            ServerDbContext db,
+            DateTime time,
+            IPAddress ip,
+            float score)
+        {
+            var address = ip.ToString();
+
+            return db.Database.ExecuteSqlAsync($"""
+                INSERT INTO ipintel_cache (address, time, score)
+                VALUES ({address}, {time}, {score})
+                ON CONFLICT (address) DO UPDATE
+                SET
+                    time = excluded.time,
+                    score = excluded.score;
+                """);
+        }
+
         #region Ban
         public override async Task<BanDef?> GetBanAsync(int id)
         {


### PR DESCRIPTION
I assume the problem was from no IP rate-limit meaning concurrent connections hit it, either way every time we get the DB we use a semaphoreslim on ops involving it so this means the DB gets reserved for up to 5 seconds on this.