### PR TITLE
Bugfix: Guardian popup spam, mech attack blocker

### DIFF
--- a/Content.Shared/Guardian/Components/GuardianComponent.cs
+++ b/Content.Shared/Guardian/Components/GuardianComponent.cs
@@ -50,4 +50,16 @@ public sealed partial class GuardianComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier DeathSound = new SoundPathSpecifier("/Audio/Voice/Human/malescream_guardian.ogg", AudioParams.Default.WithVariation(0.2f));
+
+    /// <summary>
+    /// The last time that the entity attacked another.
+    /// </summary>
+    [ViewVariables]
+    public TimeSpan LastAttackPopupTime;
+
+    /// <summary>
+    /// The last time that the user attacked the
+    /// </summary>
+    [ViewVariables]
+    public TimeSpan PopupDelay = TimeSpan.FromSeconds(1);
 }

--- a/Content.Shared/Guardian/Components/GuardianComponent.cs
+++ b/Content.Shared/Guardian/Components/GuardianComponent.cs
@@ -1,12 +1,14 @@
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Guardian.Components;
 
 /// <summary>
 /// Given to guardians to monitor their link with the host.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class GuardianComponent : Component
 {
     /// <summary>
@@ -54,12 +56,12 @@ public sealed partial class GuardianComponent : Component
     /// <summary>
     /// The last time that the entity received an attack popup.
     /// </summary>
-    [ViewVariables]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
     public TimeSpan LastAttackPopupTime;
 
     /// <summary>
-    /// The delay between showing attack popups to the entity.
+    /// The delay between showing popups to the guardian when trying to attack its host.
     /// </summary>
-    [ViewVariables]
-    public TimeSpan PopupDelay = TimeSpan.FromSeconds(1);
+    [DataField]
+    public TimeSpan AttackPopupDelay = TimeSpan.FromSeconds(1);
 }

--- a/Content.Shared/Guardian/Components/GuardianComponent.cs
+++ b/Content.Shared/Guardian/Components/GuardianComponent.cs
@@ -52,13 +52,13 @@ public sealed partial class GuardianComponent : Component
     public SoundSpecifier DeathSound = new SoundPathSpecifier("/Audio/Voice/Human/malescream_guardian.ogg", AudioParams.Default.WithVariation(0.2f));
 
     /// <summary>
-    /// The last time that the entity attacked another.
+    /// The last time that the entity received an attack popup.
     /// </summary>
     [ViewVariables]
     public TimeSpan LastAttackPopupTime;
 
     /// <summary>
-    /// The last time that the user attacked the
+    /// The delay between showing attack popups to the entity.
     /// </summary>
     [ViewVariables]
     public TimeSpan PopupDelay = TimeSpan.FromSeconds(1);

--- a/Content.Shared/Guardian/GuardianSystem.cs
+++ b/Content.Shared/Guardian/GuardianSystem.cs
@@ -42,7 +42,7 @@ public sealed partial class GuardianSystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnGuardianShutdown(Entity<GuardianComponent> ent, ref ComponentShutdown args)
     {
-        if (!TryComp<GuardianHostComponent>(ent, out var hostComponent))
+        if (!_guardianHostQuery.TryComp(ent, out GuardianHostComponent? hostComponent))
             return;
 
         _container.Remove(ent.Owner, hostComponent.GuardianContainer);
@@ -76,7 +76,7 @@ public sealed partial class GuardianSystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnGuardianPlayerDetached(Entity<GuardianComponent> ent, ref PlayerDetachedEvent args)
     {
-        if (!TryComp<GuardianHostComponent>(ent.Comp.Host, out var hostComponent) ||
+        if (!_guardianHostQuery.TryComp(ent.Comp.Host, out GuardianHostComponent? hostComponent) ||
             TerminatingOrDeleted(ent.Owner))
         {
             PredictedQueueDel(ent.Owner);
@@ -92,7 +92,7 @@ public sealed partial class GuardianSystem : EntitySystem
     private void OnGuardianPlayerAttached(Entity<GuardianComponent> ent, ref PlayerAttachedEvent args)
     {
         var host = ent.Comp.Host;
-        if (!HasComp<GuardianHostComponent>(host))
+        if (!_guardianHostQuery.HasComp(host))
         {
             PredictedQueueDel(ent.Owner);
             ent.Comp.Host = null;
@@ -149,7 +149,7 @@ public sealed partial class GuardianSystem : EntitySystem
         if (args.Args.Cancelled || args.Args.Attacker != ent.Comp.HostedGuardian)
             return;
 
-        if (TryComp<GuardianComponent>(args.Args.Attacker, out var guardian))
+        if (_guardianQuery.TryComp(args.Args.Attacker, out var guardian))
         {
             if (_timing.CurTime >= guardian.LastAttackPopupTime + guardian.PopupDelay)
             {
@@ -166,7 +166,7 @@ public sealed partial class GuardianSystem : EntitySystem
     [SubscribeLocalEvent]
     private void ToggleGuardian(Entity<GuardianHostComponent> ent)
     {
-        if (!TryComp<GuardianComponent>(ent.Comp.HostedGuardian, out var guardianComponent))
+        if (!_guardianQuery.TryComp(ent.Comp.HostedGuardian, out var guardianComponent))
             return;
 
         if (guardianComponent.GuardianLoose)
@@ -217,7 +217,7 @@ public sealed partial class GuardianSystem : EntitySystem
         }
 
         // If user is already a host don't duplicate.
-        if (HasComp<GuardianHostComponent>(target))
+        if (_guardianHostQuery.HasComp(target))
         {
             _popup.PopupEntity(Loc.GetString("guardian-already-present-invalid-creation"), user, user);
             return;
@@ -243,7 +243,7 @@ public sealed partial class GuardianSystem : EntitySystem
         if (args.Handled || args.Args.Target == null || args.Cancelled || ent.Comp.Deleted || ent.Comp.Used)
             return;
 
-        if (!_hands.IsHolding(args.Args.User, ent.Owner) || HasComp<GuardianHostComponent>(args.Args.Target))
+        if (!_hands.IsHolding(args.Args.User, ent.Owner) || _guardianHostQuery.HasComp(args.Args.Target))
             return;
 
         var hostXform = Transform(args.Args.Target.Value);
@@ -255,7 +255,7 @@ public sealed partial class GuardianSystem : EntitySystem
         _container.Insert(guardian, host.GuardianContainer);
         host.HostedGuardian = guardian;
 
-        if (TryComp<GuardianComponent>(guardian, out var guardianComp))
+        if (_guardianQuery.TryComp(guardian, out GuardianComponent? guardianComp))
         {
             guardianComp.Host = args.Args.Target.Value;
             Dirty(guardian, guardianComp);
@@ -285,7 +285,7 @@ public sealed partial class GuardianSystem : EntitySystem
     private void OnHostStateChange(Entity<GuardianHostComponent> ent, ref MobStateChangedEvent args)
     {
         if (ent.Comp.HostedGuardian == null ||
-            !TryComp<GuardianComponent>(ent.Comp.HostedGuardian, out var guardianComp))
+            !_guardianQuery.TryComp(ent.Comp.HostedGuardian, out GuardianComponent? guardianComp))
             return;
 
         if (args.NewMobState == MobState.Critical)
@@ -341,7 +341,7 @@ public sealed partial class GuardianSystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnHostMove(Entity<GuardianHostComponent> ent, ref MoveEvent args)
     {
-        if (!TryComp<GuardianComponent>(ent.Comp.HostedGuardian, out var guardianComponent) ||
+        if (!_guardianQuery.TryComp(ent.Comp.HostedGuardian, out GuardianComponent? guardianComponent) ||
             !guardianComponent.GuardianLoose)
         {
             return;

--- a/Content.Shared/Guardian/GuardianSystem.cs
+++ b/Content.Shared/Guardian/GuardianSystem.cs
@@ -36,32 +36,10 @@ public sealed partial class GuardianSystem : EntitySystem
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-        SubscribeLocalEvent<GuardianCreatorComponent, UseInHandEvent>(OnCreatorUse);
-        SubscribeLocalEvent<GuardianCreatorComponent, AfterInteractEvent>(OnCreatorInteract);
-        SubscribeLocalEvent<GuardianCreatorComponent, ExaminedEvent>(OnCreatorExamine);
-        SubscribeLocalEvent<GuardianCreatorComponent, GuardianCreatorDoAfterEvent>(OnDoAfter);
+    [Dependency] private EntityQuery<GuardianComponent> _guardianQuery;
+    [Dependency] private EntityQuery<GuardianHostComponent> _guardianHostQuery;
 
-        SubscribeLocalEvent<GuardianComponent, ComponentShutdown>(OnGuardianShutdown);
-        SubscribeLocalEvent<GuardianComponent, MoveEvent>(OnGuardianMove);
-        SubscribeLocalEvent<GuardianComponent, DamageDealtEvent>(OnGuardianDamaged);
-        SubscribeLocalEvent<GuardianComponent, PlayerAttachedEvent>(OnGuardianPlayerAttached);
-        SubscribeLocalEvent<GuardianComponent, PlayerDetachedEvent>(OnGuardianPlayerDetached);
-
-        SubscribeLocalEvent<GuardianHostComponent, ComponentInit>(OnHostInit);
-        SubscribeLocalEvent<GuardianHostComponent, MoveEvent>(OnHostMove);
-        SubscribeLocalEvent<GuardianHostComponent, MobStateChangedEvent>(OnHostStateChange);
-        SubscribeLocalEvent<GuardianHostComponent, ComponentShutdown>(OnHostShutdown);
-
-        SubscribeLocalEvent<GuardianHostComponent, GuardianToggleActionEvent>(OnPerformAction);
-
-        SubscribeLocalEvent<GuardianComponent, AttackAttemptEvent>(OnGuardianAttackAttempt);
-
-        SubscribeLocalEvent<GuardianHostComponent, MechPilotRelayedEvent<GettingAttackedAttemptEvent>>(OnPilotAttackAttempt);
-    }
-
+    [SubscribeLocalEvent]
     private void OnGuardianShutdown(Entity<GuardianComponent> ent, ref ComponentShutdown args)
     {
         if (!TryComp<GuardianHostComponent>(ent, out var hostComponent))
@@ -77,6 +55,7 @@ public sealed partial class GuardianSystem : EntitySystem
         Dirty(ent, hostComponent);
     }
 
+    [SubscribeLocalEvent]
     private void OnPerformAction(Entity<GuardianHostComponent> ent, ref GuardianToggleActionEvent args)
     {
         if (args.Handled)
@@ -94,6 +73,7 @@ public sealed partial class GuardianSystem : EntitySystem
         args.Handled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnGuardianPlayerDetached(Entity<GuardianComponent> ent, ref PlayerDetachedEvent args)
     {
         if (!TryComp<GuardianHostComponent>(ent.Comp.Host, out var hostComponent) ||
@@ -108,6 +88,7 @@ public sealed partial class GuardianSystem : EntitySystem
         RetractGuardian((ent.Comp.Host.Value, hostComponent), (ent.Owner, ent.Comp));
     }
 
+    [SubscribeLocalEvent]
     private void OnGuardianPlayerAttached(Entity<GuardianComponent> ent, ref PlayerAttachedEvent args)
     {
         var host = ent.Comp.Host;
@@ -122,12 +103,14 @@ public sealed partial class GuardianSystem : EntitySystem
         _popup.PopupEntity(Loc.GetString("guardian-available"), host.Value, host.Value);
     }
 
+    [SubscribeLocalEvent]
     private void OnHostInit(Entity<GuardianHostComponent> ent, ref ComponentInit args)
     {
         ent.Comp.GuardianContainer = _container.EnsureContainer<ContainerSlot>(ent.Owner, "GuardianContainer");
         _action.AddAction(ent.Owner, ref ent.Comp.ActionEntity, ent.Comp.Action);
     }
 
+    [SubscribeLocalEvent]
     private void OnHostShutdown(Entity<GuardianHostComponent> ent, ref ComponentShutdown args)
     {
         if (ent.Comp.HostedGuardian is not { } guardian)
@@ -144,27 +127,43 @@ public sealed partial class GuardianSystem : EntitySystem
         Dirty(ent);
     }
 
+    [SubscribeLocalEvent]
     private void OnGuardianAttackAttempt(Entity<GuardianComponent> ent, ref AttackAttemptEvent args)
     {
         if (args.Cancelled || args.Target != ent.Comp.Host)
             return;
 
-        _popup.PopupCursor(Loc.GetString("guardian-attack-host"), ent.Owner, PopupType.LargeCaution);
+        if (_timing.CurTime >= ent.Comp.LastAttackPopupTime + ent.Comp.PopupDelay)
+        {
+            _popup.PopupCursor(Loc.GetString("guardian-attack-host"), ent.Owner, PopupType.LargeCaution);
+        }
+        ent.Comp.LastAttackPopupTime = _timing.CurTime;
+
         args.Cancel();
     }
 
+    [SubscribeLocalEvent]
     private void OnPilotAttackAttempt(Entity<GuardianHostComponent> ent,
         ref MechPilotRelayedEvent<GettingAttackedAttemptEvent> args)
     {
-        if (args.Args.Cancelled)
+        if (args.Args.Cancelled || args.Args.Attacker != ent.Comp.HostedGuardian)
             return;
 
-        _popup.PopupCursor(Loc.GetString("guardian-attack-host"),
-            args.Args.Attacker,
-            PopupType.LargeCaution);
+        if (TryComp<GuardianComponent>(args.Args.Attacker, out var guardian))
+        {
+            if (_timing.CurTime >= guardian.LastAttackPopupTime + guardian.PopupDelay)
+            {
+                _popup.PopupCursor(Loc.GetString("guardian-attack-host"),
+                    args.Args.Attacker,
+                    PopupType.LargeCaution);
+            }
+            guardian.LastAttackPopupTime = _timing.CurTime;
+        }
+
         args.Args.Cancelled = true;
     }
 
+    [SubscribeLocalEvent]
     private void ToggleGuardian(Entity<GuardianHostComponent> ent)
     {
         if (!TryComp<GuardianComponent>(ent.Comp.HostedGuardian, out var guardianComponent))
@@ -179,6 +178,7 @@ public sealed partial class GuardianSystem : EntitySystem
     /// <summary>
     /// Adds the guardian host component to the user and spawns the guardian inside said component.
     /// </summary>
+    [SubscribeLocalEvent]
     private void OnCreatorUse(Entity<GuardianCreatorComponent> ent, ref UseInHandEvent args)
     {
         if (args.Handled)
@@ -188,6 +188,7 @@ public sealed partial class GuardianSystem : EntitySystem
         UseCreator(args.User, args.User, ent);
     }
 
+    [SubscribeLocalEvent]
     private void OnCreatorInteract(Entity<GuardianCreatorComponent> ent, ref AfterInteractEvent args)
     {
         if (args.Handled || args.Target == null || !args.CanReach)
@@ -236,6 +237,7 @@ public sealed partial class GuardianSystem : EntitySystem
         });
     }
 
+    [SubscribeLocalEvent]
     private void OnDoAfter(Entity<GuardianCreatorComponent> ent, ref GuardianCreatorDoAfterEvent args)
     {
         if (args.Handled || args.Args.Target == null || args.Cancelled || ent.Comp.Deleted || ent.Comp.Used)
@@ -256,6 +258,7 @@ public sealed partial class GuardianSystem : EntitySystem
         if (TryComp<GuardianComponent>(guardian, out var guardianComp))
         {
             guardianComp.Host = args.Args.Target.Value;
+            Dirty(guardian, guardianComp);
             _audio.PlayPredicted(ent.Comp.UsedSound,
                 ent.Owner,
                 args.Args.Target);
@@ -278,6 +281,7 @@ public sealed partial class GuardianSystem : EntitySystem
     /// <summary>
     /// Triggers when the host receives damage which puts the host in either critical or killed state.
     /// </summary>
+    [SubscribeLocalEvent]
     private void OnHostStateChange(Entity<GuardianHostComponent> ent, ref MobStateChangedEvent args)
     {
         if (ent.Comp.HostedGuardian == null ||
@@ -301,6 +305,7 @@ public sealed partial class GuardianSystem : EntitySystem
     /// <summary>
     /// Handles guardian receiving damage and splitting it with the host according to his defense percent.
     /// </summary>
+    [SubscribeLocalEvent]
     private void OnGuardianDamaged(Entity<GuardianComponent> ent, ref DamageDealtEvent args)
     {
         if (_timing.ApplyingState)
@@ -321,6 +326,7 @@ public sealed partial class GuardianSystem : EntitySystem
     /// <summary>
     /// Triggers while trying to examine an activator to see if it's used.
     /// </summary>
+    [SubscribeLocalEvent]
     private void OnCreatorExamine(Entity<GuardianCreatorComponent> ent, ref ExaminedEvent args)
     {
         if (!ent.Comp.Used)
@@ -332,6 +338,7 @@ public sealed partial class GuardianSystem : EntitySystem
     /// <summary>
     /// Called every time the host moves, to make sure the host and the guardian are not too far away from each other.
     /// </summary>
+    [SubscribeLocalEvent]
     private void OnHostMove(Entity<GuardianHostComponent> ent, ref MoveEvent args)
     {
         if (!TryComp<GuardianComponent>(ent.Comp.HostedGuardian, out var guardianComponent) ||
@@ -346,6 +353,7 @@ public sealed partial class GuardianSystem : EntitySystem
     /// <summary>
     /// Called every time the guardian moves: makes sure it's not out of it's allowed distance.
     /// </summary>
+    [SubscribeLocalEvent]
     private void OnGuardianMove(Entity<GuardianComponent> ent, ref MoveEvent args)
     {
         if (!ent.Comp.GuardianLoose)

--- a/Content.Shared/Guardian/GuardianSystem.cs
+++ b/Content.Shared/Guardian/GuardianSystem.cs
@@ -133,7 +133,7 @@ public sealed partial class GuardianSystem : EntitySystem
         if (args.Cancelled || args.Target != ent.Comp.Host)
             return;
 
-        if (_timing.CurTime >= ent.Comp.LastAttackPopupTime + ent.Comp.PopupDelay)
+        if (_timing.CurTime >= ent.Comp.LastAttackPopupTime + ent.Comp.AttackPopupDelay)
         {
             _popup.PopupCursor(Loc.GetString("guardian-attack-host"), ent.Owner, PopupType.LargeCaution);
         }
@@ -151,7 +151,7 @@ public sealed partial class GuardianSystem : EntitySystem
 
         if (_guardianQuery.TryComp(args.Args.Attacker, out var guardian))
         {
-            if (_timing.CurTime >= guardian.LastAttackPopupTime + guardian.PopupDelay)
+            if (_timing.CurTime >= guardian.LastAttackPopupTime + guardian.AttackPopupDelay)
             {
                 _popup.PopupCursor(Loc.GetString("guardian-attack-host"),
                     args.Args.Attacker,


### PR DESCRIPTION
## About the PR

A handful of fixes related to the guardian attack popup spam.

1. Entering combat mode alone as an unsummoned guardian does not result in a popup.
2. Popup attempts now update a timer, and 1s needs to pass by before another pops up.

## Why / Balance

Resolves #45010 and another hellbug I found while snooping as usual.

Bugfixes are good!

## Technical details

Firstly: the guardian's host is now dirtied when it is first updated.  This fixes the bug in the issue.
Secondly: timers have been added to the guardian - all VV, not synced, not serialized, _it'll be fine_
Thirdly: the attacking entity is checked when trying to attack a guardian host if it's in a mech (holy shit)

Small modernization pass with entity queries (at least for the frequently used components) and subscription-based events.

## Test plan
1. Open two clients.
2. On the first, become Urist and inject yourself with a holoparasite injector.
3. On the second, take the holoparasite ghost role.
4. Enter combat mode, you shouldn't have a popup.
5. Attack outside of the user.  You shouldn't have a popup unless wide swinging (all of this is a bit silly).
6. On the first client, let your holoparasite free.
7. On the second client, attack the user as the holoparasite, you should get _one_ popup until you target something else for a second.
8. On the first client, spawn and enter a ripley as the host.
9. On the second client, attack the user in the ripley, you should get popups and they should behave as in step 7.
10. On the second client, spawn and take over another Urist.  Attack the mech.  You should be able to, without getting a popup.

## Media

Behaviour after PR (no popup spam!):

https://github.com/user-attachments/assets/33de0ef8-9f40-4cf1-9e54-cdb1eb7cd150

Two existing bugs on master (not being able to target a guardian host in a mech as a third party, popup spam):

https://github.com/user-attachments/assets/7696b6b6-5534-4880-a9ad-a93e0d22fad8

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
:cl:
- fix: Holoparasites should no longer be spammed with popups warning them about attacking their host.