### PR TITLE
Admeme spraypainter recharges faster

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -45,7 +45,7 @@
   suffix: Admeme
   components:
   - type: AutoRecharge
-    rechargeDuration: 1
+    rechargeDuration: 0.1
 
 - type: entity
   parent: SprayPainter


### PR DESCRIPTION
## About the PR
Admeme spraypainter recharges faster, changed the recharge time from 1 to 0.1

## Why / Balance
I found that if you are spamming it you can actually run out of paint

## Technical details

## Test plan

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- you wish -->

## Changelog
no
