### PR TITLE
Astro-tile consistency pass

### DIFF
--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -1,6 +1,6 @@
 - type: tile
-  id: BaseStationTile
   abstract: true
+  id: BaseStationTile
   isSubfloor: false
   deconstructTools: [ Prying ]
   footstepSounds:
@@ -1333,8 +1333,8 @@
 
 # Grass
 - type: tile
-  id: FloorAstroGrass
   parent: BaseStationTile
+  id: FloorAstroGrass
   name: tiles-astro-grass
   sprite: /Textures/Tiles/Planet/Grass/grass.png
   variants: 4
@@ -1348,112 +1348,103 @@
     East: /Textures/Tiles/Planet/Grass/double_edge.png
     North: /Textures/Tiles/Planet/Grass/double_edge.png
     West: /Textures/Tiles/Planet/Grass/double_edge.png
-  deconstructTools: [ Cutting ]
   footstepSounds:
     collection: FootstepGrass
   itemDrop: FloorTileItemAstroGrass
 
 - type: tile
-  id: FloorMowedAstroGrass
   parent: [ BaseStationTile, FloorGrass ]
+  id: FloorMowedAstroGrass
   name: tiles-mowed-astro-grass
-  isSubfloor: false
-  deconstructTools: [ Cutting ]
+  footstepSounds:
+    collection: FootstepGrass
   itemDrop: FloorTileItemMowedAstroGrass
 
 - type: tile
-  id: FloorJungleAstroGrass
   parent: [ BaseStationTile, FloorGrassJungle ]
+  id: FloorJungleAstroGrass
   name: tiles-jungle-astro-grass
-  isSubfloor: false
-  deconstructTools: [ Cutting ]
+  footstepSounds:
+    collection: FootstepGrass
   itemDrop: FloorTileItemJungleAstroGrass
 
 - type: tile
-  parent: FloorGrassDark
+  parent: [ BaseStationTile, FloorGrassDark ]
   id: FloorDarkAstroGrass
   name: tiles-dark-astro-grass
-  baseTurf: Plating
-  isSubfloor: false
-  deconstructTools: [ Cutting ]
+  footstepSounds:
+    collection: FootstepGrass
   itemDrop: FloorTileItemDarkAstroGrass
 
 - type: tile
-  parent: FloorGrassLight
+  parent: [ BaseStationTile, FloorGrassLight ]
   id: FloorLightAstroGrass
   name: tiles-light-astro-grass
-  baseTurf: Plating
-  isSubfloor: false
-  deconstructTools: [ Cutting ]
+  footstepSounds:
+    collection: FootstepGrass
   itemDrop: FloorTileItemLightAstroGrass
 
 # Ice
 - type: tile
-  id: FloorAstroIce
   parent: BaseStationTile
+  id: FloorAstroIce
   name: tiles-astro-ice
   sprite: /Textures/Tiles/Planet/Snow/ice.png
   friction: 0.05
   mobFriction: 0.05
   mobAcceleration: 0.1
+  footstepSounds:
+    collection: BarestepHard
   itemDrop: FloorTileItemAstroIce
 
 - type: tile
-  id: FloorAstroSnow
   parent: [ BaseStationTile, FloorSnow ]
+  id: FloorAstroSnow
   name: tiles-astro-snow
-  isSubfloor: false
-  deconstructTools: [ Prying ]
+  footstepSounds:
+    collection: FootstepSnow
   itemDrop: FloorTileItemAstroSnow
 
 # Asteroid Sand
 - type: tile
-  id: FloorAstroAsteroidSand
   parent: [ BaseStationTile, FloorAsteroidSand ]
+  id: FloorAstroAsteroidSand
   name: tiles-astro-asteroid-sand
-  isSubfloor: false
-  deconstructTools: [ Prying ]
+  footstepSounds:
+    collection: FootstepAsteroid
   itemDrop: FloorTileItemAstroAsteroidSand
-  weather: false
 
 - type: tile
-  id: FloorAstroAsteroidSandBorderless
   parent: [ BaseStationTile, FloorAsteroidSandBorderless ]
+  id: FloorAstroAsteroidSandBorderless
   name: tiles-astro-asteroid-sand-borderless
-  isSubfloor: false
-  deconstructTools: [ Prying ]
+  footstepSounds:
+    collection: FootstepAsteroid
   itemDrop: FloorTileItemAstroAsteroidSand
-  weather: false
 
 - type: tile
-  parent: FloorDesert
+  parent: [ BaseStationTile, FloorDesert ]
   id: FloorDesertAstroSand
   name: tiles-desert-astro-sand
-  baseTurf: Plating
-  isSubfloor: false
-  deconstructTools: [ Prying ]
+  footstepSounds:
+    collection: FootstepAsteroid
   itemDrop: FloorTileItemDesertAstroSand
-  weather: false
 
 - type: tile
+  parent: [ BaseStationTile, FloorAsteroidIronsand ]
   id: FloorAstroIronsand
   name: tiles-astro-ironsand
-  parent: FloorAsteroidIronsand
-  baseTurf: Plating
-  isSubfloor: false
-  deconstructTools: [ Prying ]
+  footstepSounds:
+    collection: FootstepAsteroid
   itemDrop: FloorTileItemAstroIronsand
-  weather: false
 
 - type: tile
+  parent: [ BaseStationTile, FloorAsteroidIronsandBorderless ]
   id: FloorAstroIronsandBorderless
   name: tiles-astro-ironsand-borderless
-  parent: FloorAsteroidIronsandBorderless
-  baseTurf: Plating
-  isSubfloor: false
-  deconstructTools: [ Prying ]
+  footstepSounds:
+    collection: FootstepAsteroid
   itemDrop: FloorTileItemAstroIronsandBorderless
-  weather: false
 
 - type: tile
   id: FloorWoodLarge

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -6,6 +6,7 @@
   footstepSounds:
     collection: FootstepFloor
   heatCapacity: 10000
+  weather: false
   baseTurf: Plating
   baseWhitelist:
   - PlatingBrass

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -1394,8 +1394,7 @@
   friction: 0.05
   mobFriction: 0.05
   mobAcceleration: 0.1
-  footstepSounds:
-    collection: BarestepHard
+  footstepSounds: null
   itemDrop: FloorTileItemAstroIce
 
 - type: tile


### PR DESCRIPTION
## About the PR

A consistency pass over all astro tiles.

All astro tiles now:
1. Sound like their non-astro counterpart.
2. Need to be pried up, not cut.
3. Have no weather.
4. Inherit all of this from BaseStationTile.
5. Have consistently ordered fields.

Supersedes and closes #44788.

## Why / Balance

Consistency is good.

floors.yml is a horrendous pit of inconsistencies.

## Technical details

YAML ops.

All redundant fields vs. BaseStationTile have been removed.  All astro tiles that don't inherit from BaseStationTile have had it added as a parent.

## Test plan
Spawn each of the astro tiles ingame, walk around on them.  Then spawn the non-astro variant.  The two should sound the same, and the astro tiles should be able to be pried up.

## Media

Not exactly this branch, but [the same set of changes applied to the respritening PR (+ uniform variance removal)](https://github.com/AftrLite/wizden-ss14/compare/respritening-tileset...whatston3:2026-08-01-respritening-astrotile-consistency):

https://imgur.com/a/sXBYZp3 (slightly too large for github)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
:cl:
- tweak: All grass astro-tiles now need a crowbar to be pried off the floor.