### PR TITLE
Check engine version exists before publish

### DIFF
--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -28,15 +28,15 @@ jobs:
     - name: Get Engine Tag
       run: |
         cd RobustToolbox
-        git fetch --depth=1
-        echo "ENGINE_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+        git fetch --depth=1 --tags
+        echo "ENGINE_VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')" >> $GITHUB_ENV
 
-    - name: Check engine version exists
+    - name: Check Engine Version Exists
       run: |
         echo "Checking for engine version $ENGINE_VERSION"
-        curl -sSf https://robust-builds.cdn.spacestation14.com/manifest.json -o manifest.json
-        if ! jq -e --arg v "$ENGINE_VERSION" 'has($v)' manifest.json > /dev/null; then
-          echo "::error::Engine version $ENGINE_VERSION not found in the manifest."
+        if ! curl -sSf https://robust-builds.cdn.spacestation14.com/manifest.json \
+          | jq -e --arg v "$ENGINE_VERSION" 'has($v)' > /dev/null; then
+          echo "::error::Engine version $ENGINE_VERSION not found in the manifest (or the manifest could not be fetched)."
           exit 1
         fi
         echo "Engine version $ENGINE_VERSION found."

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -29,6 +29,17 @@ jobs:
       run: |
         cd RobustToolbox
         git fetch --depth=1
+        echo "ENGINE_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+
+    - name: Check engine version exists
+      run: |
+        echo "Checking for engine version $ENGINE_VERSION"
+        curl -sSf https://robust-builds.cdn.spacestation14.com/manifest.json -o manifest.json
+        if ! jq -e --arg v "$ENGINE_VERSION" 'has($v)' manifest.json > /dev/null; then
+          echo "::error::Engine version $ENGINE_VERSION not found in the manifest."
+          exit 1
+        fi
+        echo "Engine version $ENGINE_VERSION found."
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,18 @@ jobs:
     - name: Get Engine Tag
       run: |
         cd RobustToolbox
-        git fetch --depth=1
+        git fetch --depth=1 --tags
+        echo "ENGINE_VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')" >> $GITHUB_ENV
+
+    - name: Check Engine Version Exists
+      run: |
+        echo "Checking for engine version $ENGINE_VERSION"
+        if ! curl -sSf https://robust-builds.cdn.spacestation14.com/manifest.json \
+          | jq -e --arg v "$ENGINE_VERSION" 'has($v)' > /dev/null; then
+          echo "::error::Engine version $ENGINE_VERSION not found in the manifest (or the manifest could not be fetched)."
+          exit 1
+        fi
+        echo "Engine version $ENGINE_VERSION found."
 
     - name: Install dependencies
       run: dotnet restore


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Check if the requested engine version actually exists in the manifest before pushing an update out to the servers

I would make this something that runs on a PR, but as far as I can tell there are none that run in any meaningful way for this. I could include it into the submodule update checker instead or make an entirely new test for this if that is preferred.

## Why / Balance
I'm pretty sure this is the second or third time I see this happening

## Technical details
Just checks if the requested version exists in the manifest

I hardcoded the manifest url because I would assume there is no reason to ever change this, and adding an additional thing forks need to set when setting up publishing doesn't seem that good. Realistically this would only need to be changed if the manifest switches places or the cdn switches urls anyways

## Test plan
No way to really test it on master unless you break stuff on purpose :godo:

I have a failed run [here](https://github.com/Axionyxx/space-station-14/actions/runs/30120789373/job/89572647815), and a "successful" run [here](https://github.com/Axionyxx/space-station-14/actions/runs/30132348871/job/89609294002). This run is still marked as failed due to me cancelling the workflow because I don't care to run the workflow beyond my changes, but if you expand the "Check Engine Version Exists" tab you'll see it passed in one run and not in the other.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
