### PR TITLE
Labels can be put on wrapped parcels

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/parcel_wrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/parcel_wrap.yml
@@ -96,7 +96,7 @@
     - Recyclable # Parcel entity is recyclable, and when it's destroyed, it'll drop its contents.
 
 - type: entity
-  parent: [ BaseItem, BaseWrappedParcel ]
+  parent: [ BaseItem, BaseWrappedParcel, BasePaperLabelable ]
   id: WrappedParcel
   name: wrapped parcel
   description: Something wrapped up in paper. I wonder what's inside...


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Allows paper to be placed as a label on wrapped parcels

## Why / Balance
Gives parcel wraps more of a use beyond just wrapping people and putting parcel wrapped duffel bags in other duffel bags.

## Technical details
Single line of YAML

## Test plan

1. Place various types of paper on wrapped parcels of different sizes, and ensure the sprite for the label always visually stays on the parcel.
2. Use an appraisal tool on a wrapped parcel with a bounty manifest on it, which does not fulfill the bounty.
3. Use an appraisal tool on a wrapped parcel with a bounty manifest on it, which does fulfill the bounty.
4. Sell a wrapped parcel that fulfills a bounty, and confirm the bounty was fulfilled.

## Media
<img width="745" height="407" alt="Screenshot_20260723_003508" src="https://github.com/user-attachments/assets/fcd14fd1-ed2d-4b5b-b6d8-3b1b32de3b6d" />
<img width="483" height="302" alt="Screenshot_20260723_003903" src="https://github.com/user-attachments/assets/1c5bd5f3-6969-4284-b99e-91f17a8b0e1f" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
- tweak: Wrapped parcels can now have labels attached to them.
