### PR TITLE
Bugfix: Stop ID card consoles from bulldozing job icons on access changes

### DIFF
--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -158,18 +158,25 @@ public sealed partial class IdCardConsoleSystem : SharedIdCardConsoleSystem
         _idCard.TryChangeFullName(targetId, newFullName, player: player);
         _idCard.TryChangeJobTitle(targetId, newJobTitle, player: player);
 
-        if (ProtoMan.TryIndex(newJobProto, out var job)
-            && ProtoMan.Resolve(job.Icon, out var jobIcon))
+        if (ProtoMan.TryIndex(newJobProto, out var job))
         {
-            _idCard.TryChangeJobIcon(targetId, jobIcon, player: player);
-            _idCard.TryChangeJobDepartment(targetId, job);
+            if (ProtoMan.Resolve(job.Icon, out var jobIcon))
+            {
+                _idCard.TryChangeJobIcon(targetId, jobIcon, player: player);
+                _idCard.TryChangeJobDepartment(targetId, job);
+            }
+        }
+        else
+        {
+            // Can't find the job prototype, don't reassign the ID card's proto.
+            newJobProto = null;
         }
 
         UpdateStationRecord(uid, targetId, newFullName, newJobTitle, job);
         if ((!TryComp<StationRecordKeyStorageComponent>(targetId, out var keyStorage)
             || keyStorage.Key is not { } key
             || !_record.TryGetRecord<GeneralStationRecord>(key, out _))
-            && newJobProto != string.Empty)
+            && newJobProto != null)
         {
             Comp<IdCardComponent>(targetId).JobPrototype = newJobProto;
         }


### PR DESCRIPTION
## About the PR

Bugfix!
1. Checks the user's ID against null, not empty string, if it exists.
2. On a bad ID lookup, explicitly sets the value to null to prevent writing garbage out to the ID card component.

## Why / Balance

Resolves https://github.com/space-wizards/space-station-14/issues/44991.

## Technical details

Simple conditions, three month old bug.

IdCardConsoleSystem.TryWriteToTargetId allows nullable job protos as of #42884, but the comparison inside the function wasn't changed.

## Test plan
Spawn an ID card computer, a captain ID card and a clown ID card.
Put the captain ID in the computer, then the clown one.
Assign the clown to the chef job using the dropdown.
Add some new accesses.  The dropdown shouldn't change.
Eject the clown ID card, hold it in your hand.  Spawn an admin HUD, put it on.
You should have the chef job icon.

## Media

Test plan in action.

https://github.com/user-attachments/assets/0afdb563-c57c-4777-a1b3-32d0d54532db

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
really small