### PR TITLE
Fix vehicles retaining movement input after unbuckling

### DIFF
--- a/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
@@ -128,17 +128,17 @@ public abstract partial class SharedMoverController
         PhysicsSystem.UpdateIsPredicted(entity.Owner);
         PhysicsSystem.UpdateIsPredicted(entity.Comp.Source);
 
-        if (Timing.ApplyingState)
-            return;
-
         if (MoverQuery.TryComp(entity.Owner, out var inputMover))
             SetMoveInput((entity.Owner, inputMover), MoveButtons.None);
 
-        if (RelayQuery.TryComp(entity.Comp.Source, out var relay) && relay.LifeStage <= ComponentLifeStage.Running)
-        {
-            RemComp(entity.Comp.Source, relay);
-            RaiseEffectiveMoverChanged(entity.Comp.Source, entity.Owner, entity.Comp.Source);
-        }
+        if (Timing.ApplyingState)
+            return;
+
+        if (!RelayQuery.TryComp(entity.Comp.Source, out var relay) ||
+            relay.LifeStage > ComponentLifeStage.Running) return;
+
+        RemComp(entity.Comp.Source, relay);
+        RaiseEffectiveMoverChanged(entity.Comp.Source, entity.Owner, entity.Comp.Source);
     }
 
     protected virtual void UpdateMoverStatus(Entity<InputMoverComponent?, MovementRelayTargetComponent?> ent) { }


### PR DESCRIPTION
## About the PR
Resolves #44901.

Clears relayed movement input when the relay target shuts down, including during state application. This prevents vehicles from retaining stuck movement after unbuckling

## Why / Balance
Movement input should be cleared whenever the relay ends. Previously, this was skipped while applying network state, leaving stale input on the vehicle

## Technical details
Moved `SetMoveInput(..., MoveButtons.None)` before the `Timing.ApplyingState` check

## Test plan
- Buckled into a vehicle.
- Spammed movement inputs while unbuckling.
- Confirmed the vehicle stops moving.

## Media
Not required

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

## Changelog
:cl:
- fix: Fixed vehicles sometimes continuing to move after unbuckling.