### PR TITLE
Fix EntityMenu not removing entities when sprite becomes invisible

### DIFF
--- a/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
@@ -227,13 +227,12 @@ namespace Content.Client.ContextMenu.UI
                     continue;
                 }
 
-                if ((visibility & MenuVisibility.Invisible) == 0)
+                if ((visibility & MenuVisibility.Invisible) == 0
+                    && _spriteQuery.TryGetComponent(entity, out var sprite)
+                    && !sprite.Visible)
                 {
-                    if (_spriteQuery.TryGetComponent(entity, out var sprite) && !sprite.Visible)
-                    {
-                        RemoveEntity(entity);
-                        continue;
-                    }
+                    RemoveEntity(entity);
+                    continue;
                 }
 
                 if ((visibility & MenuVisibility.NoFov) == MenuVisibility.NoFov)

--- a/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
@@ -52,6 +52,9 @@ namespace Content.Client.ContextMenu.UI
         [UISystemDependency] private readonly TransformSystem _xform = default!;
         [UISystemDependency] private readonly CombatModeSystem _combatMode = default!;
 
+        private EntityQuery<TransformComponent> _xformQuery;
+        private EntityQuery<SpriteComponent> _spriteQuery;
+
         private bool _updating;
 
         /// <summary>
@@ -71,6 +74,9 @@ namespace Content.Client.ContextMenu.UI
             CommandBinds.Builder
                 .Bind(EngineKeyFunctions.UseSecondary,  new PointerInputCmdHandler(HandleOpenEntityMenu, outsidePrediction: true))
                 .Register<EntityMenuUIController>();
+
+            _xformQuery = _entityManager.GetEntityQuery<TransformComponent>();
+            _spriteQuery = _entityManager.GetEntityQuery<SpriteComponent>();
         }
 
         public void OnStateExited(GameplayState state)
@@ -211,21 +217,29 @@ namespace Content.Client.ContextMenu.UI
             visibility = ev.Visibility;
 
             _entityManager.TryGetComponent(player, out ExaminerComponent? examiner);
-            var xformQuery = _entityManager.GetEntityQuery<TransformComponent>();
 
             foreach (var entity in Elements.Keys.ToList())
             {
-                if (!xformQuery.TryGetComponent(entity, out var xform))
+                if (!_xformQuery.TryGetComponent(entity, out var xform))
                 {
                     // entity was deleted
                     RemoveEntity(entity);
                     continue;
                 }
 
+                if ((visibility & MenuVisibility.Invisible) == 0)
+                {
+                    if (_spriteQuery.TryGetComponent(entity, out var sprite) && !sprite.Visible)
+                    {
+                        RemoveEntity(entity);
+                        continue;
+                    }
+                }
+
                 if ((visibility & MenuVisibility.NoFov) == MenuVisibility.NoFov)
                     continue;
 
-                var pos = new MapCoordinates(_xform.GetWorldPosition(xform, xformQuery), xform.MapID);
+                var pos = new MapCoordinates(_xform.GetWorldPosition(xform, _xformQuery), xform.MapID);
 
                 if (!_examineSystem.CanExamine(player, pos, e => e == player || e == entity, entity, examiner))
                     RemoveEntity(entity);


### PR DESCRIPTION
## About the PR
When opened, `EntityMenu` does not include entities with invisible sprites (since `SpriteTreeSystem` skips them), but it does not check the visibility of the sprite after opening.
This PR fixes this.

## Why / Balance
Bugfix

## Test plan
See the media

## Media
`Directional visibility for wall-mounted entities` PR as an example:

https://github.com/user-attachments/assets/4715806e-679a-42ca-8037-217487dd183a

https://github.com/user-attachments/assets/12aba4f7-09b3-41a6-a87c-093fdc5bd14d

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
