### PR TITLE
Manually network MobStateComponent

### DIFF
--- a/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
+++ b/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
@@ -37,6 +37,12 @@ public abstract partial class SharedRottingSystem : EntitySystem
 
     private void OnMobStateChanged(Entity<PerishableComponent> ent, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (args.NewMobState != MobState.Dead && args.OldMobState != MobState.Dead)
             return;
 
@@ -64,6 +70,12 @@ public abstract partial class SharedRottingSystem : EntitySystem
 
     private void OnRottingMobStateChanged(EntityUid uid, RottingComponent component, MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (args.NewMobState == MobState.Dead)
             return;
 

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -41,7 +41,6 @@ public sealed partial class SleepingSystem : EntitySystem
     [Dependency] private SharedEmitSoundSystem _emitSound = default!;
     [Dependency] private StatusEffectsSystem _statusEffect = default!;
     [Dependency] private SharedStunSystem _stun = default!;
-    [Dependency] private IGameTiming _timing = default!;
 
     public static readonly EntProtoId SleepActionId = "ActionSleep";
     public static readonly EntProtoId WakeActionId = "ActionWake";
@@ -120,7 +119,7 @@ public sealed partial class SleepingSystem : EntitySystem
         // The incoming state from the server raises the event as well.
         // But the changes have also been dirtied
         // so we prevent applying them twice.
-        if (_timing.ApplyingState)
+        if (_gameTiming.ApplyingState)
             return;
 
         if (args.FellAsleep)
@@ -280,7 +279,7 @@ public sealed partial class SleepingSystem : EntitySystem
         // The incoming state from the server raises the event as well.
         // But the changes have also been dirtied
         // so we prevent applying them twice.
-        if (_timing.ApplyingState)
+        if (_gameTiming.ApplyingState)
             return;
 
         if (TryComp<SpamEmitSoundComponent>(ent, out var spam))
@@ -295,7 +294,7 @@ public sealed partial class SleepingSystem : EntitySystem
         // The incoming state from the server raises the event as well.
         // But the changes have also been dirtied
         // so we prevent applying them twice.
-        if (_timing.ApplyingState)
+        if (_gameTiming.ApplyingState)
             return;
 
         if (args.Args.NewMobState == MobState.Dead || HasComp<SleepingComponent>(args.Args.Target))

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -41,6 +41,7 @@ public sealed partial class SleepingSystem : EntitySystem
     [Dependency] private SharedEmitSoundSystem _emitSound = default!;
     [Dependency] private StatusEffectsSystem _statusEffect = default!;
     [Dependency] private SharedStunSystem _stun = default!;
+    [Dependency] private IGameTiming _timing = default!;
 
     public static readonly EntProtoId SleepActionId = "ActionSleep";
     public static readonly EntProtoId WakeActionId = "ActionWake";
@@ -116,6 +117,12 @@ public sealed partial class SleepingSystem : EntitySystem
     /// </summary>
     private void OnSleepStateChanged(Entity<MobStateComponent> ent, ref SleepStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (args.FellAsleep)
         {
             // Just in case we're not using the sleeping status
@@ -270,6 +277,12 @@ public sealed partial class SleepingSystem : EntitySystem
     /// </summary>
     private void OnMobStateChanged(Entity<SleepingComponent> ent, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (TryComp<SpamEmitSoundComponent>(ent, out var spam))
             _emitSound.SetEnabled((ent, spam), args.NewMobState == MobState.Alive);
 
@@ -279,6 +292,12 @@ public sealed partial class SleepingSystem : EntitySystem
 
     private void OnStatusMobStateChanged(Entity<ForcedSleepingStatusEffectComponent> ent, ref StatusEffectRelayedEvent<MobStateChangedEvent> args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (args.Args.NewMobState == MobState.Dead || HasComp<SleepingComponent>(args.Args.Target))
             return;
 

--- a/Content.Shared/Bible/BibleSystem.cs
+++ b/Content.Shared/Bible/BibleSystem.cs
@@ -185,6 +185,12 @@ public sealed partial class BibleSystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnFamiliarDeath(Entity<FamiliarComponent> ent, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (args.NewMobState != MobState.Dead || ent.Comp.Source == null)
             return;
 

--- a/Content.Shared/Changeling/Systems/SharedChangelingIdentitySystem.cs
+++ b/Content.Shared/Changeling/Systems/SharedChangelingIdentitySystem.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Changeling.Systems;
 
@@ -22,6 +23,7 @@ public abstract partial class SharedChangelingIdentitySystem : EntitySystem
     [Dependency] private SharedPvsOverrideSystem _pvsOverrideSystem = default!;
     [Dependency] private SharedMindSystem _mind = default!;
     [Dependency] private SharedJobSystem _job = default!;
+    [Dependency] private IGameTiming _timing = default!;
 
     public MapId? PausedMapId;
 
@@ -97,6 +99,12 @@ public abstract partial class SharedChangelingIdentitySystem : EntitySystem
 
     private void OnRecentlyDevouredMobState(Entity<RecentlyDevouredComponent> ent, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         // Once we are revived the body is no longer recently devoured.
         if (args.NewMobState != MobState.Alive)
             return;

--- a/Content.Shared/GhostTypes/StoreDamageTakenOnMindSystem.cs
+++ b/Content.Shared/GhostTypes/StoreDamageTakenOnMindSystem.cs
@@ -8,12 +8,14 @@ using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.GhostTypes;
 
 public sealed partial class StoreDamageTakenOnMindSystem : EntitySystem
 {
     [Dependency] private DamageableSystem _damageable = default!;
+    [Dependency] private IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -35,6 +37,12 @@ public sealed partial class StoreDamageTakenOnMindSystem : EntitySystem
     /// </summary>
     private void SaveBodyOnThreshold(Entity<StoreDamageTakenOnMindComponent> ent, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (args.NewMobState != MobState.Dead)
             ClearSpecialCause(ent);
 

--- a/Content.Shared/Guardian/GuardianSystem.cs
+++ b/Content.Shared/Guardian/GuardianSystem.cs
@@ -284,6 +284,12 @@ public sealed partial class GuardianSystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnHostStateChange(Entity<GuardianHostComponent> ent, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (ent.Comp.HostedGuardian == null ||
             !_guardianQuery.TryComp(ent.Comp.HostedGuardian, out GuardianComponent? guardianComp))
             return;

--- a/Content.Shared/Mobs/Components/MobStateComponent.cs
+++ b/Content.Shared/Mobs/Components/MobStateComponent.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Damage.Components;
 using Content.Shared.Mobs.Systems;
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Mobs.Components;
 
@@ -11,14 +12,13 @@ namespace Content.Shared.Mobs.Components;
 ///     (such as blur effect for unconsciousness) and managing the health HUD.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-[AutoGenerateComponentState(true)]
 [Access(typeof(MobStateSystem), typeof(MobThresholdSystem))]
 public sealed partial class MobStateComponent : Component
 {
     /// <summary>
     /// The current mob state the entity is in.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public MobState CurrentState = MobState.Alive; //default mobstate is always the lowest state level
 
     /// <summary>
@@ -28,11 +28,18 @@ public sealed partial class MobStateComponent : Component
     public MobState LastReceivedState = MobState.Alive;
 
     [DataField]
-    [AutoNetworkedField]
     public HashSet<MobState> AllowedStates = new()
     {
         MobState.Alive,
         MobState.Critical,
         MobState.Dead
     };
+}
+
+[Serializable, NetSerializable]
+public sealed class MobStateComponentState : ComponentState
+{
+    public MobState CurrentState;
+
+    public HashSet<MobState> AllowedStates = new();
 }

--- a/Content.Shared/Mobs/Systems/MobStateActionsSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobStateActionsSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Content.Shared.Mobs.Components;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Mobs.Systems;
 
@@ -10,6 +11,7 @@ namespace Content.Shared.Mobs.Systems;
 public sealed partial class MobStateActionsSystem : EntitySystem
 {
     [Dependency] private SharedActionsSystem _actions = default!;
+    [Dependency] private IGameTiming _timing = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -20,6 +22,12 @@ public sealed partial class MobStateActionsSystem : EntitySystem
 
     private void OnMobStateChanged(EntityUid uid, MobStateActionsComponent component, MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         ComposeActions(uid, component, args.NewMobState);
     }
 

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -162,7 +162,7 @@ public partial class MobStateSystem
         }
 
         if (!ent.Comp.AllowedStates.SetEquals(state.AllowedStates))
-            ent.Comp.AllowedStates = state.AllowedStates;
+            ent.Comp.AllowedStates = new (state.AllowedStates);
     }
 
     [SubscribeLocalEvent]

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -20,6 +20,7 @@ using Content.Shared.Strip.Components;
 using Content.Shared.Throwing;
 using Content.Shared.Tools.Systems;
 using System.Linq;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Mobs.Systems;
 
@@ -144,15 +145,34 @@ public partial class MobStateSystem
     #region Event Subscribers
 
     [SubscribeLocalEvent]
-    private void OnAfterAutoHandleState(Entity<MobStateComponent> ent, ref AfterAutoHandleStateEvent args)
+    private void OnMobStateHandleState(Entity<MobStateComponent> ent, ref ComponentHandleState args)
     {
-        if (ent.Comp.LastReceivedState == ent.Comp.CurrentState)
+        if (args.Current is not MobStateComponentState state)
             return;
 
-        var ev = new MobStateChangedEvent(ent, ent.Comp, ent.Comp.LastReceivedState, ent.Comp.CurrentState);
-        OnStateChanged(ent, ent.Comp, ent.Comp.LastReceivedState, ent.Comp.CurrentState);
-        RaiseLocalEvent(ent, ev, true);
-        ent.Comp.LastReceivedState = ent.Comp.CurrentState;
+        // Only raise the events and update if the state actually changed.
+        if (ent.Comp.CurrentState != state.CurrentState)
+        {
+            var lastState = ent.Comp.CurrentState;
+            ent.Comp.CurrentState = state.CurrentState;
+
+            var ev = new MobStateChangedEvent(ent, ent.Comp, lastState, ent.Comp.CurrentState);
+            OnStateChanged(ent, ent.Comp, lastState, ent.Comp.CurrentState);
+            RaiseLocalEvent(ent, ev, true);
+        }
+
+        if (!ent.Comp.AllowedStates.SetEquals(state.AllowedStates))
+            ent.Comp.AllowedStates = state.AllowedStates;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnMobStateGetState(Entity<MobStateComponent> ent, ref ComponentGetState args)
+    {
+        args.State = new MobStateComponentState
+        {
+            CurrentState = ent.Comp.CurrentState,
+            AllowedStates = ent.Comp.AllowedStates
+        };
     }
 
     [SubscribeLocalEvent]

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -161,8 +161,7 @@ public partial class MobStateSystem
             RaiseLocalEvent(ent, ev, true);
         }
 
-        if (!ent.Comp.AllowedStates.SetEquals(state.AllowedStates))
-            ent.Comp.AllowedStates = new (state.AllowedStates);
+        ent.Comp.AllowedStates = new (state.AllowedStates);
     }
 
     [SubscribeLocalEvent]

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Events;
 using Robust.Shared.GameStates;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Mobs.Systems;
 
@@ -16,6 +17,7 @@ public sealed partial class MobThresholdSystem : EntitySystem
     [Dependency] private MobStateSystem _mobStateSystem = default!;
     [Dependency] private AlertsSystem _alerts = default!;
     [Dependency] private DamageableSystem _damageable = default!;
+    [Dependency] private IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -474,6 +476,12 @@ public sealed partial class MobThresholdSystem : EntitySystem
 
     private void OnThresholdsMobState(Entity<MobThresholdsComponent> ent, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         UpdateAllEffects((ent, ent, null, null), args.NewMobState);
     }
 

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -141,6 +141,12 @@ public sealed partial class PullingSystem : EntitySystem
 
     private void OnStateChanged(EntityUid uid, PullerComponent component, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (component.Pulling == null)
             return;
 

--- a/Content.Shared/Rootable/RootableSystem.cs
+++ b/Content.Shared/Rootable/RootableSystem.cs
@@ -156,6 +156,12 @@ public sealed partial class RootableSystem : EntitySystem
 
     private void OnMobStateChanged(Entity<RootableComponent> ent, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (ent.Comp.Rooted)
             TryToggleRooting((ent, ent));
     }

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -281,6 +281,12 @@ public abstract partial class SharedBorgSystem : EntitySystem
 
     private void OnMobStateChanged(Entity<BorgChassisComponent> chassis, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (args.NewMobState == MobState.Alive)
             TryActivate(chassis, args.Origin);
         else

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Customization.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Customization.cs
@@ -64,6 +64,12 @@ public abstract partial class SharedStationAiSystem
 
     protected virtual void OnMobStateChanged(Entity<StationAiCustomizationComponent> ent, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         var state = (args.NewMobState == MobState.Dead) ? StationAiState.Dead : StationAiState.Rebooting;
         SetStationAiState(ent, state);
     }

--- a/Content.Shared/Sound/SharedEmitSoundSystem.cs
+++ b/Content.Shared/Sound/SharedEmitSoundSystem.cs
@@ -38,7 +38,6 @@ public abstract partial class SharedEmitSoundSystem : EntitySystem
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private TurfSystem _turf = default!;
-    [Dependency] private IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -71,7 +70,7 @@ public abstract partial class SharedEmitSoundSystem : EntitySystem
         // The incoming state from the server raises the event as well.
         // But the changes have also been dirtied
         // so we prevent applying them twice.
-        if (_timing.ApplyingState)
+        if (Timing.ApplyingState)
             return;
 
         // Disable this component rather than removing it because it can be brought back to life.

--- a/Content.Shared/Sound/SharedEmitSoundSystem.cs
+++ b/Content.Shared/Sound/SharedEmitSoundSystem.cs
@@ -38,6 +38,7 @@ public abstract partial class SharedEmitSoundSystem : EntitySystem
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private TurfSystem _turf = default!;
+    [Dependency] private IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -67,6 +68,12 @@ public abstract partial class SharedEmitSoundSystem : EntitySystem
 
     private void OnMobState(Entity<SoundWhileAliveComponent> entity, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         // Disable this component rather than removing it because it can be brought back to life.
         if (TryComp<SpamEmitSoundComponent>(entity, out var comp))
         {

--- a/Content.Shared/Species/Systems/GibActionSystem.cs
+++ b/Content.Shared/Species/Systems/GibActionSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Popups;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 
 namespace Content.Shared.Species;
@@ -14,6 +15,7 @@ public sealed partial class GibActionSystem : EntitySystem
     [Dependency] private SharedActionsSystem _actionsSystem = default!;
     [Dependency] private GibbingSystem _gibbing = default!;
     [Dependency] private SharedPopupSystem _popupSystem = default!;
+    [Dependency] private IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -25,6 +27,12 @@ public sealed partial class GibActionSystem : EntitySystem
 
     private void OnMobStateChanged(EntityUid uid, GibActionComponent comp, MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         // When the mob changes state, check if they're dead and give them the action if so.
         if (!TryComp<MobStateComponent>(uid, out var mobState))
             return;

--- a/Content.Shared/Stealth/SharedStealthSystem.cs
+++ b/Content.Shared/Stealth/SharedStealthSystem.cs
@@ -63,6 +63,12 @@ public abstract partial class SharedStealthSystem : EntitySystem
 
     private void OnMobStateChanged(EntityUid uid, StealthComponent component, MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (args.NewMobState == MobState.Dead)
         {
             component.Enabled = component.EnabledOnDeath;

--- a/Content.Shared/Stunnable/SharedStunSystem.Visualizer.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Visualizer.cs
@@ -1,7 +1,6 @@
 ﻿using Content.Shared.Bed.Sleep;
 using Content.Shared.Mobs;
 using Robust.Shared.Serialization;
-using Robust.Shared.Timing;
 
 namespace Content.Shared.Stunnable;
 

--- a/Content.Shared/Stunnable/SharedStunSystem.Visualizer.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Visualizer.cs
@@ -7,8 +7,6 @@ namespace Content.Shared.Stunnable;
 
 public abstract partial class SharedStunSystem
 {
-    [Dependency] private IGameTiming _timing = default!;
-
     public void InitializeAppearance()
     {
         SubscribeLocalEvent<StunVisualsComponent, MobStateChangedEvent>(OnStunMobStateChanged);
@@ -28,7 +26,7 @@ public abstract partial class SharedStunSystem
         // The incoming state from the server raises the event as well.
         // But the changes have also been dirtied
         // so we prevent applying them twice.
-        if (_timing.ApplyingState)
+        if (GameTiming.ApplyingState)
             return;
 
         Appearance.SetData(entity, StunVisuals.SeeingStars, GetStarsData(entity));

--- a/Content.Shared/Stunnable/SharedStunSystem.Visualizer.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Visualizer.cs
@@ -1,11 +1,14 @@
 ﻿using Content.Shared.Bed.Sleep;
 using Content.Shared.Mobs;
 using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Stunnable;
 
 public abstract partial class SharedStunSystem
 {
+    [Dependency] private IGameTiming _timing = default!;
+
     public void InitializeAppearance()
     {
         SubscribeLocalEvent<StunVisualsComponent, MobStateChangedEvent>(OnStunMobStateChanged);
@@ -22,6 +25,12 @@ public abstract partial class SharedStunSystem
 
     private void OnStunMobStateChanged(Entity<StunVisualsComponent> entity, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         Appearance.SetData(entity, StunVisuals.SeeingStars, GetStarsData(entity));
     }
 

--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -83,7 +83,7 @@ public abstract partial class SharedStunSystem : EntitySystem
         // The incoming state from the server raises the event as well.
         // But the changes have also been dirtied
         // so we prevent applying them twice.
-        if (_timing.ApplyingState)
+        if (GameTiming.ApplyingState)
             return;
 
         switch (args.NewMobState)

--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -80,6 +80,12 @@ public abstract partial class SharedStunSystem : EntitySystem
 
     private void OnMobStateChanged(EntityUid uid, MobStateComponent component, MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         switch (args.NewMobState)
         {
             case MobState.Alive:

--- a/Content.Shared/Trigger/Systems/TriggerOnMobstateChangeSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerOnMobstateChangeSystem.cs
@@ -3,12 +3,14 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Mobs;
 using Content.Shared.Popups;
 using Content.Shared.Trigger.Components.Triggers;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Trigger.Systems;
 
 public sealed partial class TriggerOnMobstateChangeSystem : TriggerOnXSystem
 {
     [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -23,6 +25,12 @@ public sealed partial class TriggerOnMobstateChangeSystem : TriggerOnXSystem
 
     private void OnMobStateChanged(EntityUid uid, TriggerOnMobstateChangeComponent component, MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (!component.MobState.Contains(args.NewMobState))
             return;
 
@@ -31,6 +39,12 @@ public sealed partial class TriggerOnMobstateChangeSystem : TriggerOnXSystem
 
     private void OnMobStateRelay(EntityUid uid, TriggerOnMobstateChangeComponent component, ImplantRelayEvent<MobStateChangedEvent> args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (!component.MobState.Contains(args.Args.NewMobState))
             return;
 

--- a/Content.Shared/Wagging/WaggingSystem.cs
+++ b/Content.Shared/Wagging/WaggingSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Humanoid.Markings;
 using Content.Shared.Mobs;
 using Content.Shared.Toggleable;
 using JetBrains.Annotations;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Wagging;
@@ -16,6 +17,7 @@ public sealed partial class WaggingSystem : EntitySystem
 {
     [Dependency] private SharedActionsSystem _actions = default!;
     [Dependency] private SharedVisualBodySystem _visualBody = default!;
+    [Dependency] private IGameTiming _timing = default!;
 
     /// <summary>
     /// Copies the component and its values to the clone.
@@ -75,6 +77,12 @@ public sealed partial class WaggingSystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnMobStateChanged(Entity<WaggingComponent> ent, ref MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         TryToggleWagging(ent.AsNullable(), false);
     }
 

--- a/Content.Shared/Xenoarchaeology/Artifact/XAT/XATDeathSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAT/XATDeathSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Mobs;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
 using Content.Shared.Xenoarchaeology.Artifact.XAT.Components;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Xenoarchaeology.Artifact.XAT;
 
@@ -10,6 +11,7 @@ namespace Content.Shared.Xenoarchaeology.Artifact.XAT;
 public sealed partial class XATDeathSystem : BaseXATSystem<XATDeathComponent>
 {
     [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private IGameTiming _timing = default!;
 
     [Dependency] private EntityQuery<XenoArtifactComponent> _xenoArtifactQuery = default!;
 
@@ -23,6 +25,12 @@ public sealed partial class XATDeathSystem : BaseXATSystem<XATDeathComponent>
 
     private void OnMobStateChanged(MobStateChangedEvent args)
     {
+        // The incoming state from the server raises the event as well.
+        // But the changes have also been dirtied
+        // so we prevent applying them twice.
+        if (_timing.ApplyingState)
+            return;
+
         if (args.NewMobState != MobState.Dead)
             return;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Updated the MobStateChangedEvent to be manually networked for raising the event on client, instead of using AfterAutoHandleState.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
Updated the MobStateChangedEvent to be manually networked for raising the event on client, instead of using AfterAutoHandleState.

Also added ApplyingState checks to all Shared systems that make use of the event.

The reason we do this is because if we change mobstate in a predicted way, the event would get raised both from the initial state change AND then from the client getting the data as well. So we return early if a state is applied so we only receive it once.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Play around with everything that listens to your mob state being changed.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

`MobStateComponent` is now manually networked. Any changes to it must be handled in the relevant `ComponentGetState` and `ComponentHandleState` subscriptios as well as moved to `MobStateComponentState`.
`MobStateChangedEvent` is also now raised on client after a server state is received. Shared systems that use it should return early if a state is currently being applied using `IGameTiming.ApplyingState`.
Please read the [Prediction Guide](https://docs.spacestation14.com/en/ss14-by-example/prediction-guide.html#prediction-checklist) for why it is done this way.


## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
