### PR TITLE
Always raise MobStateChanged on client

### DIFF
--- a/Content.Shared/Mobs/Components/MobStateComponent.cs
+++ b/Content.Shared/Mobs/Components/MobStateComponent.cs
@@ -2,31 +2,37 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Mobs.Systems;
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Mobs.Components
+namespace Content.Shared.Mobs.Components;
+
+/// <summary>
+///     When attached to an <see cref="DamageableComponent"/>,
+///     this component will handle critical and death behaviors for mobs.
+///     Additionally, it handles sending effects to clients
+///     (such as blur effect for unconsciousness) and managing the health HUD.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState(true)]
+[Access(typeof(MobStateSystem), typeof(MobThresholdSystem))]
+public sealed partial class MobStateComponent : Component
 {
     /// <summary>
-    ///     When attached to an <see cref="DamageableComponent"/>,
-    ///     this component will handle critical and death behaviors for mobs.
-    ///     Additionally, it handles sending effects to clients
-    ///     (such as blur effect for unconsciousness) and managing the health HUD.
+    /// The current mob state the entity is in.
     /// </summary>
-    [RegisterComponent]
-    [NetworkedComponent]
-    [AutoGenerateComponentState]
-    [Access(typeof(MobStateSystem), typeof(MobThresholdSystem))]
-    public sealed partial class MobStateComponent : Component
-    {
-        //default mobstate is always the lowest state level
-        [AutoNetworkedField, ViewVariables]
-        public MobState CurrentState { get; set; } = MobState.Alive;
+    [DataField, AutoNetworkedField]
+    public MobState CurrentState = MobState.Alive; //default mobstate is always the lowest state level
 
-        [DataField]
-        [AutoNetworkedField]
-        public HashSet<MobState> AllowedStates = new()
-            {
-                MobState.Alive,
-                MobState.Critical,
-                MobState.Dead
-            };
-    }
+    /// <summary>
+    /// The last state that was received by the client
+    /// </summary>
+    [ViewVariables]
+    public MobState LastReceivedState = MobState.Alive;
+
+    [DataField]
+    [AutoNetworkedField]
+    public HashSet<MobState> AllowedStates = new()
+    {
+        MobState.Alive,
+        MobState.Critical,
+        MobState.Dead
+    };
 }

--- a/Content.Shared/Mobs/Systems/MobStateSystem.StateMachine.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.StateMachine.cs
@@ -33,7 +33,7 @@ public partial class MobStateSystem
         if (!_mobStateQuery.Resolve(entity, ref component))
             return;
 
-        var ev = new UpdateMobStateEvent {Target = entity, Component = component, Origin = origin};
+        var ev = new UpdateMobStateEvent { Target = entity, Component = component, Origin = origin };
         RaiseLocalEvent(entity, ref ev);
         ChangeState(entity, component, ev.State, origin: origin);
     }

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -49,6 +49,7 @@ public partial class MobStateSystem
         SubscribeLocalEvent<MobStateComponent, AttemptPacifiedAttackEvent>(OnAttemptPacifiedAttack);
         SubscribeLocalEvent<MobStateComponent, DamageModifyEvent>(OnDamageModify);
         SubscribeLocalEvent<MobStateComponent, AttemptToolRefineEvent>(OnAttemptToolRefine);
+        SubscribeLocalEvent<MobStateComponent, AfterAutoHandleStateEvent>(OnAfterAutoHandleState);
 
         SubscribeLocalEvent<MobStateComponent, UnbuckleAttemptEvent>(OnUnbuckleAttempt);
 
@@ -154,6 +155,17 @@ public partial class MobStateSystem
     }
 
     #region Event Subscribers
+
+    private void OnAfterAutoHandleState(Entity<MobStateComponent> ent, ref AfterAutoHandleStateEvent args)
+    {
+        if (ent.Comp.LastReceivedState == ent.Comp.CurrentState)
+            return;
+
+        var ev = new MobStateChangedEvent(ent, ent.Comp, ent.Comp.LastReceivedState, ent.Comp.CurrentState);
+        OnStateChanged(ent, ent.Comp, ent.Comp.LastReceivedState, ent.Comp.CurrentState);
+        RaiseLocalEvent(ent, ev, true);
+        ent.Comp.LastReceivedState = ent.Comp.CurrentState;
+    }
 
     private void OnSleepAttempt(EntityUid target, MobStateComponent component, ref TryingToSleepEvent args)
     {

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -28,35 +28,20 @@ public partial class MobStateSystem
     //General purpose event subscriptions. If you can avoid it register these events inside their own systems
     private void SubscribeEvents()
     {
-        SubscribeLocalEvent<MobStateComponent, BeforeGettingStrippedEvent>(OnGettingStripped);
         SubscribeLocalEvent<MobStateComponent, ChangeDirectionAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, UseAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, AttackAttemptEvent>(CheckAct);
-        SubscribeLocalEvent<MobStateComponent, ConsciousAttemptEvent>(CheckConcious);
         SubscribeLocalEvent<MobStateComponent, ThrowAttemptEvent>(CheckAct);
-        SubscribeLocalEvent<MobStateComponent, SpeakAttemptEvent>(OnSpeakAttempt);
-        SubscribeLocalEvent<MobStateComponent, IsEquippingAttemptEvent>(OnEquipAttempt);
         SubscribeLocalEvent<MobStateComponent, EmoteAttemptEvent>(CheckAct);
-        SubscribeLocalEvent<MobStateComponent, IsUnequippingAttemptEvent>(OnUnequipAttempt);
         SubscribeLocalEvent<MobStateComponent, DropAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, PickupAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, StartPullAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, UpdateCanMoveEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, StandAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, PointAttemptEvent>(CheckAct);
-        SubscribeLocalEvent<MobStateComponent, TryingToSleepEvent>(OnSleepAttempt);
-        SubscribeLocalEvent<MobStateComponent, CombatModeShouldHandInteractEvent>(OnCombatModeShouldHandInteract);
-        SubscribeLocalEvent<MobStateComponent, AttemptPacifiedAttackEvent>(OnAttemptPacifiedAttack);
-        SubscribeLocalEvent<MobStateComponent, DamageModifyEvent>(OnDamageModify);
-        SubscribeLocalEvent<MobStateComponent, AttemptToolRefineEvent>(OnAttemptToolRefine);
-        SubscribeLocalEvent<MobStateComponent, AfterAutoHandleStateEvent>(OnAfterAutoHandleState);
-
-        SubscribeLocalEvent<MobStateComponent, UnbuckleAttemptEvent>(OnUnbuckleAttempt);
-
-        // Actions
-        SubscribeLocalEvent<ActionRequireMobStateComponent, ActionAttemptEvent>(OnMobStateActionAttempt);
     }
 
+    [SubscribeLocalEvent]
     private void OnUnbuckleAttempt(Entity<MobStateComponent> ent, ref UnbuckleAttemptEvent args)
     {
         // TODO is this necessary?
@@ -72,6 +57,7 @@ public partial class MobStateSystem
         RaiseLocalEvent(target, ref ev);
     }
 
+    [SubscribeLocalEvent]
     private void CheckConcious(Entity<MobStateComponent> ent, ref ConsciousAttemptEvent args)
     {
         switch (ent.Comp.CurrentState)
@@ -146,6 +132,7 @@ public partial class MobStateSystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnAttemptToolRefine(Entity<MobStateComponent> ent, ref AttemptToolRefineEvent args)
     {
         if (!IsDead(ent, ent))
@@ -156,6 +143,7 @@ public partial class MobStateSystem
 
     #region Event Subscribers
 
+    [SubscribeLocalEvent]
     private void OnAfterAutoHandleState(Entity<MobStateComponent> ent, ref AfterAutoHandleStateEvent args)
     {
         if (ent.Comp.LastReceivedState == ent.Comp.CurrentState)
@@ -167,12 +155,14 @@ public partial class MobStateSystem
         ent.Comp.LastReceivedState = ent.Comp.CurrentState;
     }
 
+    [SubscribeLocalEvent]
     private void OnSleepAttempt(EntityUid target, MobStateComponent component, ref TryingToSleepEvent args)
     {
         if (IsDead(target, component))
             args.Cancelled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnGettingStripped(EntityUid target, MobStateComponent component, BeforeGettingStrippedEvent args)
     {
         // Incapacitated or dead targets get stripped two or three times as fast. Makes stripping corpses less tedious.
@@ -182,6 +172,7 @@ public partial class MobStateSystem
             args.Multiplier /= 2;
     }
 
+    [SubscribeLocalEvent]
     private void OnSpeakAttempt(EntityUid uid, MobStateComponent component, SpeakAttemptEvent args)
     {
         if (HasComp<AllowNextCritSpeechComponent>(uid))
@@ -204,6 +195,7 @@ public partial class MobStateSystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnEquipAttempt(EntityUid target, MobStateComponent component, IsEquippingAttemptEvent args)
     {
         // is this a self-equip, or are they being stripped?
@@ -211,6 +203,7 @@ public partial class MobStateSystem
             CheckAct(target, component, args);
     }
 
+    [SubscribeLocalEvent]
     private void OnUnequipAttempt(EntityUid target, MobStateComponent component, IsUnequippingAttemptEvent args)
     {
         // is this a self-equip, or are they being stripped?
@@ -218,6 +211,7 @@ public partial class MobStateSystem
             CheckAct(target, component, args);
     }
 
+    [SubscribeLocalEvent]
     private void OnCombatModeShouldHandInteract(EntityUid uid, MobStateComponent component, ref CombatModeShouldHandInteractEvent args)
     {
         // Disallow empty-hand-interacting in combat mode
@@ -226,16 +220,19 @@ public partial class MobStateSystem
             args.Cancelled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnAttemptPacifiedAttack(Entity<MobStateComponent> ent, ref AttemptPacifiedAttackEvent args)
     {
         args.Cancelled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnDamageModify(Entity<MobStateComponent> ent, ref DamageModifyEvent args)
     {
         args.Damage *= _damageable.UniversalMobDamageModifier;
     }
 
+    [SubscribeLocalEvent]
     private void OnMobStateActionAttempt(Entity<ActionRequireMobStateComponent> ent, ref ActionAttemptEvent args)
     {
         if (_mobStateQuery.TryComp(args.User, out var mobState) &&

--- a/Content.Shared/Mobs/Systems/MobStateSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.cs
@@ -18,13 +18,11 @@ public partial class MobStateSystem : EntitySystem
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
-    private ISawmill _sawmill = default!;
 
     [Dependency] private EntityQuery<MobStateComponent> _mobStateQuery = default!;
 
     public override void Initialize()
     {
-        _sawmill = LogManager.GetSawmill("MobState");
         base.Initialize();
         SubscribeEvents();
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
We raise the MobStateChangedEvent on client. Always.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Needed bugfix for ling.

## Technical details
<!-- Summary of code changes for easier review. -->
We raise the event on client after a state is handled. This is neccessary because damage overlay doesn't enjoy being changed from dead -> alive in a predicted way.

We cache the last state on the client, and if we receive a state and the mobstate is different, we raise the event on client.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Check out #40514 with this PR
2. Crit self with a throngler
3. Enter stasis
4. Exit stasis
5. No temporary blindness until your damage changes

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/ab01d006-573c-42ec-a352-7cd121792cbd

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
