### PR TITLE
Fix stack test async + stack system warning

### DIFF
--- a/Content.IntegrationTests/Tests/Stacks/StackTests.cs
+++ b/Content.IntegrationTests/Tests/Stacks/StackTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Content.IntegrationTests.Fixtures;
 using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Server.Stack;
-using Content.Shared.Stacks;
 using Robust.Shared.GameObjects;
 using static Content.IntegrationTests.Tests.Stacks.StackTestPrototypes;
 
@@ -16,7 +15,7 @@ public sealed class StackTest : GameTest
     [SidedDependency(Side.Server)] private readonly StackSystem _sStackSystem = default!;
 
     [Test]
-    [Description("Tests for SharedStackSystem.SetCount .")]
+    [Description("Tests for SharedStackSystem.SetCount.")]
     public async Task SetTest()
     {
         var stack = await Spawn(StackEnt1);
@@ -26,15 +25,15 @@ public sealed class StackTest : GameTest
         Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(2));
 
         // Lowering the count
-        await Server.WaitPost(() =>_sStackSystem.SetCount((stack, null), 1));
+        await Server.WaitPost(() => _sStackSystem.SetCount((stack, null), 1));
         Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(1));
 
         // Setting above the max count clamps to max
-        await Server.WaitPost(() =>_sStackSystem.SetCount((stack, null), 31));
+        await Server.WaitPost(() => _sStackSystem.SetCount((stack, null), 31));
         Assert.That(_sStackSystem.GetCount(stack), Is.EqualTo(30));
 
         // Setting to 0 deletes the stack
-        await Server.WaitPost(() =>_sStackSystem.SetCount((stack, null), 0));
+        await Server.WaitPost(() => _sStackSystem.SetCount((stack, null), 0));
         await Server.WaitRunTicks(1);
         Assert.That(SEntMan.EntityCount, Is.Zero);
     }
@@ -79,12 +78,12 @@ public sealed class StackTest : GameTest
 
         await Server.WaitPost(() =>
         {
-             stacks =
-             [
-                 SSpawn(StackEnt1),
-                 SSpawn(StackEnt2),
-                 SSpawn(StackEnt30),
-             ];
+            stacks =
+            [
+                SSpawn(StackEnt1),
+                SSpawn(StackEnt2),
+                SSpawn(StackEnt30),
+            ];
 
             _sStackSystem.MergeStacks(ref stacks);
         });
@@ -124,7 +123,7 @@ public sealed class StackTest : GameTest
         var donor = await SpawnAtPosition(StackEnt1, map.GridCoords);
         var receiver = await SpawnAtPosition(StackEnt1, map.GridCoords);
 
-        _sStackSystem.TryMergeToContacts(donor);
+        await Server.WaitPost(() => _sStackSystem.TryMergeToContacts(donor));
 
         // Wait for queue deletion
         await Server.WaitRunTicks(1);

--- a/Content.Shared/Stacks/SharedStackSystem.API.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.API.cs
@@ -29,7 +29,7 @@ public abstract partial class SharedStackSystem
         var stackId = ProtoMan.Index(stackEnt.Comp.StackTypeId);
         var entityUid = PredictedSpawnNextToOrDrop(stackId.Spawn, stackEnt.Owner);
 
-        SetCount(entityUid, 1);
+        SetCount((entityUid, null), 1);
         return entityUid;
     }
 


### PR DESCRIPTION
## About the PR

Fixes a stack test call that was missing an async wrapper (L127).

Also resolves a warning in SharedStackSystem.API.cs and does a little bit of whitespace cleanup.

## Why / Balance

Resolves #44721.  https://github.com/space-wizards/space-station-14/issues/44721#issuecomment-5005760634 was correct.

## Technical details
async ops.

API: use the Entity<T?> call instead of EntityUid, which causes the warning.  The two calls are equivalent.

## Test plan
Run tests!

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
nope
