### PR TITLE
Bugfix: Check UIDs in TryMergeStacks

### DIFF
--- a/Content.Shared/Stacks/SharedStackSystem.API.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.API.cs
@@ -120,7 +120,7 @@ public abstract partial class SharedStackSystem
     {
         transferred = 0;
 
-        if (donor == recipient)
+        if (donor.Owner == recipient.Owner)
             return false;
 
         // Recipient is being torn down, don't give it anything.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Explicitly checks EntityUids in SharedStackSystem.TryMergeStacks vs. an Entity<T?> comparison.

Thanks to @riccardi48 for helping discuss this quickly on Discord.

## Why / Balance

Component nullability can vary in Entity<T?>, which will fail the comparison (!)

On master at the moment, there's a bug where if you take one sheet of steel in your hand, then split one off from it, it destroys the complete stack.  (This works with any complete split)

## Technical details

Equality ops.  Comparing EntityUid directly vs. Entity<T?>, which could have varying components.

Should this equality check be inside of Entity<T> in RT?

## Test plan

Take one sheet of steel in your hand, then split one off from it, it should move to your other hand.
Do this with a borg as well.

## Media

Silly, but really - split off one unit from a stack, put it in your hand, and then split a unit from the stack.

<img width="236" height="226" alt="image" src="https://github.com/user-attachments/assets/9c97366f-850d-475e-8494-8674adf0adde" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
small!