### PR TITLE
Remove redunant code from the client airlock system and (hopefully) fix windoors sprite states after reconnecting

### DIFF
--- a/Content.Client/Doors/AirlockSystem.cs
+++ b/Content.Client/Doors/AirlockSystem.cs
@@ -121,17 +121,5 @@ public sealed partial class AirlockSystem : SharedAirlockSystem
                 && !boltedVisible
             );
         }
-
-        switch (state)
-        {
-            case DoorState.Open:
-                _sprite.LayerSetRsiState((uid, args.Sprite), DoorVisualLayers.BaseUnlit, comp.ClosingSpriteState);
-                _sprite.LayerSetAnimationTime((uid, args.Sprite), DoorVisualLayers.BaseUnlit, 0);
-                break;
-            case DoorState.Closed:
-                _sprite.LayerSetRsiState((uid, args.Sprite), DoorVisualLayers.BaseUnlit, comp.OpeningSpriteState);
-                _sprite.LayerSetAnimationTime((uid, args.Sprite), DoorVisualLayers.BaseUnlit, 0);
-                break;
-        }
     }
 }


### PR DESCRIPTION
## About the PR
This pr removes... Probably redunant code? I tried to analyze it, but it does literally nothing. Why should the airlock reset its animation when it's already hangled by other systems? It just breaks appearance states.

## Why / Balance
Finally reconnecting without sprite issues.

## Technical details
N/A

## Test plan
1. Run the client and server
2. Spawn windoors
3. Interact with them
4. Everything is fine
5. Attempt to reconnect
6. Everything is fine 2

## Media
https://github.com/user-attachments/assets/1c69e05e-9912-4eac-a880-98b0ed035e6f

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- fix: Fixed airlocks playing everlasting opening animation after reconnecting
