### PR TITLE
Make creating the database not take 2 whole seconds in integration tests

### DIFF
--- a/Content.IntegrationTests/PoolManager.Cvars.cs
+++ b/Content.IntegrationTests/PoolManager.Cvars.cs
@@ -12,6 +12,7 @@ public static partial class PoolManager
     {
         // @formatter:off
         (CCVars.DatabaseSynchronous.Name,     "true"),
+        (CCVars.DatabaseSnapshot.Name,        "true"),
         (CCVars.DatabaseSqliteDelay.Name,     "0"),
         (CCVars.HolidaysEnabled.Name,         "false"),
         (CCVars.GameMap.Name,                 TestMap),

--- a/Content.IntegrationTests/Tests/Preferences/ServerDbSqliteTests.cs
+++ b/Content.IntegrationTests/Tests/Preferences/ServerDbSqliteTests.cs
@@ -64,7 +64,7 @@ namespace Content.IntegrationTests.Tests.Preferences
             var conn = new SqliteConnection("Data Source=:memory:");
             conn.Open();
             builder.UseSqlite(conn);
-            return new ServerDbSqlite(() => builder.Options, true, cfg, true, opsLog, serialization);
+            return new ServerDbSqlite(() => builder.Options, true, cfg, true, opsLog, serialization, false);
         }
 
         [Test]

--- a/Content.Server/Database/ServerDbManager.cs
+++ b/Content.Server/Database/ServerDbManager.cs
@@ -421,6 +421,7 @@ namespace Content.Server.Database
         private ISawmill _sawmill = default!;
 
         private bool _synchronous;
+        private bool _snapshot;
         // When running in integration tests, we'll use a single in-memory SQLite database connection.
         // This is that connection, close it when we shut down.
         private SqliteConnection? _sqliteInMemoryConnection;
@@ -437,6 +438,7 @@ namespace Content.Server.Database
             _sawmill = _logMgr.GetSawmill("db.manager");
 
             _synchronous = _cfg.GetCVar(CCVars.DatabaseSynchronous);
+            _snapshot = _cfg.GetCVar(CCVars.DatabaseSnapshot);
 
             var engine = _cfg.GetCVar(CCVars.DatabaseEngine).ToLower();
             var opsLog = _logMgr.GetSawmill("db.op");
@@ -445,7 +447,7 @@ namespace Content.Server.Database
             {
                 case "sqlite":
                     SetupSqlite(out var contextFunc, out var inMemory);
-                    _db = new ServerDbSqlite(contextFunc, inMemory, _cfg, _synchronous, opsLog, _serialization);
+                    _db = new ServerDbSqlite(contextFunc, inMemory, _cfg, _synchronous, opsLog, _serialization, _snapshot);
                     break;
                 case "postgres":
                     var (pgOptions, conString) = CreatePostgresOptions();

--- a/Content.Server/Database/ServerDbSqlite.cs
+++ b/Content.Server/Database/ServerDbSqlite.cs
@@ -52,7 +52,7 @@ namespace Content.Server.Database
 
             if (synchronous)
             {
-                // EnsureCreated means you can't later apply migrations, fine for tests
+                // EnsureCreated means you can't apply migrations later, fine for tests
                 if (snapshot)
                     prefsCtx.Database.EnsureCreated();
                 else

--- a/Content.Server/Database/ServerDbSqlite.cs
+++ b/Content.Server/Database/ServerDbSqlite.cs
@@ -38,7 +38,8 @@ namespace Content.Server.Database
             IConfigurationManager cfg,
             bool synchronous,
             ISawmill opsLog,
-            ISerializationManager serialization)
+            ISerializationManager serialization,
+            bool snapshot)
             : base(opsLog, serialization)
         {
             _options = options;
@@ -51,7 +52,12 @@ namespace Content.Server.Database
 
             if (synchronous)
             {
-                prefsCtx.Database.Migrate();
+                // EnsureCreated means you can't later apply migrations, fine for tests
+                if (snapshot)
+                    prefsCtx.Database.EnsureCreated();
+                else
+                    prefsCtx.Database.Migrate();
+
                 _dbReadyTask = Task.CompletedTask;
                 prefsCtx.Dispose();
             }

--- a/Content.Shared/CCVar/CCVars.Database.cs
+++ b/Content.Shared/CCVar/CCVars.Database.cs
@@ -74,4 +74,12 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> DatabaseSynchronous =
         CVarDef.Create("database.sync", false, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Creates the SQLite database using EnsureCreated instead of Migrate, if using SQLite.
+    ///     Setting this to true means you cannot later apply migrations.
+    ///     Meant to be used in integration tests only.
+    /// </summary>
+    public static readonly CVarDef<bool> DatabaseSnapshot =
+        CVarDef.Create("database.snapshot", false, CVar.SERVERONLY);
 }

--- a/Content.Shared/CCVar/CCVars.Database.cs
+++ b/Content.Shared/CCVar/CCVars.Database.cs
@@ -77,7 +77,7 @@ public sealed partial class CCVars
 
     /// <summary>
     ///     Creates the SQLite database using EnsureCreated instead of Migrate, if using SQLite.
-    ///     Setting this to true means you cannot later apply migrations.
+    ///     Setting this to true means you cannot apply migrations later.
     ///     Meant to be used in integration tests only.
     /// </summary>
     public static readonly CVarDef<bool> DatabaseSnapshot =


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
ServerDbSqlite 1885 ms > 144 ms (33.7% > 6.31% of ServerIntegrationInstance.Init time)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
CVar to toggle it on/off
You could technically use this outside tests but there's no reason to, its implemented the same way as the synchronous toggle though

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
