### PR TITLE
Fix machine frames crashing game when destroyed by gun

### DIFF
--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -56,11 +56,11 @@ public sealed partial class ProjectileSystem : SharedProjectileSystem
             damageRequired -= _damageableSystem.GetTotalDamage((target, damageableComponent));
             damageRequired = FixedPoint2.Max(damageRequired, FixedPoint2.Zero);
         }
-        var deleted = Deleted(target);
 
-        if (_damageableSystem.TryChangeDamage((target, damageableComponent), ev.Damage, out var damage, component.IgnoreResistances, origin: component.Shooter) && Exists(component.Shooter))
+        if (_damageableSystem.TryChangeDamage((target, damageableComponent), ev.Damage, out var damage, component.IgnoreResistances, origin: component.Shooter)
+            && Exists(component.Shooter))
         {
-            if (!deleted)
+            if (!Deleted(target))
             {
                 _color.RaiseEffect(Color.Red, new List<EntityUid> { target }, Filter.Pvs(target, entityManager: EntityManager));
             }
@@ -76,7 +76,7 @@ public sealed partial class ProjectileSystem : SharedProjectileSystem
             component.ProjectileSpent = true;
         }
 
-        if (!deleted)
+        if (!Deleted(target))
         {
             _guns.PlayImpactSound(target, damage, component.SoundHit, component.ForceSound);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
`ProjectileSystem` would throw a system exception and crash the game when a machine frame was destroyed by a gun, this was because `OnStartCollide` checked if the target was deleted too early, before any operation was done to it, so it always returned an incorrect value when the entity was actually destroyed elsewhere.

## Why / Balance
resolves https://github.com/space-wizards/space-station-14/issues/45039

## Technical details
Previously, the code checked if the target was removed only once before performing the damage and then used that boolean everywhere else, so it always returned false and the application attempted to access an already deleted entity, in this case throwing the exception `System.Collections.Generic.KeyNotFoundException: Entity x does not have a component of type Robust.Shared.GameObjects.TransformComponent`
To address this issue, `OnStartCollide` should check Deleted before doing any actions that access the entity, rather than just at the start of the collision.

## Test plan
1) Spawn a machine frame
2) Spawn whatever gun
3) Destroy the machine frame with the gun, the program doesn't crash anymore

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Machine frames no longer crash the game when destroyed by a gun.
