### PR TITLE
Allow projectile spells to set velocity inheritance

### DIFF
--- a/Content.Shared/Magic/Events/ProjectileSpellEvent.cs
+++ b/Content.Shared/Magic/Events/ProjectileSpellEvent.cs
@@ -16,4 +16,10 @@ public sealed partial class ProjectileSpellEvent : WorldTargetActionEvent
     /// </summary>
     [DataField]
     public float ProjectileSpeed = 25f;
+
+    /// <summary>
+    /// Wether or not this should inherit the velocity of the shooter.
+    /// </summary>
+    [DataField]
+    public bool InheritVelocity = true;
 }

--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -280,7 +280,7 @@ public abstract partial class SharedMagicSystem : EntitySystem
         var xform = Transform(ev.Performer);
         var fromCoords = xform.Coordinates;
         var toCoords = ev.Target;
-        var userVelocity = _physics.GetMapLinearVelocity(ev.Performer);
+        var userVelocity = ev.InheritVelocity ? _physics.GetMapLinearVelocity(ev.Performer) : Vector2.Zero;
 
         // If applicable, this ensures the projectile is parented to grid on spawn, instead of the map.
         var fromMap = _transform.ToMapCoordinates(fromCoords);

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -267,6 +267,7 @@
     event: !type:ProjectileSpellEvent
       prototype: ProjectileDragonsBreath
       projectileSpeed: 5
+      inheritVelocity: false
 
 - type: entity
   parent: Smoke


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR allows for projectile spells to inherit or ignore the caster's velocity.

Fixes #44796

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bugfix. Space dragon's fire breath was speeding up or slowing down if they were moving forward or backward.

## Technical details
<!-- Summary of code changes for easier review. -->

We've added an optional (true by default) parameter that allows the spell to ignore the caster's velocity.

SnappingOpossum posted a patch file on discord, so I tested and opened a PR to get the fix landed.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

As a space dragon, use your fire breath while moving in different directions. See that the breath/ball simply moves at a constant speed in the direction you pointed when clicking, regardless of movement.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/7e518f4d-a8d3-4dfb-aac8-a0481833bffe

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: SnappingOpossum
- fix: Fixed space dragon fire breath projectile speed while moving around

