### PR TITLE
Minor SharedRoleSystem code cleanup

### DIFF
--- a/Content.Server/Roles/RoleSystem.cs
+++ b/Content.Server/Roles/RoleSystem.cs
@@ -78,8 +78,10 @@ public sealed partial class RoleSystem : SharedRoleSystem
         }
         else
         {
-            var error = $"The Character Window of {mindString} potentially did not update immediately : session error";
-            _adminLogger.Add(LogType.Mind, LogImpact.Medium, $"{error}");
+            _adminLogger.Add(
+                LogType.Mind,
+                LogImpact.Medium,
+                $"The Character Window of {mindString} potentially did not update immediately : session error");
         }
     }
 }

--- a/Content.Server/Roles/RoleSystem.cs
+++ b/Content.Server/Roles/RoleSystem.cs
@@ -1,12 +1,16 @@
 using Content.Server.Chat.Managers;
+using Content.Shared.Administration.Logs;
 using Content.Shared.Chat;
+using Content.Shared.Database;
 using Content.Shared.Mind;
 using Content.Shared.Roles;
+using Robust.Shared.Network;
 
 namespace Content.Server.Roles;
 
 public sealed partial class RoleSystem : SharedRoleSystem
 {
+    [Dependency] private ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private IChatManager _chat = default!;
 
     public string? MindGetBriefing(EntityUid? mindId)
@@ -64,6 +68,19 @@ public sealed partial class RoleSystem : SharedRoleSystem
             default,
             false,
             session.Channel);
+    }
+
+    protected override void UpdateCharacterWindow(NetUserId? user, MindStringRepresentation mindString)
+    {
+        if (Player.TryGetSessionById(user, out var session))
+        {
+            RaiseNetworkEvent(new MindRoleTypeChangedEvent(), session.Channel);
+        }
+        else
+        {
+            var error = $"The Character Window of {mindString} potentially did not update immediately : session error";
+            _adminLogger.Add(LogType.Mind, LogImpact.Medium, $"{error}");
+        }
     }
 }
 

--- a/Content.Shared/Roles/SharedRoleSystem.cs
+++ b/Content.Shared/Roles/SharedRoleSystem.cs
@@ -24,7 +24,6 @@ public abstract partial class SharedRoleSystem : EntitySystem
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
-    [Dependency] private INetManager _net = default!;
     [Dependency] protected ISharedPlayerManager Player = default!;
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
     [Dependency] private SharedMindSystem _minds = default!;
@@ -259,19 +258,7 @@ public abstract partial class SharedRoleSystem : EntitySystem
         comp.Subtype = subtype;
         Dirty(mind, comp);
 
-        // Update player character window
-        if (Player.TryGetSessionById(comp.UserId, out var session))
-        {
-            // The engine will not allow the client to specify the channel, so they must not run this line.
-            // We also don't want or need the client to make this event in the first place
-            if (_net.IsServer)
-                RaiseNetworkEvent(new MindRoleTypeChangedEvent(), session.Channel);
-        }
-        else
-        {
-            var error = $"The Character Window of {_minds.MindOwnerLoggingString(comp)} potentially did not update immediately : session error";
-            _adminLogger.Add(LogType.Mind, LogImpact.Medium, $"{error}");
-        }
+        UpdateCharacterWindow(comp.UserId, _minds.MindOwnerLoggingString(comp));
 
         if (comp.OwnedEntity is null)
         {
@@ -286,6 +273,14 @@ public abstract partial class SharedRoleSystem : EntitySystem
             LogImpact.High,
             $"Role Type of {ToPrettyString(comp.OwnedEntity)} changed to {roleTypeId}, {subtype}");
     }
+
+    /// <summary>
+    /// Server only. Informs the specified player's CharacterUIController that their mind role has changed,
+    /// So that their Character window gets updated if it is currently open.
+    /// </summary>
+    /// <param name="user">The player that will be updated.</param>
+    /// <param name="mindString">The name of the mob's controlling mind. Only used for logging.</param>
+    protected virtual void UpdateCharacterWindow(NetUserId? user, MindStringRepresentation mindString) { }
 
     /// <summary>
     /// Finds and removes all mind roles of a specific type

--- a/Content.Shared/Roles/SharedRoleSystem.cs
+++ b/Content.Shared/Roles/SharedRoleSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
+using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -23,6 +24,7 @@ public abstract partial class SharedRoleSystem : EntitySystem
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
+    [Dependency] private INetManager _net = default!;
     [Dependency] protected ISharedPlayerManager Player = default!;
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
     [Dependency] private SharedMindSystem _minds = default!;
@@ -259,7 +261,12 @@ public abstract partial class SharedRoleSystem : EntitySystem
 
         // Update player character window
         if (Player.TryGetSessionById(comp.UserId, out var session))
-            RaiseNetworkEvent(new MindRoleTypeChangedEvent(), session.Channel);
+        {
+            // The engine will not allow the client to specify the channel, so they must not run this line.
+            // We also don't want or need the client to make this event in the first place
+            if (_net.IsServer)
+                RaiseNetworkEvent(new MindRoleTypeChangedEvent(), session.Channel);
+        }
         else
         {
             var error = $"The Character Window of {_minds.MindOwnerLoggingString(comp)} potentially did not update immediately : session error";


### PR DESCRIPTION
## About the PR
Minor refactor, no gameplay changes

## Why / Balance
Fixes some rare antag-related crash scenarios which were annoying in Debug

## Technical details
SharedRoleSystem used the variant of RaiseNetworkMessage which specifies the session. This is only allowed on the server, not on the client, so having it in Shared was risky. Now that some antag systems are being moved to shared, our debt is due. 
The offending code has been moved to the server

## Test plan
Check out #43864
Run two clients
Make client 1 Head Rev
Make client 2 take over a Urist to lose the mindshield
Make client 1 convert client 2 with a flash
Make client 2 use an implant remover on itself
Game crashes

Apply patch from this PR. Repeat test
Game does not crash


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
