### PR TITLE
Fix default metamorphic glasses (e.g. milk) solution not showing

### DIFF
--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
@@ -81,7 +81,8 @@ public sealed partial class SolutionContainerVisualsSystem : VisualizerSystem<So
                 fillSprite = reagentProto.MetamorphicSprite ?? fillSprite;
             }
             else if (reagentProto?.MetamorphicSprite == null)
-                // The reagent has no metamorphic sprite, so use the default one
+                // The reagent has no metamorphic sprite, but the default one
+                // will still be used. So we set the fill to visible.
                 SpriteSystem.LayerSetVisible(ent, fillLayer, true);
             else
                 SpriteSystem.LayerSetVisible(ent, fillLayer, false);

--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
@@ -80,6 +80,9 @@ public sealed partial class SolutionContainerVisualsSystem : VisualizerSystem<So
                 changeColor = reagentProto.MetamorphicChangeColor;
                 fillSprite = reagentProto.MetamorphicSprite ?? fillSprite;
             }
+            else if (reagentProto?.MetamorphicSprite == null)
+                // The reagent has no metamorphic sprite, so use the default one
+                SpriteSystem.LayerSetVisible(ent, fillLayer, true);
             else
                 SpriteSystem.LayerSetVisible(ent, fillLayer, false);
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR fixes a bug that was introduced in #39442 ("Fix error texture for harmpack hand solution visuals"). Currently on master, when you fill a metamorphic glass with a solution that uses the default metamorphic glass sprite, it looks empty. For example, milk and water glasses always appear empty. This bugfix makes the solution visible again.

Note that the inhand sprites work just fine in both versions!

## Why / Balance
I'd prefer to be able to see what's in a glass!

## Technical details
Before #39442, SolutionContainerVisualsSystem.cs [\(link\)](https://github.com/space-wizards/space-station-14/pull/39442/changes#diff-707f677e559e2f97e2837986057da6385c02389d3fabaf981c9b52409b4d2763R77) would check to see if the solution had a custom "fill" sprite. If it did not, it would make the fill layer visible so the default fill could be seen.

In #39442, perryprog greatly simplified the code (genuinely, great job, thank you for doing that!) but seems to have left out the part  that checks if the solution has a custom fill sprite. This code adds a couple of lines to do that.

In theory, we could do away with the default-managing code if we just used YAML parents to create a default solution prototype instead. But I'm not going to do that for now, I assume there's a reason the code is the way it is.

## Test plan
1. Pour a solution that uses the default sprite (e.g. milk) into a metamorphic glass.
2. Pour a solution that uses a custom sprite (e.g. beer) into a metamorphic glass.
3. Inspect the 2 sprites to make sure the liquid is visible in both of them.

## Media

Here's what a metamorphic glass of water, milk, beer, and absinthe look like on master currently:

<img width="648" height="644" alt="Metamorphic glasses of water, milk, beer, and absinthe. The metamorphic glasses of water and milk appear to be empty." src="https://github.com/user-attachments/assets/6f1b6e9a-9a7d-4cf0-922a-f6bd52c35caf" />

Here's what those glasses look like after the bugfix:
<img width="648" height="644" alt="Metamorphic glasses of water, milk, beer, and absinthe. The metamorphic glasses appear full, as they should be." src="https://github.com/user-attachments/assets/9ca0ef12-c61f-408f-8fda-24c9bdc3acef" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed bug where metamorphic glasses of some liquids (e.g. water) appeared to be empty.
