### PR TITLE
Added Wheelchairs to Medical Techfab

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/vehicles.yml
@@ -80,6 +80,14 @@
     price: 70
 
 - type: entity
+  parent: VehicleWheelchair
+  id: VehicleWheelchairFolded
+  suffix: folded
+  components:
+  - type: Foldable
+    folded: true
+
+- type: entity
   id: VehicleJanicart
   parent: BaseVehicleStrap
   name: janicart

--- a/Resources/Prototypes/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/vehicles.yml
@@ -86,6 +86,8 @@
   components:
   - type: Foldable
     folded: true
+  - type: Strap
+    enabled: False
 
 - type: entity
   id: VehicleJanicart

--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -49,6 +49,7 @@
   - OffsetCane
   - OffsetCaneWood
   - JetInjector
+  - VehicleWheelchairFolded
 
 - type: latheRecipePack
   id: RollerBedsStatic

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -276,3 +276,11 @@
     Plastic: 250
     Silver: 400
     Gold: 50 # A bit of gold for the gold ornaments on it!
+
+- type: latheRecipe
+  id: VehicleWheelchairFolded
+  result: VehicleWheelchairFolded
+  completetime: 1
+  materials:
+    Steel: 500
+    Plastic: 300


### PR DESCRIPTION
## About the PR
Re-added Wheelchair back to Medical Techfab.

## Why / Balance
Was removed during the vehicle removal. Wheelchairs are now finally back!

## Technical details
Created a new prototype as a forced folded Wheelchair 
Added Recipe for Folded Wheelchair and added it to Medical lathe pack. 

## Test plan
Spawn Medical Fab w/ Steel and Plastic.
Craft a wheelchair that's already folded and ready to go.
Open and sit down on your new favorite wheelchair.

## Media
<img width="621" height="198" alt="image" src="https://github.com/user-attachments/assets/6034fdbc-84f9-43de-9d18-0cca19f36940" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- add: Wheelchairs can now be made in the Medical Techfab.

