### PR TITLE
Bugfix: Holosigns, dragon rifts align themselves with the grid

### DIFF
--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -40,7 +40,7 @@ public sealed partial class DragonSystem : EntitySystem
     /// <summary>
     /// Minimum distance between 2 rifts allowed.
     /// </summary>
-    private const int RiftRange = 15;
+    private const int RiftRange = 5;
 
     /// <summary>
     /// Radius of tiles
@@ -161,8 +161,10 @@ public sealed partial class DragonSystem : EntitySystem
             }
         }
 
+        var position = _transform.GetWorldPosition(xform);
+
         // cant put a rift on solars
-        foreach (var tile in _map.GetTilesIntersecting(xform.GridUid.Value, grid, new Circle(_transform.GetWorldPosition(xform), RiftTileRadius), false))
+        foreach (var tile in _map.GetTilesIntersecting(xform.GridUid.Value, grid, new Circle(position, RiftTileRadius), false))
         {
             if (!_turf.IsSpace(tile))
                 continue;
@@ -171,8 +173,7 @@ public sealed partial class DragonSystem : EntitySystem
             return;
         }
 
-        var (position, rotation) = _transform.GetWorldPositionRotation(xform);
-        var carpUid = Spawn(component.RiftPrototype, new MapCoordinates(position, xform.MapID), rotation: rotation);
+        var carpUid = Spawn(component.RiftPrototype, new MapCoordinates(position, xform.MapID), rotation: Transform(xform.GridUid.Value).LocalRotation);
 
         component.Rifts.Add(carpUid);
         Comp<DragonRiftComponent>(carpUid).Dragon = uid;

--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -49,18 +49,6 @@ public sealed partial class DragonSystem : EntitySystem
 
     private const int RiftsAllowed = 3;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<DragonComponent, MapInitEvent>(OnInit);
-        SubscribeLocalEvent<DragonComponent, ComponentShutdown>(OnShutdown);
-        SubscribeLocalEvent<DragonComponent, DragonSpawnRiftActionEvent>(OnSpawnRift);
-        SubscribeLocalEvent<DragonComponent, RefreshMovementSpeedModifiersEvent>(OnDragonMove);
-        SubscribeLocalEvent<DragonComponent, MobStateChangedEvent>(OnMobStateChanged);
-        SubscribeLocalEvent<DragonComponent, EntityZombifiedEvent>(OnZombified);
-    }
-
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -111,17 +99,20 @@ public sealed partial class DragonSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnInit(EntityUid uid, DragonComponent component, MapInitEvent args)
     {
         Roar(uid, component);
         _actions.AddAction(uid, ref component.SpawnRiftActionEntity, component.SpawnRiftAction);
     }
 
+    [SubscribeLocalEvent]
     private void OnShutdown(EntityUid uid, DragonComponent component, ComponentShutdown args)
     {
         DeleteRifts(uid, false, component);
     }
 
+    [SubscribeLocalEvent]
     private void OnSpawnRift(EntityUid uid, DragonComponent component, DragonSpawnRiftActionEvent args)
     {
         if (component.Weakened)
@@ -180,6 +171,7 @@ public sealed partial class DragonSystem : EntitySystem
     }
 
     // TODO: just make this a move speed modifier component???
+    [SubscribeLocalEvent]
     private void OnDragonMove(EntityUid uid, DragonComponent component, RefreshMovementSpeedModifiersEvent args)
     {
         if (component.Weakened)
@@ -188,6 +180,7 @@ public sealed partial class DragonSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnMobStateChanged(EntityUid uid, DragonComponent component, MobStateChangedEvent args)
     {
         // Deletes all rifts after dying
@@ -201,6 +194,7 @@ public sealed partial class DragonSystem : EntitySystem
         DeleteRifts(uid, false, component);
     }
 
+    [SubscribeLocalEvent]
     private void OnZombified(Entity<DragonComponent> ent, ref EntityZombifiedEvent args)
     {
         // prevent carp attacking zombie dragon

--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -40,7 +40,7 @@ public sealed partial class DragonSystem : EntitySystem
     /// <summary>
     /// Minimum distance between 2 rifts allowed.
     /// </summary>
-    private const int RiftRange = 5;
+    private const int RiftRange = 15;
 
     /// <summary>
     /// Radius of tiles

--- a/Content.Shared/Holosign/HolosignSystem.cs
+++ b/Content.Shared/Holosign/HolosignSystem.cs
@@ -43,11 +43,7 @@ public sealed partial class HolosignSystem : EntitySystem
 
         // overlapping of the same holo on one tile remains allowed to allow holofan refreshes
         if (ent.Comp.PredictedSpawn || _net.IsServer)
-        {
-            // TODO: make a proxy for this method.
-            var worldRotation = _transform.GetWorldRotation(args.ClickLocation.EntityId);
-            EntityManager.PredictedSpawnAtPosition(ent.Comp.SignProto, args.ClickLocation, rotation: worldRotation);
-        }
+            PredictedSpawnAtPosition(ent.Comp.SignProto, args.ClickLocation);
 
         args.Handled = true;
     }

--- a/Content.Shared/Holosign/HolosignSystem.cs
+++ b/Content.Shared/Holosign/HolosignSystem.cs
@@ -10,7 +10,6 @@ public sealed partial class HolosignSystem : EntitySystem
 {
     [Dependency] private INetManager _net = default!;
     [Dependency] private PowerCellSystem _powerCell = default!;
-    [Dependency] private SharedTransformSystem _transform = default!;
 
     [SubscribeLocalEvent]
     private void OnExamine(Entity<HolosignProjectorComponent> ent, ref ExaminedEvent args)

--- a/Content.Shared/Holosign/HolosignSystem.cs
+++ b/Content.Shared/Holosign/HolosignSystem.cs
@@ -10,15 +10,9 @@ public sealed partial class HolosignSystem : EntitySystem
 {
     [Dependency] private INetManager _net = default!;
     [Dependency] private PowerCellSystem _powerCell = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<HolosignProjectorComponent, BeforeRangedInteractEvent>(OnBeforeInteract);
-        SubscribeLocalEvent<HolosignProjectorComponent, ExaminedEvent>(OnExamine);
-    }
-
+    [SubscribeLocalEvent]
     private void OnExamine(Entity<HolosignProjectorComponent> ent, ref ExaminedEvent args)
     {
         // TODO: This should probably be using an itemstatus
@@ -37,6 +31,7 @@ public sealed partial class HolosignSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnBeforeInteract(Entity<HolosignProjectorComponent> ent, ref BeforeRangedInteractEvent args)
     {
         if (args.Handled
@@ -50,7 +45,8 @@ public sealed partial class HolosignSystem : EntitySystem
         if (ent.Comp.PredictedSpawn || _net.IsServer)
         {
             // TODO: make a proxy for this method.
-            EntityManager.PredictedSpawnAtPosition(ent.Comp.SignProto, args.ClickLocation, Angle.Zero);
+            var worldRotation = _transform.GetWorldRotation(args.ClickLocation.EntityId);
+            EntityManager.PredictedSpawnAtPosition(ent.Comp.SignProto, args.ClickLocation, rotation: worldRotation);
         }
 
         args.Handled = true;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Fixes two regressions introduced in https://github.com/space-wizards/space-station-14/pull/44494:
1. Holosigns and fans spawned at map north.
2. Dragon rifts spawned at a bizarre angle.

## Why / Balance
I goofed.

## Technical details

Spawn ops.  Learn to read with Whatstone.

1. The angle in SpawnAtPosition is relative to the world, which in my defense, isn't documented in the function.
2. The dragon rift angle also needs to be relative to the map, but should be the grid's rotation, so we fix that.
3. Swaps DragonSystem and HolosignSystem over to use subscription attributes while we're here.  Mistakes into miracles.

## Test plan
Build in dev, hop on the shuttle, park it at some jaunty angle w.r.t. the world
Spawn holosign projector, place a few signs down, they should be rotated with respect to the user.
Spawn space dragon, control it, put a rift down.  It should be upright w.r.t. the grid.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/c78ff28e-446f-43e1-b075-b6e81725467b

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
ehh, only on vulture