### PR TITLE
re-allow humans with non realistic eye colors

### DIFF
--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -166,12 +166,11 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
 
     public static HumanoidCharacterAppearance EnsureValid(HumanoidCharacterAppearance appearance, ProtoId<SpeciesPrototype> species, Sex sex)
     {
-
         var proto = IoCManager.Resolve<IPrototypeManager>();
         var markingManager = IoCManager.Resolve<MarkingManager>();
 
         var skinColor = appearance.SkinColor;
-        var eyeColor = appearance.EyeColor;
+        var eyeColor = ClampColor(appearance.EyeColor); // not using ClampEyeColorToStrategy so characters can have fun eye colours
         var validatedMarkings = appearance.Markings.ShallowClone();
 
         if (proto.TryIndex(species, out var speciesProto))
@@ -179,7 +178,6 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
             var coloration = proto.Index(speciesProto.SkinColoration);
             var organs = markingManager.GetOrgans(species);
             skinColor = coloration.Strategy.EnsureVerified(skinColor);
-            eyeColor = ClampEyeColorToStrategy(eyeColor, coloration);
 
             foreach (var (organ, _) in appearance.Markings)
             {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fixes #44799 

`ClampEyeColorToStrategy` in validation call is good in theory, but in practice adhering to the strategy set by `skincolorations.yml` for humanoids means you cant really have fun eye colours.
you could soap this by having seperate strategies for newly generated characters vs validating characters, but that seems a little arbitrary. probably not worth it

## Test plan
1. make human character with funky coloured eyes
2. press save

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- fix: Human characters can once again have coloured eyes.
