### PR TITLE
Cleanup implant tags

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -47,11 +47,6 @@
     softness: 5
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
-  - type: Tag
-    tags:
-    - SubdermalImplant
-    - HideContextMenu
-    - Flashlight
   - type: UnpoweredFlashlight
 
 - type: entity
@@ -70,9 +65,6 @@
       collection: BikeHorn
       params:
         variation: 0.125
-  - type: Tag
-    tags:
-    - BikeHorn
 
 #Security implants
 
@@ -253,9 +245,6 @@
     interfaces:
       enum.VoiceMaskUIKey.Key:
         type: VoiceMaskBoundUserInterface
-  - type: Tag
-    tags:
-    - SubdermalImplant
 
 #Nuclear Operative/Special Exclusive implants
 
@@ -327,10 +316,6 @@
       intensitySlope: 15
       maxIntensity: 70
       canCreateVacuum: true
-    - type: Tag
-      tags:
-      - SubdermalImplant
-      - HideContextMenu
 
 - type: entity
   parent: BaseSubdermalImplant
@@ -352,10 +337,6 @@
   - type: SpawnOnTrigger
     proto: Acidifier
     predicted: true
-  - type: Tag
-    tags:
-    - SubdermalImplant
-    - HideContextMenu
 
 - type: entity
   parent: BaseSubdermalImplant


### PR DESCRIPTION
## About the PR

Cleans up subdermal implant tags.  Some were redundant, some were unnecessary, some caused odd behaviour!

## Why / Balance

Bugfix from tag misuse.

Fixes an issue reported at https://discord.com/channels/310555209753690112/1529577565227057283

## Technical details

Inheritance ops.  All of the subdermal implants should have the SubdermalImplant and HideContextMenu implant (you shouldn't ever _see_ the implant itself, let alone right-click interact with it).

Microbomb tags left alone - it doesn't demolish the parent's tags.

Acidifier/Macrobomb are redundantly redefining the base set of tags, so these were removed.

## Test plan

1. Spawn a happy honk meal, a proximity sensor, a cyborg left arm and a bike horn implanter.
2. Implant yourself with the implanter.
3. Try and construct a honkbot.
4. Fail miserably.
5. Spawn and inject yourself with an identity mask injector.
6. Use your action, it should work as normal.

For completeness, inject yourself with a death acidifier and macrobomb, check the linked entities in the Implanted component, their tags should be HideContextMenu and SubdermalImplant.

## Media

Construction failure when trying to build a honkbot in the test steps.
<img width="1282" height="759" alt="image" src="https://github.com/user-attachments/assets/fdf6cc3e-7cc3-41fc-8f27-a30fc14f5de8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
small!
