### PR TITLE
Bugfix: Better lifecycle handling for DisposalHolderComponent and BeingDisposedComponent

### DIFF
--- a/Content.Shared/Disposal/Holder/SharedDisposalHolderSystem.cs
+++ b/Content.Shared/Disposal/Holder/SharedDisposalHolderSystem.cs
@@ -19,41 +19,41 @@ namespace Content.Shared.Disposal.Holder;
 /// </summary>
 public abstract partial class SharedDisposalHolderSystem : EntitySystem
 {
+    [Dependency] private INetManager _net = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private DisposalTubeSystem _disposalTube = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedContainerSystem _container = default!;
+    [Dependency] private SharedEyeSystem _eye = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
     [Dependency] private SharedTransformSystem _xform = default!;
-    [Dependency] private INetManager _net = default!;
-    [Dependency] private SharedEyeSystem _eye = default!;
 
-    private EntityQuery<TransformComponent> _xformQuery;
+    [Dependency] private EntityQuery<TransformComponent> _xformQuery;
 
     /// <summary>
     /// Allowed characters for tagging disposed entities.
     /// </summary>
     public static readonly Regex TagRegex = new("^[a-zA-Z0-9, ]*$", RegexOptions.Compiled);
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        _xformQuery = GetEntityQuery<TransformComponent>();
-
-        SubscribeLocalEvent<DisposalHolderComponent, ComponentStartup>(OnComponentStartup);
-        SubscribeLocalEvent<DisposalHolderComponent, BeforeExplodeEvent>(OnExploded);
-
-        SubscribeLocalEvent<ActorComponent, DisposalSystemTransitionEvent>(OnActorTransition);
-        SubscribeLocalEvent<BeingDisposedComponent, GetVisMaskEvent>(OnGetVisibility);
-    }
-
+    [SubscribeLocalEvent]
     private void OnComponentStartup(Entity<DisposalHolderComponent> ent, ref ComponentStartup args)
     {
         // Ensure the holder will have its container
         ent.Comp.Container = _container.EnsureContainer<Container>(ent, nameof(DisposalHolderComponent));
     }
 
+    [SubscribeLocalEvent]
+    private void OnComponentRemove(Entity<DisposalHolderComponent> ent, ref ComponentRemove args)
+    {
+        if (ent.Comp.Container is not { } container)
+            return;
+
+        // Inform the contained entities that they aren't in disposals anymore.
+        foreach (var contained in container.ContainedEntities)
+            DetachEntity(contained);
+    }
+
+    [SubscribeLocalEvent]
     private void OnExploded(Entity<DisposalHolderComponent> ent, ref BeforeExplodeEvent args)
     {
         if (ent.Comp.Container == null)
@@ -62,18 +62,30 @@ public abstract partial class SharedDisposalHolderSystem : EntitySystem
         args.Contents.AddRange(ent.Comp.Container.ContainedEntities);
     }
 
+    [SubscribeLocalEvent]
     private void OnActorTransition(Entity<ActorComponent> ent, ref DisposalSystemTransitionEvent args)
     {
         // Refreshes visibility mask of a player, leading to OnGetVisibility being called
         _eye.RefreshVisibilityMask(ent.Owner);
     }
 
+    [SubscribeLocalEvent]
     private void OnGetVisibility(Entity<BeingDisposedComponent> entity, ref GetVisMaskEvent ev)
     {
         // Prevents mispredictions by allowing players in the disposal system
         // to be sent any entities that are hidden under subfloors
         if (HasComp<BeingDisposedComponent>(ev.Entity))
             ev.VisibilityMask |= (int)VisibilityFlags.Subfloor;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnDisposedRemovedFromContainer(Entity<BeingDisposedComponent> ent, ref EntGotRemovedFromContainerMessage args)
+    {
+        if (args.Container.Owner != ent.Comp.Holder)
+            return;
+
+        // Freedom.
+        DetachEntity(ent);
     }
 
     /// <summary>

--- a/Content.Shared/Disposal/Holder/SharedDisposalHolderSystem.cs
+++ b/Content.Shared/Disposal/Holder/SharedDisposalHolderSystem.cs
@@ -81,11 +81,8 @@ public abstract partial class SharedDisposalHolderSystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnDisposedRemovedFromContainer(Entity<BeingDisposedComponent> ent, ref EntGotRemovedFromContainerMessage args)
     {
-        if (args.Container.Owner != ent.Comp.Holder)
-            return;
-
-        // Freedom.
-        DetachEntity(ent);
+        if (args.Container.Owner == ent.Comp.Holder)
+            DetachEntity(ent);
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR

A set of proposed fixes for the disposals lifecycle.

## Why / Balance

Should fix #45136.

## Technical details

Two new calls: one for the entity leaving the disposal holder, another for the disposal holder having its component removed (on teardown or via divine intervention).

Disposal holder entities are removed via SharedDisposalHolderSystem.DetachEntity when removed from the container (teleportation) or when the container is no longer a disposal unit.  The second call _may not_ be needed, and shouldn't happen in regular gameplay, but makes some logical sense as a teardown function for the container.

Moves events in SharedDisposalHolderSystem to subscription attributes and ordered the system dependencies while we're in the neighbourhood.

## Test plan

Replicate the test steps from https://github.com/space-wizards/space-station-14/issues/45136#issuecomment-5176468379

1. Create a disposals loop, add a disposal unit (make it reasonably large)
2. Create a bluespace anomaly trap and an anomaly scanner.
3. Take over a Urist and step into the trap.
4. When your anomaly is about to pulse, enter the disposals and flush yourself.
5. You should teleport out of the tubes when it pulses.
6. Interact with anything after leaving the tubes.

## Media

https://github.com/user-attachments/assets/a38917b3-533e-4a22-9cda-cc0808dbf560

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
This seems very specific, but I'll write one up if you want.
