### PR TITLE
Re-enable a few midround shuttles and make them more common overall.

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -502,7 +502,7 @@
   components:
   - type: StationEvent
     earliestStart: 35
-    weight: 5.5
+    weight: 6
     minimumPlayers: 20
     duration: null # LoneOpsSpawn needs an infinite duration so that it inherits the NukeOpsRule things of an actually appropriate end screen (not always "Neutral outcome!") and... ending the game if the station is nuked.
     occursDuringRoundEnd: false

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -445,7 +445,7 @@
       min: 1200 # 20 mins
       max: 7200 # 120 mins # you probably arent getting a second visitor shuttle in one round, but it is possible.
     scheduledGameRules: !type:NestedSelector
-      prob: 0.05 # Only 1 in 20 rounds...
+      prob: 0.1 # Only 1 in 10 rounds...
       tableId: SpaceTrafficControlTable
 
 # variation passes

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -4,9 +4,11 @@
   id: UnknownShuttlesHostileTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
-    - id: LoneOpsSpawn
     - id: UnknownShuttleManOWar
     - id: UnknownShuttleInstigator
+    - id: UnknownShuttleNTQuark
+    - id: UnknownShuttleSyndieEvacPod
+    - id: UnknownShuttleHonki
 
 # Shuttle Game Rules
 
@@ -40,7 +42,7 @@
   id: UnknownShuttleHonki
   components:
   - type: StationEvent
-    weight: 2
+    weight: 0.2
   - type: LoadMapRule
     gridPath: /Maps/Shuttles/ShuttleEvent/honki.yml
 
@@ -49,7 +51,7 @@
   id: UnknownShuttleSyndieEvacPod
   components:
   - type: StationEvent
-    weight: 5 # lower because weird freelance roles
+    weight: 0.3
     maxOccurrences: 2
   - type: LoadMapRule
     gridPath: /Maps/Shuttles/ShuttleEvent/syndie_evacpod.yml
@@ -59,7 +61,7 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    weight: .5 # Hopefully this is uncommon enough, it needs to be uncommon enough that people wont waste time metaknowledging it.
+    weight: 0.1
     earliestStart: 45 # late to hopefully have enough ghosts to fill all roles quickly.
     minimumPlayers: 25
   - type: LoadMapRule
@@ -70,7 +72,7 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    weight: 0.1 #  approximately 1/1000 on the random hostile shuttle table. Golden Legendary!
+    weight: 0.2
   - type: LoadMapRule
     gridPath: /Maps/Shuttles/ShuttleEvent/instigator.yml
 
@@ -79,6 +81,6 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    weight: 1 # lower because antags
+    weight: 0.2
   - type: LoadMapRule
     gridPath: /Maps/Shuttles/ShuttleEvent/manowar.yml


### PR DESCRIPTION
NT Quark my beloved.

## About the PR
Changed the Shuttle Scheduler in a few ways:
1. Made the scheduler run more often
2. Removed loneop from the scheduler (it'll still spawn through regular events, I microbalanced the odds higher but that bit DOES NOT MATTER)
3. Add back the Syndi Evac Pod, the Honki, and the NT Quark to the scheduler
4. Buff the odds for each thing to spawn

Exact values here:
<img width="1508" height="410" alt="image" src="https://github.com/user-attachments/assets/9c92e33b-67ae-494e-9374-b7ddcdc42832" />


## Why / Balance
*cracks knuckles* Thesis defence time let's go

Visitor shuttles were removed for a good reason, they're boring and they don't do much. Two were kept in game - AT A 0.08% CHANCE???? And three were kept in-file for being good midrounds (but they were still 1984'd from the scheduler).

People need more round variation chaos on wizden, it's one of the main complaints levied. Furthermore, in my personal optinion, the Survival gamemode is the true Spation experience that a lot of people have fun with, and reintroducing some of that chaos into your average round is a good thing.

Obviously I'm incredibly biased towards the NT Quark, but let me talk about the Instigator. A reasonably fun alternative to the Lone Op - roughly equal in power, anyway - it has a **1/1250** chance of spawning in a round. That's... ridiculous, and honestly we shouldn't have that level of randomised rarity in major content ever.

Also, if we're talking about how "balanced" these are, let's not forget that Wizard is still in the game (at roughly equal odds to the shuttles I'm proposing here), and has FAR more power to fuck up rounds (in a negative sense).

## Technical details
YAML!

## Test plan
1. Open dev
2. Run `stationevent:simulate SpaceTrafficControlEvent ...` with various parameters to see that the values work out

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog

:cl:
- add: Readded the NT Quark, Honki, and Syndi Evac Pod to the shuttle pool.
- tweak: Buffed the chance for the Man o' War and Syndi Instigator to appear.
