### PR TITLE
Add toggle to the AFK automatic checks for downstreams

### DIFF
--- a/Content.Server/Afk/AFKSystem.cs
+++ b/Content.Server/Afk/AFKSystem.cs
@@ -108,7 +108,6 @@ public sealed partial class AFKSystem : EntitySystem
         _playerManager.PlayerStatusChanged -= OnPlayerChange;
         _afkManager.PlayerDidActionEvent -= OnPlayerAction;
         _cfg.UnsubValueChanged(CCVars.AfkTime, OnAfkTimeChanged);
-        _cfg.UnsubValueChanged(CCVars.AdminAfkTime, OnAdminAfkTimeChanged);
     }
 
     private void OnPlayerAction(ICommonSession session)

--- a/Content.Server/Afk/AFKSystem.cs
+++ b/Content.Server/Afk/AFKSystem.cs
@@ -108,6 +108,7 @@ public sealed partial class AFKSystem : EntitySystem
         _playerManager.PlayerStatusChanged -= OnPlayerChange;
         _afkManager.PlayerDidActionEvent -= OnPlayerAction;
         _cfg.UnsubValueChanged(CCVars.AfkTime, OnAfkTimeChanged);
+        _cfg.UnsubValueChanged(CCVars.AdminAfkTime, OnAdminAfkTimeChanged);
     }
 
     private void OnPlayerAction(ICommonSession session)

--- a/Content.Server/Afk/AfkConfirmSystem.cs
+++ b/Content.Server/Afk/AfkConfirmSystem.cs
@@ -38,8 +38,6 @@ public sealed partial class AfkConfirmSystem : EntitySystem
     {
         base.Initialize();
 
-        _afkAutomaticChecks = _cfg.GetCVar(CCVars.AfkAutomaticChecks);
-
         // Unafking does NOT clear it, require them to confirm via the window so they don't just random mash buttons.
         SubscribeLocalEvent<AFKEvent>(OnAfk);
         _players.PlayerStatusChanged += OnPlayerStatusChanged;

--- a/Content.Server/Afk/AfkConfirmSystem.cs
+++ b/Content.Server/Afk/AfkConfirmSystem.cs
@@ -32,9 +32,13 @@ public sealed partial class AfkConfirmSystem : EntitySystem
     private readonly Dictionary<ICommonSession, AfkConfirmation> _confirmations = new();
     private readonly Dictionary<ICommonSession, AfkConfirmation> _tempConfirmation = new();
 
+    private bool _afkAutomaticChecks;
+
     public override void Initialize()
     {
         base.Initialize();
+
+        _afkAutomaticChecks = _cfg.GetCVar(CCVars.AfkAutomaticChecks); // No changed listener, this CVar is config file only
 
         // Unafking does NOT clear it, require them to confirm via the window so they don't just random mash buttons.
         SubscribeLocalEvent<AFKEvent>(OnAfk);
@@ -58,6 +62,8 @@ public sealed partial class AfkConfirmSystem : EntitySystem
 
     private void OnAfk(ref AFKEvent ev)
     {
+        if (!_afkAutomaticChecks) // If no automatic checks, just don't consume the event.
+            return;
         TryStartConfirmation(ev.Session);
     }
 

--- a/Content.Server/Afk/AfkConfirmSystem.cs
+++ b/Content.Server/Afk/AfkConfirmSystem.cs
@@ -41,7 +41,7 @@ public sealed partial class AfkConfirmSystem : EntitySystem
         // Unafking does NOT clear it, require them to confirm via the window so they don't just random mash buttons.
         SubscribeLocalEvent<AFKEvent>(OnAfk);
         _players.PlayerStatusChanged += OnPlayerStatusChanged;
-        _cfg.OnValueChanged(CCVars.AfkAutomaticChecks, OnAfkAutomaticChecksToggled);
+        Subs.CVar(_cfg, CCVars.AfkAutomaticChecks, b => _afkAutomaticChecks = b, true);
         _cfg.OnValueChanged(CCVars.AfkTime, OnAfkTimeChanged);
     }
 

--- a/Content.Server/Afk/AfkConfirmSystem.cs
+++ b/Content.Server/Afk/AfkConfirmSystem.cs
@@ -104,11 +104,6 @@ public sealed partial class AfkConfirmSystem : EntitySystem
             _confirmations.Remove(args.Session);
     }
 
-    private void OnAfkAutomaticChecksToggled(bool value)
-    {
-        _afkAutomaticChecks = value;
-    }
-
     private void OnAfkTimeChanged(float value)
     {
         if (value > 0)

--- a/Content.Server/Afk/AfkConfirmSystem.cs
+++ b/Content.Server/Afk/AfkConfirmSystem.cs
@@ -56,7 +56,6 @@ public sealed partial class AfkConfirmSystem : EntitySystem
 
         _confirmations.Clear();
         _players.PlayerStatusChanged -= OnPlayerStatusChanged;
-        _cfg.UnsubValueChanged(CCVars.AfkAutomaticChecks, OnAfkAutomaticChecksToggled);
         _cfg.UnsubValueChanged(CCVars.AfkTime, OnAfkTimeChanged);
     }
 

--- a/Content.Server/Afk/AfkConfirmSystem.cs
+++ b/Content.Server/Afk/AfkConfirmSystem.cs
@@ -32,17 +32,18 @@ public sealed partial class AfkConfirmSystem : EntitySystem
     private readonly Dictionary<ICommonSession, AfkConfirmation> _confirmations = new();
     private readonly Dictionary<ICommonSession, AfkConfirmation> _tempConfirmation = new();
 
-    private bool _afkAutomaticChecks;
+    private bool _afkAutomaticChecks; // CCVar
 
     public override void Initialize()
     {
         base.Initialize();
 
-        _afkAutomaticChecks = _cfg.GetCVar(CCVars.AfkAutomaticChecks); // No changed listener, this CVar is config file only
+        _afkAutomaticChecks = _cfg.GetCVar(CCVars.AfkAutomaticChecks);
 
         // Unafking does NOT clear it, require them to confirm via the window so they don't just random mash buttons.
         SubscribeLocalEvent<AFKEvent>(OnAfk);
         _players.PlayerStatusChanged += OnPlayerStatusChanged;
+        _cfg.OnValueChanged(CCVars.AfkAutomaticChecks, OnAfkAutomaticChecksToggled);
         _cfg.OnValueChanged(CCVars.AfkTime, OnAfkTimeChanged);
     }
 
@@ -57,6 +58,7 @@ public sealed partial class AfkConfirmSystem : EntitySystem
 
         _confirmations.Clear();
         _players.PlayerStatusChanged -= OnPlayerStatusChanged;
+        _cfg.UnsubValueChanged(CCVars.AfkAutomaticChecks, OnAfkAutomaticChecksToggled);
         _cfg.UnsubValueChanged(CCVars.AfkTime, OnAfkTimeChanged);
     }
 
@@ -64,6 +66,7 @@ public sealed partial class AfkConfirmSystem : EntitySystem
     {
         if (!_afkAutomaticChecks) // If no automatic checks, just don't consume the event.
             return;
+
         TryStartConfirmation(ev.Session);
     }
 
@@ -101,6 +104,11 @@ public sealed partial class AfkConfirmSystem : EntitySystem
     {
         if (args.NewStatus == SessionStatus.Disconnected)
             _confirmations.Remove(args.Session);
+    }
+
+    private void OnAfkAutomaticChecksToggled(bool value)
+    {
+        _afkAutomaticChecks = value;
     }
 
     private void OnAfkTimeChanged(float value)

--- a/Content.Shared/CCVar/CCVars.Misc.cs
+++ b/Content.Shared/CCVar/CCVars.Misc.cs
@@ -31,6 +31,13 @@ public sealed partial class CCVars
         CVarDef.Create("anomaly.generation_grid_bounds_scale", 0.6f, CVar.SERVERONLY);
 
     /// <summary>
+    ///     Wether the server should mark people as AFK automatically at all. If disabled, AFK checks are admin-only.
+    ///     Intended to be configurable by config file only, this setting should not be changed in-game.
+    /// </summary>
+    public static readonly CVarDef<bool> AfkAutomaticChecks =
+        CVarDef.Create("afk.automatic_checks", true, CVar.SERVERONLY);
+
+    /// <summary>
     ///     How long a client can go without any input before being considered AFK.
     /// </summary>
     [CVarControl(AdminFlags.VarEdit, min: 0f, max: float.MaxValue)]

--- a/Content.Shared/CCVar/CCVars.Misc.cs
+++ b/Content.Shared/CCVar/CCVars.Misc.cs
@@ -31,7 +31,7 @@ public sealed partial class CCVars
         CVarDef.Create("anomaly.generation_grid_bounds_scale", 0.6f, CVar.SERVERONLY);
 
     /// <summary>
-    ///     Wether the server should mark people as AFK automatically at all. If disabled, AFK checks are admin-only.
+    ///     If enabled, the server automatically triggers an AFK check popup when a player's inactivity exceeds afk.time (or admin.afk_time for admins)
     /// </summary>
     public static readonly CVarDef<bool> AfkAutomaticChecks =
         CVarDef.Create("afk.automatic_checks", true, CVar.SERVERONLY);

--- a/Content.Shared/CCVar/CCVars.Misc.cs
+++ b/Content.Shared/CCVar/CCVars.Misc.cs
@@ -32,7 +32,6 @@ public sealed partial class CCVars
 
     /// <summary>
     ///     Wether the server should mark people as AFK automatically at all. If disabled, AFK checks are admin-only.
-    ///     Intended to be configurable by config file only, this setting should not be changed in-game.
     /// </summary>
     public static readonly CVarDef<bool> AfkAutomaticChecks =
         CVarDef.Create("afk.automatic_checks", true, CVar.SERVERONLY);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Added a CVar option to disable automatic AFK checks for server owners.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Some downstreams do not want this system active.

## Technical details
<!-- Summary of code changes for easier review. -->

Design choice: Made this a config-file only (CVar.SERVERONLY) CVar, this system should not be toggled in-flight.

Technical choice: System still initialises, but just doesn't consume the AFKEvent when it's raised. This means other applications such as admin logs etc. can still consume the AFKEvent when it's raised in future.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Set `afk.time = 5`, `admin.afk_time = 5` and `afk.automatic_checks = true` and run Client + Server. Observe the popup in five seconds. Then shut down the server and set `afk.automatic_checks = false`. Run Client + Server. Observe no popup within five seconds. Admin-initiated check still works.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

No media.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

None.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

Irrelevant for players, this is a config setting for downstreams only.