### PR TITLE
Add scream emote for chasm falls (reviving #44075)

### DIFF
--- a/Content.Shared/Chasm/ChasmComponent.cs
+++ b/Content.Shared/Chasm/ChasmComponent.cs
@@ -1,6 +1,8 @@
-﻿using Content.Shared.Whitelist;
+﻿using Content.Shared.Chat.Prototypes;
+using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Chasm;
 
@@ -29,6 +31,12 @@ public sealed partial class ChasmComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier FallingSound = new SoundPathSpecifier("/Audio/Effects/falling.ogg");
+
+    /// <summary>
+    /// Optional emote that should play when an entity falls into the chasm.
+    /// </summary>
+    [DataField]
+    public ProtoId<EmotePrototype>? Emote = "Scream";
 }
 
 /// <summary>

--- a/Content.Shared/Chasm/ChasmSystem.cs
+++ b/Content.Shared/Chasm/ChasmSystem.cs
@@ -150,6 +150,7 @@ public sealed partial class ChasmSystem : EntitySystem
 
     #endregion Public API
 
+    [SubscribeLocalEvent]
     private static void OnUpdateCanMove(Entity<ChasmFallingComponent> entity, ref UpdateCanMoveEvent args)
     {
         args.Cancel();

--- a/Content.Shared/Chasm/ChasmSystem.cs
+++ b/Content.Shared/Chasm/ChasmSystem.cs
@@ -26,6 +26,7 @@ public sealed partial class ChasmSystem : EntitySystem
     [Dependency] private EntityQuery<ChasmComponent> _chasmQuery;
     [Dependency] private EntityQuery<ChasmFallingComponent> _chasmFallingQuery;
 
+    /// <inheritdoc />
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -102,6 +103,12 @@ public sealed partial class ChasmSystem : EntitySystem
             RemCompDeferred<ChasmFallingComponent>(fallingEnt);
         }
     }
+
+    [SubscribeLocalEvent]
+    private static void OnUpdateCanMove(Entity<ChasmFallingComponent> entity, ref UpdateCanMoveEvent args)
+    {
+        args.Cancel();
+    }
     #endregion Event Handlers
 
     #region Public API
@@ -149,10 +156,4 @@ public sealed partial class ChasmSystem : EntitySystem
     }
 
     #endregion Public API
-
-    [SubscribeLocalEvent]
-    private static void OnUpdateCanMove(Entity<ChasmFallingComponent> entity, ref UpdateCanMoveEvent args)
-    {
-        args.Cancel();
-    }
 }

--- a/Content.Shared/Chasm/ChasmSystem.cs
+++ b/Content.Shared/Chasm/ChasmSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.ActionBlocker;
+using Content.Shared.Chat;
 using Content.Shared.Movement.Events;
 using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Weapons.Misc;
@@ -17,6 +18,7 @@ public sealed partial class ChasmSystem : EntitySystem
 {
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private ActionBlockerSystem _blocker = default!;
+    [Dependency] private SharedChatSystem _chat = default!;
     [Dependency] private SharedGrapplingGunSystem _grapple = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
@@ -24,17 +26,7 @@ public sealed partial class ChasmSystem : EntitySystem
     [Dependency] private EntityQuery<ChasmFallingComponent> _chasmFallingQuery;
     [Dependency] private EntityQuery<ChasmComponent> _chasmQuery;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<ChasmComponent, StepTriggeredOffEvent>(OnStepTriggered);
-        SubscribeLocalEvent<ChasmComponent, StepTriggerAttemptEvent>(OnStepTriggerAttempt);
-        SubscribeLocalEvent<ChasmComponent, ComponentShutdown>(OnShutdown);
-
-        SubscribeLocalEvent<ChasmFallingComponent, UpdateCanMoveEvent>(OnUpdateCanMove);
-    }
-
+    #region Event Handlers
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -61,6 +53,7 @@ public sealed partial class ChasmSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnStepTriggered(Entity<ChasmComponent> entity, ref StepTriggeredOffEvent args)
     {
         // already doomed
@@ -85,19 +78,49 @@ public sealed partial class ChasmSystem : EntitySystem
         StartFalling(entity.AsNullable(), args.Tripper);
     }
 
+    [SubscribeLocalEvent]
+    private void OnStepTriggerAttempt(Entity<ChasmComponent> entity, ref StepTriggerAttemptEvent args)
+    {
+        if (_grapple.IsEntityHooked(args.Tripper))
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        args.Continue = true;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnShutdown(Entity<ChasmComponent> entity, ref ComponentShutdown args)
+    {
+        var e = EntityQueryEnumerator<ChasmFallingComponent>();
+        while (e.MoveNext(out var fallingEnt, out var falling))
+        {
+            if (falling.FallingInto != entity.Owner)
+                continue;
+
+            RemCompDeferred<ChasmFallingComponent>(fallingEnt);
+        }
+    }
+    #endregion Event Handlers
+
+    #region Public API
     /// <summary>
     /// Causes <paramref name="tripper"/> to fall into <paramref name="chasm"/>: starts a falling animation, optionally
     /// plays a sound, and eventually deletes <paramref name="tripper"/>.
     /// If <paramref name="chasm"/> does not have a <see cref="ChasmComponent"/> component, does nothing and returns null.
     /// </summary>
+    /// <param name="playSound">Whether or not the chasm should play a sound when the entity falls in.</param>
+    /// <param name="playEmote">Whether or not <paramref name="tripper"/> should try to emote when falling into the chasm.</param>
     /// <returns>
-    /// <paramref name="tripper"/> with its new <see cref="ChasmFallingComponent"/>, if the entity did start falling. Null otherwise.
+    /// <paramref name="tripper"/> with its new <see cref="ChasmFallingComponent"/>, if the entity did start falling, null otherwise.
     /// </returns>
     [PublicAPI]
     public Entity<ChasmFallingComponent>? StartFalling(
         Entity<ChasmComponent?> chasm,
         EntityUid tripper,
-        bool playSound = true
+        bool playSound = true,
+        bool playEmote = true
     )
     {
         if (!_chasmQuery.Resolve(chasm, ref chasm.Comp, logMissing: false))
@@ -112,6 +135,9 @@ public sealed partial class ChasmSystem : EntitySystem
         if (playSound)
             _audio.PlayPredicted(chasm.Comp.FallingSound, chasm, tripper);
 
+        if (playEmote && chasm.Comp.Emote is { } emote)
+            _chat.TryEmoteWithChat(tripper, emote);
+
         var chasmEvent = new EntityStartedFallingIntoChasmEvent((tripper, falling));
         RaiseLocalEvent(chasm, ref chasmEvent);
         var tripperEvent = new StartedFallingIntoChasmEvent((chasm, chasm.Comp));
@@ -122,31 +148,10 @@ public sealed partial class ChasmSystem : EntitySystem
         return ret;
     }
 
-    private void OnStepTriggerAttempt(Entity<ChasmComponent> entity, ref StepTriggerAttemptEvent args)
-    {
-        if (_grapple.IsEntityHooked(args.Tripper))
-        {
-            args.Cancelled = true;
-            return;
-        }
-
-        args.Continue = true;
-    }
+    #endregion Public API
 
     private static void OnUpdateCanMove(Entity<ChasmFallingComponent> entity, ref UpdateCanMoveEvent args)
     {
         args.Cancel();
-    }
-
-    private void OnShutdown(Entity<ChasmComponent> entity, ref ComponentShutdown args)
-    {
-        var e = EntityQueryEnumerator<ChasmFallingComponent>();
-        while (e.MoveNext(out var fallingEnt, out var falling))
-        {
-            if (falling.FallingInto != entity.Owner)
-                continue;
-
-            RemCompDeferred<ChasmFallingComponent>(fallingEnt);
-        }
     }
 }

--- a/Content.Shared/Chasm/ChasmSystem.cs
+++ b/Content.Shared/Chasm/ChasmSystem.cs
@@ -16,17 +16,16 @@ namespace Content.Shared.Chasm;
 /// </summary>
 public sealed partial class ChasmSystem : EntitySystem
 {
-    [Dependency] private SharedAudioSystem _audio = default!;
+    [Dependency] private IGameTiming _timing = default!;
     [Dependency] private ActionBlockerSystem _blocker = default!;
+    [Dependency] private EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedChatSystem _chat = default!;
     [Dependency] private SharedGrapplingGunSystem _grapple = default!;
-    [Dependency] private IGameTiming _timing = default!;
-    [Dependency] private EntityWhitelistSystem _whitelist = default!;
 
-    [Dependency] private EntityQuery<ChasmFallingComponent> _chasmFallingQuery;
     [Dependency] private EntityQuery<ChasmComponent> _chasmQuery;
+    [Dependency] private EntityQuery<ChasmFallingComponent> _chasmFallingQuery;
 
-    #region Event Handlers
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -53,6 +52,7 @@ public sealed partial class ChasmSystem : EntitySystem
         }
     }
 
+    #region Event Handlers
     [SubscribeLocalEvent]
     private void OnStepTriggered(Entity<ChasmComponent> entity, ref StepTriggeredOffEvent args)
     {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Chasms now support arbitrary emotes (defaulting to a scream) when characters fall into it.

Picking up the torch from #44075.

## Why / Balance

Very funny.

## Technical details

New field in ChasmComponent for an arbitrary emote.
ChasmSystem.StartFalling has a new parameter for whether or not to emote.
Moved system over to use subscriptions, reordered methods and added regions for the relevant sections.
Alphabetized the entity system dependencies and ordered them after non-system dependencies.

## Test plan

Spawn chasm, jump into chasm.  Scream your lungs out.

## Media

https://github.com/user-attachments/assets/5420873e-ebb4-46ca-8afb-09d155ec3d87

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

Not technically breaking, only additive, but we add it just in case.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

`ChasmSystem.StartFalling` now has a new `playEmote` parameter.  Set this to false if an entity should not try to scream when falling into a chasm.

## Changelog
:cl: modder123543
- add: Characters now scream when they fall into a chasm.