### PR TITLE
Galaxythistles are flowers

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1731,7 +1731,7 @@
   - type: Tag
     tags:
     - Galaxythistle
-    - Fruit # Probably?
+    - Flower
   - type: FoodSequenceElement
     entries:
       Taco: Galaxythistle

--- a/Resources/Prototypes/Recipes/Cooking/food_sequence_element.yml
+++ b/Resources/Prototypes/Recipes/Cooking/food_sequence_element.yml
@@ -1113,7 +1113,7 @@
   - sprite: Objects/Specific/Hydroponics/galaxythistle.rsi
     state: produce
   tags:
-  - Fruit
+  - Flower
 
 - type: foodSequenceElement
   id: GalaxythistleBurger
@@ -1122,7 +1122,7 @@
   - sprite: Objects/Specific/Hydroponics/galaxythistle.rsi
     state: produce
   tags:
-  - Fruit
+  - Flower
 
 # bungo
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Galaxythistle now have the Flower tag instead of the Fruit tag.

## Why / Balance
https://en.wikipedia.org/wiki/Thistle

Pretty sure galaxythistles take about the same amount of time to grow as poppies, so the balance shouldn't be affected.

## Breaking Changes
Galaxythistles now have the Flower tag instead of the Fruit tag.

## Technical details
Single line YAML change

## Test plan
Confirm they have the tag with view variables and confirm it's spelt the same way as the tag poppies have?
I'm pretty sure the only use of the flower tag is for bounties, and i don't know a way of quickly getting a specific cargo bounty in the dev environment.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl: 
- tweak: Galaxythistles are now counted as flowers for the purpose of bounties.
