### PR TITLE
Validate EntProtoId and EntProtoId<T> CVars in ConfigPresetTests.TestLoadAll

### DIFF
--- a/Content.IntegrationTests/Tests/ConfigPresetTests.cs
+++ b/Content.IntegrationTests/Tests/ConfigPresetTests.cs
@@ -19,7 +19,6 @@ public sealed class ConfigPresetTests : GameTest
 
         var resources = server.ResolveDependency<IResourceManager>();
         var config = server.ResolveDependency<IConfigurationManager>();
-        var prototypes = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitPost(() =>
         {
@@ -41,7 +40,7 @@ public sealed class ConfigPresetTests : GameTest
                 {
                     var stream = resources.ContentFileRead(preset);
                     Assert.DoesNotThrow(() => config.LoadDefaultsFromTomlStream(stream));
-                    Assert.That(prototypes.ValidateCVars(), Is.Empty);
+                    Assert.That(SProtoMan.ValidateCVars(), Is.Empty);
                 }
             });
 

--- a/Content.IntegrationTests/Tests/ConfigPresetTests.cs
+++ b/Content.IntegrationTests/Tests/ConfigPresetTests.cs
@@ -4,6 +4,7 @@ using Content.IntegrationTests.Fixtures;
 using Content.Server.Entry;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
+using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests;
 
@@ -18,6 +19,7 @@ public sealed class ConfigPresetTests : GameTest
 
         var resources = server.ResolveDependency<IResourceManager>();
         var config = server.ResolveDependency<IConfigurationManager>();
+        var prototypes = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitPost(() =>
         {
@@ -39,6 +41,7 @@ public sealed class ConfigPresetTests : GameTest
                 {
                     var stream = resources.ContentFileRead(preset);
                     Assert.DoesNotThrow(() => config.LoadDefaultsFromTomlStream(stream));
+                    Assert.That(prototypes.ValidateCVars(), Is.Empty);
                 }
             });
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Requires https://github.com/space-wizards/RobustToolbox/pull/6925
To this test I return
The YAML linter automatically calls this too, for current and default values

Example output:
```
Multiple failures or warnings in test:
  1)   Assert.That(prototypes.ValidateCVars(), Is.Empty)
  Expected: <empty>
  But was:  < "EntProtoId CVar failed validation. No entity prototype found with id abcd1234.", "EntProtoId CVar failed validation. Entity prototype 'ActionFireStarter' does not have a component of type 'Buckle'." >
```

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
