### PR TITLE
Fix @name highlights not omitting your name in deadchat and admin chat.

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -123,7 +123,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
             // Make sure the character's name is highlighted only when mentioned directly (eg. it's said by someone),
             // for example in 'Name Surname says, "..."' 'Name Surname' won't be highlighted.
             keyword = StartAtSign.Replace(keyword,
-                $@"(?<=(?<=(OOC|DEAD|ADMIN):.*:.*)|(?<=,.*{_chatSpeechDoubleQuoteBegin}.*)|(?<=\n.*))");
+                $@"(?<=(?<=(L?OOC|DEAD|ADMIN):.*:.*)|(?<=,.*{_chatSpeechDoubleQuoteBegin}.*)|(?<=\n.*))");
 
             _highlights.Add(keyword);
         }

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -123,7 +123,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
             // Make sure the character's name is highlighted only when mentioned directly (eg. it's said by someone),
             // for example in 'Name Surname says, "..."' 'Name Surname' won't be highlighted.
             keyword = StartAtSign.Replace(keyword,
-                $"(?<=(?<=^.?OOC:.*:.*)|(?<=,.*{_chatSpeechDoubleQuoteBegin}.*)|(?<=\\n.*))");
+                $@"(?<=(?<=(OOC|DEAD|ADMIN):.*:.*)|(?<=,.*{_chatSpeechDoubleQuoteBegin}.*)|(?<=\n.*))");
 
             _highlights.Add(keyword);
         }

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -123,7 +123,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
             // Make sure the character's name is highlighted only when mentioned directly (eg. it's said by someone),
             // for example in 'Name Surname says, "..."' 'Name Surname' won't be highlighted.
             keyword = StartAtSign.Replace(keyword,
-                $"(?<=(?<=^.?OOC:.*:.*)|(?<=,.*{_chatSpeechDoubleQuoteBegin}.*)|(?<=\\n.*)|(?<=:.*))");
+                $"(?<=(?<=^.?OOC:.*:.*)|(?<=,.*{_chatSpeechDoubleQuoteBegin}.*)|(?<=\\n.*))");
 
             _highlights.Add(keyword);
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fix `@name` highlights highlighting the speaker's name before the colon in deadchat and admin chat:

<img width="451" height="127" alt="image" src="https://github.com/user-attachments/assets/617defe5-04eb-4c12-bed7-e4c616adf5e4" />



## Technical details
<!-- Summary of code changes for easier review. -->
Removed the recent `(?<=:.*)`, it's no good and was only looking for one colon, meanwhile there are two in deadchat: `DEAD: <name>: <message>`. Instead added DEAD and ADMIN to the `(?<=` lookbehind which already looks for the two colons we need.

I also dropped the requirement of the regex being at the start of a message (the `^`). I tried not doing that and incorporating the `(F)` before messages while dead that allows following the entity, but in the wrapped message it's `[cmdlink="(F)" command="ghost_follow_entity 4572" /]` and the wrapped message is what is being checked by highlights, so that's pretty cumbersome. The only issue arising from this is that if someone literally says something like `DEAD: Name Surname: asdf`, it will highlight `@Name`, but that's still part of something a person said, and also nobody should ever say something like that, so that's fine probably.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="629" height="389" alt="2026-07-20-23h22m40s_Content Client" src="https://github.com/user-attachments/assets/583f2435-983b-45df-8a77-16ee4a31e8de" />