### PR TITLE
Conveyor belts actions tweak

### DIFF
--- a/Resources/Prototypes/Entities/Structures/conveyor.yml
+++ b/Resources/Prototypes/Entities/Structures/conveyor.yml
@@ -6,11 +6,12 @@
     mode: SnapgridCenter
   components:
   - type: Rotatable
-    rotateWhileAnchored: true
+    rotateWhileAnchored: false
   - type: Clickable
   - type: InteractionOutline
   - type: Transform
     anchored: true
+  - type: Anchorable
   - type: Sprite
     sprite: Structures/conveyor.rsi
     state: conveyor_stopped


### PR DESCRIPTION
resolves https://github.com/space-wizards/space-station-14/issues/45026

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Conveyor belts can only be rotated when unanchored from the floor.

## Why / Balance
Makes it slightly harded to mess up builds, now requiring the extra step of acquiring a wrench (which admittedly isn't that hard on LRP/MRP) also it's more realistic to have conveyor belts be able to be rotated only when not actually bolted to the ground.

## Technical details
Added Anchorable component in `conveyor.toml` and set the `rotateWhileAnchored` field in the Rotatable component to false.

## Test plan
Simply spawn a conveyor belt and see that the "rotate" verb is not available unless the conveyor is unanchored.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- tweak: Conveyor belts can now be anchored and unanchored with a wrench. They will now only be able to rotate when not anchored.
