### PR TITLE
Remove ActiveInputMoverComponent immediately when paused

### DIFF
--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Systems;
 using Content.Shared.Movement.Components;
-using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Shuttles.Systems;
@@ -52,7 +51,7 @@ public sealed partial class MoverController : SharedMoverController
         // Become unactive [sic] if we don't have PhysicsComp.IgnorePaused
         if (PhysicsQuery.TryComp(ent, out var phys) && phys.IgnorePaused)
             return;
-        RemCompDeferred<ActiveInputMoverComponent>(ent);
+        RemComp<ActiveInputMoverComponent>(ent);
     }
 
     private void OnEntityUnpaused(Entity<InputMoverComponent> ent, ref EntityUnpausedEvent args)

--- a/Content.Shared/Movement/Components/ActiveInputMoverComponent.cs
+++ b/Content.Shared/Movement/Components/ActiveInputMoverComponent.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.Movement.Components;
 /// </remarks>
 /// <seealso cref="InputMoverComponent"/>
 /// <seealso cref="SharedMoverController.UpdateMoverStatus"/>
-[RegisterComponent, UnsavedComponent, Access(typeof(SharedMoverController))]
+[RegisterComponent, Access(typeof(SharedMoverController))]
 public sealed partial class ActiveInputMoverComponent : Component
 {
     /// <summary>
@@ -24,4 +24,4 @@ public sealed partial class ActiveInputMoverComponent : Component
     /// </remarks>
     [DataField, ViewVariables]
     public EntityUid? RelayedFrom;
-};
+}

--- a/Content.Shared/Movement/Components/ActiveInputMoverComponent.cs
+++ b/Content.Shared/Movement/Components/ActiveInputMoverComponent.cs
@@ -13,7 +13,7 @@ namespace Content.Shared.Movement.Components;
 /// </remarks>
 /// <seealso cref="InputMoverComponent"/>
 /// <seealso cref="SharedMoverController.UpdateMoverStatus"/>
-[RegisterComponent, Access(typeof(SharedMoverController))]
+[RegisterComponent, UnsavedComponent, Access(typeof(SharedMoverController))]
 public sealed partial class ActiveInputMoverComponent : Component
 {
     /// <summary>


### PR DESCRIPTION
## About the PR
Fixes the problem in #44831 by removing ActiveInputMoverComponent immediately when an entity is paused.

## Why / Balance
`ActiveInputMoverComponent` is a runtime marker managed and recreated by `MoverController`, so it should not be serialized as part of persistent map state

## Technical details
Replaced RemCompDeferred with RemComp.

## Test plan
Run `SaveLoadSaveTest` with the changes from #44831

## Media
Not required

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

## Changelog
No player-facing changes