### PR TITLE
Minor tram driver fixes

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Wildcards/tramdriver.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Wildcards/tramdriver.yml
@@ -20,9 +20,9 @@
 - type: loadout
   id: TramDriverGlovesWhite
   equipment:
-    head: ClothingHandsGlovesColorWhite
+    gloves: ClothingHandsGlovesColorWhite
 
 - type: loadout
   id: TramDriverGlovesBlack
   equipment:
-    head: ClothingHandsGlovesColorBlack
+    gloves: ClothingHandsGlovesColorBlack

--- a/Resources/Prototypes/Roles/Antags/base.yml
+++ b/Resources/Prototypes/Roles/Antags/base.yml
@@ -71,3 +71,5 @@
   abstract: true
   parent: [ MindshieldRestrictedAntag, CyborgBlacklistedAntag, InternBlacklistedAntag ]
   id: RestrictedAntag
+  jobBlacklist:
+  - TramDriver

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/tramdriver.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/tramdriver.yml
@@ -13,9 +13,6 @@
   - Maintenance
   - Service # the tram has command + service access
   - External # to pick up people trapped in the tramway's space
-  special: # we don't want it becoming an antag... for now at least
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
 
 - type: startingGear
   id: TramDriverGear


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed mindshields from tram drivers, added them to the jobBlacklist of RestrictedAntag. Made gloves actually start in the gloves slot instead of the head.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
_"# we don't want it becoming an antag... for now at least"_
Gloves were trying to equip to the wrong slot.

## Technical details
<!-- Summary of code changes for easier review. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
For the mindshield part, force a map that allows tram drivers, restart, check for a mindshield.
For the antag part, idk be a tram driver and run sleeper agent while you got the preference on.
For the gloves, select them in loadout and see that they appear properly.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Tram drivers no longer start with a mind shield implanted.
- fix: Tram drivers can no longer start as antags or become sleeper agents.
- fix: Tram drivers now properly start with gloves equipped when they have them selected.
