### PR TITLE
fix: make bluespace beaker normal sized item like large beaker

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry.yml
@@ -315,7 +315,7 @@
 
 - type: entity
   name: bluespace beaker
-  parent: [SolutionGinormous, BaseBeakerMetallic] # 240u a tile
+  parent: [SolutionGinormous, BaseBeakerMetallic] # Bluespace items hold 8x the solution of regular items (240u a tile)
   description: Powered by experimental bluespace technology.
   id: BluespaceBeaker
   components:
@@ -328,7 +328,7 @@
   - type: SolutionContainerVisuals
     maxFillLevels: 0
   - type: Item
-    size: Normal # Bluespace items hold 8x the solution of regular items
+    size: Normal
 
 - type: entity
   name: dropper

--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry.yml
@@ -315,7 +315,7 @@
 
 - type: entity
   name: bluespace beaker
-  parent: [SolutionGinormous, BaseBeakerMetallic]
+  parent: [SolutionGinormous, BaseBeakerMetallic] # 240u a tile
   description: Powered by experimental bluespace technology.
   id: BluespaceBeaker
   components:
@@ -327,6 +327,8 @@
       - state: beakerbluespace
   - type: SolutionContainerVisuals
     maxFillLevels: 0
+  - type: Item
+    size: Normal # Bluespace items hold 8x the solution of regular items
 
 - type: entity
   name: dropper


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changes bluespace beaker item size to Normal.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, bluespace items aren't standardized in their sizing, and this intends to normalize all bluespace items to be 8x the size of their normal counterparts. Given that the bluespace beaker is modeled after the large beaker, it sees fit that it should be upgraded to the normal size as well. 

## Technical details
<!-- Summary of code changes for easier review. -->
- Upgraded bluespace beaker to size: Normal
- Clarification that bluespace items are supposed to be 8x the solution size of regular items, giving them 240u a tile.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Open game, see it takes 4 tiles instead of 2

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="302" height="174" alt="image" src="https://github.com/user-attachments/assets/a7e0ce8f-c77e-4f66-82b8-f7d876fe5632" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Bluespace beakers can't fit in your pockets anymore.
This standardizes bluespace items to be 240u a tile.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Bluespace beakers are now 2x2