### PR TITLE
Spraypainter YML cleanup

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -45,7 +45,7 @@
   suffix: Admeme
   components:
   - type: AutoRecharge
-    rechargeDuration: 1
+    rechargeDuration: 0.1
 
 - type: entity
   parent: SprayPainter

--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -1,7 +1,8 @@
 - type: entity
   parent: BaseItem
-  id: SprayPainter
+  id: SprayPainterRecharging
   name: spray painter
+  suffix: Admeme
   description: A spray painter for painting airlocks, pipes, and other items.
   components:
   - type: Sprite
@@ -16,7 +17,7 @@
       enum.SprayPainterUiKey.Key:
         type: SprayPainterBoundUserInterface
   - type: SprayPainter
-    colorPalette:
+    colorPalette: # Atmos pipes preset colors
       red: '#FF1212FF'
       yellow: '#B3A234FF'
       brown: '#947507FF'
@@ -32,20 +33,18 @@
       mix: '#947507'
   - type: StaticPrice
     price: 40
-  - type: LimitedCharges
-    maxCharges: 15
-    lastCharges: 15
   - type: PhysicalComposition
     materialComposition:
       Steel: 100
 
 - type: entity
-  parent: SprayPainter
-  id: SprayPainterRecharging
-  suffix: Admeme
+  parent: SprayPainterRecharging
+  id: SprayPainter
+  suffix: ""
   components:
-  - type: AutoRecharge
-    rechargeDuration: 0.1
+  - type: LimitedCharges
+    maxCharges: 15
+    lastCharges: 15
 
 - type: entity
   parent: SprayPainter
@@ -64,6 +63,8 @@
   components:
   - type: LimitedCharges
     lastCharges: -1
+
+# Ammo
 
 - type: entity
   parent: BaseItem


### PR DESCRIPTION
## About the PR
Cleanup, added some comments
Admeme spraypainter is now a base which means it doesn't have to recharge

## Why / Balance
admeme spraypainter was charging a little to slow when i was using it in dev, now there's no charge, no problem

## Technical details
the `LimitedCharges` component was in base which meant that you had to add auto recharge component to admeme version. Now the "recharging" version is a base.

(I would like to also change the id of admeme version (which is `SprayPainterRecharging`) to something like `Base`, but im not sure if i should do that)

## Test plan
Spawn spraypainters, look that they work normally, admeme one doesn't require any charges

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
not player facing
