### PR TITLE
Fix borgs showing incorrect verbs

### DIFF
--- a/Content.Shared/Wires/SharedWiresSystem.cs
+++ b/Content.Shared/Wires/SharedWiresSystem.cs
@@ -106,6 +106,9 @@ public abstract partial class SharedWiresSystem : EntitySystem
         if (!IsPanelOpen(ent.Owner))
             return;
 
+        if (!UI.HasUi(ent.Owner, WiresUiKey.Key))
+            return;
+
         var actor = args.User;
         var verb = new AlternativeVerb
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

If you unlock a cyborg, and use a screwdriver on it, then right click the borg, you get a verb which does nothing:

<img width="732" height="644" alt="image" src="https://github.com/user-attachments/assets/1ab7b6f8-922c-4c19-af55-99709b6d65bd" />

Cyborgs have a `WiresPanelComponent`, which is where this comes from, but they don't have a wires UI in their BUI.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->


This setup is confusing. When you right-click an unlocked, opened cyborg, you're expecting to get into the _maintenance panel_ for that cyborg, but that button does nothing! the _correct_ button to press is "Toggle UI".

## Technical details
<!-- Summary of code changes for easier review. -->

Trivial - check UI exists before offering a verb to open it.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Spawn a cyborg, unlock and use a screwdriver to open panel. Right click on the cyborg. See no "Open maintenance panel" button.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="522" height="591" alt="2026-08-03_18-57" src="https://github.com/user-attachments/assets/63a5a861-4f56-4f9d-88f5-5dc18e0c7d97" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
