### PR TITLE
Hand blocker for vehicles (and mechs)

### DIFF
--- a/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
+++ b/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
@@ -8,7 +8,7 @@ using Content.Shared.Mech;
 using Content.Shared.Mech.Components;
 using Content.Shared.Mech.Equipment.Components;
 using Content.Shared.Mobs.Components;
-using Content.Shared.Vehicle;
+using Content.Shared.Vehicle.Systems;
 using Content.Shared.Wall;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;

--- a/Content.Server/Mech/Systems/MechEquipmentSystem.cs
+++ b/Content.Server/Mech/Systems/MechEquipmentSystem.cs
@@ -3,7 +3,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
 using Content.Shared.Mech.Components;
 using Content.Shared.Mech.Equipment.Components;
-using Content.Shared.Vehicle;
+using Content.Shared.Vehicle.Systems;
 using Content.Shared.Whitelist;
 
 namespace Content.Server.Mech.Systems;

--- a/Content.Shared/CardboardBox/SharedCardboardBoxSystem.cs
+++ b/Content.Shared/CardboardBox/SharedCardboardBoxSystem.cs
@@ -5,7 +5,7 @@ using Content.Shared.Stealth;
 using Content.Shared.Stealth.Components;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
-using Content.Shared.Vehicle;
+using Content.Shared.Vehicle.Systems;
 using Content.Shared.Vehicle.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -459,11 +459,8 @@ namespace Content.Shared.Cuffs
                     break;
             }
 
-            if (_virtualItem.TrySpawnVirtualItemInHand(handcuff, uid, out var virtItem1))
-                EnsureComp<UnremoveableComponent>(virtItem1.Value);
-
-            if (_virtualItem.TrySpawnVirtualItemInHand(handcuff, uid, out var virtItem2))
-                EnsureComp<UnremoveableComponent>(virtItem2.Value);
+            _virtualItem.TrySpawnUnremoveableVirtualItemInHand(handcuff, uid);
+            _virtualItem.TrySpawnUnremoveableVirtualItemInHand(handcuff, uid);
         }
 
         /// <summary>

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -458,9 +458,7 @@ namespace Content.Shared.Cuffs
                 if (freeHands == 2)
                     break;
             }
-
-            _virtualItem.TrySpawnUnremoveableVirtualItemInHand(handcuff, uid);
-            _virtualItem.TrySpawnUnremoveableVirtualItemInHand(handcuff, uid);
+            _virtualItem.TrySpawnUnremoveableVirtualItemInHand(handcuff, uid, count: 2);
         }
 
         /// <summary>

--- a/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
+++ b/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Components;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
@@ -144,6 +145,24 @@ public abstract partial class SharedVirtualItemSystem : EntitySystem
             return false;
 
         _handsSystem.DoPickup(user, empty, virtualItem.Value);
+        return true;
+    }
+
+    /// <summary>
+    /// Spawns an unremoveable virtual item in an empty hand.
+    /// </summary>
+    public bool TrySpawnUnremoveableVirtualItemInHand(EntityUid blockingEnt, EntityUid user, bool dropOthers = false, bool silent = false)
+    {
+        return TrySpawnUnremoveableVirtualItemInHand(blockingEnt, user, out _, dropOthers, silent: silent);
+    }
+
+    /// <inheritdoc cref="TrySpawnUnremoveableVirtualItemInHand(Robust.Shared.GameObjects.EntityUid,Robust.Shared.GameObjects.EntityUid,bool,bool)"/>
+    public bool TrySpawnUnremoveableVirtualItemInHand(EntityUid blockingEnt, EntityUid user, [NotNullWhen(true)] out EntityUid? virtualItem, bool dropOthers = false, string? empty = null, bool silent = false)
+    {
+        if (!TrySpawnVirtualItemInHand(blockingEnt, user, out virtualItem, dropOthers, empty, silent))
+            return false;
+
+        EnsureComp<UnremoveableComponent>(virtualItem.Value);
         return true;
     }
 

--- a/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
+++ b/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
@@ -151,7 +151,17 @@ public abstract partial class SharedVirtualItemSystem : EntitySystem
     /// <summary>
     /// Spawns unremoveable virtual items in empty hands.
     /// </summary>
-    public bool TrySpawnUnremoveableVirtualItemInHand(EntityUid blockingEnt, EntityUid user, int count = 1, bool dropOthers = false, bool silent = false)
+    /// <param name="blockingEnt">The entity that the virtual items will copy.</param>
+    /// <param name="user">The entity whose hands will hold the virtual items.</param>
+    /// <param name="count">The number of virtual items to spawn.</param>
+    /// <param name="dropOthers">Whether to try dropping other items to make space.</param>
+    /// <param name="silent">Whether to suppress popups when dropping other items.</param>
+    public bool TrySpawnUnremoveableVirtualItemInHand(
+        EntityUid blockingEnt,
+        EntityUid user,
+        int count = 1,
+        bool dropOthers = false,
+        bool silent = false)
     {
         for (var i = 0; i < count; i++)
         {
@@ -161,8 +171,22 @@ public abstract partial class SharedVirtualItemSystem : EntitySystem
         return true;
     }
 
-    /// <inheritdoc cref="TrySpawnUnremoveableVirtualItemInHand(Robust.Shared.GameObjects.EntityUid,Robust.Shared.GameObjects.EntityUid,bool,bool)"/>
-    public bool TrySpawnUnremoveableVirtualItemInHand(EntityUid blockingEnt, EntityUid user, [NotNullWhen(true)] out EntityUid? virtualItem, bool dropOthers = false, string? empty = null, bool silent = false)
+    /// <summary>
+    /// Spawns an unremoveable virtual item in an empty hand.
+    /// </summary>
+    /// <param name="blockingEnt">The entity that the virtual item will copy.</param>
+    /// <param name="user">The entity whose hand will hold the virtual item.</param>
+    /// <param name="virtualItem">The spawned virtual item, if successful.</param>
+    /// <param name="dropOthers">Whether to try dropping another item to make space.</param>
+    /// <param name="empty">The hand to insert the virtual item into, if known.</param>
+    /// <param name="silent">Whether to suppress the popup when dropping another item.</param>
+    public bool TrySpawnUnremoveableVirtualItemInHand(
+        EntityUid blockingEnt,
+        EntityUid user,
+        [NotNullWhen(true)] out EntityUid? virtualItem,
+        bool dropOthers = false,
+        string? empty = null,
+        bool silent = false)
     {
         if (!TrySpawnVirtualItemInHand(blockingEnt, user, out virtualItem, dropOthers, empty, silent))
             return false;

--- a/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
+++ b/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
@@ -149,11 +149,16 @@ public abstract partial class SharedVirtualItemSystem : EntitySystem
     }
 
     /// <summary>
-    /// Spawns an unremoveable virtual item in an empty hand.
+    /// Spawns unremoveable virtual items in empty hands.
     /// </summary>
-    public bool TrySpawnUnremoveableVirtualItemInHand(EntityUid blockingEnt, EntityUid user, bool dropOthers = false, bool silent = false)
+    public bool TrySpawnUnremoveableVirtualItemInHand(EntityUid blockingEnt, EntityUid user, int count = 1, bool dropOthers = false, bool silent = false)
     {
-        return TrySpawnUnremoveableVirtualItemInHand(blockingEnt, user, out _, dropOthers, silent: silent);
+        for (var i = 0; i < count; i++)
+        {
+            if (!TrySpawnUnremoveableVirtualItemInHand(blockingEnt, user, out _, dropOthers, silent: silent))
+                return false;
+        }
+        return true;
     }
 
     /// <inheritdoc cref="TrySpawnUnremoveableVirtualItemInHand(Robust.Shared.GameObjects.EntityUid,Robust.Shared.GameObjects.EntityUid,bool,bool)"/>

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -11,7 +11,7 @@ using Content.Shared.Mech.Components;
 using Content.Shared.Mech.Equipment.Components;
 using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
-using Content.Shared.Vehicle;
+using Content.Shared.Vehicle.Systems;
 using Content.Shared.Vehicle.Components;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Whitelist;

--- a/Content.Shared/Vehicle/Components/ContainerVehicleComponent.cs
+++ b/Content.Shared/Vehicle/Components/ContainerVehicleComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared.Vehicle.Systems;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Vehicle.Components;
 

--- a/Content.Shared/Vehicle/Components/GenericKeyedVehicleComponent.cs
+++ b/Content.Shared/Vehicle/Components/GenericKeyedVehicleComponent.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Whitelist;
+﻿using Content.Shared.Vehicle.Systems;
+using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.Vehicle.Components;

--- a/Content.Shared/Vehicle/Components/StrapVehicleComponent.cs
+++ b/Content.Shared/Vehicle/Components/StrapVehicleComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared.Vehicle.Systems;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Vehicle.Components;
 

--- a/Content.Shared/Vehicle/Components/VehicleComponent.cs
+++ b/Content.Shared/Vehicle/Components/VehicleComponent.cs
@@ -47,6 +47,12 @@ public sealed partial class VehicleComponent : Component
     public bool RequiresHands = true;
 
     /// <summary>
+    /// The number of the operator's hands occupied while operating this vehicle.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int BlockedHands;
+
+    /// <summary>
     /// Whether the operator can attack while operating this vehicle.
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Vehicle/Components/VehicleComponent.cs
+++ b/Content.Shared/Vehicle/Components/VehicleComponent.cs
@@ -48,12 +48,6 @@ public sealed partial class VehicleComponent : Component
     public bool RequiresHands = true;
 
     /// <summary>
-    /// The number of the operator's hands occupied while operating this vehicle.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public int BlockedHands;
-
-    /// <summary>
     /// Whether the operator can attack while operating this vehicle.
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Vehicle/Components/VehicleComponent.cs
+++ b/Content.Shared/Vehicle/Components/VehicleComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Damage;
+using Content.Shared.Vehicle.Systems;
 using Content.Shared.Whitelist;
 using JetBrains.Annotations;
 using Robust.Shared.GameStates;

--- a/Content.Shared/Vehicle/Components/VehicleHandBlockerComponent.cs
+++ b/Content.Shared/Vehicle/Components/VehicleHandBlockerComponent.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Vehicle.Systems;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Vehicle.Components;
+
+/// <summary>
+/// Occupies the operator's hands while they are operating a vehicle.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(VehicleSystem))]
+public sealed partial class VehicleHandBlockerComponent : Component
+{
+    /// <summary>
+    /// The number of hands to occupy.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int BlockedHands = 1;
+}

--- a/Content.Shared/Vehicle/Components/VehicleOperatorComponent.cs
+++ b/Content.Shared/Vehicle/Components/VehicleOperatorComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared.Vehicle.Systems;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Vehicle.Components;
 

--- a/Content.Shared/Vehicle/Systems/VehicleSystem.Key.cs
+++ b/Content.Shared/Vehicle/Systems/VehicleSystem.Key.cs
@@ -2,7 +2,7 @@ using System.Linq;
 using Content.Shared.Vehicle.Components;
 using Robust.Shared.Containers;
 
-namespace Content.Shared.Vehicle;
+namespace Content.Shared.Vehicle.Systems;
 
 public sealed partial class VehicleSystem
 {

--- a/Content.Shared/Vehicle/Systems/VehicleSystem.Operator.cs
+++ b/Content.Shared/Vehicle/Systems/VehicleSystem.Operator.cs
@@ -2,7 +2,7 @@ using Content.Shared.Buckle.Components;
 using Content.Shared.Vehicle.Components;
 using Robust.Shared.Containers;
 
-namespace Content.Shared.Vehicle;
+namespace Content.Shared.Vehicle.Systems;
 
 public sealed partial class VehicleSystem
 {

--- a/Content.Shared/Vehicle/Systems/VehicleSystem.cs
+++ b/Content.Shared/Vehicle/Systems/VehicleSystem.cs
@@ -39,6 +39,7 @@ public sealed partial class VehicleSystem : EntitySystem
     [Dependency] private EntityQuery<AppearanceComponent> _appearanceQuery;
     [Dependency] private EntityQuery<InputMoverComponent> _inputMoverQuery;
     [Dependency] private EntityQuery<HandsComponent> _handsQuery;
+    [Dependency] private EntityQuery<VehicleHandBlockerComponent> _handBlockerQuery;
 
     /// <remarks>
     /// We subscribe to BeforeDamageChangedEvent so that we can access the damage value before the container is applied.
@@ -323,9 +324,9 @@ public sealed partial class VehicleSystem : EntitySystem
         if (entity.Comp.RequiresHands && (!_handsQuery.HasComp(uid) || !_actionBlocker.CanInteract(uid, entity)))
             return false;
 
-        if (entity.Comp.BlockedHands > 0 &&
+        if (_handBlockerQuery.TryComp(entity, out var handBlocker) &&
             (!_handsQuery.TryComp(uid, out var hands) ||
-             _hands.GetHandCount((uid, hands)) < entity.Comp.BlockedHands))
+             _hands.GetHandCount((uid, hands)) < handBlocker.BlockedHands))
             return false;
 
         return _actionBlocker.CanConsciouslyPerformAction(uid);
@@ -336,13 +337,13 @@ public sealed partial class VehicleSystem : EntitySystem
     /// </summary>
     private bool TryBlockHands(Entity<VehicleComponent> vehicle, EntityUid operatorUid)
     {
-        if (vehicle.Comp.BlockedHands == 0)
+        if (!_handBlockerQuery.TryComp(vehicle, out var handBlocker))
             return true;
 
         if (_virtualItem.TrySpawnUnremoveableVirtualItemInHand(
                 vehicle.Owner,
                 operatorUid,
-                vehicle.Comp.BlockedHands,
+                handBlocker.BlockedHands,
                 dropOthers: true)) return true;
 
         UnblockHands(vehicle.Owner, operatorUid);

--- a/Content.Shared/Vehicle/Systems/VehicleSystem.cs
+++ b/Content.Shared/Vehicle/Systems/VehicleSystem.cs
@@ -339,17 +339,14 @@ public sealed partial class VehicleSystem : EntitySystem
         if (vehicle.Comp.BlockedHands == 0)
             return true;
 
-        for (var i = 0; i < vehicle.Comp.BlockedHands; i++)
-        {
-            if (_virtualItem.TrySpawnUnremoveableVirtualItemInHand(
-                    vehicle.Owner,
-                    operatorUid,
-                    dropOthers: true)) continue;
- 
-            UnblockHands(vehicle.Owner, operatorUid);
-            return false;
-        }
-        return true;
+        if (_virtualItem.TrySpawnUnremoveableVirtualItemInHand(
+                vehicle.Owner,
+                operatorUid,
+                vehicle.Comp.BlockedHands,
+                dropOthers: true)) return true;
+
+        UnblockHands(vehicle.Owner, operatorUid);
+        return false;
     }
 
     /// <summary>

--- a/Content.Shared/Vehicle/Systems/VehicleSystem.cs
+++ b/Content.Shared/Vehicle/Systems/VehicleSystem.cs
@@ -257,6 +257,7 @@ public sealed partial class VehicleSystem : EntitySystem
         if (_vehicleQuery.TryComp(vehicleUid, out var vehicle))
             return TryRemoveOperator((vehicleUid.Value, vehicle));
 
+        UnblockHands(vehicleUid.Value, operatorEntity.Owner);
         ClearOperatorRelays(operatorEntity.Owner, vehicleUid.Value);
         operatorEntity.Comp.Vehicle = null;
         RemCompDeferred<VehicleOperatorComponent>(operatorEntity.Owner);

--- a/Content.Shared/Vehicle/Systems/VehicleSystem.cs
+++ b/Content.Shared/Vehicle/Systems/VehicleSystem.cs
@@ -341,16 +341,13 @@ public sealed partial class VehicleSystem : EntitySystem
 
         for (var i = 0; i < vehicle.Comp.BlockedHands; i++)
         {
-            if (!_virtualItem.TrySpawnVirtualItemInHand(
+            if (_virtualItem.TrySpawnUnremoveableVirtualItemInHand(
                     vehicle.Owner,
                     operatorUid,
-                    out var virtualItem,
-                    dropOthers: true))
-            {
-                UnblockHands(vehicle.Owner, operatorUid);
-                return false;
-            }
-            EnsureComp<UnremoveableComponent>(virtualItem.Value);
+                    dropOthers: true)) continue;
+ 
+            UnblockHands(vehicle.Owner, operatorUid);
+            return false;
         }
         return true;
     }

--- a/Content.Shared/Vehicle/Systems/VehicleSystem.cs
+++ b/Content.Shared/Vehicle/Systems/VehicleSystem.cs
@@ -17,7 +17,7 @@ using JetBrains.Annotations;
 using Robust.Shared.Containers;
 using Robust.Shared.Timing;
 
-namespace Content.Shared.Vehicle;
+namespace Content.Shared.Vehicle.Systems;
 
 /// <summary>
 /// Handles logic relating to vehicles.

--- a/Content.Shared/Vehicle/VehicleSystem.cs
+++ b/Content.Shared/Vehicle/VehicleSystem.cs
@@ -4,8 +4,10 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Interaction.Components;
+using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
@@ -27,7 +29,9 @@ public sealed partial class VehicleSystem : EntitySystem
     [Dependency] private SharedContainerSystem _container = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private EntityWhitelistSystem _entityWhitelist = default!;
+    [Dependency] private SharedHandsSystem _hands = default!;
     [Dependency] private SharedMoverController _mover = default!;
+    [Dependency] private SharedVirtualItemSystem _virtualItem = default!;
     [Dependency] private IGameTiming _timing = default!;
 
     [Dependency] private EntityQuery<VehicleComponent> _vehicleQuery;
@@ -146,6 +150,9 @@ public sealed partial class VehicleSystem : EntitySystem
         if (!CanOperate(entity.AsNullable(), operatorUid))
             return false;
 
+        if (!TryBlockHands(entity, operatorUid))
+            return false;
+
         entity.Comp.Operator = operatorUid;
 
         if (_operatorQuery.HasComp(operatorUid))
@@ -196,6 +203,8 @@ public sealed partial class VehicleSystem : EntitySystem
             currentOperatorComponent.Vehicle = null;
             RemCompDeferred<VehicleOperatorComponent>(currentOperator);
         }
+
+        UnblockHands(entity.Owner, currentOperator);
 
         entity.Comp.Operator = null;
         ClearOperatorRelays(currentOperator, entity);
@@ -313,7 +322,44 @@ public sealed partial class VehicleSystem : EntitySystem
         if (entity.Comp.RequiresHands && (!_handsQuery.HasComp(uid) || !_actionBlocker.CanInteract(uid, entity)))
             return false;
 
+        if (entity.Comp.BlockedHands > 0 &&
+            (!_handsQuery.TryComp(uid, out var hands) ||
+             _hands.GetHandCount((uid, hands)) < entity.Comp.BlockedHands))
+            return false;
+
         return _actionBlocker.CanConsciouslyPerformAction(uid);
+    }
+
+    /// <summary>
+    /// Attempts to occupy the configured number of the operator's hands.
+    /// </summary>
+    private bool TryBlockHands(Entity<VehicleComponent> vehicle, EntityUid operatorUid)
+    {
+        if (vehicle.Comp.BlockedHands == 0)
+            return true;
+
+        for (var i = 0; i < vehicle.Comp.BlockedHands; i++)
+        {
+            if (!_virtualItem.TrySpawnVirtualItemInHand(
+                    vehicle.Owner,
+                    operatorUid,
+                    out var virtualItem,
+                    dropOthers: true))
+            {
+                UnblockHands(vehicle.Owner, operatorUid);
+                return false;
+            }
+            EnsureComp<UnremoveableComponent>(virtualItem.Value);
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Removes hand blockers owned by the specified vehicle.
+    /// </summary>
+    private void UnblockHands(EntityUid vehicleUid, EntityUid operatorUid)
+    {
+        _virtualItem.DeleteInHandsMatching(operatorUid, vehicleUid);
     }
 
     /// <summary>

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -8,6 +8,7 @@
   - type: MechAir
   - type: Vehicle
     canAttack: true
+  - type: VehicleHandBlocker
     blockedHands: 2
   - type: ContainerVehicle
     containerId: "mech-pilot-slot"

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -8,6 +8,7 @@
   - type: MechAir
   - type: Vehicle
     canAttack: true
+    blockedHands: 2
   - type: ContainerVehicle
     containerId: "mech-pilot-slot"
   - type: AirFilter

--- a/Resources/Prototypes/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/vehicles.yml
@@ -98,6 +98,8 @@
     noMovementLayers:
       movement:
         state: vehicle
+  - type: Vehicle
+    blockedHands: 1
   - type: GenericKeyedVehicle
     containerId: key_slot
     keyWhitelist:

--- a/Resources/Prototypes/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/vehicles.yml
@@ -99,7 +99,7 @@
       movement:
         state: vehicle
   - type: Vehicle
-    blockedHands: 1
+  - type: VehicleHandBlocker
   - type: GenericKeyedVehicle
     containerId: key_slot
     keyWhitelist:


### PR DESCRIPTION
## About the PR
Added configurable hand blocking for vehicle operators. Janicarts occupy one hand, while mechs occupy two, and wheelchairs 0

## Why / Balance
Prevents operators from freely using hands that should be occupied by vehicle controls

## Technical details
- Added `BlockedHands` field to `VehicleComponent`
- Vehicles use unremovable virtual items to occupy the configured number of hands.
- Hand blockers are removed when the operator exits.
- Moved vehicle systems to `Content.Shared.Vehicle.Systems` and updated references.

## Test plan
- Enter and exit a janicart; verify one hand is blocked and restored afterward.
- Enter and exit a mech; verify both hands are blocked and restored afterward.
- Verify entities without enough hands cannot operate the vehicle.

## Media
Not required

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
Vehicle systems were moved from `Content.Shared.Vehicle` to `Content.Shared.Vehicle.Systems`.

## Changelog
:cl:
- tweak: Operating certain vehicles now requires free hands: one for the janicart and two for all mechs.