### PR TITLE
Orders can no longer be approved on different map

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -154,19 +154,9 @@ namespace Content.Server.Cargo.Systems
             }
 
             var station = _station.GetOwningStation(uid);
-            // No station entity
-            if (station is null)
-            {
-                _popup.PopupCursor(Loc.GetString("cargo-console-station-not-found"), args.Actor);
-                PlayDenySound(uid, component);
-                return;
-            }
-
-            var stationGrid = _station.GetLargestGrid(station.Value);
 
             // No station to deduct from.
-            if (stationGrid == null ||
-                Transform(stationGrid.Value).MapID != Transform(uid).MapID ||
+            if (!OnSameMap(uid, station) ||
                 !TryComp(station, out StationBankAccountComponent? bank) ||
                 !TryComp(station, out StationDataComponent? stationData) ||
                 !TryGetOrderDatabase(station, out var orderDatabase))
@@ -273,6 +263,16 @@ namespace Content.Server.Cargo.Systems
             UpdateBankAccount((station.Value, bank), -cost, order.Account);
             UpdateOrders(station.Value);
         }
+
+        private bool OnSameMap(EntityUid uid, EntityUid? station)
+        {
+            if (station is null ||
+                _station.GetLargestGrid(station.Value) is not { } stationGrid)
+                return false;
+
+            return Transform(stationGrid).MapID == Transform(uid).MapID;
+        }
+
 
         private EntityUid? TryFulfillOrder(Entity<StationDataComponent> stationData, ProtoId<CargoAccountPrototype> account, CargoOrderData order, StationCargoOrderDatabaseComponent orderDatabase)
         {

--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -154,10 +154,19 @@ namespace Content.Server.Cargo.Systems
             }
 
             var station = _station.GetOwningStation(uid);
+            // No station entity
+            if (station is null)
+            {
+                _popup.PopupCursor(Loc.GetString("cargo-console-station-not-found"), args.Actor);
+                PlayDenySound(uid, component);
+                return;
+            }
+
+            var stationGrid = _station.GetLargestGrid(station.Value);
 
             // No station to deduct from.
-            if (station == null ||
-                Transform(station.Value).MapID != Transform(uid).MapID ||
+            if (stationGrid == null ||
+                Transform(stationGrid.Value).MapID != Transform(uid).MapID ||
                 !TryComp(station, out StationBankAccountComponent? bank) ||
                 !TryComp(station, out StationDataComponent? stationData) ||
                 !TryGetOrderDatabase(station, out var orderDatabase))

--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -6,6 +6,7 @@ using Content.Shared.Cargo.BUI;
 using Content.Shared.Cargo.Components;
 using Content.Shared.Cargo.Events;
 using Content.Shared.Cargo.Prototypes;
+using Content.Shared.Coordinates;
 using Content.Shared.Database;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Interaction;
@@ -155,7 +156,9 @@ namespace Content.Server.Cargo.Systems
             var station = _station.GetOwningStation(uid);
 
             // No station to deduct from.
-            if (!TryComp(station, out StationBankAccountComponent? bank) ||
+            if (station == null ||
+                Transform(station.Value).MapID != Transform(uid).MapID ||
+                !TryComp(station, out StationBankAccountComponent? bank) ||
                 !TryComp(station, out StationDataComponent? stationData) ||
                 !TryGetOrderDatabase(station, out var orderDatabase))
             {


### PR DESCRIPTION
## About the PR
Check title

## Why / Balance
This removes the whole point of the console emaging. Right now orders can be approved even in FTL to prevent, for example, shotgun purchases from the radio.

## Technical details
N/A

## Test plan
1. Run the server and client in release
2. Spawn orders console on the shuttle or expedition
3. Try to approve the order during FTL or on the expedition

## Media
https://github.com/user-attachments/assets/4b227cae-e81d-4601-9587-4376eade528b

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- tweak: Orders can no longer be approved during FTL and on the expeditions.