### PR TITLE
Fix ActionUI allocations

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -633,6 +633,18 @@ public sealed partial class ActionUIController : UIController, IOnStateChanged<G
     {
         _dragShadow.Texture = null;
         _dragShadow.Visible = false;
+        UpdateActionBarBackgrounds();
+    }
+
+    private void UpdateActionBarBackgrounds()
+    {
+        if (_container == null)
+            return;
+
+        foreach (var button in _container.GetButtons())
+        {
+            button.UpdateBackground();
+        }
     }
 
     private void UnloadGui()
@@ -734,7 +746,11 @@ public sealed partial class ActionUIController : UIController, IOnStateChanged<G
 
     public override void FrameUpdate(FrameEventArgs args)
     {
+        var wasDragging = IsDragging;
         _menuDragHelper.Update(args.DeltaSeconds);
+
+        if (wasDragging != IsDragging)
+            UpdateActionBarBackgrounds();
         if (_window is {UpdateNeeded: true})
             SearchAndDisplay();
     }

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -8,6 +8,7 @@ using Content.Shared.Actions.Components;
 using Content.Shared.Charges.Systems;
 using Content.Shared.Examine;
 using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
@@ -30,6 +31,7 @@ public sealed class ActionButton : Control, IEntityControl
     private bool _beingHovered;
     private bool _depressed;
     private bool _toggled;
+    private Texture? _slotBackground;
 
     public BoundKeyFunction? KeyBind
     {
@@ -168,6 +170,8 @@ public sealed class ActionButton : Control, IEntityControl
     {
         base.OnThemeUpdated();
         Label.FontColorOverride = Theme.ResolveColorOrSpecified("whiteText");
+        _slotBackground = Theme.ResolveTexture("SlotBackground");
+        UpdateBackground();
     }
 
     private void OnPressed(GUIBoundKeyEventArgs args)
@@ -290,7 +294,7 @@ public sealed class ActionButton : Control, IEntityControl
         if (Action != null ||
             _controller.IsDragging && GetPositionInParent() == Parent?.ChildCount - 1)
         {
-            Button.Texture = Theme.ResolveTexture("SlotBackground");
+            Button.Texture = _slotBackground;
         }
         else
         {
@@ -327,8 +331,6 @@ public sealed class ActionButton : Control, IEntityControl
     protected override void FrameUpdate(FrameEventArgs args)
     {
         base.FrameUpdate(args);
-
-        UpdateBackground();
 
         Cooldown.Visible = Action?.Comp.Cooldown != null;
         if (Action?.Comp is not {} action)


### PR DESCRIPTION
It was doing respath construction every frame (and runtime can't intern them). Now we just update the background when actually required for themes.

no.1 allocations on client atm.