### PR TITLE
[Hotfix] Update the Wizden maxpop count

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/vulture.toml
+++ b/Resources/ConfigPresets/WizardsDen/vulture.toml
@@ -3,6 +3,7 @@
 [game]
 hostname = "[EN][Testing] Wizard's Den Vulture [NA East]"
 desc = "Official English testing server for Space Station 14.\nVanilla, roleplay ruleset.\n\nYou can play with the newest changes to the game here, but these changes may not be final or stable, and may be reverted before the next stable release.\nPlease report bugs on our GitHub, forum, or community Discord."
+soft_max_players = 67
 panic_bunker.enabled = false
 panic_bunker.disable_with_admins = false
 panic_bunker.enable_without_admins = false

--- a/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
+++ b/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
@@ -4,7 +4,7 @@
 [game]
 desc             = "Official English Space Station 14 servers. Vanilla, roleplay ruleset."
 lobbyenabled     = true
-soft_max_players = 80
+soft_max_players = 65
 lobbyduration    = 300 # 5 minutes lobby timer
 panic_bunker.enabled = true
 panic_bunker.min_overall_minutes = 120


### PR DESCRIPTION
As per the explanation on Discord here: https://discord.com/channels/310555209753690112/1181561039729479741/1531746321961189548

This change is being done after an evaluation of where the sweet spot is for what our current game mechanics afford. 
It is not a permanent or "goal" maxpop for the game, just for the current featureset. 

Should be merged alongside #44996