### PR TITLE
Firehelmets have small power cell now

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -279,6 +279,11 @@
     coolingCoefficient: 0.8
   - type: FireProtection
     reduction: 0.15 # not fully sealed so less protection
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellSmall
   - type: IdentityBlocker
   - type: Tag
     tags:


### PR DESCRIPTION
## About the PR
Reduced the power cell in fire helmets from medium one to small one

## Why / Balance
Fire helmets can be found in every fire locker and in every fire helmet you can find a power cell and there are quite a lot of them mapped everywhere. 
That's a lot of good batteries that can be just ripped out whenever you run out of flashlight power. This change will hopefully cause some people to use cell chargers more often.

## Technical details
yml

## Test plan
spawn power helmet
look inside
small power cell

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- tweak: Fire Helmets now have small power cell instead of medium one.
