### PR TITLE
Shorten goliath stun duration

### DIFF
--- a/Content.Server/Stunnable/Components/StunOnCollideComponent.cs
+++ b/Content.Server/Stunnable/Components/StunOnCollideComponent.cs
@@ -1,4 +1,5 @@
 using Content.Server.Stunnable.Systems;
+using Content.Shared.Whitelist;
 
 namespace Content.Server.Stunnable.Components;
 
@@ -62,5 +63,11 @@ public sealed partial class StunOnCollideComponent : Component
     /// Fixture we track for the collision.
     /// </summary>
     [DataField("fixture")] public string FixtureID = "projectile";
+
+    ///<summary>
+    /// Allows blacklisting of entities
+    /// </summary>
+    [DataField]
+    public EntityWhitelist Blacklist = new();
 }
 

--- a/Content.Server/Stunnable/Systems/StunOnCollideSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunOnCollideSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Movement.Systems;
 using JetBrains.Annotations;
 using Content.Shared.Throwing;
 using Robust.Shared.Physics.Events;
+using Content.Shared.Whitelist;
 
 namespace Content.Server.Stunnable.Systems;
 
@@ -11,6 +12,7 @@ internal sealed partial class StunOnCollideSystem : EntitySystem
 {
     [Dependency] private StunSystem _stunSystem = default!;
     [Dependency] private MovementModStatusSystem _movementMod = default!;
+    [Dependency] private EntityWhitelistSystem _entityWhitelist = default!;
 
     public override void Initialize()
     {
@@ -55,6 +57,9 @@ internal sealed partial class StunOnCollideSystem : EntitySystem
             return;
 
         TryDoCollideStun(ent, args.OtherEntity);
+
+        if (_entityWhitelist.IsWhitelistPass(ent.Comp.Blacklist, args.OtherEntity))
+            return;
     }
 
     private void HandleThrow(Entity<StunOnCollideComponent> ent, ref ThrowDoHitEvent args)

--- a/Content.Server/Stunnable/Systems/StunOnCollideSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunOnCollideSystem.cs
@@ -24,6 +24,9 @@ internal sealed partial class StunOnCollideSystem : EntitySystem
 
     private void TryDoCollideStun(Entity<StunOnCollideComponent> ent, EntityUid target)
     {
+        if (_entityWhitelist.IsWhitelistPass(ent.Comp.Blacklist, args.OtherEntity))
+            return;
+
         _stunSystem.TryKnockdown(target, ent.Comp.KnockdownAmount, ent.Comp.Refresh, ent.Comp.AutoStand, ent.Comp.Drop, true);
 
         if (ent.Comp.Refresh)
@@ -57,9 +60,6 @@ internal sealed partial class StunOnCollideSystem : EntitySystem
             return;
 
         TryDoCollideStun(ent, args.OtherEntity);
-
-        if (_entityWhitelist.IsWhitelistPass(ent.Comp.Blacklist, args.OtherEntity))
-            return;
     }
 
     private void HandleThrow(Entity<StunOnCollideComponent> ent, ref ThrowDoHitEvent args)

--- a/Content.Server/Stunnable/Systems/StunOnCollideSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunOnCollideSystem.cs
@@ -24,7 +24,7 @@ internal sealed partial class StunOnCollideSystem : EntitySystem
 
     private void TryDoCollideStun(Entity<StunOnCollideComponent> ent, EntityUid target)
     {
-        if (_entityWhitelist.IsWhitelistPass(ent.Comp.Blacklist, args.OtherEntity))
+        if (_entityWhitelist.IsWhitelistPass(ent.Comp.Blacklist, target))
             return;
 
         _stunSystem.TryKnockdown(target, ent.Comp.KnockdownAmount, ent.Comp.Refresh, ent.Comp.AutoStand, ent.Comp.Drop, true);

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -132,6 +132,7 @@
     layers:
     - state: goliath_tentacle_wiggle
   - type: StunOnContact
+    duration: 1
     blacklist:
       tags:
       - Goliath

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -131,8 +131,10 @@
     sprite: Mobs/Aliens/Asteroid/goliath.rsi
     layers:
     - state: goliath_tentacle_wiggle
-  - type: StunOnContact
-    duration: 1
+  - type: StunOnCollide
+    stunAmount: 1
+    knockdownAmount: 5
+    fixture: fix
     blacklist:
       tags:
       - Goliath


### PR DESCRIPTION
## About the PR
Shortens the stun length goliath tentacles do

## Why / Balance
Goliaths can hold you hostage through windows and there's nothing you can do to get away if there's more than one. Now you can get up and run away instead of lay on the floor until you either suffocate or the round restarts.

https://github.com/user-attachments/assets/a9f6bcce-a0e5-4f29-9de5-696e9d7b3583

## Technical details
Adds a duration line to the tentacles prototype

## Test plan
Spawn goliath, get knocked down, get up and flee

## Media
https://github.com/user-attachments/assets/205b8b37-dfe0-4086-9090-f0b987f98379



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

## Changelog
:cl:
- tweak: Goliath tentacles now stun for a much shorter duration
