### PR TITLE
Add Head tag to OrganBaseHead

### DIFF
--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -99,6 +99,9 @@
       - SnoutCover
       - HeadSide
       - HeadTop
+  - type: Tag
+    tags:
+    - Head
 
 - type: entity
   parent:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Adds the Head tag back to OrganBaseHead.

## Why / Balance

Resolves #44981.

## Technical details

Why keep the tag?

Good question!

It could be converted to a marker component (e.g. `HeadComponent`), as it has a very specific parent, and is unlikely to need removal in any of its children, but that starts down a path to get the roughly 800 tags in tags.yml into marker components.  Not too bad to do, and possibly a fine choice, but arguably not here.  Happy to swap over should you wish.

## Test plan
Spawn a head (dealer's choice, ideally all of them)
Spawn a ritual chair for each of the heads you spawned.
Place the head upon the chair.
Ta-da.  Cursed chair.

## Media

https://github.com/user-attachments/assets/2d5bb65b-45df-4942-b627-0d06b502ca42

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
small