### PR TITLE
Add bolt signal to door outputs

### DIFF
--- a/Content.Server/DeviceLinking/Components/DoorSignalControlComponent.cs
+++ b/Content.Server/DeviceLinking/Components/DoorSignalControlComponent.cs
@@ -20,5 +20,8 @@ namespace Content.Server.DeviceLinking.Components
 
         [DataField("onOpenPort", customTypeSerializer: typeof(PrototypeIdSerializer<SourcePortPrototype>))]
         public string OutOpen = "DoorStatus";
+
+        [DataField("onBoltPort", customTypeSerializer: typeof(PrototypeIdSerializer<SourcePortPrototype>))]
+        public string OutBolt = "DoorBoltStatus";
     }
 }

--- a/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
@@ -22,6 +22,7 @@ namespace Content.Server.DeviceLinking.Systems
             SubscribeLocalEvent<DoorSignalControlComponent, ComponentInit>(OnInit);
             SubscribeLocalEvent<DoorSignalControlComponent, SignalReceivedEvent>(OnSignalReceived);
             SubscribeLocalEvent<DoorSignalControlComponent, DoorStateChangedEvent>(OnStateChanged);
+            SubscribeLocalEvent<DoorSignalControlComponent, DoorBoltsChangedEvent>(OnBoltsChanged);
         }
 
         private void OnInit(EntityUid uid, DoorSignalControlComponent component, ComponentInit args)
@@ -29,6 +30,10 @@ namespace Content.Server.DeviceLinking.Systems
 
             _signalSystem.EnsureSinkPorts(uid, component.OpenPort, component.ClosePort, component.TogglePort);
             _signalSystem.EnsureSourcePorts(uid, component.OutOpen);
+
+            // only doors that can actually be bolted get the port, e.g. not shutters
+            if (HasComp<DoorBoltComponent>(uid))
+                _signalSystem.EnsureSourcePorts(uid, component.OutBolt);
         }
 
         private void OnSignalReceived(EntityUid uid, DoorSignalControlComponent component, ref SignalReceivedEvent args)
@@ -98,6 +103,11 @@ namespace Content.Server.DeviceLinking.Systems
                 // say the door is open whenever it would be letting air pass
                 _signalSystem.SendSignal(uid, door.OutOpen, true);
             }
+        }
+
+        private void OnBoltsChanged(EntityUid uid, DoorSignalControlComponent door, DoorBoltsChangedEvent args)
+        {
+            _signalSystem.SendSignal(uid, door.OutBolt, args.BoltsDown);
         }
     }
 }

--- a/Resources/Locale/en-US/machine-linking/transmitter_ports.ftl
+++ b/Resources/Locale/en-US/machine-linking/transmitter_ports.ftl
@@ -19,6 +19,9 @@ signal-port-description-right = This port is invoked whenever the lever is moved
 signal-port-name-doorstatus = Door status
 signal-port-description-doorstatus = This port is invoked with HIGH when the door opens and LOW when the door finishes closing.
 
+signal-port-name-doorboltstatus = Door bolt status
+signal-port-description-doorboltstatus = This port is invoked with HIGH when the door is bolted and LOW when it is unbolted.
+
 signal-port-name-dockstatus = Dock status
 signal-port-description-dockstatus = This port is invoked with HIGH when docked and LOW when undocked.
 

--- a/Resources/Prototypes/DeviceLinking/source_ports.yml
+++ b/Resources/Prototypes/DeviceLinking/source_ports.yml
@@ -47,6 +47,11 @@
   defaultLinks: [ DoorBolt ]
 
 - type: sourcePort
+  id: DoorBoltStatus
+  name: signal-port-name-doorboltstatus
+  description: signal-port-description-doorboltstatus
+
+- type: sourcePort
   id: DockStatus
   name: signal-port-name-dockstatus
   description: signal-port-description-dockstatus

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -126,8 +126,10 @@
   - type: DeviceLinkSource
     ports:
       - DoorStatus
+      - DoorBoltStatus
     lastSignals:
       DoorStatus: false
+      DoorBoltStatus: false
   - type: SoundOnOverload
   - type: SpawnOnOverload
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -77,8 +77,10 @@
   - type: DeviceLinkSource
     ports:
     - DoorStatus
+    - DoorBoltStatus
     lastSignals:
       DoorStatus: false
+      DoorBoltStatus: false
   - type: Damageable
     damageModifierSet: Glass
   - type: Injurable


### PR DESCRIPTION
## About the PR
Airlocks now emit a signal to signify their bolt status ("door bolt status").

## Why / Balance
This is a prerequisite for any device that interact with airlock bolts via signals and expects it to be reliable, as right now bolts can be set but not queried via signals.

## Technical details
Added a conditional source to the DoorSignalControlSystem, it does not show for airlocks that don't have the bolt component

## Test plan
Add airlocks, link them to something (A light toggle), un/bolt the airlock, watch the light turn on or off accordingly.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.


## Changelog
:cl:
- tweak: Airlocks now report their bolt status as a signal
