### PR TITLE
Artifact trigger continuation popup

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
@@ -172,22 +172,24 @@ public sealed partial class XenoArtifactComponent : Component
     /// </summary>
     [DataField]
     public LocId? UnlockBeginMsg = "artifact-unlock-state-begin";
+
     /// <summary>
     /// Message shown on trigger being applied successfully whilst the artifact is unlocking
     /// </summary>
     [DataField]
     public LocId? UnlockContinueMsg = "artifact-unlock-state-continue";
+
     /// <summary>
     /// Message shown on artifact unlocking ending successfully
     /// </summary>
     [DataField]
     public LocId? UnlockSuccessMsg = "artifact-unlock-state-end-success";
+
     /// <summary>
     /// Message shown on artifact unlocking ending unsuccessfully
     /// </summary>
     [DataField]
     public LocId? UnlockFailureMsg = "artifact-unlock-state-end-failure";
-
 }
 
 /// <summary>

--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
@@ -166,6 +166,28 @@ public sealed partial class XenoArtifactComponent : Component
     /// </summary>
     [DataField]
     public EntProtoId<InstantActionComponent> SelfActivateAction = "ActionArtifactActivate";
+
+    /// <summary>
+    /// Message shown on artifact unlock beginning
+    /// </summary>
+    [DataField]
+    public LocId? UnlockBeginMsg = "artifact-unlock-state-begin";
+    /// <summary>
+    /// Message shown on trigger being applied successfully whilst the artifact is unlocking
+    /// </summary>
+    [DataField]
+    public LocId? UnlockContinueMsg = "artifact-unlock-state-continue";
+    /// <summary>
+    /// Message shown on artifact unlocking ending successfully
+    /// </summary>
+    [DataField]
+    public LocId? UnlockSuccessMsg = "artifact-unlock-state-end-success";
+    /// <summary>
+    /// Message shown on artifact unlocking ending unsuccessfully
+    /// </summary>
+    [DataField]
+    public LocId? UnlockFailureMsg = "artifact-unlock-state-end-failure";
+
 }
 
 /// <summary>

--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
@@ -168,25 +168,25 @@ public sealed partial class XenoArtifactComponent : Component
     public EntProtoId<InstantActionComponent> SelfActivateAction = "ActionArtifactActivate";
 
     /// <summary>
-    /// Message shown on artifact unlock beginning
+    /// Message shown on artifact unlock beginning.
     /// </summary>
     [DataField]
     public LocId? UnlockBeginMsg = "artifact-unlock-state-begin";
 
     /// <summary>
-    /// Message shown on trigger being applied successfully whilst the artifact is unlocking
+    /// Message shown on trigger being applied successfully whilst the artifact is unlocking.
     /// </summary>
     [DataField]
     public LocId? UnlockContinueMsg = "artifact-unlock-state-continue";
 
     /// <summary>
-    /// Message shown on artifact unlocking ending successfully
+    /// Message shown on artifact unlocking ending successfully.
     /// </summary>
     [DataField]
     public LocId? UnlockSuccessMsg = "artifact-unlock-state-end-success";
 
     /// <summary>
-    /// Message shown on artifact unlocking ending unsuccessfully
+    /// Message shown on artifact unlocking ending with failure.
     /// </summary>
     [DataField]
     public LocId? UnlockFailureMsg = "artifact-unlock-state-end-failure";

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
@@ -65,7 +65,7 @@ public abstract partial class SharedXenoArtifactSystem
     /// </summary>
     public void FinishUnlockingState(Entity<XenoArtifactUnlockingComponent, XenoArtifactComponent> ent)
     {
-        string unlockAttemptResultMsg;
+        string? unlockAttemptResultMsg;
         XenoArtifactComponent artifactComponent = ent;
         XenoArtifactUnlockingComponent unlockingComponent = ent;
 
@@ -74,7 +74,7 @@ public abstract partial class SharedXenoArtifactSystem
         {
             SetNodeUnlocked((ent, artifactComponent), node.Value);
             ActivateNode((ent, ent), (node.Value, node.Value), null, null, Transform(ent).Coordinates, false);
-            unlockAttemptResultMsg = "artifact-unlock-state-end-success";
+            unlockAttemptResultMsg = ent.Comp2.UnlockSuccessMsg;
 
             // as an experiment - unlocking node doesn't activate it, activation is left for player to decide.
             // var activated = ActivateNode((ent, artifactComponent), node.Value, null, null, Transform(ent).Coordinates, false);
@@ -83,13 +83,14 @@ public abstract partial class SharedXenoArtifactSystem
         }
         else
         {
-            unlockAttemptResultMsg = "artifact-unlock-state-end-failure";
+            unlockAttemptResultMsg = ent.Comp2.UnlockFailureMsg;
             soundEffect = unlockingComponent.UnlockActivationFailedSound;
         }
 
         if (_net.IsServer)
         {
-            _popup.PopupEntity(Loc.GetString(unlockAttemptResultMsg), ent);
+            if (unlockAttemptResultMsg != null)
+                _popup.PopupEntity(Loc.GetString(unlockAttemptResultMsg), ent);
             _audio.PlayPvs(soundEffect, ent.Owner);
         }
 

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
@@ -74,7 +74,7 @@ public abstract partial class SharedXenoArtifactSystem
         {
             SetNodeUnlocked((ent, artifactComponent), node.Value);
             ActivateNode((ent, ent), (node.Value, node.Value), null, null, Transform(ent).Coordinates, false);
-            unlockAttemptResultMsg = ent.Comp2.UnlockSuccessMsg;
+            unlockAttemptResultMsg = artifactComponent.UnlockSuccessMsg;
 
             // as an experiment - unlocking node doesn't activate it, activation is left for player to decide.
             // var activated = ActivateNode((ent, artifactComponent), node.Value, null, null, Transform(ent).Coordinates, false);
@@ -83,7 +83,7 @@ public abstract partial class SharedXenoArtifactSystem
         }
         else
         {
-            unlockAttemptResultMsg = ent.Comp2.UnlockFailureMsg;
+            unlockAttemptResultMsg = artifactComponent.UnlockFailureMsg;
             soundEffect = unlockingComponent.UnlockActivationFailedSound;
         }
 
@@ -91,6 +91,7 @@ public abstract partial class SharedXenoArtifactSystem
         {
             if (unlockAttemptResultMsg != null)
                 _popup.PopupEntity(Loc.GetString(unlockAttemptResultMsg), ent);
+
             _audio.PlayPvs(soundEffect, ent.Owner);
         }
 

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAT.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAT.cs
@@ -70,7 +70,7 @@ public abstract partial class SharedXenoArtifactSystem
             unlockingComp.EndTime = _timing.CurTime + ent.Comp.UnlockStateDuration;
             Log.Debug($"{ToPrettyString(ent)} entered unlocking state");
 
-            if (_net.IsServer && ent.Comp.UnlockBeginMsg != null)
+            if (ent.Comp.UnlockBeginMsg != null)
                 _popup.PopupEntity(Loc.GetString(ent.Comp.UnlockBeginMsg), ent);
             Dirty(ent);
         }
@@ -88,7 +88,7 @@ public abstract partial class SharedXenoArtifactSystem
                 // we add time on each new trigger, if it is not going to fail us
                 unlockingComp.EndTime += ent.Comp.UnlockStateIncrementPerNode;
 
-            if (_net.IsServer && ent.Comp.UnlockContinueMsg != null)
+            if (ent.Comp.UnlockContinueMsg != null)
                 _popup.PopupEntity(Loc.GetString(ent.Comp.UnlockContinueMsg), ent);
         }
 

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAT.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAT.cs
@@ -70,8 +70,8 @@ public abstract partial class SharedXenoArtifactSystem
             unlockingComp.EndTime = _timing.CurTime + ent.Comp.UnlockStateDuration;
             Log.Debug($"{ToPrettyString(ent)} entered unlocking state");
 
-            if (_net.IsServer)
-                _popup.PopupEntity(Loc.GetString("artifact-unlock-state-begin"), ent);
+            if (_net.IsServer && ent.Comp.UnlockBeginMsg != null)
+                _popup.PopupEntity(Loc.GetString(ent.Comp.UnlockBeginMsg), ent);
             Dirty(ent);
         }
         else if (node != null)
@@ -87,6 +87,9 @@ public abstract partial class SharedXenoArtifactSystem
                )
                 // we add time on each new trigger, if it is not going to fail us
                 unlockingComp.EndTime += ent.Comp.UnlockStateIncrementPerNode;
+
+            if (_net.IsServer && ent.Comp.UnlockContinueMsg != null)
+                _popup.PopupEntity(Loc.GetString(ent.Comp.UnlockContinueMsg), ent);
         }
 
         if (node != null && unlockingComp.TriggeredNodeIndexes.Add(GetIndex(ent, node.Value)))

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAT.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAT.cs
@@ -72,6 +72,7 @@ public abstract partial class SharedXenoArtifactSystem
 
             if (ent.Comp.UnlockBeginMsg != null)
                 _popup.PopupEntity(Loc.GetString(ent.Comp.UnlockBeginMsg), ent);
+
             Dirty(ent);
         }
         else if (node != null)

--- a/Resources/Locale/en-US/xenoarchaeology/artifact-component.ftl
+++ b/Resources/Locale/en-US/xenoarchaeology/artifact-component.ftl
@@ -4,6 +4,7 @@ artifact-verb-activate = Activate artifact
 
 ### Unlocking
 artifact-unlock-state-begin = It begins to shift in strange ways...
+artifact-unlock-state-continue = The shifting continues, intensifying...
 artifact-unlock-state-end-success = It slows down, visibly changed.
 artifact-unlock-state-end-failure = It slows down before uneventfully stopping.
 


### PR DESCRIPTION
Adds a popup when you successfully complete a new trigger on an artifact node that has multiple triggers

## About the PR
There's a popup for when the artifact starts unlocking and one for when it ends, but if there's multiple triggers there is no visual indicator for when a trigger is actually achieved unless you have a node scanner. 

## Why / Balance
More direct visual feedback and a minor quality of life so you don't have to entirely rely on a node scanner to know you're making progress.

It does overlap if the action required for the trigger also produces a popup such as splashing water. Or the trigger activates immediately after the artifact unlocks such as multiple gasses being in the air.

## Technical details
Adds a LocId DataField to the XenoArtifactComponent. When an artifact is in the unlocking state and a new trigger is activated, this pops up.

Also made all the popups LocId DataFields because customisability is nice and I intend to use it in the future. (Motivation pending)

## Test plan
Activate one artifact node that has another above it
Activate that node trigger again, then the one of the above node. The second trigger's activation will provide a new popup saying "the shifting continues, intensifying..." to indicate progress has been made.

## Media
A xenoartifact with an Instrument, Magboots, and Inspection trigger done in order.

https://github.com/user-attachments/assets/29d3fb28-8b51-43fc-9e70-b9c242e5bcf9
## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
Probably none.

## Changelog
:cl:
- tweak: Artifact nodes with multiple triggers now have a popup when each trigger is activated successfully.
