### PR TITLE
Bugfix: destructible disposals, empty contents on destruction

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -85,6 +85,9 @@
         - MachineMask
         layer:
         - MachineLayer
+  - type: Damageable
+  - type: Injurable
+    damageContainer: StructuralInorganic
   - type: Destructible
     thresholds:
     - trigger:
@@ -103,6 +106,9 @@
           SheetSteel1:
             min: 1
             max: 1
+      - !type:EmptyContainersBehaviour
+        containers:
+        - DisposalUnitComponent
   - type: Appearance
   - type: UserInterface
     interfaces:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Cherry-picking a bit off of #44755 re: destructible disposal units.

## Why / Balance

They're currently indestructible and destroy everything when demolished.

## Technical details

Damageable/Injurable taken from BaseStructureDestructible (don't want to reparent due to differing structure health).

Empty behaviour taken straight from #44755.  Just take --ours and ignore this, should be fine.

## Test plan

Spawn disaposal unit.  Turn it off.
Spawn mugs.
Put mugs in disposal unit.
Spawn pickaxe.
Destroy disposal unit with pickaxe.
Receive mugs back.

## Media

https://github.com/user-attachments/assets/c91c03f2-ba25-471a-bce3-b87a66b5713f

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
:cl: aada
- fix: Disposals now are destructible again, and they eject their contents when destroyed.