### PR TITLE
RecyclerLoopTest: check all materials, simplify test.

### DIFF
--- a/Content.IntegrationTests/Tests/Materials/ReclaimerLoopTest.cs
+++ b/Content.IntegrationTests/Tests/Materials/ReclaimerLoopTest.cs
@@ -18,24 +18,24 @@ public sealed class ReclaimerLoopTest : InteractionTest
     //ProtoIDs we need
     private static readonly EntProtoId ApcId = "APCBasic";
     private static readonly EntProtoId FloorTileId = "FloorTileItemSteel";
-
-    private static readonly string[] Reclaimers = GameDataScrounger.EntitiesWithComponent("MaterialReclaimer");
+    private static readonly EntProtoId Recycler = "Recycler";
 
     [SidedDependency(Side.Server)] private readonly SharedMaterialReclaimerSystem _materialReclaimerSystem = null!;
 
     [Test]
-    [TestCaseSource(nameof(Reclaimers))]
     [TestOf(typeof(MaterialReclaimerSystem))]
     [TestOf(typeof(MaterialReclaimerComponent))]
     [Description("For every material that a reclaimer can spawn, make sure that it cannot get stuck in a loop of spawning then recycling.")]
     [TrackingIssue("https://github.com/space-wizards/space-station-14/issues/39691")]
-    public async Task MaterialSpawnLoopTest(string reclaimerId)
+    public async Task MaterialSpawnLoopTest()
     {
         //Spawn the reclaimer
-        await SpawnTarget(reclaimerId, PlayerCoords);
-        Assert.That(STarget, Is.Not.Null, "STarget was null, did the reclaimer spawn correctly?");
+        await SpawnTarget(Recycler, PlayerCoords);
+        Assert.That(STarget, Is.Not.Null, "STarget was null, did the recycler spawn correctly?");
 
+        // Check that we can actually reclaim materials in the test.
         var reclaimComp = Comp<MaterialReclaimerComponent>(Target);
+        Assert.That(reclaimComp.ReclaimMaterials, "The recycler cannot reclaim materials!");
 
         // Power the reclaimer
         await SpawnEntity(ApcId, SEntMan.GetCoordinates(TargetCoords));
@@ -47,14 +47,10 @@ public sealed class ReclaimerLoopTest : InteractionTest
         });
 
         //Assert that reclaimer enabled
-        Assert.That(reclaimComp.Enabled, "The reclaimer did not get or stay enabled");
+        Assert.That(reclaimComp.Enabled, "The recycler did not get or stay enabled");
 
         //put a floor tile down
         await InteractUsing(FloorTileId);
-
-        // Reclaimer can't reclaim materials?  Job's done.
-        if (!reclaimComp.ReclaimMaterials)
-            return;
 
         using (Assert.EnterMultipleScope())
         {
@@ -82,7 +78,7 @@ public sealed class ReclaimerLoopTest : InteractionTest
                 Assert.That(
                     HandSys.GetActiveItem((SPlayer, Hands)),
                     Is.Not.Null,
-                    $"The material that should not have been reclaimed, {matStack}, is no longer in our hands. The reclaimer was {reclaimerId}");
+                    $"The material that should not have been reclaimed, {matStack}, is no longer in our hands.");
             }
         }
     }

--- a/Content.IntegrationTests/Tests/Materials/ReclaimerLoopTest.cs
+++ b/Content.IntegrationTests/Tests/Materials/ReclaimerLoopTest.cs
@@ -59,13 +59,13 @@ public sealed class ReclaimerLoopTest : InteractionTest
         using (Assert.EnterMultipleScope())
         {
             //For each material, assert that it is not recyclable (and would thus cause a recycling loop)
-            foreach (ProtoId<MaterialPrototype> material in ProtoMan.EnumeratePrototypes<MaterialPrototype>())
+            foreach (var material in ProtoMan.EnumeratePrototypes<MaterialPrototype>())
             {
-                var matStack = ProtoMan.Index(material).StackEntity;
+                var matStack = material.StackEntity;
                 Assert.That(
                     matStack,
                     Is.Not.Null,
-                    $"The material, {material}, did not have a stackentity associated with it. You may need to add a stackEntity to its Reagents/Materials yml file.");
+                    $"The material, {material.ID}, did not have a stackentity associated with it. You may need to add a stackEntity to its Reagents/Materials yml file.");
 
                 var matInHands = await PlaceInHands(matStack);
                 var matInHandsUid = ToServer(matInHands);

--- a/Content.IntegrationTests/Tests/Materials/ReclaimerLoopTest.cs
+++ b/Content.IntegrationTests/Tests/Materials/ReclaimerLoopTest.cs
@@ -18,24 +18,24 @@ public sealed class ReclaimerLoopTest : InteractionTest
     //ProtoIDs we need
     private static readonly EntProtoId ApcId = "APCBasic";
     private static readonly EntProtoId FloorTileId = "FloorTileItemSteel";
-    private static readonly EntProtoId Recycler = "Recycler";
+
+    private static readonly string[] Reclaimers = GameDataScrounger.EntitiesWithComponent("MaterialReclaimer");
 
     [SidedDependency(Side.Server)] private readonly SharedMaterialReclaimerSystem _materialReclaimerSystem = null!;
 
     [Test]
+    [TestCaseSource(nameof(Reclaimers))]
     [TestOf(typeof(MaterialReclaimerSystem))]
     [TestOf(typeof(MaterialReclaimerComponent))]
     [Description("For every material that a reclaimer can spawn, make sure that it cannot get stuck in a loop of spawning then recycling.")]
     [TrackingIssue("https://github.com/space-wizards/space-station-14/issues/39691")]
-    public async Task MaterialSpawnLoopTest()
+    public async Task MaterialSpawnLoopTest(string reclaimerId)
     {
         //Spawn the reclaimer
-        await SpawnTarget(Recycler, PlayerCoords);
-        Assert.That(STarget, Is.Not.Null, "STarget was null, did the recycler spawn correctly?");
+        await SpawnTarget(reclaimerId, PlayerCoords);
+        Assert.That(STarget, Is.Not.Null, "STarget was null, did the reclaimer spawn correctly?");
 
-        // Check that we can actually reclaim materials in the test.
         var reclaimComp = Comp<MaterialReclaimerComponent>(Target);
-        Assert.That(reclaimComp.ReclaimMaterials, "The recycler cannot reclaim materials!");
 
         // Power the reclaimer
         await SpawnEntity(ApcId, SEntMan.GetCoordinates(TargetCoords));
@@ -47,10 +47,14 @@ public sealed class ReclaimerLoopTest : InteractionTest
         });
 
         //Assert that reclaimer enabled
-        Assert.That(reclaimComp.Enabled, "The recycler did not get or stay enabled");
+        Assert.That(reclaimComp.Enabled, "The reclaimer did not get or stay enabled");
 
         //put a floor tile down
         await InteractUsing(FloorTileId);
+
+        // Reclaimer can't reclaim materials?  Job's done.
+        if (!reclaimComp.ReclaimMaterials)
+            return;
 
         using (Assert.EnterMultipleScope())
         {
@@ -78,7 +82,7 @@ public sealed class ReclaimerLoopTest : InteractionTest
                 Assert.That(
                     HandSys.GetActiveItem((SPlayer, Hands)),
                     Is.Not.Null,
-                    $"The material that should not have been reclaimed, {matStack}, is no longer in our hands.");
+                    $"The material that should not have been reclaimed, {matStack}, is no longer in our hands. The reclaimer was {reclaimerId}");
             }
         }
     }

--- a/Content.IntegrationTests/Tests/Materials/ReclaimerLoopTest.cs
+++ b/Content.IntegrationTests/Tests/Materials/ReclaimerLoopTest.cs
@@ -2,13 +2,9 @@ using Content.IntegrationTests.Fixtures.Attributes;
 using Content.IntegrationTests.Tests.Interaction;
 using Content.IntegrationTests.Utility;
 using Content.Server.Materials;
-using Content.Server.Spawners.Components;
 using Content.Shared.Materials;
-using Content.Shared.Sprite;
-using Content.Shared.Whitelist;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
-using System.Collections.Generic;
 
 namespace Content.IntegrationTests.Tests.Materials;
 
@@ -26,7 +22,6 @@ public sealed class ReclaimerLoopTest : InteractionTest
     private static readonly string[] Reclaimers = GameDataScrounger.EntitiesWithComponent("MaterialReclaimer");
 
     [SidedDependency(Side.Server)] private readonly SharedMaterialReclaimerSystem _materialReclaimerSystem = null!;
-    [SidedDependency(Side.Server)] private readonly EntityWhitelistSystem _entityWhitelistSystem = null!;
 
     [Test]
     [TestCaseSource(nameof(Reclaimers))]

--- a/Content.IntegrationTests/Tests/Materials/ReclaimerLoopTest.cs
+++ b/Content.IntegrationTests/Tests/Materials/ReclaimerLoopTest.cs
@@ -15,7 +15,7 @@ namespace Content.IntegrationTests.Tests.Materials;
 [TestOf(typeof(MaterialReclaimerComponent))]
 public sealed class ReclaimerLoopTest : InteractionTest
 {
-    //ProtoIDs we need
+    // ProtoIDs we need
     private static readonly EntProtoId ApcId = "APCBasic";
     private static readonly EntProtoId FloorTileId = "FloorTileItemSteel";
 
@@ -31,34 +31,34 @@ public sealed class ReclaimerLoopTest : InteractionTest
     [TrackingIssue("https://github.com/space-wizards/space-station-14/issues/39691")]
     public async Task MaterialSpawnLoopTest(string reclaimerId)
     {
-        //Spawn the reclaimer
+        // Spawn the reclaimer
         await SpawnTarget(reclaimerId, PlayerCoords);
-        Assert.That(STarget, Is.Not.Null, "STarget was null, did the reclaimer spawn correctly?");
+        Assume.That(STarget, Is.Not.Null, "STarget was null, did the reclaimer spawn correctly?");
 
         var reclaimComp = Comp<MaterialReclaimerComponent>(Target);
 
         // Power the reclaimer
         await SpawnEntity(ApcId, SEntMan.GetCoordinates(TargetCoords));
         await RunTicks(1);
-        //Set reclaimer to enabled
+        // Set reclaimer to enabled
         await Server.WaitPost(() =>
         {
             _materialReclaimerSystem.SetReclaimerEnabled((EntityUid)STarget, true);
         });
 
-        //Assert that reclaimer enabled
-        Assert.That(reclaimComp.Enabled, "The reclaimer did not get or stay enabled");
+        // Check that reclaimer enabled
+        Assume.That(reclaimComp.Enabled, "The reclaimer did not get or stay enabled");
 
-        //put a floor tile down
+        // Put a floor tile down
         await InteractUsing(FloorTileId);
 
-        // Reclaimer can't reclaim materials?  Job's done.
+        // Reclaimer can't reclaim materials? Job's done.
         if (!reclaimComp.ReclaimMaterials)
-            return;
+            Assert.Ignore("Cannot reclaim materials");
 
         using (Assert.EnterMultipleScope())
         {
-            //For each material, assert that it is not recyclable (and would thus cause a recycling loop)
+            // For each material, assert that it is not recyclable (and would thus cause a recycling loop)
             foreach (var material in ProtoMan.EnumeratePrototypes<MaterialPrototype>())
             {
                 var matStack = material.StackEntity;
@@ -70,7 +70,7 @@ public sealed class ReclaimerLoopTest : InteractionTest
                 var matInHands = await PlaceInHands(matStack);
                 var matInHandsUid = ToServer(matInHands);
 
-                //Assert we're holding material
+                // Assert we're holding material
                 Assert.That(
                     HandSys.GetActiveItem((SPlayer, Hands)),
                     Is.EqualTo(matInHandsUid),
@@ -78,7 +78,7 @@ public sealed class ReclaimerLoopTest : InteractionTest
 
                 await Interact();
 
-                //Assert Hands not empty
+                // Assert Hands not empty
                 Assert.That(
                     HandSys.GetActiveItem((SPlayer, Hands)),
                     Is.Not.Null,

--- a/Content.IntegrationTests/Tests/Materials/ReclaimerLoopTest.cs
+++ b/Content.IntegrationTests/Tests/Materials/ReclaimerLoopTest.cs
@@ -21,13 +21,12 @@ public sealed class ReclaimerLoopTest : InteractionTest
 {
     //ProtoIDs we need
     private static readonly EntProtoId ApcId = "APCBasic";
-    private static readonly EntProtoId FloorTileId = "FloorTileItemSteelCheckerDark";
+    private static readonly EntProtoId FloorTileId = "FloorTileItemSteel";
 
     private static readonly string[] Reclaimers = GameDataScrounger.EntitiesWithComponent("MaterialReclaimer");
 
     [SidedDependency(Side.Server)] private readonly SharedMaterialReclaimerSystem _materialReclaimerSystem = null!;
     [SidedDependency(Side.Server)] private readonly EntityWhitelistSystem _entityWhitelistSystem = null!;
-    [SidedDependency(Side.Server)] private readonly IComponentFactory _compFactory = null!;
 
     [Test]
     [TestCaseSource(nameof(Reclaimers))]
@@ -42,42 +41,6 @@ public sealed class ReclaimerLoopTest : InteractionTest
         Assert.That(STarget, Is.Not.Null, "STarget was null, did the reclaimer spawn correctly?");
 
         var reclaimComp = Comp<MaterialReclaimerComponent>(Target);
-        //If the reclaimer can produce materials
-        var reclaimsMaterials = reclaimComp.ReclaimMaterials;
-
-        //if the reclaimer has reclaimsMaterials and is able to produce materials
-        //go through all recyclable items, compile a HashSet of producible materials
-        HashSet<ProtoId<MaterialPrototype>> producibleMaterials = []; //If reclaimMaterials is false, this will stay empty
-        if (reclaimsMaterials)
-        {
-            foreach (var proto in ProtoMan.EnumeratePrototypes<EntityPrototype>())
-            {
-                //we don't care about items that don't recycle into anything physical
-                if (!proto.HasComp<PhysicalCompositionComponent>(_compFactory))
-                    continue;
-
-                //spawners and random items mess things up quickly, avoid them too
-                if (proto.HasComp<RandomSpriteComponent>(_compFactory) || proto.HasComp<EntityTableSpawnerComponent>(_compFactory))
-                    continue;
-
-                var currentScrap = await Spawn(proto.ID);
-                var currentScrapUid = ToServer(currentScrap);
-                var currentScrapCompositionComp = Comp<PhysicalCompositionComponent>(currentScrap);
-
-                //If it's on the whitelist for the reclaimer, and not on its blacklist.
-                if (_entityWhitelistSystem.CheckBoth(currentScrapUid, reclaimComp.Blacklist, reclaimComp.Whitelist))
-                {
-                    //for each material it produces, add it to the HashSet
-                    foreach (var (mat, _) in currentScrapCompositionComp.MaterialComposition)
-                    {
-                        ProtoId<MaterialPrototype> matAsProto = ProtoMan.Index<MaterialPrototype>(mat);
-                        producibleMaterials.Add(matAsProto);
-                    }
-                }
-
-                await Delete(currentScrapUid);
-            }
-        }
 
         // Power the reclaimer
         await SpawnEntity(ApcId, SEntMan.GetCoordinates(TargetCoords));
@@ -94,10 +57,14 @@ public sealed class ReclaimerLoopTest : InteractionTest
         //put a floor tile down
         await InteractUsing(FloorTileId);
 
+        // Reclaimer can't reclaim materials?  Job's done.
+        if (!reclaimComp.ReclaimMaterials)
+            return;
+
         using (Assert.EnterMultipleScope())
         {
-            //For each producible Material, assert that it is not recyclable (and would thus cause a recycling loop)
-            foreach (ProtoId<MaterialPrototype> material in producibleMaterials)
+            //For each material, assert that it is not recyclable (and would thus cause a recycling loop)
+            foreach (ProtoId<MaterialPrototype> material in ProtoMan.EnumeratePrototypes<MaterialPrototype>())
             {
                 var matStack = ProtoMan.Index(material).StackEntity;
                 Assert.That(

--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -113,6 +113,7 @@
 
 - type: material
   id: Bones
+  stackEntity: MaterialBones1
   name: materials-bones
   unit: materials-unit-piece
   icon: { sprite: Objects/Materials/materials.rsi, state: bones }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

In ReclaimerLoopTest, checks that _every_ material is not recyclable in each of the recyclers.

## Why / Balance

Fixes #44966.  We hope.

## Technical details

No more entity spawning to check what's recyclable!  Just spawn all of the materials.

Otherwise, test is the same.  We _technically_ do need to do this for each recycler in case they have odd whitelists - we could also construct a test recycler with a minimal whitelist and nix the TestCaseSource altogether (🙏) but that hasn't been done.

Adds a spawn entity to bones, since it didn't have one.

## Test plan

Run tests!

Runs on my machine award.

<img width="317" height="65" alt="image" src="https://github.com/user-attachments/assets/2e151d97-9fca-4c3a-96fd-66abb2d9f99f" />

## Media

<img width="787" height="1000" alt="image" src="https://github.com/user-attachments/assets/6ce0578b-d6f5-4a1c-80c4-53b6cf2ecd63" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
not player-facing
