### PR TITLE
Bugfix: Metamorphic glass overlay layers show incorrectly.

### DIFF
--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
@@ -136,7 +136,7 @@ public sealed partial class SolutionContainerVisualsSystem : VisualizerSystem<So
         var reagentProto = ProtoMan.Index<ReagentPrototype>(baseOverride);
 
         if (SpriteSystem.LayerMapTryGet(ent, component.OverlayLayer, out var overlayLayer, false))
-            SpriteSystem.LayerSetVisible(ent, overlayLayer, reagentProto.MetamorphicSprite is not null);
+            SpriteSystem.LayerSetVisible(ent, overlayLayer, reagentProto.MetamorphicSprite is null);
 
         if (!SpriteSystem.LayerMapTryGet(ent, component.BaseLayer, out var baseLayer, false))
             return null;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Fixes a logical error with the metamorphic glass overlays.

## Why / Balance

Oversight, missed in #44917

## Technical details

Logical negation - if the metamorphic sprite is null (and does NOT exist), we want our overlay (the front of the glass) visible, and vice versa.

## Test plan
Pour some milk into a coupe glass, a metamorphic glass, and a shotglass.  They should look fine, each should have the front of the glass showing.
Drain the glass.
All three should look fine.
Pour some beer into a glass.
It shouldn't have an erroneous overlay.

## Media

Mmm.  Room temperature milk.

<img width="377" height="436" alt="image" src="https://github.com/user-attachments/assets/f1f35537-10a3-4fdb-a09f-aeb49a31e3a4" />

Compare with a screenshot from master (courtesy of @HyperB1)
<img width="648" height="644" alt="image" src="https://github.com/user-attachments/assets/2bc2d8d8-ffca-4f0b-b870-d2eeb01c42be" />

Note the missing bottom lip of the glass, and the lack of any transparent overlay on the liquid.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
please no