### PR TITLE
Fix percussion channel and switch to one-based channel indexes in instrument UI.

### DIFF
--- a/Content.Client/Instruments/InstrumentSystem.cs
+++ b/Content.Client/Instruments/InstrumentSystem.cs
@@ -185,7 +185,9 @@ public sealed partial class InstrumentSystem : SharedInstrumentSystem
         instrument.Renderer.FilteredChannels.SetAll(false);
         instrument.Renderer.FilteredChannels.Or(instrument.FilteredChannels);
 
-        instrument.Renderer.DisablePercussionChannel = !instrument.AllowPercussion;
+        instrument.Renderer.DisablePercussionChannel = !instrument.AllowPercussion |
+                                                       instrument.FilteredChannels[RobustMidiEvent.PercussionChannel];
+
         instrument.Renderer.DisableProgramChangeEvent = !instrument.AllowProgramChange;
 
         for (int i = 0; i < RobustMidiEvent.MaxChannels; i++)

--- a/Content.Client/Instruments/UI/ChannelItem.xaml.cs
+++ b/Content.Client/Instruments/UI/ChannelItem.xaml.cs
@@ -23,7 +23,7 @@ public sealed partial class ChannelItem : Control
         set
         {
             field = value;
-            ChannelNumberLabel.Text = value.ToString();
+            ChannelNumberLabel.Text = (value + 1).ToString();
         }
     }
 

--- a/Content.Client/Instruments/UI/ChannelsControl.xaml.cs
+++ b/Content.Client/Instruments/UI/ChannelsControl.xaml.cs
@@ -65,6 +65,23 @@ public sealed partial class ChannelsControl : Control
         }
     }
 
+    private void ClearChannels()
+    {
+        TrackSelectorButton.Disabled = true;
+        InstrumentSelectorButton.Disabled = true;
+        ProgramSelectorButton.Disabled = true;
+
+        foreach (var child in ChannelsContainer.Children)
+        {
+            if (child is not ChannelItem cItem)
+                return;
+
+            cItem.ChannelName = "";
+            cItem.ChannelState = false;
+            cItem.Visible = false;
+        }
+    }
+
     /// <summary>
     /// Replaces the current list of channels with the passed one.
     /// </summary>
@@ -74,26 +91,18 @@ public sealed partial class ChannelsControl : Control
     /// <param name="channels">List of channels consisting of their index, display name and state.</param>
     public void SetChannels(MidiChannelInfo[] channels)
     {
-        TrackSelectorButton.Disabled = true;
-        InstrumentSelectorButton.Disabled = true;
-        ProgramSelectorButton.Disabled = true;
+        ClearChannels();
 
-        for (var i = 0; i < RobustMidiEvent.MaxChannels; i++)
+        foreach (var channel in channels)
         {
-            if (i >= ChannelsContainer.ChildCount || i < 0)
-                return;
-
-            if (ChannelsContainer.Children[i] is not ChannelItem cItem)
-                return;
-
-            cItem.ChannelName = "";
-            cItem.ChannelState = false;
-            cItem.Visible = false;
-
-            if (i >= channels.Length)
+            if (channel.Id < 0 || channel.Id >= RobustMidiEvent.MaxChannels)
                 continue;
 
-            var channel = channels[i];
+            if (channel.Id >= ChannelsContainer.ChildCount)
+                continue;
+
+            if (ChannelsContainer.Children[channel.Id] is not ChannelItem cItem)
+                continue;
 
             if (channel.TrackName.Length > 0)
                 TrackSelectorButton.Disabled = false;

--- a/Content.Client/Instruments/UI/InstrumentBoundUserInterface.cs
+++ b/Content.Client/Instruments/UI/InstrumentBoundUserInterface.cs
@@ -304,25 +304,34 @@ public sealed partial class InstrumentBoundUserInterface : BoundUserInterface
 
         for (var i = 0; i < RobustMidiEvent.MaxChannels; i++)
         {
+            bool channelFound = false;
             var trackName = "";
             var instrumentName = "";
             var programName = "";
             var state = !instrument?.FilteredChannels[i] ?? false;
-            if (i != RobustMidiEvent.PercussionChannel
+            // Always show percussion channel if the instrument allows it, resolved or not.
+            if (i == RobustMidiEvent.PercussionChannel && instrument!.AllowPercussion)
+            {
+                channelFound = true;
+                programName = _percussionLabel;
+            }
+            else if (instrument!.IsInputOpen)
+            {
+                channelFound = true;
+            }
+            else if (i != RobustMidiEvent.PercussionChannel
                 && activeInstrument != null
                 && activeInstrument.Tracks.TryGetValue(i, out var resolvedMidiChannel)
                 && resolvedMidiChannel != null)
             {
+                channelFound = true;
                 trackName = resolvedMidiChannel.TrackName ?? "";
                 instrumentName = resolvedMidiChannel.InstrumentName ?? "";
                 programName = resolvedMidiChannel.ProgramName ?? "";
+            }
+
+            if (channelFound)
                 channelSettings.Add(new MidiChannelInfo(i, trackName, instrumentName, programName, state));
-            }
-            // Always show percussion channel if the instrument allows it, resolved or not.
-            else if (i == RobustMidiEvent.PercussionChannel && instrument!.AllowPercussion)
-            {
-                channelSettings.Add(new MidiChannelInfo(i, trackName, instrumentName, _percussionLabel, state));
-            }
         }
 
         _channelsControl.SetChannels(channelSettings.ToArray());

--- a/Content.Client/Instruments/UI/InstrumentBoundUserInterface.cs
+++ b/Content.Client/Instruments/UI/InstrumentBoundUserInterface.cs
@@ -33,6 +33,7 @@ public sealed partial class InstrumentBoundUserInterface : BoundUserInterface
     private readonly MinVolumeControl _minVolumeControl = new();
 
     private InstrumentMenu? _instrumentMenu;
+    private string _percussionLabel = "";
 
     public InstrumentBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
@@ -42,6 +43,8 @@ public sealed partial class InstrumentBoundUserInterface : BoundUserInterface
     protected override void Open()
     {
         base.Open();
+
+        _percussionLabel = _loc.GetString("instruments-component-channels-percussion-channel-name");
 
         var instrument = EntMan.GetComponent<InstrumentComponent>(Owner);
 
@@ -304,15 +307,21 @@ public sealed partial class InstrumentBoundUserInterface : BoundUserInterface
             var trackName = "";
             var instrumentName = "";
             var programName = "";
-            if (activeInstrument != null
+            var state = !instrument?.FilteredChannels[i] ?? false;
+            if (i != RobustMidiEvent.PercussionChannel
+                && activeInstrument != null
                 && activeInstrument.Tracks.TryGetValue(i, out var resolvedMidiChannel)
                 && resolvedMidiChannel != null)
             {
                 trackName = resolvedMidiChannel.TrackName ?? "";
                 instrumentName = resolvedMidiChannel.InstrumentName ?? "";
                 programName = resolvedMidiChannel.ProgramName ?? "";
-                var state = !instrument?.FilteredChannels[i] ?? false;
                 channelSettings.Add(new MidiChannelInfo(i, trackName, instrumentName, programName, state));
+            }
+            // Always show percussion channel if the instrument allows it, resolved or not.
+            else if (i == RobustMidiEvent.PercussionChannel && instrument!.AllowPercussion)
+            {
+                channelSettings.Add(new MidiChannelInfo(i, trackName, instrumentName, _percussionLabel, state));
             }
         }
 
@@ -331,6 +340,6 @@ public sealed partial class InstrumentBoundUserInterface : BoundUserInterface
 public readonly record struct MidiChannelInfo(
     int Id,
     string TrackName,
-    string ProgramName,
     string InstrumentName,
+    string ProgramName,
     bool FilterState);

--- a/Resources/Locale/en-US/instruments/instruments-component.ftl
+++ b/Resources/Locale/en-US/instruments/instruments-component.ftl
@@ -36,6 +36,7 @@ instruments-component-channels-menu = MIDI Channel Selection
 instruments-component-channels-all-button = On
 instruments-component-channels-clear-button = Off
 instruments-component-channels-all-channels-label = All Channels
+instruments-component-channels-percussion-channel-name = [Percussion]
 instruments-component-channels-name-display-selector-label = Display Name
 instruments-component-channels-name-display-selector-track-button = Track
 instruments-component-channels-name-display-selector-program-button = Program


### PR DESCRIPTION
closes #44958

## About the PR
This is a batch of small fixes following the instrument UI overhaul:
- Fixes `InstrumentSystem` ignoring the user toggling the percussion channel off on supported instruments.
- Fixes the Instrument UI not showing the percussion channel on supported instruments.
- All channels are now displayed when the source is MIDI Input.
- Channels are now being displayed using a one-based index instead of zero-based.

## Why / Balance
Improving the user experience regarding instruments and MIDI.

## Technical details
One atomic change in `Content.Client.InstrumentSystem`, rest is UI. This PR does **not** fix the mess that is MIDI tracks and channels but at least allows players to use instruments with percussion channels properly again. Fixing the other mess will take a lot longer I imagine.

## Test plan
- Spawn instrument that allows percussion (i.e.: Super Synthesizer)
- Play MIDI with notes on percussion channel. (i.e.: https://onlinesequencer.net/5553061)
- Check channel configuration, toggle [Percussion] to turn it on/off.

## Media
<img width="514" height="458" alt="image" src="https://github.com/user-attachments/assets/7d8ee823-ce3e-4caa-9a8f-54cc663debff" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- fix: Instruments that support percussion can now filter the percussion channel again.
