### PR TITLE
Bugfix: Broken Computers are destructible again

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
@@ -1,10 +1,8 @@
 - type: entity
-  id: BaseStructureComputer
-  parent: BaseStructure
   abstract: true
+  parent: BaseStructure
+  id: BaseStructureComputerIndestructible
   components:
-  - type: Physics
-    bodyType: Static
   - type: Fixtures
     fixtures:
       fix1:
@@ -21,9 +19,17 @@
   - type: Anchorable
   - type: Construction
     graph: Computer
-    node: frameUnsecured
   - type: Sprite
     drawdepth: Objects
+
+- type: entity
+  abstract: true
+  parent: BaseStructureComputerIndestructible
+  id: BaseStructureComputer
+  components:
+  - type: Construction
+    graph: Computer
+    node: frameUnsecured
   - type: Damageable
     damageModifierSet: Electronic
   - type: Injurable
@@ -65,7 +71,7 @@
           monitorUnsecured: { state: 4 }
 
 - type: entity
-  parent: BaseStructureComputer
+  parent: BaseStructureComputerIndestructible
   id: ComputerBroken
   name: broken computer
   description: This computer has seen better days.

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
@@ -1,8 +1,10 @@
 - type: entity
-  abstract: true
+  id: BaseStructureComputer
   parent: BaseStructure
-  id: BaseStructureComputerIndestructible
+  abstract: true
   components:
+  - type: Physics
+    bodyType: Static
   - type: Fixtures
     fixtures:
       fix1:
@@ -19,17 +21,9 @@
   - type: Anchorable
   - type: Construction
     graph: Computer
+    node: frameUnsecured
   - type: Sprite
     drawdepth: Objects
-
-- type: entity
-  abstract: true
-  parent: BaseStructureComputerIndestructible
-  id: BaseStructureComputer
-  components:
-  - type: Construction
-    graph: Computer
-    node: frameUnsecured
   - type: Damageable
     damageModifierSet: Electronic
   - type: Injurable
@@ -71,7 +65,7 @@
           monitorUnsecured: { state: 4 }
 
 - type: entity
-  parent: BaseStructureComputerIndestructible
+  parent: BaseStructureComputer
   id: ComputerBroken
   name: broken computer
   description: This computer has seen better days.

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
@@ -79,6 +79,10 @@
   - type: Construction
     graph: Computer
     node: monitorBroken
+  - type: Damageable
+    damageModifierSet: Electronic
+  - type: Injurable
+    damageContainer: StructuralInorganic
   - type: Sprite
     sprite: Structures/Machines/computers.rsi
     drawdepth: Objects


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes a regression from https://github.com/space-wizards/space-station-14/pull/44644 where broken computers wouldn't be damageable.
## Why / Balance
Seems like a bug.

## Technical details
Just reverts the whole edit as making a special Indestructible computer seems pointless.

## Test plan
grab a knife and break some computers.

## Media



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
