### PR TITLE
Make more ApcPowerReceiverComponent fields DataFields

### DIFF
--- a/Content.Client/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Client/Power/Components/ApcPowerReceiverComponent.cs
@@ -5,5 +5,4 @@ namespace Content.Client.Power.Components;
 [RegisterComponent]
 public sealed partial class ApcPowerReceiverComponent : SharedApcPowerReceiverComponent
 {
-    public override float Load { get; set; }
 }

--- a/Content.Client/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Client/Power/Components/ApcPowerReceiverComponent.cs
@@ -2,7 +2,6 @@
 
 namespace Content.Client.Power.Components;
 
+/// <inheritdoc />
 [RegisterComponent]
-public sealed partial class ApcPowerReceiverComponent : SharedApcPowerReceiverComponent
-{
-}
+public sealed partial class ApcPowerReceiverComponent : SharedApcPowerReceiverComponent;

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -1,60 +1,34 @@
-using Content.Server.Power.NodeGroups;
 using Content.Server.Power.Pow3r;
 using Content.Shared.Power.Components;
 
-namespace Content.Server.Power.Components
+namespace Content.Server.Power.Components;
+
+/// <inheritdoc />
+[RegisterComponent]
+public sealed partial class ApcPowerReceiverComponent : SharedApcPowerReceiverComponent
 {
-    /// <summary>
-    ///     Attempts to link with a nearby <see cref="ApcPowerProviderComponent"/>s
-    ///     so that it can receive power from a <see cref="IApcNet"/>.
-    /// </summary>
-    [RegisterComponent]
-    public sealed partial class ApcPowerReceiverComponent : SharedApcPowerReceiverComponent
+    /// <inheritdoc />
+    public override float Load
     {
-        /// <summary>
-        ///     Amount of charge this needs from an APC per second to function.
-        /// </summary>
-        [DataField("powerLoad")]
-        public override float Load
-        {
-            get => NetworkLoad.DesiredPower;
-            set => NetworkLoad.DesiredPower = value;
-        }
-
-        public ApcPowerProviderComponent? Provider = null;
-
-        /// <summary>
-        ///     When false, causes this to appear powered even if not receiving power from an Apc.
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        public override bool NeedsPower
-        {
-            get => _needsPower;
-            set
-            {
-                _needsPower = value;
-            }
-        }
-
-        [DataField("needsPower")]
-        private bool _needsPower = true;
-
-        /// <summary>
-        ///     When true, causes this to never appear powered.
-        /// </summary>
-        [DataField("powerDisabled")]
-        public override bool PowerDisabled
-        {
-            get => !NetworkLoad.Enabled;
-            set => NetworkLoad.Enabled = !value;
-        }
-
-        [ViewVariables]
-        public PowerState.Load NetworkLoad { get; } = new PowerState.Load
-        {
-            DesiredPower = 5
-        };
-
-        public float PowerReceived => NetworkLoad.ReceivingPower;
+        get => NetworkLoad.DesiredPower;
+        set => NetworkLoad.DesiredPower = value;
     }
+
+    public ApcPowerProviderComponent? Provider = null;
+
+    /// <inheritdoc />
+    public override bool PowerDisabled
+    {
+        get => !NetworkLoad.Enabled;
+        set => NetworkLoad.Enabled = !value;
+    }
+
+    [ViewVariables]
+    public PowerState.Load NetworkLoad { get; } = new PowerState.Load
+    {
+        DesiredPower = 5
+    };
+
+    public float PowerReceived => NetworkLoad.ReceivingPower;
 }
+

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -14,6 +14,9 @@ public sealed partial class ApcPowerReceiverComponent : SharedApcPowerReceiverCo
         set => NetworkLoad.DesiredPower = value;
     }
 
+    /// <summary>
+    ///     The component currently providing this entity with power.
+    /// </summary>
     public ApcPowerProviderComponent? Provider = null;
 
     /// <inheritdoc />
@@ -23,11 +26,17 @@ public sealed partial class ApcPowerReceiverComponent : SharedApcPowerReceiverCo
         set => NetworkLoad.Enabled = !value;
     }
 
+    /// <summary>
+    ///     The load of the network as an object used by Pow3r.
+    /// </summary>
     [ViewVariables]
     public PowerState.Load NetworkLoad { get; } = new PowerState.Load
     {
         DesiredPower = 5
     };
 
+    /// <summary>
+    ///     The power currently being received, in watts.
+    /// </summary>
     public float PowerReceived => NetworkLoad.ReceivingPower;
 }

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class ApcPowerReceiverComponent : SharedApcPowerReceiverCo
     }
 
     /// <summary>
-    ///     The component currently providing this entity with power.
+    /// The component currently providing this entity with power.
     /// </summary>
     public ApcPowerProviderComponent? Provider = null;
 
@@ -27,7 +27,7 @@ public sealed partial class ApcPowerReceiverComponent : SharedApcPowerReceiverCo
     }
 
     /// <summary>
-    ///     The load of the network as an object used by Pow3r.
+    /// The load of the network as an object used by Pow3r.
     /// </summary>
     [ViewVariables]
     public PowerState.Load NetworkLoad { get; } = new PowerState.Load
@@ -36,7 +36,7 @@ public sealed partial class ApcPowerReceiverComponent : SharedApcPowerReceiverCo
     };
 
     /// <summary>
-    ///     The power currently being received, in watts.
+    /// The power currently being received, in watts.
     /// </summary>
     public float PowerReceived => NetworkLoad.ReceivingPower;
 }

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -31,4 +31,3 @@ public sealed partial class ApcPowerReceiverComponent : SharedApcPowerReceiverCo
 
     public float PowerReceived => NetworkLoad.ReceivingPower;
 }
-

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -45,16 +45,6 @@ namespace Content.Server.Power.EntitySystems
             });
         }
 
-        /// <summary>
-        /// ComponentStartup handler: force a dirty if our state doesn't match the client's default initial state.
-        /// </summary>
-        [SubscribeLocalEvent]
-        private void OnReceiverStartup(EntityUid uid, ApcPowerReceiverComponent component, ComponentStartup args)
-        {
-            if (component.NeedsPower || component.PowerDisabled)
-                Dirty(uid, component);
-        }
-
         [SubscribeLocalEvent]
         private void OnProviderShutdown(EntityUid uid, ApcPowerProviderComponent component, ComponentShutdown args)
         {

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -20,29 +20,13 @@ namespace Content.Server.Power.EntitySystems
         [Dependency] private EntityQuery<ApcPowerProviderComponent> _provQuery = default!;
         [Dependency] private EntityQuery<HandsComponent> _handsQuery = default!;
 
-        public override void Initialize()
-        {
-            base.Initialize();
-            SubscribeLocalEvent<ApcPowerReceiverComponent, ExaminedEvent>(OnExamined);
-
-            SubscribeLocalEvent<ApcPowerReceiverComponent, ExtensionCableSystem.ProviderConnectedEvent>(OnProviderConnected);
-            SubscribeLocalEvent<ApcPowerReceiverComponent, ExtensionCableSystem.ProviderDisconnectedEvent>(OnProviderDisconnected);
-
-            SubscribeLocalEvent<ApcPowerProviderComponent, ComponentShutdown>(OnProviderShutdown);
-            SubscribeLocalEvent<ApcPowerProviderComponent, ExtensionCableSystem.ReceiverConnectedEvent>(OnReceiverConnected);
-            SubscribeLocalEvent<ApcPowerProviderComponent, ExtensionCableSystem.ReceiverDisconnectedEvent>(OnReceiverDisconnected);
-
-            SubscribeLocalEvent<ApcPowerReceiverComponent, GetVerbsEvent<Verb>>(OnGetVerbs);
-            SubscribeLocalEvent<PowerSwitchComponent, GetVerbsEvent<AlternativeVerb>>(AddSwitchPowerVerb);
-
-            SubscribeLocalEvent<ApcPowerReceiverComponent, ComponentGetState>(OnGetState);
-        }
-
+        [SubscribeLocalEvent]
         private void OnExamined(Entity<ApcPowerReceiverComponent> ent, ref ExaminedEvent args)
         {
             args.PushMarkup(GetExamineText(ent.Comp.Powered));
         }
 
+        [SubscribeLocalEvent]
         private void OnGetVerbs(EntityUid uid, ApcPowerReceiverComponent component, GetVerbsEvent<Verb> args)
         {
             if (!_adminManager.HasAdminFlag(args.User, AdminFlags.Admin))
@@ -53,7 +37,7 @@ namespace Content.Server.Power.EntitySystems
             {
                 Text = Loc.GetString("verb-debug-toggle-need-power"),
                 Category = VerbCategory.Debug,
-                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/smite.svg.192dpi.png")), // "smite" is a lightning bolt
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/smite.svg.192dpi.png")), // "smite" is a lightning bolt
                 Act = () =>
                 {
                     SetNeedsPower(uid, !component.NeedsPower, component);
@@ -61,6 +45,17 @@ namespace Content.Server.Power.EntitySystems
             });
         }
 
+        /// <summary>
+        /// ComponentStartup handler: force a dirty if our state doesn't match the client's default initial state.
+        /// </summary>
+        [SubscribeLocalEvent]
+        private void OnReceiverStartup(EntityUid uid, ApcPowerReceiverComponent component, ComponentStartup args)
+        {
+            if (component.NeedsPower || component.PowerDisabled)
+                Dirty(uid, component);
+        }
+
+        [SubscribeLocalEvent]
         private void OnProviderShutdown(EntityUid uid, ApcPowerProviderComponent component, ComponentShutdown args)
         {
             foreach (var receiver in component.LinkedReceivers)
@@ -72,6 +67,7 @@ namespace Content.Server.Power.EntitySystems
             component.LinkedReceivers.Clear();
         }
 
+        [SubscribeLocalEvent]
         private void OnProviderConnected(Entity<ApcPowerReceiverComponent> receiver, ref ExtensionCableSystem.ProviderConnectedEvent args)
         {
             var providerUid = args.Provider.Owner;
@@ -83,6 +79,7 @@ namespace Content.Server.Power.EntitySystems
             ProviderChanged(receiver);
         }
 
+        [SubscribeLocalEvent]
         private void OnProviderDisconnected(Entity<ApcPowerReceiverComponent> receiver, ref ExtensionCableSystem.ProviderDisconnectedEvent args)
         {
             receiver.Comp.Provider = null;
@@ -90,6 +87,7 @@ namespace Content.Server.Power.EntitySystems
             ProviderChanged(receiver);
         }
 
+        [SubscribeLocalEvent]
         private void OnReceiverConnected(Entity<ApcPowerProviderComponent> provider, ref ExtensionCableSystem.ReceiverConnectedEvent args)
         {
             if (_recQuery.TryGetComponent(args.Receiver, out var receiver))
@@ -98,6 +96,7 @@ namespace Content.Server.Power.EntitySystems
             }
         }
 
+        [SubscribeLocalEvent]
         private void OnReceiverDisconnected(EntityUid uid, ApcPowerProviderComponent provider, ExtensionCableSystem.ReceiverDisconnectedEvent args)
         {
             if (_recQuery.TryGetComponent(args.Receiver, out var receiver))
@@ -106,40 +105,43 @@ namespace Content.Server.Power.EntitySystems
             }
         }
 
-        private void AddSwitchPowerVerb(EntityUid uid, PowerSwitchComponent component, GetVerbsEvent<AlternativeVerb> args)
+        [SubscribeLocalEvent]
+        private void AddSwitchPowerVerb(Entity<PowerSwitchComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
         {
-            if(!args.CanAccess || !args.CanInteract)
+            if (!args.CanAccess || !args.CanInteract)
                 return;
 
             if (!_handsQuery.HasComp(args.User))
                 return;
 
-            if (!_recQuery.TryGetComponent(uid, out var receiver))
+            if (!_recQuery.TryGetComponent(ent, out var receiver))
                 return;
 
             if (!receiver.NeedsPower)
                 return;
 
+            var user = args.User;
             AlternativeVerb verb = new()
             {
                 Act = () =>
                 {
-                    TogglePower(uid, user: args.User);
+                    TogglePower(ent, user: user);
                 },
-                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/Spare/poweronoff.svg.192dpi.png")),
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/Spare/poweronoff.svg.192dpi.png")),
                 Text = Loc.GetString("power-switch-component-toggle-verb"),
                 Priority = -3
             };
             args.Verbs.Add(verb);
         }
 
-        private void OnGetState(EntityUid uid, ApcPowerReceiverComponent component, ref ComponentGetState args)
+        [SubscribeLocalEvent]
+        private void OnGetState(Entity<ApcPowerReceiverComponent> ent, ref ComponentGetState args)
         {
             args.State = new ApcPowerReceiverComponentState
             {
-                Powered = component.Powered,
-                NeedsPower = component.NeedsPower,
-                PowerDisabled = component.PowerDisabled,
+                Powered = ent.Comp.Powered,
+                NeedsPower = ent.Comp.NeedsPower,
+                PowerDisabled = ent.Comp.PowerDisabled,
             };
         }
 

--- a/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
+++ b/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
@@ -9,6 +9,9 @@ namespace Content.Shared.Power.Components;
 [NetworkedComponent]
 public abstract partial class SharedApcPowerReceiverComponent : Component
 {
+    /// <summary>
+    ///     If true, this entity either doesn't need power, or is currently receiving the power it needs.
+    /// </summary>
     [ViewVariables]
     public bool Powered;
 

--- a/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
+++ b/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
@@ -3,32 +3,32 @@
 namespace Content.Shared.Power.Components;
 
 /// <summary>
-///     Attempts to link with a nearby <see cref="ApcPowerProviderComponent"/>s
-///     so that it can receive power from a <see cref="IApcNet"/>.
+/// Attempts to link with a nearby <see cref="ApcPowerProviderComponent"/>s
+/// so that it can receive power from a <see cref="IApcNet"/>.
 /// </summary>
 [NetworkedComponent]
 public abstract partial class SharedApcPowerReceiverComponent : Component
 {
     /// <summary>
-    ///     If true, this entity either doesn't need power, or is currently receiving the power it needs.
+    /// If true, this entity either doesn't need power, or is currently receiving the power it needs.
     /// </summary>
     [ViewVariables]
     public bool Powered;
 
     /// <summary>
-    ///     When false, causes this to appear powered even if not receiving power from an Apc.
+    /// When false, causes this to appear powered even if not receiving power from an Apc.
     /// </summary>
     [DataField]
     public bool NeedsPower = true;
 
     /// <summary>
-    ///     When true, causes this to never appear powered.
+    /// When true, causes this to never appear powered.
     /// </summary>
     [DataField]
     public virtual bool PowerDisabled { get; set; }
 
     /// <summary>
-    ///     Amount of power this needs from an APC in watts to function.
+    /// Amount of power this needs from an APC in watts to function.
     /// </summary>
     [DataField("powerLoad")]
     public virtual float Load { get; set; }

--- a/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
+++ b/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
@@ -28,7 +28,7 @@ public abstract partial class SharedApcPowerReceiverComponent : Component
     public virtual bool PowerDisabled { get; set; }
 
     /// <summary>
-    ///     Amount of charge this needs from an APC per second to function.
+    ///     Amount of power this needs from an APC in watts to function.
     /// </summary>
     [DataField("powerLoad")]
     public virtual float Load { get; set; }

--- a/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
+++ b/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
@@ -28,7 +28,7 @@ public abstract partial class SharedApcPowerReceiverComponent : Component
     public virtual bool PowerDisabled { get; set; }
 
     /// <summary>
-    /// Amount of power this needs from an APC in watts to function.
+    /// Amount of power this needs from an APC to function, in watts.
     /// </summary>
     [DataField("powerLoad")]
     public virtual float Load { get; set; }

--- a/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
+++ b/Content.Shared/Power/Components/SharedApcPowerReceiverComponent.cs
@@ -2,6 +2,10 @@
 
 namespace Content.Shared.Power.Components;
 
+/// <summary>
+///     Attempts to link with a nearby <see cref="ApcPowerProviderComponent"/>s
+///     so that it can receive power from a <see cref="IApcNet"/>.
+/// </summary>
 [NetworkedComponent]
 public abstract partial class SharedApcPowerReceiverComponent : Component
 {
@@ -11,15 +15,18 @@ public abstract partial class SharedApcPowerReceiverComponent : Component
     /// <summary>
     ///     When false, causes this to appear powered even if not receiving power from an Apc.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    public virtual bool NeedsPower { get; set;}
+    [DataField]
+    public bool NeedsPower = true;
 
     /// <summary>
     ///     When true, causes this to never appear powered.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public virtual bool PowerDisabled { get; set; }
 
-    // Doesn't actually do anything on the client just here for shared code.
-    public abstract float Load { get; set; }
+    /// <summary>
+    ///     Amount of charge this needs from an APC per second to function.
+    /// </summary>
+    [DataField("powerLoad")]
+    public virtual float Load { get; set; }
 }


### PR DESCRIPTION
## About the PR

What it says on the tin, plus a small subscription attribute change to PowerReceiverSystem, plus resolving two whitespace IDE warnings.

## Why / Balance

Resolves #45005.

## Technical details

If the ApcPowerReceiver starts with PowerDisabled true (like in the atmos freezer), it doesn't receive a dirty state.  This fixes that - we check if the state doesn't match the default (by the way, NeedsPower should _possibly_ default to true, as it does on the server!)

## Test plan
1. Load the dev map.
2. Everything should be powered.  Nice.
3. Spawn a machine frame, an atmos freezer board, 4 machine components, and a coil of LV wires.
4. Assemble the freezer.
5. Check the UI.  Off by default.  Nice.

## Media

Nice.
<img width="649" height="327" alt="image" src="https://github.com/user-attachments/assets/4de5af93-f33f-432a-8089-ebbd869637d2" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
Nice.