### PR TITLE
Improve gibbing documentation comments

### DIFF
--- a/Content.Shared/Gibbing/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/GibbingSystem.cs
@@ -19,8 +19,12 @@ public sealed partial class GibbingSystem : EntitySystem
     private static readonly SoundSpecifier? GibSound = new SoundCollectionSpecifier("gib", AudioParams.Default.WithVariation(0.025f));
 
     /// <summary>
-    /// Gibs an entity.
+    /// Attempts to gib an entity.
     /// </summary>
+    /// <remarks>
+    /// <see cref="SharedDestructibleSystem.DestroyEntity" /> gets the final say on if an entity ends up deleted.
+    /// If you want to intercept gibbing, intercept <see cref="DestructionAttemptEvent" />
+    /// </remarks>
     /// <param name="ent">The entity to gib.</param>
     /// <param name="dropGiblets">Whether or not to drop giblets.</param>
     /// <param name="user">The user gibbing the entity, if any.</param>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Better documentation for gibbing API.

## Why / Balance
Someone got confused in another PR and added a duplicate event to handle something that was already handled by existing code.

## Technical details
More words.

## Test plan
Read the words in Rider or the like.

## Media
<img width="872" height="758" alt="grafik" src="https://github.com/user-attachments/assets/c2f0a444-0cd7-4d26-86ac-87045648e95a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
