### PR TITLE
Resized survival box and added flare back

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -8,7 +8,7 @@
     shape: 0,0,1,2
   - type: Storage
     grid:
-      - 0,0,2,3
+      - 0,0,1,2
   - type: EntityTableContainerFill
     containers:
       storagebase: !type:AllSelector

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -4,6 +4,11 @@
   name: O2 survival box
   description: A small box containing a breath mask, an emergency oxygen tank, and an emergency medipen. Standard-issue for most oxygen-breathing crew.
   components:
+  - type: Item
+    size: 5
+  - type: Storage
+    grid:
+      - 0,0,2,3
   - type: EntityTableContainerFill
     containers:
       storagebase: !type:AllSelector
@@ -11,6 +16,7 @@
         - id: ClothingMaskBreath
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
+        - id: Flare
   - type: Sprite
     layers:
     - state: internals

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -4,7 +4,7 @@
   abstract: true
   components:
   - type: Item
-    shape:
+    shape: 0,0,1,2
   - type: Storage
     grid:
       - "0,0,1,2"
@@ -29,7 +29,7 @@
     - state: emergencytank
 
 - type: entity
-  parent: BoxSurvival
+  parent: BaseBoxSurvival
   id: BoxSurvivalNitrogen
   name: N2 survival box
   description: A small box containing a breath mask, an emergency nitrogen tank, and an emergency medipen. Standard-issue for most nitrogen-breathing crew.
@@ -47,7 +47,7 @@
     - state: nitrogentank
 
 - type: entity
-  parent: BoxSurvival
+  parent: BaseBoxSurvival
   id: BoxSurvivalEngineering
   name: extended-capacity O2 survival box
   description: A small box containing a breath mask, an extended-capacity emergency oxygen tank, and an emergency medipen. Issued to oxygen-breathing crew whose job responsibilities often take them to places with no atmosphere.
@@ -83,7 +83,7 @@
     - state: nitrogentank
 
 - type: entity
-  parent: BoxSurvival
+  parent: BaseBoxSurvival
   id: BoxSurvivalSecurity
   name: security O2 survival box
   description: A small box containing a gas mask, an emergency oxygen tank, and an emergency medipen. Issued to oxygen-breathing members of the security staff.
@@ -115,7 +115,7 @@
     - state: nitrogentank
 
 - type: entity
-  parent: BoxSurvival
+  parent: BaseBoxSurvival
   id: BoxSurvivalMedical
   name: medical O2 survival box
   description: A small box containing a medical mask, an emergency oxygen tank, and an emergency medipen. Issued to oxygen-breathing members of the medical staff.
@@ -264,7 +264,7 @@
 # Uses a 2x2 box mostly just because the 3x3 boxes don't fit into already-filled ERT backpacks.
 # "Military" might be a misnomer, since NT isn't technically a government entity, but whatever.
 - type: entity
-  parent: BoxSurvival
+  parent: BaseBoxSurvival
   id: BoxSurvivalMilitaryDouble
   name: military O2 survival box
   description: A military-grade survival box containing a double-capacity emergency oxygen tank, an emergency medipen, and an emergency flare.

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -5,11 +5,11 @@
   components:
   - type: Item
     shape:
-      - 0,0,2,1
+      - 0,0,1,2
   - type: Storage
-    grid:
-      - "0,0,2,1"
     sortStyle: Size
+    grid:
+      - "0,0,1,2"
 
 - type: entity
   parent: BaseBoxSurvival

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -5,7 +5,7 @@
   description: A small box containing a breath mask, an emergency oxygen tank, and an emergency medipen. Standard-issue for most oxygen-breathing crew.
   components:
   - type: Item
-    size: 5
+    shape: 0,0,1,2
   - type: Storage
     grid:
       - 0,0,2,3

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -1,14 +1,20 @@
 - type: entity
   parent: BoxCardboardSmall
+  id: BaseBoxSurvival
+  abstract: true
+  components:
+  - type: Item
+    shape:
+  - type: Storage
+    grid:
+      - "0,0,1,2"
+
+- type: entity
+  parent: BaseBoxSurvival
   id: BoxSurvival
   name: O2 survival box
   description: A small box containing a breath mask, an emergency oxygen tank, and an emergency medipen. Standard-issue for most oxygen-breathing crew.
   components:
-  - type: Item
-    shape: 0,0,1,2
-  - type: Storage
-    grid:
-      - 0,0,1,2
   - type: EntityTableContainerFill
     containers:
       storagebase: !type:AllSelector

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -7,7 +7,6 @@
     shape:
       - 0,0,1,2
   - type: Storage
-    sortStyle: Size
     grid:
       - "0,0,1,2"
 

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -4,10 +4,12 @@
   abstract: true
   components:
   - type: Item
-    shape: 0,0,1,2
+    shape:
+      - 0,0,2,1
   - type: Storage
     grid:
-      - "0,0,1,2"
+      - "0,0,2,1"
+    sortStyle: Size
 
 - type: entity
   parent: BaseBoxSurvival
@@ -65,7 +67,7 @@
     - state: extendedtank
 
 - type: entity
-  parent: BoxSurvivalEngineering
+  parent: BaseBoxSurvival
   id: BoxSurvivalEngineeringNitrogen
   name: extended-capacity N2 survival box
   description: A small box containing a breath mask, an extended-capacity emergency nitrogen tank, and an emergency medipen. Issued to nitrogen-breathing crew whose job responsibilities often take them to places with no atmosphere.
@@ -97,7 +99,7 @@
         - id: EmergencyMedipen
 
 - type: entity
-  parent: BoxSurvivalSecurity
+  parent: BaseBoxSurvival
   id: BoxSurvivalSecurityNitrogen
   name: security N2 survival box
   description: A small box containing a gas mask, an emergency nitrogen tank, and an emergency medipen. Issued to nitrogen-breathing members of the security staff.
@@ -129,7 +131,7 @@
         - id: EmergencyMedipen
 
 - type: entity
-  parent: BoxSurvivalMedical
+  parent: BaseBoxSurvival
   id: BoxSurvivalMedicalNitrogen
   name: medical N2 survival box
   description: A small box containing a medical mask, an emergency nitrogen tank, and an emergency medipen. Issued to nitrogen-breathing members of the medical staff.

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -42,13 +42,14 @@
         - id: ClothingMaskBreath
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
+        - id: Flare
   - type: Sprite
     layers:
     - state: internals
     - state: nitrogentank
 
 - type: entity
-  parent: BaseBoxSurvival
+  parent: BoxSurvival
   id: BoxSurvivalEngineering
   name: extended-capacity O2 survival box
   description: A small box containing a breath mask, an extended-capacity emergency oxygen tank, and an emergency medipen. Issued to oxygen-breathing crew whose job responsibilities often take them to places with no atmosphere.
@@ -60,13 +61,14 @@
         - id: ClothingMaskBreath
         - id: ExtendedEmergencyOxygenTankFilled
         - id: EmergencyMedipen
+        - id: Flare
   - type: Sprite
     layers:
     - state: internals
     - state: extendedtank
 
 - type: entity
-  parent: BaseBoxSurvival
+  parent: BoxSurvivalNitrogen
   id: BoxSurvivalEngineeringNitrogen
   name: extended-capacity N2 survival box
   description: A small box containing a breath mask, an extended-capacity emergency nitrogen tank, and an emergency medipen. Issued to nitrogen-breathing crew whose job responsibilities often take them to places with no atmosphere.
@@ -78,13 +80,14 @@
         - id: ClothingMaskBreath
         - id: ExtendedEmergencyNitrogenTankFilled
         - id: EmergencyMedipen
+        - id: Flare
   - type: Sprite
     layers:
     - state: internals
     - state: nitrogentank
 
 - type: entity
-  parent: BaseBoxSurvival
+  parent: BoxSurvival
   id: BoxSurvivalSecurity
   name: security O2 survival box
   description: A small box containing a gas mask, an emergency oxygen tank, and an emergency medipen. Issued to oxygen-breathing members of the security staff.
@@ -96,9 +99,10 @@
         - id: ClothingMaskGasSecurity
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
+        - id: Flare
 
 - type: entity
-  parent: BaseBoxSurvival
+  parent: BoxSurvivalNitrogen
   id: BoxSurvivalSecurityNitrogen
   name: security N2 survival box
   description: A small box containing a gas mask, an emergency nitrogen tank, and an emergency medipen. Issued to nitrogen-breathing members of the security staff.
@@ -110,13 +114,14 @@
         - id: ClothingMaskGasSecurity
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
+        - id: Flare
   - type: Sprite
     layers:
     - state: internals
     - state: nitrogentank
 
 - type: entity
-  parent: BaseBoxSurvival
+  parent: BoxSurvival
   id: BoxSurvivalMedical
   name: medical O2 survival box
   description: A small box containing a medical mask, an emergency oxygen tank, and an emergency medipen. Issued to oxygen-breathing members of the medical staff.
@@ -128,9 +133,10 @@
         - id: ClothingMaskBreathMedical
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
+        - id: Flare
 
 - type: entity
-  parent: BaseBoxSurvival
+  parent: BoxSurvivalNitrogen
   id: BoxSurvivalMedicalNitrogen
   name: medical N2 survival box
   description: A small box containing a medical mask, an emergency nitrogen tank, and an emergency medipen. Issued to nitrogen-breathing members of the medical staff.
@@ -142,6 +148,7 @@
         - id: ClothingMaskBreathMedical
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
+        - id: Flare
   - type: Sprite
     layers:
     - state: internals
@@ -159,6 +166,7 @@
         - id: ClothingMaskBreath
         - id: EmergencyFunnyOxygenTankFilled
         - id: EmergencyMedipen
+        - id: Flare
 
 - type: entity
   parent: BoxSurvivalHug
@@ -172,6 +180,7 @@
         - id: ClothingMaskBreath
         - id: EmergencyNitrogenTankFilled # This should probably be replaced by an equivalent to the funny emergency oxygen tank, once that exists
         - id: EmergencyMedipen
+        - id: Flare
 
 # Primarily intended for antagonists that spawn outside the station (e.g ninjas, wizards)
 # Contains food and water because, unlike normal crew, we don't want to force them to seek food mid-round.
@@ -265,7 +274,7 @@
 # Uses a 2x2 box mostly just because the 3x3 boxes don't fit into already-filled ERT backpacks.
 # "Military" might be a misnomer, since NT isn't technically a government entity, but whatever.
 - type: entity
-  parent: BaseBoxSurvival
+  parent: BoxCardboardSmall
   id: BoxSurvivalMilitaryDouble
   name: military O2 survival box
   description: A military-grade survival box containing a double-capacity emergency oxygen tank, an emergency medipen, and an emergency flare.

--- a/Resources/Prototypes/Entities/Objects/Misc/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/box.yml
@@ -26,7 +26,7 @@
   id: BoxBaseSmall
   components:
   - type: Item
-    size: Small
+    size: Normal
     shape:
     - 0,0,1,1
   - type: Storage
@@ -37,7 +37,7 @@
 
 - type: entity
   abstract: true
-  parent: BoxBaseSmall
+  parent: BaseBoxSurvival
   id: BoxBaseHug
   components:
   - type: Item


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the components of BoxSurvival so it doesn't inherit BoxCarboardSmall

## Why / Balance
Makes the survival box occupy a size of 5 and has a flare in it

## Technical details
added to components and added id flare

## Test plan
Verified code compiles and looked a changes in game

Before change:
O2 Survival Box:
<img width="142" height="83" alt="image" src="https://github.com/user-attachments/assets/94bc4741-d47a-496e-a2d4-3943522b578c" />

N2 Survival Box:
<img width="121" height="80" alt="image" src="https://github.com/user-attachments/assets/c3f18f48-6835-4069-92a3-eba81f7537cb" />


After change:
O2 Survival Box:
<img width="142" height="117" alt="image" src="https://github.com/user-attachments/assets/e08569c2-6f4d-411c-aa2d-a604f9a0391b" />

N2 Survival Box:
<img width="153" height="107" alt="image" src="https://github.com/user-attachments/assets/99c89c0c-8876-4ac7-9c41-213c76ec7ed0" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- add: Flare has been added back to the survival box
- tweak: Survival boxes have been made larger. 