### PR TITLE
Bugfix: You can once again hear when you talk.

### DIFF
--- a/Content.Shared/Chat/SharedChatSystem.Emote.cs
+++ b/Content.Shared/Chat/SharedChatSystem.Emote.cs
@@ -157,7 +157,7 @@ public abstract partial class SharedChatSystem
         // optional override params > general params for all sounds in set > individual sound params
         var param = audioParams ?? proto.GeneralParams ?? sound.Params;
 
-        if (_net.IsServer) // Chat is not predicted.
+        if (_net.IsServer) // TODO: replace this call with PlayPredicted when chat is predicted.
             _audio.PlayPvs(sound, uid, param);
 
         return true;

--- a/Content.Shared/Speech/EntitySystems/SpeechNoiseSystem.cs
+++ b/Content.Shared/Speech/EntitySystems/SpeechNoiseSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Chat;
 using Content.Shared.Random.Helpers;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -10,6 +11,7 @@ namespace Content.Shared.Speech.EntitySystems;
 public sealed partial class SpeechSoundSystem : EntitySystem
 {
     [Dependency] private IGameTiming _gameTiming = default!;
+    [Dependency] private INetManager _net = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
 
     [SubscribeLocalEvent]
@@ -27,7 +29,8 @@ public sealed partial class SpeechSoundSystem : EntitySystem
 
         var sound = GetSpeechSound(ent, args.Message);
         ent.Comp.LastTimeSoundPlayed = currentTime;
-        _audio.PlayPredicted(sound, ent, ent);
+        if (_net.IsServer) // TODO: replace this call with PlayPredicted when chat is predicted.
+            _audio.PlayPvs(sound, ent);
     }
 
     /// <summary>

--- a/Content.Shared/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Shared/Speech/EntitySystems/VocalSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Random.Helpers;
 using Content.Shared.Speech.Components;
 using JetBrains.Annotations;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -15,6 +16,7 @@ namespace Content.Shared.Speech.EntitySystems;
 public sealed partial class VocalSystem : EntitySystem
 {
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private INetManager _net = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedChatSystem _chat = default!;
     [Dependency] private SharedActionsSystem _actions = default!;
@@ -95,7 +97,8 @@ public sealed partial class VocalSystem : EntitySystem
         var random = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(ent.Owner), GetNetEntity(user));
         if (random.Prob(ent.Comp.WilhelmProbability))
         {
-            _audio.PlayPredicted(ent.Comp.Wilhelm, ent.Owner, user, ent.Comp.Wilhelm.Params);
+            if (_net.IsServer) // TODO: replace this call with PlayPredicted when chat is predicted. (Remember to pass `user` and not `ent` as user)
+                _audio.PlayPvs(ent.Comp.Wilhelm, ent.Owner, ent.Comp.Wilhelm.Params);
             return true;
         }
 


### PR DESCRIPTION
## About the PR

Fixes a bug where you aren't able to hear yourself talk, and applies the same changes to the Wilhelm scream, which should suffer from the same issue.  Introduced by #44772.

## Why / Balance

OOK!

(Bugfix, small but annoying issue, feels bad)

## Technical details

Same solution as #44950.  Left TODOs on all three instances changed by this for future archaeologists when predicting chat.

Had a look through #44772, didn't find any other instances of PlayPredicted on code that only runs server-side sometimes.

Chat is only run on the server, so the predicted sound doesn't play for the attached entity (and when you're speaking, that's you!)

## Test plan

1. Spawn and become Pun Pun.
3. Say something.
4. OOK.
5. Spawn and become Urist.
6. Set VocalComponent.WilhelmProbability to one.
7. Scream - specifically through chat.
8. AUUUUUGH!

## Media

https://github.com/user-attachments/assets/0f52deb3-30f6-4504-bedc-3ee1ef7b57ab

https://github.com/user-attachments/assets/dcac7db2-a9c3-4e99-b76e-a4103fb96edc

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
I suppose, player facing, but I don't like it.
:cl:
- fix: You can once again hear when you speak.