### PR TITLE
Hotfix: Fix mistaken AudioParams.WithVariation calls + LockComponent cleanup

### DIFF
--- a/Content.Shared/Lock/LockComponent.cs
+++ b/Content.Shared/Lock/LockComponent.cs
@@ -16,9 +16,8 @@ public sealed partial class LockComponent : Component
     /// <summary>
     /// Whether or not the lock is locked.
     /// </summary>
-    [DataField("locked"), ViewVariables(VVAccess.ReadWrite)]
-    [AutoNetworkedField]
-    public bool Locked  = true;
+    [DataField, AutoNetworkedField]
+    public bool Locked = true;
 
     /// <summary>
     /// If true, will show verbs to lock and unlock the item. Otherwise, it will not.
@@ -35,8 +34,7 @@ public sealed partial class LockComponent : Component
     /// <summary>
     /// Whether or not the lock is locked by simply clicking.
     /// </summary>
-    [DataField("lockOnClick"), ViewVariables(VVAccess.ReadWrite)]
-    [AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public bool LockOnClick;
 
     /// <summary>
@@ -80,7 +78,7 @@ public sealed partial class LockComponent : Component
     /// <summary>
     /// The sound played when unlocked.
     /// </summary>
-    [DataField("unlockingSound"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField("unlockingSound")]
     public SoundSpecifier? UnlockSound = new SoundPathSpecifier("/Audio/Machines/door_lock_off.ogg")
     {
         Params = AudioParams.Default.AddVolume(-5f),
@@ -89,10 +87,10 @@ public sealed partial class LockComponent : Component
     /// <summary>
     /// The sound played when locked.
     /// </summary>
-    [DataField("lockingSound"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField("lockingSound")]
     public SoundSpecifier? LockSound = new SoundPathSpecifier("/Audio/Machines/door_lock_on.ogg")
     {
-        Params = AudioParams.Default.WithVariation(-5f)
+        Params = AudioParams.Default.AddVolume(-5f)
     };
 
     /// <summary>

--- a/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
+++ b/Content.Shared/Power/EntitySystems/SharedPowerReceiverSystem.cs
@@ -68,7 +68,7 @@ public abstract partial class SharedPowerReceiverSystem : EntitySystem
         if (playSwitchSound)
         {
             _audio.PlayPredicted(new SoundPathSpecifier("/Audio/Machines/machine_switch.ogg"), uid, user: user,
-                AudioParams.Default.WithVariation(-2f));
+                AudioParams.Default.AddVolume(-2f));
         }
 
         if (_netMan.IsClient && receiver.PowerDisabled)


### PR DESCRIPTION

## About the PR

Fixes a few uses of AudioParams.WithVariation that were erroneously changed in #36259

Also cleans up the LockComponent DataFields while we're here.

## Why / Balance

Bugfix, cleanup.

Resolves #44951.

## Technical details

The parameters were unchanged, but the lines themselves are in the other PR.  Check for yourself, each was WithVolume before.

## Test plan

Open locks.  Toggle some power switches.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
small!
