### PR TITLE
Lock uplink items when evac lands

### DIFF
--- a/Content.Server/Store/Conditions/RestrictOnEvacCondition.cs
+++ b/Content.Server/Store/Conditions/RestrictOnEvacCondition.cs
@@ -1,0 +1,12 @@
+using Content.Server.Shuttles.Systems;
+using Content.Shared.Store;
+
+namespace Content.Server.Store.Conditions;
+
+public sealed partial class RestrictOnEvacCondition : ListingCondition
+{
+    public override bool Condition(ListingConditionArgs args)
+    {
+        return !args.EntityManager.System<EmergencyShuttleSystem>().EmergencyShuttleArrived;
+    }
+}

--- a/Resources/Prototypes/Catalog/UplinkCatalog/ammo.yml
+++ b/Resources/Prototypes/Catalog/UplinkCatalog/ammo.yml
@@ -10,6 +10,8 @@
     Telecrystal: 1
   categories:
   - UplinkAmmo
+  conditions:
+  - !type:RestrictOnEvacCondition
 
 # For the C20R
 - type: listing


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Evac bombing is just a super common thing right now. The bombing itself isn't the worst thing, but people are purchasing their entire uplink on evac which causes the rest of the round to be very dull as nothing really happens.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Call evac with `callshuttle 1`
Purchase the magazine see that it works
Once evac lands, try to purchase see that it doesn't work

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: You can now now longer purchase uplink items once evacuation has arrived.
