### PR TITLE
Sudden nuke arm event

### DIFF
--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -304,7 +304,7 @@ public sealed partial class NukeSystem : EntitySystem
 
         DisarmBomb(uid, component);
 
-        var ev = new NukeDisarmSuccessEvent();
+        var ev = new NukeDisarmSuccessEvent(uid);
         RaiseLocalEvent(ev);
 
         args.Handled = true;
@@ -627,6 +627,7 @@ public sealed partial class NukeSystem : EntitySystem
         RaiseLocalEvent(new NukeExplodedEvent()
         {
             OwningStation = transform.GridUid,
+            ExplodedNuke = uid,
         });
 
         _sound.StopStationEventMusic(uid, StationEventMusicType.Nuke);
@@ -699,14 +700,15 @@ public sealed partial class NukeSystem : EntitySystem
 public sealed class NukeExplodedEvent : EntityEventArgs
 {
     public EntityUid? OwningStation;
+    public EntityUid ExplodedNuke;
 }
 
 /// <summary>
 ///     Raised directed on the nuke when its disarm doafter is successful.
 ///     So the game knows not to end.
 /// </summary>
-public sealed class NukeDisarmSuccessEvent : EntityEventArgs
+public sealed class NukeDisarmSuccessEvent(EntityUid disarmedNuke) : EntityEventArgs
 {
-
+    public EntityUid DisarmedNuke = disarmedNuke;
 }
 

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -403,6 +403,10 @@ public sealed partial class NukeSystem : EntitySystem
                 {
                     _itemSlots.SetLock(uid, component.DiskSlot, true);
                 }
+                else // handling case of wizard recalling disk out of armed Nuke
+                {
+                    DisarmBomb(uid, component);
+                }
 
                 break;
         }

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Explosion.EntitySystems;
 using Content.Server.Pinpointer;
 using Content.Server.Popups;
 using Content.Server.Station.Systems;
+using Content.Server.StationEvents.Components;
 using Content.Shared.Audio;
 using Content.Shared.AlertLevel;
 using Content.Shared.Containers.ItemSlots;
@@ -145,6 +146,17 @@ public sealed partial class NukeSystem : EntitySystem
     private void OnRemove(EntityUid uid, NukeComponent component, ComponentRemove args)
     {
         _itemSlots.RemoveItemSlot(uid, component.DiskSlot);
+
+        var query = EntityQueryEnumerator<SuddenNukeArmRuleComponent>();
+
+        while (query.MoveNext(out _, out var suddenNukeArmRuleComponent))
+        {
+            if (suddenNukeArmRuleComponent.PickedNuke == uid)
+            {
+                suddenNukeArmRuleComponent.PickedNuke = null;
+                break;
+            }
+        }
     }
 
     private void OnItemSlotChanged(EntityUid uid, NukeComponent component, ContainerModifiedMessage args)

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -398,14 +398,6 @@ public sealed partial class NukeSystem : EntitySystem
             case NukeStatus.AWAIT_ARM:
                 // do nothing, wait for arm button to be pressed
                 break;
-            case NukeStatus.ARMED:
-                // handling case of wizard recalling disk out of armed Nuke
-                if (!component.DiskSlot.HasItem)
-                {
-                    DisarmBomb(uid, component);
-                }
-
-                break;
         }
     }
 
@@ -526,7 +518,6 @@ public sealed partial class NukeSystem : EntitySystem
         // enable the navmap beacon for people to find it
         _navMap.SetBeaconEnabled(uid, true);
 
-        _itemSlots.SetLock(uid, component.DiskSlot, true);
         if (!nukeXform.Anchored)
         {
             // Admin command shenanigans, just make sure.
@@ -575,7 +566,6 @@ public sealed partial class NukeSystem : EntitySystem
         _navMap.SetBeaconEnabled(uid, false);
 
         // start bomb cooldown
-        _itemSlots.SetLock(uid, component.DiskSlot, false);
         component.Status = NukeStatus.COOLDOWN;
         component.CooldownTime = component.Cooldown;
 

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -398,6 +398,13 @@ public sealed partial class NukeSystem : EntitySystem
             case NukeStatus.AWAIT_ARM:
                 // do nothing, wait for arm button to be pressed
                 break;
+            case NukeStatus.ARMED:
+                if (component.DiskSlot.HasItem)
+                {
+                    _itemSlots.SetLock(uid, component.DiskSlot, true);
+                }
+
+                break;
         }
     }
 
@@ -518,6 +525,11 @@ public sealed partial class NukeSystem : EntitySystem
         // enable the navmap beacon for people to find it
         _navMap.SetBeaconEnabled(uid, true);
 
+        if (component.DiskSlot.HasItem)
+        {
+            _itemSlots.SetLock(uid, component.DiskSlot, true);
+        }
+
         if (!nukeXform.Anchored)
         {
             // Admin command shenanigans, just make sure.
@@ -566,6 +578,7 @@ public sealed partial class NukeSystem : EntitySystem
         _navMap.SetBeaconEnabled(uid, false);
 
         // start bomb cooldown
+        _itemSlots.SetLock(uid, component.DiskSlot, false);
         component.Status = NukeStatus.COOLDOWN;
         component.CooldownTime = component.Cooldown;
 

--- a/Content.Server/StationEvents/Components/SuddenNukeArmRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/SuddenNukeArmRuleComponent.cs
@@ -4,8 +4,14 @@
 public sealed partial class SuddenNukeArmRuleComponent : Component
 {
     /// <summary>
-    /// The nuke that will be picked for arming.
+    /// The nuke picked for arming.
     /// </summary>
     [DataField]
     public EntityUid? PickedNuke;
+
+    /// <summary>
+    /// The nuke that exploded.
+    /// </summary>
+    [DataField]
+    public EntityUid? ExplodedNuke;
 }

--- a/Content.Server/StationEvents/Components/SuddenNukeArmRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/SuddenNukeArmRuleComponent.cs
@@ -1,0 +1,11 @@
+﻿namespace Content.Server.StationEvents.Components;
+
+[RegisterComponent]
+public sealed partial class SuddenNukeArmRuleComponent : Component
+{
+    /// <summary>
+    /// The nuke that will be picked for arming.
+    /// </summary>
+    [DataField]
+    public EntityUid? PickedNuke;
+}

--- a/Content.Server/StationEvents/Events/SuddenNukeArmRule.cs
+++ b/Content.Server/StationEvents/Events/SuddenNukeArmRule.cs
@@ -3,6 +3,7 @@ using Content.Server.Nuke;
 using Content.Server.RoundEnd;
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
+using Content.Shared.Nuke;
 using Content.Shared.Station.Components;
 
 namespace Content.Server.StationEvents.Events;
@@ -22,7 +23,7 @@ public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArm
 
     private bool IsNukePicked(out HashSet<EntityUid> pickedNukes)
     {
-        pickedNukes = new HashSet<EntityUid>();
+        pickedNukes = [];
 
         var query = EntityQueryEnumerator<SuddenNukeArmRuleComponent>();
         while (query.MoveNext(out _, out var suddenNukeArmRuleComponent))
@@ -63,6 +64,11 @@ public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArm
 
             if (IsNukePicked(out var existingPickedNukes)
                 && existingPickedNukes.Contains(nukeUid))
+            {
+                continue;
+            }
+
+            if (nukeComponent.Status == NukeStatus.ARMED)
             {
                 continue;
             }

--- a/Content.Server/StationEvents/Events/SuddenNukeArmRule.cs
+++ b/Content.Server/StationEvents/Events/SuddenNukeArmRule.cs
@@ -20,7 +20,7 @@ public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArm
         SubscribeLocalEvent<NukeDisarmSuccessEvent>(OnNukeDisarm);
     }
 
-    public bool IsNukePicked(out HashSet<EntityUid> pickedNukes)
+    private bool IsNukePicked(out HashSet<EntityUid> pickedNukes)
     {
         pickedNukes = new HashSet<EntityUid>();
 

--- a/Content.Server/StationEvents/Events/SuddenNukeArmRule.cs
+++ b/Content.Server/StationEvents/Events/SuddenNukeArmRule.cs
@@ -20,6 +20,22 @@ public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArm
         SubscribeLocalEvent<NukeDisarmSuccessEvent>(OnNukeDisarm);
     }
 
+    public bool IsNukePicked(out HashSet<EntityUid> pickedNukes)
+    {
+        pickedNukes = new HashSet<EntityUid>();
+
+        var query = EntityQueryEnumerator<SuddenNukeArmRuleComponent>();
+        while (query.MoveNext(out _, out var suddenNukeArmRuleComponent))
+        {
+            if (suddenNukeArmRuleComponent.PickedNuke is not null)
+            {
+                pickedNukes.Add(suddenNukeArmRuleComponent.PickedNuke.Value);
+            }
+        }
+
+        return pickedNukes.Count > 0;
+    }
+
     protected override void Started(EntityUid uid,
         SuddenNukeArmRuleComponent component,
         GameRuleComponent gameRule,
@@ -45,6 +61,12 @@ public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArm
                 continue;
             }
 
+            if (IsNukePicked(out var existingPickedNukes)
+                && existingPickedNukes.Contains(nukeUid))
+            {
+                continue;
+            }
+
             // If nuke was already armed by other causes and then disarmed,
             // start counter from beginning again to give leeway.
             _nukeSystem.SetRemainingTime(nukeUid, nukeComponent.Timer);
@@ -56,19 +78,22 @@ public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArm
         }
     }
 
+
     private void OnNukeExploded(NukeExplodedEvent ev)
     {
-        var query = EntityQueryEnumerator<SuddenNukeArmRuleComponent>();
-
-        while (query.MoveNext(out _, out var suddenNukeArmRuleComponent))
+        if (IsNukePicked(out var pickedNukes) && pickedNukes.Contains(ev.ExplodedNuke))
         {
-            if (suddenNukeArmRuleComponent.PickedNuke is null)
+            var query = EntityQueryEnumerator<SuddenNukeArmRuleComponent>();
+
+            while (query.MoveNext(out _, out var component))
             {
-                continue;
+                if (component.PickedNuke == ev.ExplodedNuke)
+                {
+                    component.ExplodedNuke = ev.ExplodedNuke;
+                }
             }
 
             _roundEndSystem.EndRound();
-            break;
         }
     }
 
@@ -78,7 +103,11 @@ public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArm
 
         while (query.MoveNext(out _, out var suddenNukeArmRuleComponent))
         {
-            suddenNukeArmRuleComponent.PickedNuke = null;
+            if (ev.DisarmedNuke == suddenNukeArmRuleComponent.PickedNuke)
+            {
+                suddenNukeArmRuleComponent.PickedNuke = null;
+                break;
+            }
         }
     }
 
@@ -89,7 +118,7 @@ public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArm
     {
         base.AppendRoundEndText(uid, component, gameRule, ref args);
 
-        if (component.PickedNuke is null)
+        if (component.ExplodedNuke is null || component.PickedNuke != component.ExplodedNuke)
         {
             return;
         }

--- a/Content.Server/StationEvents/Events/SuddenNukeArmRule.cs
+++ b/Content.Server/StationEvents/Events/SuddenNukeArmRule.cs
@@ -1,0 +1,100 @@
+﻿using Content.Server.GameTicking;
+using Content.Server.Nuke;
+using Content.Server.RoundEnd;
+using Content.Server.StationEvents.Components;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Station.Components;
+
+namespace Content.Server.StationEvents.Events;
+
+public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArmRuleComponent>
+{
+    [Dependency] private NukeSystem _nukeSystem = default!;
+    [Dependency] private RoundEndSystem _roundEndSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<NukeExplodedEvent>(OnNukeExploded);
+        SubscribeLocalEvent<NukeDisarmSuccessEvent>(OnNukeDisarm);
+    }
+
+    protected override void Started(EntityUid uid,
+        SuddenNukeArmRuleComponent component,
+        GameRuleComponent gameRule,
+        GameRuleStartedEvent args)
+    {
+        if (!TryGetRandomStation(out var chosenStation))
+            return;
+
+        if (!TryComp<StationDataComponent>(chosenStation, out var stationData))
+            return;
+
+        var grid = StationSystem.GetLargestGrid((chosenStation.Value, stationData));
+
+        if (grid is null)
+            return;
+
+        var query = EntityQueryEnumerator<NukeComponent>();
+
+        while (query.MoveNext(out var nukeUid, out var nukeComponent))
+        {
+            if (Transform(nukeUid).ParentUid != grid)
+            {
+                continue;
+            }
+
+            // If nuke was already armed by other causes and then disarmed,
+            // start counter from beginning again to give leeway.
+            _nukeSystem.SetRemainingTime(nukeUid, nukeComponent.Timer);
+
+            _nukeSystem.ArmBomb(nukeUid, nukeComponent);
+
+            component.PickedNuke = nukeUid;
+            break;
+        }
+    }
+
+    private void OnNukeExploded(NukeExplodedEvent ev)
+    {
+        var query = EntityQueryEnumerator<SuddenNukeArmRuleComponent>();
+
+        while (query.MoveNext(out _, out var suddenNukeArmRuleComponent))
+        {
+            if (suddenNukeArmRuleComponent.PickedNuke is null)
+            {
+                continue;
+            }
+
+            _roundEndSystem.EndRound();
+            break;
+        }
+    }
+
+    private void OnNukeDisarm(NukeDisarmSuccessEvent ev)
+    {
+        var query = EntityQueryEnumerator<SuddenNukeArmRuleComponent>();
+
+        while (query.MoveNext(out _, out var suddenNukeArmRuleComponent))
+        {
+            suddenNukeArmRuleComponent.PickedNuke = null;
+        }
+    }
+
+    protected override void AppendRoundEndText(EntityUid uid,
+        SuddenNukeArmRuleComponent component,
+        GameRuleComponent gameRule,
+        ref RoundEndTextAppendEvent args)
+    {
+        base.AppendRoundEndText(uid, component, gameRule, ref args);
+
+        if (component.PickedNuke is null)
+        {
+            return;
+        }
+
+        args.AddLine(Loc.GetString("sudden-nuke-arm-event-end-round-nuke-exploded"));
+        args.AddLine("");
+    }
+}

--- a/Content.Server/StationEvents/Events/SuddenNukeArmRule.cs
+++ b/Content.Server/StationEvents/Events/SuddenNukeArmRule.cs
@@ -37,21 +37,28 @@ public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArm
         return pickedNukes.Count > 0;
     }
 
-    protected override void Started(EntityUid uid,
+    protected override void Started(
+        EntityUid uid,
         SuddenNukeArmRuleComponent component,
         GameRuleComponent gameRule,
-        GameRuleStartedEvent args)
+        GameRuleStartedEvent args
+    )
     {
         if (!TryGetRandomStation(out var chosenStation))
+        {
             return;
+        }
 
         if (!TryComp<StationDataComponent>(chosenStation, out var stationData))
+        {
             return;
+        }
 
         var grid = StationSystem.GetLargestGrid((chosenStation.Value, stationData));
-
         if (grid is null)
+        {
             return;
+        }
 
         var query = EntityQueryEnumerator<NukeComponent>();
 
@@ -87,20 +94,22 @@ public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArm
 
     private void OnNukeExploded(NukeExplodedEvent ev)
     {
-        if (IsNukePicked(out var pickedNukes) && pickedNukes.Contains(ev.ExplodedNuke))
+        if (!IsNukePicked(out var pickedNukes) || !pickedNukes.Contains(ev.ExplodedNuke))
         {
-            var query = EntityQueryEnumerator<SuddenNukeArmRuleComponent>();
-
-            while (query.MoveNext(out _, out var component))
-            {
-                if (component.PickedNuke == ev.ExplodedNuke)
-                {
-                    component.ExplodedNuke = ev.ExplodedNuke;
-                }
-            }
-
-            _roundEndSystem.EndRound();
+            return;
         }
+
+        var query = EntityQueryEnumerator<SuddenNukeArmRuleComponent>();
+
+        while (query.MoveNext(out _, out var component))
+        {
+            if (component.PickedNuke == ev.ExplodedNuke)
+            {
+                component.ExplodedNuke = ev.ExplodedNuke;
+            }
+        }
+
+        _roundEndSystem.EndRound();
     }
 
     private void OnNukeDisarm(NukeDisarmSuccessEvent ev)

--- a/Content.Server/StationEvents/Events/SuddenNukeArmRule.cs
+++ b/Content.Server/StationEvents/Events/SuddenNukeArmRule.cs
@@ -13,14 +13,6 @@ public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArm
     [Dependency] private NukeSystem _nukeSystem = default!;
     [Dependency] private RoundEndSystem _roundEndSystem = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<NukeExplodedEvent>(OnNukeExploded);
-        SubscribeLocalEvent<NukeDisarmSuccessEvent>(OnNukeDisarm);
-    }
-
     private bool IsNukePicked(out HashSet<EntityUid> pickedNukes)
     {
         pickedNukes = [];
@@ -92,6 +84,7 @@ public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArm
     }
 
 
+    [SubscribeLocalEvent]
     private void OnNukeExploded(NukeExplodedEvent ev)
     {
         if (!IsNukePicked(out var pickedNukes) || !pickedNukes.Contains(ev.ExplodedNuke))
@@ -112,6 +105,7 @@ public sealed partial class SuddenNukeArmRule : StationEventSystem<SuddenNukeArm
         _roundEndSystem.EndRound();
     }
 
+    [SubscribeLocalEvent]
     private void OnNukeDisarm(NukeDisarmSuccessEvent ev)
     {
         var query = EntityQueryEnumerator<SuddenNukeArmRuleComponent>();

--- a/Resources/Locale/en-US/station-events/events/sudden-nuke-arm.ftl
+++ b/Resources/Locale/en-US/station-events/events/sudden-nuke-arm.ftl
@@ -1,0 +1,1 @@
+﻿sudden-nuke-arm-event-end-round-nuke-exploded = The Nuclear fission explosive malfunctioned and detonated the station in a fatal accident!

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -690,11 +690,7 @@
   parent: BaseStationEvent
   id: SuddenNukeArm
   components:
-#  - type: StationEvent
-#    weight: 4
-#    minimumPlayers: 15
-  - type: StationEvent # for testing, temporary. to see if the event is run by scheduler. try in traitors/secret gamemode.
-    weight: 20
-    earliestStart: 2
-    minimumPlayers: 0
+  - type: StationEvent
+    weight: 4
+    minimumPlayers: 15
   - type: SuddenNukeArmRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -22,6 +22,7 @@
     - id: SnakeSpawnHorde
     - id: SpiderClownSpawnHorde
     - id: SpiderSpawnHorde
+    - id: SuddenNukeArm
     - id: VentClog
 
 - type: entityTable
@@ -684,3 +685,16 @@
     antags:
     - !type:FixedAntagCount
       proto: DerelictSyndicateAssaultCyborg
+
+- type: entity
+  parent: BaseStationEvent
+  id: SuddenNukeArm
+  components:
+#  - type: StationEvent
+#    weight: 4
+#    minimumPlayers: 15
+  - type: StationEvent # for testing, temporary. to see if the event is run by scheduler. try in traitors/secret gamemode.
+    weight: 20
+    earliestStart: 2
+    minimumPlayers: 0
+  - type: SuddenNukeArmRule


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About
Add a random event where the nuke suddenly arms itself. The disk must be inserted, and the nuke defused within 300 seconds.
The event has relatively low weight and should happen less frequently than every full shift of 90 minutes.

## Why
- Kinda hilarious
- Follows Unpredictability and Chaos design pillar (my favourite). From now on, you never know for sure what armed the nuke until you check (Except the captain; only they know because they have the disk).
- Slightly prunes prolonged rounds where many people are dead, including the captain, but not enough to end the round, and nobody calls evac due to, e.g., total power failure.
- Removes absolute certainty about nukies when people hear the nuke just got armed without previous callouts. This is kinda funny, and also there's less metagaming potential.
- Disincentivizes obfuscating the nuke disk excessively.

## Test plan
1. enter round on a map with a nuke, or spawn a nuke.
2. Type command `addgamerule SuddenNukeArm`.
3. It arms after a moment!
4. Go make coffee (mandatory)
5. Everyone dies. The round ends with flavor round end text.

The round only ends, and the round-end flavor text is only added when the nuke armed by the event explodes.

## Technical details
<!-- Summary of code changes for easier review. -->
We keep track of the nuke armed by the event at `SuddenNukeArmRuleComponent.PickedNuke` to clear it if it's defused, and if precisely that nuke exploded, we know the event caused detonation, and we add round-end flavor text.

While the nuke is armed, we now allow inserting the disk, but that locks it, and it cannot be removed until the nuke is disarmed. Then the captain can insert the disk after this event happens and disarm the nuke.

## Media
<img width="985" height="331" alt="image" src="https://github.com/user-attachments/assets/e6fd7f91-6337-468c-b456-f6573ac0f254" />


## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added a new random event: the nuclear fission explosive can suddenly arm itself on rare occasions.