### PR TITLE
Bugfix: Light tubes and bulbs break into glass shards

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -68,10 +68,10 @@
   - type: Destructible
     thresholds:
     - trigger: *DamageTrigger10
-      behaviors:
+      behaviors: &BehaviorsSpawnShardGlass
       - !type:SpawnEntitiesBehavior
         spawn:
-          LightBulbBroken:
+          ShardGlass:
             min: 1
             max: 1
 
@@ -87,12 +87,7 @@
   - type: Destructible
     thresholds:
     - trigger: *DamageTrigger10
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          LightTubeBroken:
-            min: 1
-            max: 1
+      behaviors: *BehaviorsSpawnShardGlass
 
 # Lighting color values gathered from
 # https://andi-siess.de/rgb-to-color-temperature/


### PR DESCRIPTION
## About the PR

Fixes a regression from #44644 where light bulbs/tubes would break into their broken version which would break into their broken version.

## Why / Balance

Seems like an unintended change in behaviour.

## Technical details

Sets the entity spawn from LightBulb/TubeBroken to ShardGlass.

Why ShardGlass directly and not TubeBroken, then ShardGlass?  The breakage behaviour at 5 damage already breaks the entity - it replaces its sprite with a cracked one and prevents it from working in a fixture, and spawning a new lightbulb/tube does three undesirable things:

1. causes a slight jitter in placement due to difference in spawn placement
2. causes a slight hue change for non-identical bulbs/tubes (e.g. LED, sodium)
3. has its own Breakage behaviour at 5 damage which will break the bulb (a no-op, but still!)

This restores probably the easiest way to get glass shards in the game.

## Test plan

Chuck some lights.

## Media

Current behaviour on master:

https://github.com/user-attachments/assets/30b31a9f-cec8-400f-927b-83b6704f1a0c

Behaviour on head of PR - the lights spawned to the left are freshly spawned broken variants.  Note that they behave the same as regular lights - running their destruction behaviour on the first toss (a no-op in their case) then running destruction and turning into a shard.

https://github.com/user-attachments/assets/27665e57-46eb-4838-a5fe-0eec8117997c

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

#Changelog

🆑
 - fix: Light bulbs and tubes once again break into glass shards when sufficiently damaged.
