### PR TITLE
TriggerOnCollision for Impact Grenades

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/base_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/base_grenades.yml
@@ -32,6 +32,14 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
+      impact_grenade:
+        shape: !type:PhysShapeCircle
+          radius: 0.2
+        density: 20 # derived from base_item
+        mask:
+        - ItemMask
+        restitution: 0.3
+        friction: 0.2
 
 - type: entity # Starts fuse after taking 10 damage.
   abstract: true
@@ -62,6 +70,9 @@
   components:
   - type: TriggerOnLand
   - type: LandAtCursor
+  - type: TriggerOnCollide
+    fixtureID: impact_grenade
+    maxTriggers: 1
 
 - type: entity # Instantly detonates/activates after taking 45 damage.
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/base_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/base_grenades.yml
@@ -32,14 +32,6 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
-      impact_grenade:
-        shape: !type:PhysShapeCircle
-          radius: 0.2
-        density: 20 # derived from base_item
-        mask:
-        - ItemMask
-        restitution: 0.3
-        friction: 0.2
 
 - type: entity # Starts fuse after taking 10 damage.
   abstract: true
@@ -71,7 +63,7 @@
   - type: TriggerOnLand
   - type: LandAtCursor
   - type: TriggerOnCollide
-    fixtureID: impact_grenade
+    fixtureID: fix1
     maxTriggers: 1
 
 - type: entity # Instantly detonates/activates after taking 45 damage.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added TriggerOnCollision component to ImpactGrenadeBase so they explode when hitting a wall, such as in zero-G.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Zero-gravity completely nullifies the use of EMP grenades as wall collisions don't cause them to activate (Issue #43799). This trigger uses the existing 'fix1' fixture, so the grenade still passes through players like normal using the ItemMask as to prevent future impact grenades from being handheld budget fireballs.

## Technical details
<!-- Summary of code changes for easier review. -->
Added TriggerOnCollision to ImpactGrenadeBase in base_grenade.yml on line(s) 65-67.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Tested two ways, spawn in anything that uses the ImpactGrenadeBase:
- Leave the gravity on, then get somewhat close to a wall and aim a good distance past it, so it hits the wall before it can land.  When thrown, it should explode immediately upon contact, instead of falling to the floor then exploding.
- Turn the gravity off, throw towards any wall, it should explode immediately upon contact.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

**Without** the fix in zero-G:

https://github.com/user-attachments/assets/e5a608bb-4639-4180-ad0f-b65a94f1d1cc

**With** the fix in zero-G:

https://github.com/user-attachments/assets/dd859194-f4b7-4ff3-b922-5f64f745eb1e

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

N/A

## Changelog
:cl:
- fix: Impact grenades now explode when hitting a wall, making them usable in zero-G.