### PR TITLE
Lights fixes while mapping + yml cleanup

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -101,11 +101,11 @@
             max: 2
 
 - type: entity
-  parent: AlwaysPoweredWallLight
-  id: PoweredlightEmpty
   name: light
-  suffix: Empty
   description: "A light fixture. Draws power and produces light when equipped with a light tube."
+  id: PoweredlightEmpty
+  suffix: Empty
+  parent: AlwaysPoweredWallLight
   components:
   - type: Sprite
     sprite: Structures/Wallmounts/Lighting/light_tube.rsi
@@ -147,10 +147,10 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: PoweredlightEmpty
   id: Poweredlight
-  suffix: ""
   description: "A light fixture. Draws power and produces light when equipped with a light tube."
+  suffix: ""
+  parent: PoweredlightEmpty
   components:
   - type: Sprite
     state: base
@@ -172,10 +172,10 @@
 
 #LED lights
 - type: entity
-  parent: Poweredlight
   id: PoweredlightLED
-  suffix: LED
   description: "A light fixture. Draws power and produces light when equipped with a light tube."
+  suffix: LED
+  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LedLightTube
@@ -203,10 +203,10 @@
 
 #Exterior lights
 - type: entity
-  parent: Poweredlight
   id: PoweredlightExterior
-  suffix: Exterior
   description: "A light fixture. Draws power and produces light when equipped with a light tube."
+  suffix: Exterior
+  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: ExteriorLightTube
@@ -229,10 +229,10 @@
 
 #Sodium lights
 - type: entity
-  parent: Poweredlight
   id: PoweredlightSodium
-  suffix: Sodium
   description: "A light fixture. Draws power and produces light when equipped with a light tube."
+  suffix: Sodium
+  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: SodiumLightTube
@@ -306,11 +306,11 @@
       node: bulbLight
 
 - type: entity
-  parent: SmallLight
-  id: PoweredSmallLightEmpty
   name: small light
-  suffix: Empty
   description: "A light fixture. Draws power and produces light when equipped with a light bulb."
+  id: PoweredSmallLightEmpty
+  suffix: Empty
+  parent: SmallLight
   components:
   - type: Sprite
     sprite: Structures/Wallmounts/Lighting/light_small.rsi
@@ -352,9 +352,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: PoweredSmallLightEmpty
   id: PoweredLEDSmallLight
   suffix: LED
+  parent: PoweredSmallLightEmpty
   components:
   - type: Sprite
     state: base
@@ -373,9 +373,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: PoweredSmallLightEmpty
   id: PoweredDimSmallLight
   suffix: Dim
+  parent: PoweredSmallLightEmpty
   components:
   - type: Sprite
     state: base
@@ -394,9 +394,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: PoweredSmallLightEmpty
   id: PoweredWarmSmallLight
   suffix: Warm
+  parent: PoweredSmallLightEmpty
   components:
   - type: Sprite
     state: base
@@ -415,9 +415,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: PoweredSmallLightEmpty
   id: PoweredSmallLight
   suffix: ""
+  parent: PoweredSmallLightEmpty
   components:
   - type: Sprite
     state: base
@@ -492,9 +492,9 @@
 #Coloured lights
 
 - type: entity
-  parent: Poweredlight
   id: PoweredlightCyan
   suffix: Cyan
+  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalCyan
@@ -510,9 +510,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightCyan
   suffix: Always Powered, Cyan
+  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -521,9 +521,9 @@
     color: "#47f8ff"
 
 - type: entity
-  parent: Poweredlight
   id: PoweredlightBlue
   suffix: Blue
+  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalBlue
@@ -539,9 +539,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightBlue
   suffix: Always Powered, Blue
+  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -550,9 +550,9 @@
     color: "#39a1ff"
 
 - type: entity
-  parent: Poweredlight
   id: PoweredlightYellow
   suffix: Yellow
+  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalYellow
@@ -568,9 +568,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightYellow
   suffix: Always Powered, Yellow
+  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -579,9 +579,9 @@
     color: "#ffde46"
 
 - type: entity
-  parent: Poweredlight
   id: PoweredlightPink
   suffix: Pink
+  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalPink
@@ -597,9 +597,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightPink
   suffix: Always Powered, Pink
+  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -608,9 +608,9 @@
     color: "#ff66cc"
 
 - type: entity
-  parent: Poweredlight
   id: PoweredlightOrange
   suffix: Orange
+  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalOrange
@@ -626,9 +626,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightOrange
   suffix: Always Powered, Orange
+  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -637,9 +637,10 @@
     color: "#ff8227"
 
 - type: entity
-  parent: Poweredlight
   id: PoweredlightBlack
   suffix: Black
+  parent: Poweredlight
+  description:
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalBlack
@@ -655,9 +656,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightBlack
   suffix: Always Powered, Black
+  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -666,9 +667,9 @@
     color: "#363636"
 
 - type: entity
-  parent: Poweredlight
   id: PoweredlightRed
   suffix: Red
+  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalRed
@@ -684,9 +685,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightRed
   suffix: Always Powered, Red
+  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -695,9 +696,9 @@
     color: "#fb4747"
 
 - type: entity
-  parent: Poweredlight
   id: PoweredlightGreen
   suffix: Green
+  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalGreen
@@ -713,9 +714,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightGreen
   suffix: Always Powered, Green
+  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -150,7 +150,6 @@
   parent: PoweredlightEmpty
   id: Poweredlight
   suffix: ""
-  description: "A light fixture. Draws power and produces light when equipped with a light tube."
   components:
   - type: Sprite
     state: base
@@ -170,7 +169,6 @@
   parent: Poweredlight
   id: PoweredlightLED
   suffix: LED
-  description: "A light fixture. Draws power and produces light when equipped with a light tube."
   components:
   - type: PoweredLight
     hasLampOnSpawn: LedLightTube
@@ -201,7 +199,6 @@
   parent: Poweredlight
   id: PoweredlightExterior
   suffix: Exterior
-  description: "A light fixture. Draws power and produces light when equipped with a light tube."
   components:
   - type: PoweredLight
     hasLampOnSpawn: ExteriorLightTube
@@ -232,7 +229,6 @@
   parent: Poweredlight
   id: PoweredlightSodium
   suffix: Sodium
-  description: "A light fixture. Draws power and produces light when equipped with a light tube."
   components:
   - type: PoweredLight
     hasLampOnSpawn: SodiumLightTube

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -164,11 +164,6 @@
     range: 2
     sound:
       path: /Audio/Ambience/Objects/light_hum.ogg
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 2
-    popupText: powered-light-component-burn-hand
 
 #LED lights
 - type: entity
@@ -196,8 +191,8 @@
   suffix: Always Powered, LED
   components:
   - type: PointLight
-    radius: 10
-    energy: 2.5
+    radius: 15
+    energy: 1
     softness: 0.9
     color: "#EEEEFF"
 
@@ -210,6 +205,11 @@
   components:
   - type: PoweredLight
     hasLampOnSpawn: ExteriorLightTube
+  - type: PointLight
+    radius: 12
+    energy: 4.5
+    softness: 0.5
+    color: "#B4FCF0"
   - type: DamageOnInteract
     damage:
       types:
@@ -238,14 +238,9 @@
     hasLampOnSpawn: SodiumLightTube
   - type: PointLight
     radius: 10
-    energy: 2.5
-    softness: 0.9
+    energy: 4
+    softness: 0.5
     color: "#FFAF38"
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 2
-    popupText: powered-light-component-burn-hand
 
 - type: entity
   parent: AlwaysPoweredWallLight
@@ -275,6 +270,7 @@
       sprite: Structures/Wallmounts/Lighting/light_small.rsi
       state: base
     - type: PointLight
+      color: "#FFD1A3"
       energy: 1.0
       radius: 6
       softness: 1.1
@@ -348,7 +344,7 @@
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 2
+        Heat: 1
     popupText: powered-light-component-burn-hand
 
 - type: entity
@@ -366,11 +362,6 @@
     color: "#EEEEFF"
   - type: PoweredLight
     hasLampOnSpawn: LedLightBulb
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 1
-    popupText: powered-light-component-burn-hand
 
 - type: entity
   parent: PoweredSmallLightEmpty
@@ -387,11 +378,6 @@
     color: "#ba473f"
   - type: PoweredLight
     hasLampOnSpawn: DimLightBulb
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 1
-    popupText: powered-light-component-burn-hand
 
 - type: entity
   parent: PoweredSmallLightEmpty
@@ -405,7 +391,7 @@
     radius: 6
     energy: 1
     softness: 3
-    color: "#FF8A0C"
+    color: "#FF9833"
   - type: PoweredLight
     hasLampOnSpawn: WarmLightBulb
   - type: DamageOnInteract
@@ -490,235 +476,171 @@
             max: 1
 
 #Coloured lights
+- type: entity
+  abstract: true
+  parent: PoweredLight
+  id: PoweredlightColor
+  components:
+  - type: PointLight
+    radius: 8
+    energy: 3
+    softness: 0.5
+  - type: DamageOnInteract
+    damage:
+      types:
+        Heat: 2
+    popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: Poweredlight
+  abstract: true
+  parent: AlwaysPoweredWallLight
+  id: AlwaysPoweredlightColor
+  components:
+  - type: PointLight
+    radius: 8
+    energy: 3
+    softness: 0.5
+
+- type: entity
+  parent: PoweredlightColor
   id: PoweredlightCyan
   suffix: Cyan
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalCyan
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#47f8ff"
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 2
-    popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
+  parent: AlwaysPoweredlightColor
   id: AlwaysPoweredlightCyan
   suffix: Always Powered, Cyan
   components:
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#47f8ff"
 
 - type: entity
-  parent: Poweredlight
+  parent: PoweredlightColor
   id: PoweredlightBlue
   suffix: Blue
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalBlue
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#39a1ff"
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 2
-    popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
+  parent: AlwaysPoweredlightColor
   id: AlwaysPoweredlightBlue
   suffix: Always Powered, Blue
   components:
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#39a1ff"
 
 - type: entity
-  parent: Poweredlight
+  parent: PoweredlightColor
   id: PoweredlightYellow
   suffix: Yellow
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalYellow
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#ffde46"
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 2
-    popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
+  parent: AlwaysPoweredlightColor
   id: AlwaysPoweredlightYellow
   suffix: Always Powered, Yellow
   components:
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#ffde46"
 
 - type: entity
-  parent: Poweredlight
+  parent: PoweredlightColor
   id: PoweredlightPink
   suffix: Pink
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalPink
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#ff66cc"
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 2
-    popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
+  parent: AlwaysPoweredlightColor
   id: AlwaysPoweredlightPink
   suffix: Always Powered, Pink
   components:
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#ff66cc"
 
 - type: entity
-  parent: Poweredlight
+  parent: PoweredlightColor
   id: PoweredlightOrange
   suffix: Orange
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalOrange
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#ff8227"
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 2
-    popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
+  parent: AlwaysPoweredlightColor
   id: AlwaysPoweredlightOrange
   suffix: Always Powered, Orange
   components:
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#ff8227"
 
 - type: entity
-  parent: Poweredlight
+  parent: PoweredlightColor
   id: PoweredlightBlack
   suffix: Black
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalBlack
   - type: PointLight
-    radius: 8
-    energy: 1
-    softness: 0.5
     color: "#363636"
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 2
-    popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
+  parent: AlwaysPoweredlightColor
   id: AlwaysPoweredlightBlack
   suffix: Always Powered, Black
   components:
   - type: PointLight
-    radius: 8
-    energy: 1
-    softness: 0.5
     color: "#363636"
 
 - type: entity
-  parent: Poweredlight
+  parent: PoweredlightColor
   id: PoweredlightRed
   suffix: Red
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalRed
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#fb4747"
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 2
-    popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
+  parent: AlwaysPoweredlightColor
   id: AlwaysPoweredlightRed
   suffix: Always Powered, Red
   components:
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#fb4747"
 
 - type: entity
-  parent: Poweredlight
+  parent: PoweredlightColor
   id: PoweredlightGreen
   suffix: Green
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalGreen
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#52ff39"
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 2
-    popupText: powered-light-component-burn-hand
 
 - type: entity
-  parent: AlwaysPoweredWallLight
+  parent: AlwaysPoweredlightColor
   id: AlwaysPoweredlightGreen
   suffix: Always Powered, Green
   components:
   - type: PointLight
-    radius: 8
-    energy: 3
-    softness: 0.5
     color: "#52ff39"

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -604,6 +604,7 @@
   suffix: Always Powered, Black
   components:
   - type: PointLight
+    energy: 1
     color: "#363636"
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -474,7 +474,7 @@
 #Coloured lights
 - type: entity
   abstract: true
-  parent: PoweredLight
+  parent: Poweredlight
   id: PoweredlightColor
   components:
   - type: PointLight
@@ -595,6 +595,7 @@
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalBlack
   - type: PointLight
+    energy: 1
     color: "#363636"
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -101,11 +101,11 @@
             max: 2
 
 - type: entity
-  name: light
-  description: "A light fixture. Draws power and produces light when equipped with a light tube."
-  id: PoweredlightEmpty
-  suffix: Empty
   parent: AlwaysPoweredWallLight
+  id: PoweredlightEmpty
+  name: light
+  suffix: Empty
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
   components:
   - type: Sprite
     sprite: Structures/Wallmounts/Lighting/light_tube.rsi
@@ -147,10 +147,10 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
-  id: Poweredlight
-  description: "A light fixture. Draws power and produces light when equipped with a light tube."
-  suffix: ""
   parent: PoweredlightEmpty
+  id: Poweredlight
+  suffix: ""
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
   components:
   - type: Sprite
     state: base
@@ -172,10 +172,10 @@
 
 #LED lights
 - type: entity
-  id: PoweredlightLED
-  description: "A light fixture. Draws power and produces light when equipped with a light tube."
-  suffix: LED
   parent: Poweredlight
+  id: PoweredlightLED
+  suffix: LED
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
   components:
   - type: PoweredLight
     hasLampOnSpawn: LedLightTube
@@ -203,10 +203,10 @@
 
 #Exterior lights
 - type: entity
-  id: PoweredlightExterior
-  description: "A light fixture. Draws power and produces light when equipped with a light tube."
-  suffix: Exterior
   parent: Poweredlight
+  id: PoweredlightExterior
+  suffix: Exterior
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
   components:
   - type: PoweredLight
     hasLampOnSpawn: ExteriorLightTube
@@ -229,10 +229,10 @@
 
 #Sodium lights
 - type: entity
-  id: PoweredlightSodium
-  description: "A light fixture. Draws power and produces light when equipped with a light tube."
-  suffix: Sodium
   parent: Poweredlight
+  id: PoweredlightSodium
+  suffix: Sodium
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
   components:
   - type: PoweredLight
     hasLampOnSpawn: SodiumLightTube
@@ -306,11 +306,11 @@
       node: bulbLight
 
 - type: entity
-  name: small light
-  description: "A light fixture. Draws power and produces light when equipped with a light bulb."
-  id: PoweredSmallLightEmpty
-  suffix: Empty
   parent: SmallLight
+  id: PoweredSmallLightEmpty
+  name: small light
+  suffix: Empty
+  description: "A light fixture. Draws power and produces light when equipped with a light bulb."
   components:
   - type: Sprite
     sprite: Structures/Wallmounts/Lighting/light_small.rsi
@@ -352,9 +352,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: PoweredSmallLightEmpty
   id: PoweredLEDSmallLight
   suffix: LED
-  parent: PoweredSmallLightEmpty
   components:
   - type: Sprite
     state: base
@@ -373,9 +373,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: PoweredSmallLightEmpty
   id: PoweredDimSmallLight
   suffix: Dim
-  parent: PoweredSmallLightEmpty
   components:
   - type: Sprite
     state: base
@@ -394,9 +394,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: PoweredSmallLightEmpty
   id: PoweredWarmSmallLight
   suffix: Warm
-  parent: PoweredSmallLightEmpty
   components:
   - type: Sprite
     state: base
@@ -415,9 +415,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: PoweredSmallLightEmpty
   id: PoweredSmallLight
   suffix: ""
-  parent: PoweredSmallLightEmpty
   components:
   - type: Sprite
     state: base
@@ -492,9 +492,9 @@
 #Coloured lights
 
 - type: entity
+  parent: Poweredlight
   id: PoweredlightCyan
   suffix: Cyan
-  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalCyan
@@ -510,9 +510,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightCyan
   suffix: Always Powered, Cyan
-  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -521,9 +521,9 @@
     color: "#47f8ff"
 
 - type: entity
+  parent: Poweredlight
   id: PoweredlightBlue
   suffix: Blue
-  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalBlue
@@ -539,9 +539,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightBlue
   suffix: Always Powered, Blue
-  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -550,9 +550,9 @@
     color: "#39a1ff"
 
 - type: entity
+  parent: Poweredlight
   id: PoweredlightYellow
   suffix: Yellow
-  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalYellow
@@ -568,9 +568,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightYellow
   suffix: Always Powered, Yellow
-  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -579,9 +579,9 @@
     color: "#ffde46"
 
 - type: entity
+  parent: Poweredlight
   id: PoweredlightPink
   suffix: Pink
-  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalPink
@@ -597,9 +597,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightPink
   suffix: Always Powered, Pink
-  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -608,9 +608,9 @@
     color: "#ff66cc"
 
 - type: entity
+  parent: Poweredlight
   id: PoweredlightOrange
   suffix: Orange
-  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalOrange
@@ -626,9 +626,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightOrange
   suffix: Always Powered, Orange
-  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -637,10 +637,9 @@
     color: "#ff8227"
 
 - type: entity
+  parent: Poweredlight
   id: PoweredlightBlack
   suffix: Black
-  parent: Poweredlight
-  description:
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalBlack
@@ -656,9 +655,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightBlack
   suffix: Always Powered, Black
-  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -667,9 +666,9 @@
     color: "#363636"
 
 - type: entity
+  parent: Poweredlight
   id: PoweredlightRed
   suffix: Red
-  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalRed
@@ -685,9 +684,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightRed
   suffix: Always Powered, Red
-  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8
@@ -696,9 +695,9 @@
     color: "#fb4747"
 
 - type: entity
+  parent: Poweredlight
   id: PoweredlightGreen
   suffix: Green
-  parent: Poweredlight
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightTubeCrystalGreen
@@ -714,9 +713,9 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: AlwaysPoweredWallLight
   id: AlwaysPoweredlightGreen
   suffix: Always Powered, Green
-  parent: AlwaysPoweredWallLight
   components:
   - type: PointLight
     radius: 8

--- a/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
@@ -1,9 +1,9 @@
 - type: entity
+  parent: BaseStructure
   id: LightPostSmall
   name: post light
-  description: "An always powered light."
   suffix: Always Powered
-  parent: BaseStructure
+  description: "An always powered light."
   components:
   - type: Sprite
     sprite: Structures/Lighting/LightPosts/small_light_post.rsi
@@ -63,11 +63,11 @@
   - type: RequireProjectileTarget
 
 - type: entity
+  parent: LightPostSmall
   id: PoweredLightPostSmallEmpty
   name: post light
-  description: "A small light post."
   suffix: Empty
-  parent: LightPostSmall
+  description: "A small light post."
   components:
   - type: Sprite
     sprite: Structures/Lighting/LightPosts/small_light_post.rsi
@@ -112,11 +112,10 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: PoweredLightPostSmallEmpty
   id: PoweredLightPostSmall
   name: post light
-  description: "A light fixture. Draws power and produces light when equipped with a light tube."
   suffix: ""
-  parent: PoweredLightPostSmallEmpty
   components:
   - type: Sprite
     state: base
@@ -137,11 +136,10 @@
     popupText: powered-light-component-burn-hand
 
 - type: entity
+  parent: PoweredLightPostSmallEmpty
   id: PoweredLEDLightPostSmall
   name: post light
-  description: "A light fixture. Draws power and produces light when equipped with a light tube."
   suffix: LED
-  parent: PoweredLightPostSmallEmpty
   components:
   - type: Sprite
     state: base

--- a/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
@@ -129,11 +129,6 @@
     range: 3
     sound:
       path: /Audio/Ambience/Objects/light_hum.ogg
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 2
-    popupText: powered-light-component-burn-hand
 
 - type: entity
   parent: PoweredLightPostSmallEmpty

--- a/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
@@ -32,9 +32,9 @@
         - BulletImpassable
   - type: PointLight
     radius: 10
-    energy: 2.5
-    softness: 0.9
-    color: "#EEEEFF"
+    energy: 0.8
+    softness: 1
+    color: "#FFE4CE"
   - type: Anchorable
   - type: InteractionOutline
   - type: Damageable

--- a/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
@@ -67,7 +67,7 @@
   id: PoweredLightPostSmallEmpty
   name: post light
   suffix: Empty
-  description: "A small light post."
+  description: "A small light post. Draws power and produces light when equipped with a light tube."
   components:
   - type: Sprite
     sprite: Structures/Lighting/LightPosts/small_light_post.rsi


### PR DESCRIPTION
## About the PR
Matched the light of uninitialized powered lights and always powered lights to initialized powered lights 
YML cleanup  

## Why / Balance
Was annoying. Some lights were incorrect color while mapping and when you loaded the map, poof, diffrent color. This has been fixed.
And while i was at it, cleanup the YML to be a little bit shorter

## Technical details
yml

## Test plan
hard to test.....
I made a map with all the lights, saved it, did `mapping 1 testlights.yml`, then looked at the lights, then did `mapinit 1` and looked if anything was diffrent.
But honestly, you can just at the Media with before and after

## Media
# BEFORE
not initialized map
<img width="896" height="722" alt="image" src="https://github.com/user-attachments/assets/76ff0ee9-5a86-4ef2-96a0-34d876ce058f" />

initialized map
<img width="892" height="724" alt="image" src="https://github.com/user-attachments/assets/6cedc248-9f25-427e-a8e4-5928a267c064" />

# AFTER
not initialized map
<img width="895" height="723" alt="image" src="https://github.com/user-attachments/assets/116b7539-c03f-478a-adc2-7d42bd38bc7a" />

initialized map
<img width="891" height="731" alt="image" src="https://github.com/user-attachments/assets/60cc30c0-d78d-4875-ad8e-c6cad02e8ba9" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
not player facing, only useful for mapping really
