### PR TITLE
Refresh both weightless and movement speed modifiers on each refresh call.

### DIFF
--- a/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
+++ b/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
@@ -72,10 +72,9 @@ namespace Content.Shared.Movement.Systems
         }
 
         /// <summary>
-        /// This API method refreshes the movement modifiers for either being weightless, or being grounded depending
-        /// on which modifiers the entity is currently using.
+        /// This API method refreshes the movement modifiers for both being weightless and grounded.
         /// </summary>
-        /// <param name="ent">The entity we're refreshing modifiers for</param>
+        /// <param name="ent">The entity we're refreshing modifiers for.</param>
         public void RefreshMovementModifiers(Entity<MovementSpeedModifierComponent?> ent)
         {
             RefreshWeightlessModifiers(ent);

--- a/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
+++ b/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
@@ -78,10 +78,8 @@ namespace Content.Shared.Movement.Systems
         /// <param name="ent">The entity we're refreshing modifiers for</param>
         public void RefreshMovementModifiers(Entity<MovementSpeedModifierComponent?> ent)
         {
-            if (_gravity.IsWeightless(ent.Owner))
-                RefreshWeightlessModifiers(ent);
-            else
-                RefreshMovementSpeedModifiers(ent);
+            RefreshWeightlessModifiers(ent);
+            RefreshMovementSpeedModifiers(ent);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

In RefreshMovementModifiers, RefreshWeightlessModifiers and RefreshMovementSpeedModifiers are called every time, unconditionally.

## Why / Balance

Upon request.

Fixes a bug with disposals.

## Technical details

Condition ops.

## Test plan

Hop into space, equip a suit, your weightless and movement speeds should stay up to date.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
