### PR TITLE
Mech Control Panel now closes on Pilot Eject.

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -227,6 +227,7 @@ public sealed partial class MechSystem : SharedMechSystem
         if (!TryEject(uid, component))
             return;
 
+        _ui.CloseUi(uid, MechUiKey.Key);
         args.Handled = true;
     }
 

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -213,6 +213,7 @@ public sealed partial class MechSystem : SharedMechSystem
             _popup.PopupEntity(Loc.GetString("mech-no-enter", ("item", uid)), Identity.Entity(args.User, EntityManager));
             return;
         }
+
         TryInsert(uid, args.User, component);
         args.Handled = true;
     }
@@ -222,8 +223,10 @@ public sealed partial class MechSystem : SharedMechSystem
     {
         if (args.Cancelled || args.Handled)
             return;
+
         if (!TryEject(uid, component))
             return;
+
         args.Handled = true;
     }
 

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -185,6 +185,7 @@ public sealed partial class MechSystem : SharedMechSystem
                     if (args.User == uid || args.User == operatorUid)
                     {
                         TryEject(uid, component);
+                        _ui.CloseUi(uid, MechUiKey.Key);
                         return;
                     }
 
@@ -212,7 +213,6 @@ public sealed partial class MechSystem : SharedMechSystem
             _popup.PopupEntity(Loc.GetString("mech-no-enter", ("item", uid)), Identity.Entity(args.User, EntityManager));
             return;
         }
-
         TryInsert(uid, args.User, component);
         args.Handled = true;
     }
@@ -222,10 +222,8 @@ public sealed partial class MechSystem : SharedMechSystem
     {
         if (args.Cancelled || args.Handled)
             return;
-
         if (!TryEject(uid, component))
             return;
-
         args.Handled = true;
     }
 

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -184,8 +184,8 @@ public sealed partial class MechSystem : SharedMechSystem
                 {
                     if (args.User == uid || args.User == operatorUid)
                     {
-                        TryEject(uid, component);
-                        _ui.CloseUi(uid, MechUiKey.Key);
+                        if(TryEject(uid, component))
+                            _ui.CloseUi(uid, MechUiKey.Key);
                         return;
                     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Small fix to mech control panel behavior persisting after exiting the mech.

## Why / Balance
Asked around and @kontakt pointed out the issue as something small they wanted someone to look at. 

## Technical details
Added _ui.CloseUI() function call to MechSystem.cs OnAlternativeVerb() function, line 188.

## Test plan
Enter Ripley -> Open Mech Control Panel -> Exit the mech without closing the control panel.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

(Update 7/31/2026) Would be useful if I included the actual issue, original bug report video from Discord: https://www.youtube.com/watch?v=Sb3jj0_ualQ

Small fix but I had the video anyways

https://github.com/user-attachments/assets/6b730dfb-600d-4b0b-92a9-11bbdce4e5d3

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
N/A

## Changelog
N/A
