### PR TITLE
[STAGING] Increase afk time limit

### DIFF
--- a/Content.Shared/CCVar/CCVars.Misc.cs
+++ b/Content.Shared/CCVar/CCVars.Misc.cs
@@ -35,7 +35,8 @@ public sealed partial class CCVars
     /// </summary>
     [CVarControl(AdminFlags.VarEdit, min: 0f, max: float.MaxValue)]
     public static readonly CVarDef<float> AfkTime =
-        CVarDef.Create("afk.time", 300f, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("afk.time", 600f, CVar.SERVER | CVar.REPLICATED);
+        // If afk players become an issue again, implement using a more agressive time limit when server pop is near full
 
     /// <summary>
     ///     How long a player has to confirm they are not AFK before being disconnected.

--- a/Content.Shared/CCVar/CCVars.Misc.cs
+++ b/Content.Shared/CCVar/CCVars.Misc.cs
@@ -36,7 +36,7 @@ public sealed partial class CCVars
     [CVarControl(AdminFlags.VarEdit, min: 0f, max: float.MaxValue)]
     public static readonly CVarDef<float> AfkTime =
         CVarDef.Create("afk.time", 600f, CVar.SERVER | CVar.REPLICATED);
-        // If afk players become an issue again, implement using a more agressive time limit when server pop is near full
+        // If afk players become an issue again, implement using a more aggressive time limit when server pop is near full
 
     /// <summary>
     ///     How long a player has to confirm they are not AFK before being disconnected.


### PR DESCRIPTION
## About the PR
Increase AFK time limit to 10 minutes (from 5 minutes)

## Why / Balance
Received some player complaints related to the shortness of the afk timer, particularly in situations where:
- player is reading the rules of a new server (should implement scroll-detection, but this is a faster remedy to the issue)
- dead player walking away from their computer while waiting for the emergency shuttle to finish the round

I'm not personally convinced that it's a valid complaint that one gets kicked if they are not actually there playing the game, but at least until we have improved AFK detection in edge cases (reading rules in the lobby, maybe observing the round as a ghost while orbiting someone?) we might as well accomodate the request

A 10 minute AFK kick will presumably still accomplish the original goals of the system

## Technical details
cvar change

## Test plan
Log into client, wait 10 minutes

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl: Errant
- tweak: AFK detection time has been increased to 10 minutes.
