### PR TITLE
Fix not being able to stack atmos devices

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/atmospherics.yml
+++ b/Resources/Prototypes/Recipes/Construction/atmospherics.yml
@@ -22,6 +22,13 @@
   conditions:
   - !type:NoUnstackableInTile
 
+# we allow stacking for shit like radiators on top of atmosdevices
+# for now (trademark patent pending)
+- type: construction
+  abstract: true
+  parent: BaseAtmos
+  id: BaseGasDeviceStackable
+
 - type: construction
   abstract: true
   parent: BaseGasDevice
@@ -34,6 +41,13 @@
   id: BaseGasBinary
   graph: GasBinary
   placementMode: AlignAtmosPipeLayers # most binary devices support layers
+
+- type: construction
+  abstract: true
+  parent: BaseGasDeviceStackable
+  id: BaseGasBinaryStackable
+  graph: GasBinary
+  placementMode: AlignAtmosPipeLayers
 
 - type: construction
   abstract: true
@@ -370,13 +384,13 @@
   placementMode: SnapgridCenter
 
 - type: construction
-  parent: BaseGasBinary
+  parent: BaseGasBinaryStackable
   id: HeatExchanger
   targetNode: radiator
   placementMode: SnapgridCenter
 
 - type: construction
-  parent: BaseGasBinary
+  parent: BaseGasBinaryStackable
   id: HeatExchangerBend
   name: construction-recipe-heat-exchanger-bend
   targetNode: bendradiator


### PR DESCRIPTION
## About the PR
Fixed a regression caused in #44637 that caused certain atmosdevices (rads) to not stack

## Why / Balance
Unintended change and I don't want to deal with the arguments about it

## Technical details
Oops i dont want to inherit one component in an inheritance tree so i must make a specific carveout for stackables

## Test plan
Build vent on one tile
Build radiator on the same time
Notice they both build fine

## Media
roombateg v3 works now

<img width="381" height="364" alt="image" src="https://github.com/user-attachments/assets/c2ebe124-8bcf-4859-a228-6aea6e473cad" />

still get 1984'd if you try to stack
<img width="403" height="269" alt="image" src="https://github.com/user-attachments/assets/f0d069c4-7267-453c-aa33-b6aa7b884b51" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
- fix: Fixed a bug that made you unable to stack radiators on other atmospherics devices.
