### PR TITLE
Fix ShouldIgnoreRestrictions logic

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -52,7 +52,7 @@ public abstract partial class SharedHandsSystem
     private bool ShouldIgnoreRestrictions(EntityUid user)
     {
         //Checks if the Entity is something that shouldn't care about drop distance or walls ie Aghost
-        return !_tagSystem.HasTag(user, BypassDropChecksTag);
+        return _tagSystem.HasTag(user, BypassDropChecksTag);
     }
 
     /// <summary>
@@ -203,7 +203,7 @@ public abstract partial class SharedHandsSystem
         var requestedDropDistance = dropVector.Length();
         var dropLength = dropVector.Length();
 
-        if (ShouldIgnoreRestrictions(user))
+        if (!ShouldIgnoreRestrictions(user))
         {
             if (dropVector.Length() > SharedInteractionSystem.InteractionRange)
             {
@@ -216,6 +216,7 @@ public abstract partial class SharedHandsSystem
 
         if (dropLength < requestedDropDistance)
             return origin.Position + dropVector.Normalized() * dropLength;
+
         return target.Position;
     }
 


### PR DESCRIPTION
## About the PR
Invert the return expression of `ShouldIgnoreRestrictions` to match its name.

## Why / Balance
Logically, `ShouldIgnoreRestrictions` returning `true` implies "this user **should** ignore restrictions, thus they **should** have the bypass tag". This wasn't how it worked, however, instead returning `true` when the user **didn't** have the bypass tag.

## Technical details
The method has only one call site, which was itself inverted such that reading the code makes sense.

## Test plan
- Ensure the aghost can still bypass drop restrictions
- Ensure normal players cannot bypass drop restrictions

## Media
[Screencast_20260728_152124.webm](https://github.com/user-attachments/assets/f3846837-c68d-4d58-8155-1e83389ec9a5)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
N/A

## Changelog
N/A
