### PR TITLE
add disable ghost bubbles if ghost not visibility

### DIFF
--- a/Content.Client/Ghost/GhostSystem.cs
+++ b/Content.Client/Ghost/GhostSystem.cs
@@ -23,10 +23,10 @@ namespace Content.Client.Ghost
 
         private bool _ghostVisibility = true;
 
-        private bool GhostVisibility
+        public bool GhostVisibility
         {
             get => _ghostVisibility;
-            set
+            private set
             {
                 if (_ghostVisibility == value)
                 {

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -880,10 +880,11 @@ public sealed partial class ChatUIController : UIController
                 break;
 
             case ChatChannel.Dead:
-                if (_ghost is not {IsGhost: true})
+                if (_ghost is not { IsGhost: true})
                     break;
 
-                AddSpeechBubble(msg, SpeechBubble.SpeechType.Say);
+                if (_ghost.GhostVisibility)
+                    AddSpeechBubble(msg, SpeechBubble.SpeechType.Say);
                 break;
 
             case ChatChannel.Emotes:


### PR DESCRIPTION
## About the PR
Disable bubles when ghost visibility turn off

## Why / Balance
This small QoL improvement lets you use replays and record gameplay while ghosting, with no risk of interference from other ghosts.
But for a better effect, it is necessary to be able to toggle the visibility of your own ghost.

## Technical details
Adds a new condition to the dead chat output that checks GhostSystem.GhostVisibility, showing the text bubble only if the condition is true.
Makes GhostSystem.GhostVisibility have a private setter.

## Test plan
Launch 2 clients
- Launch the server
- Connect
- Become a ghost on both clients
- Type something in dead chat — the message should be visible on both clients
- Toggle ghost visibility on one client and type a message in dead chat on the other — the message should not be visible on the first client


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1150" height="429" alt="Знімок екрана 2026-06-01 152244" src="https://github.com/user-attachments/assets/d53abd2a-20e5-4b9d-a540-f23fb9bed1f7" />
<img width="1628" height="615" alt="Знімок екрана 2026-06-01 152310" src="https://github.com/user-attachments/assets/833c8799-9a0e-4aca-8c1f-ee21be8d048f" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
GhostSystem.GhostVisibility now public and get private set

## Changelog
:cl:
- fix: Toggling ghost visibility now removes the text bubble output above their heads.