### PR TITLE
Fix: Tiles with a Closed Material Door have no atmosphere

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
@@ -44,6 +44,7 @@
       path: /Audio/Effects/stonedoor_openclose.ogg
   - type: Appearance
   - type: Airtight
+    noAirWhenFullyAirBlocked: false
   - type: Damageable
     damageModifierSet: Metallic
   - type: Injurable


### PR DESCRIPTION
## About the PR
This PR Modifies the Airtight Component for BaseMaterialDoor to add the `noAirWhenFullyAirBlocked` and set it to false.

## Why / Balance
This allows an atmosphere to exist in the same tile as material doors with their doors closed; no longer causing pressure/asphyx damage for anything that can crawl under doors or for the brief moment upon opening and entering the door. 

Resolves: https://github.com/space-wizards/space-station-14/issues/44613

## Technical details

Modifies line 47 to add the following to the AirtightComponent
```
    noAirWhenFullyAirBlocked: false
```
The door is still airtight to tiles around it, but the tile now keeps its current atmosphere.

## Test plan

1. Open dev env.
2. Press F5, search wooden door, place one
3. same as step 2, but place a mouse.
4. Debug control the mouse mob
5. run under the wooden door and sit for 10-20 seconds. Mouse will not gasp

## Media
<img width="1633" height="497" alt="image" src="https://github.com/user-attachments/assets/e2cd6b6d-98cc-40ba-9265-2f7dba346946" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Any children of BaseMaterialDoor that _do_ require NoAirWhenFullyAirBlocked to be True will need to be manually adjusted. If there would be anything breaking, it would likely be a downstream edge case.

## Changelog

:cl:
- fix: Doors made of wood, metal, and rare materials now maintain the atmosphere on their tile when their doors are closed. Mice can breathe under them now!
