### PR TITLE
Feature/issue 41116 artifacts partial fix

### DIFF
--- a/Content.Server/Xenoarchaeology/Artifact/XAE/Components/XAERandomTeleportInvokerComponent.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/Components/XAERandomTeleportInvokerComponent.cs
@@ -1,6 +1,6 @@
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Xenoarchaeology.Artifact.XAE.Components;
+namespace Content.Server.Xenoarchaeology.Artifact.XAE.Components;
 
 /// <summary>
 /// When activated, will teleport the artifact

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/Components/XAERandomTeleportInvokerComponent.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/Components/XAERandomTeleportInvokerComponent.cs
@@ -1,23 +1,21 @@
-using Robust.Shared.GameStates;
-
 namespace Content.Server.Xenoarchaeology.Artifact.XAE.Components;
 
 /// <summary>
 /// When activated, will teleport the artifact
 /// to a random position within a certain radius
 /// </summary>
-[RegisterComponent, Access(typeof(XAERandomTeleportInvokerSystem)), NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, Access(typeof(XAERandomTeleportInvokerSystem))]
 public sealed partial class XAERandomTeleportInvokerComponent : Component
 {
     /// <summary>
     /// The max distance that the artifact will teleport.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float MaxRange = 15f;
 
     /// <summary>
     /// The min distance that the artifact will teleport.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float MinRange = 6f;
 }

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/Components/XAEShuffleComponent.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/Components/XAEShuffleComponent.cs
@@ -10,6 +10,6 @@ public sealed partial class XAEShuffleComponent : Component
     /// <summary>
     /// Radius, within which mobs would be switched.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float Radius = 7.5f;
 }

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/Components/XAEShuffleComponent.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/Components/XAEShuffleComponent.cs
@@ -1,12 +1,10 @@
-using Robust.Shared.GameStates;
-
 namespace Content.Server.Xenoarchaeology.Artifact.XAE.Components;
 
 /// <summary>
 /// When activated, will shuffle the position of all players
 /// within a certain radius.
 /// </summary>
-[RegisterComponent, Access(typeof(XAEShuffleSystem)), NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, Access(typeof(XAEShuffleSystem))]
 public sealed partial class XAEShuffleComponent : Component
 {
     /// <summary>

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/Components/XAEShuffleComponent.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/Components/XAEShuffleComponent.cs
@@ -1,6 +1,6 @@
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Xenoarchaeology.Artifact.XAE.Components;
+namespace Content.Server.Xenoarchaeology.Artifact.XAE.Components;
 
 /// <summary>
 /// When activated, will shuffle the position of all players

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAERandomTeleportInvokerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAERandomTeleportInvokerSystem.cs
@@ -1,10 +1,12 @@
+using Content.Server.Xenoarchaeology.Artifact.XAE.Components;
 using Content.Shared.Popups;
 using Content.Shared.Random.Helpers;
-using Content.Shared.Xenoarchaeology.Artifact.XAE.Components;
-using Robust.Shared.Timing;
+using Content.Shared.Xenoarchaeology.Artifact;
+using Content.Shared.Xenoarchaeology.Artifact.XAE;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Timing;
 
-namespace Content.Shared.Xenoarchaeology.Artifact.XAE;
+namespace Content.Server.Xenoarchaeology.Artifact.XAE;
 
 /// <summary>
 /// System for teleporting artifact activator into random position.
@@ -21,6 +23,7 @@ public sealed partial class XAERandomTeleportInvokerSystem : BaseXAESystem<XAERa
     {
         var random = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(ent));
 
+        // todo: for prediction we need to have delay between activation and make a viewersub at a target spot
         // todo: teleport person who activated artifact with artifact itself
         var component = ent.Comp;
 

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAEShuffleSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAEShuffleSystem.cs
@@ -1,9 +1,10 @@
+using Content.Server.Xenoarchaeology.Artifact.XAE.Components;
 using Content.Shared.Mobs.Components;
-using Content.Shared.Xenoarchaeology.Artifact.XAE.Components;
+using Content.Shared.Xenoarchaeology.Artifact;
+using Content.Shared.Xenoarchaeology.Artifact.XAE;
 using Robust.Shared.Random;
-using Robust.Shared.Timing;
 
-namespace Content.Shared.Xenoarchaeology.Artifact.XAE;
+namespace Content.Server.Xenoarchaeology.Artifact.XAE;
 
 /// <summary>
 /// System that handles mob entities spacial shuffling effect.
@@ -13,7 +14,6 @@ public sealed partial class XAEShuffleSystem : BaseXAESystem<XAEShuffleComponent
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SharedTransformSystem _xform = default!;
-    [Dependency] private IGameTiming _timing = default!;
 
     [Dependency] private EntityQuery<MobStateComponent> _mobState = default!;
 
@@ -23,9 +23,6 @@ public sealed partial class XAEShuffleSystem : BaseXAESystem<XAEShuffleComponent
     /// <inheritdoc />
     protected override void OnActivated(Entity<XAEShuffleComponent> ent, ref XenoArtifactNodeActivatedEvent args)
     {
-        if(!_timing.IsFirstTimePredicted)
-            return;
-
         List<Entity<TransformComponent>> toShuffle = new();
         _entities.Clear();
         _lookup.GetEntitiesInRange(ent.Owner, ent.Comp.Radius, _entities, LookupFlags.Dynamic | LookupFlags.Sundries);

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEDamageInAreaSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEDamageInAreaSystem.cs
@@ -1,5 +1,5 @@
-using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
+using Content.Shared.Random.Helpers;
 using Content.Shared.Whitelist;
 using Content.Shared.Xenoarchaeology.Artifact.XAE.Components;
 using Robust.Shared.Random;
@@ -12,7 +12,6 @@ namespace Content.Shared.Xenoarchaeology.Artifact.XAE;
 /// </summary>
 public sealed partial class XAEDamageInAreaSystem : BaseXAESystem<XAEDamageInAreaComponent>
 {
-    [Dependency] private IRobustRandom _random = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private EntityWhitelistSystem _whitelistSystem = default!;
@@ -24,15 +23,13 @@ public sealed partial class XAEDamageInAreaSystem : BaseXAESystem<XAEDamageInAre
     /// <inheritdoc />
     protected override void OnActivated(Entity<XAEDamageInAreaComponent> ent, ref XenoArtifactNodeActivatedEvent args)
     {
-        if (!_timing.IsFirstTimePredicted)
-            return;
-
+        var random = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(ent));
         var damageInAreaComponent = ent.Comp;
         _entitiesInRange.Clear();
         _lookup.GetEntitiesInRange(ent.Owner, damageInAreaComponent.Radius, _entitiesInRange);
         foreach (var entityInRange in _entitiesInRange)
         {
-            if (!_random.Prob(damageInAreaComponent.DamageChance))
+            if (!random.Prob(damageInAreaComponent.DamageChance))
                 continue;
 
             if (_whitelistSystem.IsWhitelistFail(damageInAreaComponent.Whitelist, entityInRange))

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEDamageInAreaSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEDamageInAreaSystem.cs
@@ -23,16 +23,16 @@ public sealed partial class XAEDamageInAreaSystem : BaseXAESystem<XAEDamageInAre
     /// <inheritdoc />
     protected override void OnActivated(Entity<XAEDamageInAreaComponent> ent, ref XenoArtifactNodeActivatedEvent args)
     {
-        var random = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(ent));
         var damageInAreaComponent = ent.Comp;
         _entitiesInRange.Clear();
         _lookup.GetEntitiesInRange(ent.Owner, damageInAreaComponent.Radius, _entitiesInRange);
         foreach (var entityInRange in _entitiesInRange)
         {
-            if (!random.Prob(damageInAreaComponent.DamageChance))
+            if (_whitelistSystem.IsWhitelistFail(damageInAreaComponent.Whitelist, entityInRange))
                 continue;
 
-            if (_whitelistSystem.IsWhitelistFail(damageInAreaComponent.Whitelist, entityInRange))
+            var random = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(entityInRange));
+            if (!random.Prob(damageInAreaComponent.DamageChance))
                 continue;
 
             _damageable.TryChangeDamage(entityInRange, damageInAreaComponent.Damage, damageInAreaComponent.IgnoreResistances);

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERandomTeleportInvokerSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERandomTeleportInvokerSystem.cs
@@ -1,16 +1,16 @@
 using Content.Shared.Popups;
-using Content.Shared.Xenoarchaeology.Artifact.Components;
+using Content.Shared.Random.Helpers;
 using Content.Shared.Xenoarchaeology.Artifact.XAE.Components;
-using Robust.Shared.Random;
 using Robust.Shared.Timing;
-using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
 
 namespace Content.Shared.Xenoarchaeology.Artifact.XAE;
 
+/// <summary>
+/// System for teleporting artifact activator into random position.
+/// </summary>
 public sealed partial class XAERandomTeleportInvokerSystem : BaseXAESystem<XAERandomTeleportInvokerComponent>
 {
-    [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedTransformSystem _xform = default!;
     [Dependency] private IGameTiming _timing = default!;
@@ -19,15 +19,15 @@ public sealed partial class XAERandomTeleportInvokerSystem : BaseXAESystem<XAERa
     /// <inheritdoc />
     protected override void OnActivated(Entity<XAERandomTeleportInvokerComponent> ent, ref XenoArtifactNodeActivatedEvent args)
     {
-        if (!_timing.IsFirstTimePredicted)
-            return;
+        var random = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(ent));
+
         // todo: teleport person who activated artifact with artifact itself
         var component = ent.Comp;
 
         var xform = Transform(args.Artifact);
         _popup.PopupCoordinates(Loc.GetString("blink-artifact-popup"), xform.Coordinates, PopupType.Medium);
 
-        var offsetTo = _random.NextVector2(component.MinRange, component.MaxRange);
+        var offsetTo = random.NextVector2(component.MinRange, component.MaxRange);
 
         _xform.AttachToGridOrMap(args.Artifact);
         _jointSystem.ClearJoints(args.Artifact);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed some invalid usages of IsFirstTimePredicted, replaced mispredicting randomness with SharedRandomExtensions.PredictedRandom

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Part of https://github.com/space-wizards/space-station-14/issues/41116
## Technical details
<!-- Summary of code changes for easier review. -->
Due to the fact that client and server will have different collections returned by _lookup.GetEntitiesInRange i had to re-create predicted random for each specific case when we find whitelisted entity.
Random teleport thing was working okay sometimes but when it was teleporting out of PVS it bugged hard, so had to move it to server. To make it predicted we can try make a viewersub at the target spot but that would require having specific delay between activation and teleport, which i would like but it needs further design.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
(replace localhost@JoeGenero  with your local session, autocomplete will help)

teleport

1. Spawn artifacts 
```xenoartifact:spawnartwithnode localhost@JoeGenero DummyArtifactItem XenoArtifactTeleport TriggerExamine ```
2. Examine artifact while controlling mob
3. Wait until node unlocks
4. Activate artifact 
5. Observe that teleport was triggered and teleported away

shuffle
1. Spawn artifacts 
```xenoartifact:spawnartwithnode localhost@JoeGenero DummyArtifactItem XenoArtifactShuffle TriggerExamine ```
2. Examine artifact while controlling mob
3. Wait until node unlocks
4. Go close any other mob and  Activate artifact 
5. Observe that teleport was triggered and teleported away

damage in area
1. Spawn artifacts 
```xenoartifact:spawnartwithnode localhost@JoeGenero DummyArtifactItem XenoArtifactShatterWindows TriggerExamine ```
2. Examine artifact while controlling mob
3. Wait until node unlocks
4. Go close to windows (or spawn them) and Activate artifact 
5. Observe that windows get damaged without any delay

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
