### PR TITLE
Bugfix: Better RCD LocId handling.

### DIFF
--- a/Content.Client/RCD/RCDMenuBoundUserInterface.cs
+++ b/Content.Client/RCD/RCDMenuBoundUserInterface.cs
@@ -2,6 +2,7 @@ using Content.Client.Popups;
 using Content.Client.UserInterface.Controls;
 using Content.Shared.RCD;
 using Content.Shared.RCD.Components;
+using Content.Shared.RCD.Systems;
 using JetBrains.Annotations;
 using Robust.Client.UserInterface;
 using Robust.Shared.Collections;
@@ -17,6 +18,7 @@ public sealed partial class RCDMenuBoundUserInterface : BoundUserInterface
     [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private ISharedPlayerManager _playerManager = default!;
     [Dependency] private PopupSystem _popup = default!;
+    [Dependency] private RCDSystem _rcd = default!;
 
     private const string TopLevelActionCategory = "Main";
 
@@ -118,20 +120,12 @@ public sealed partial class RCDMenuBoundUserInterface : BoundUserInterface
         if (_playerManager.LocalSession?.AttachedEntity == null)
             return;
 
-        var msg = Loc.GetString("rcd-component-change-mode", ("mode", Loc.GetString(proto.SetName)));
+        var rcdName = _rcd.GetPrototypeName(proto);
+
+        var msg = Loc.GetString("rcd-component-change-mode", ("mode", rcdName));
 
         if (proto.Mode is RcdMode.ConstructTile or RcdMode.ConstructObject)
-        {
-            var name = Loc.GetString(proto.SetName);
-
-            if (proto.Prototype != null &&
-                _prototypeManager.TryIndex(proto.Prototype, out var entProto)) // don't use Resolve because this can be a tile
-            {
-                name = entProto.Name;
-            }
-
-            msg = Loc.GetString("rcd-component-change-build-mode", ("name", name));
-        }
+            msg = Loc.GetString("rcd-component-change-build-mode", ("name", rcdName));
 
         // Popup message
         _popup.PopupEntity(msg, Owner);
@@ -139,19 +133,7 @@ public sealed partial class RCDMenuBoundUserInterface : BoundUserInterface
 
     private string GetTooltip(RCDPrototype proto)
     {
-        string tooltip;
-
-        if (proto.Mode is RcdMode.ConstructTile or RcdMode.ConstructObject
-            && proto.Prototype != null
-            && _prototypeManager.TryIndex(proto.Prototype, out var entProto)) // don't use Resolve because this can be a tile
-        {
-            tooltip = Loc.GetString(entProto.Name);
-        }
-        else
-        {
-            tooltip = Loc.GetString(proto.SetName);
-        }
-
+        var tooltip = _rcd.GetPrototypeName(proto);
         tooltip = OopsConcat(char.ToUpper(tooltip[0]).ToString(), tooltip.Remove(0, 1));
 
         return tooltip;

--- a/Content.Shared/RCD/RCDPrototype.cs
+++ b/Content.Shared/RCD/RCDPrototype.cs
@@ -26,7 +26,7 @@ public sealed partial class RCDPrototype : IPrototype
     /// Defaults to the rcd-unknown LocId otherwise.
     /// </summary>
     /// <remarks>
-    /// Use <see cref="RcdSystem.GetPrototypeName"/> instead of using this directly.
+    /// Use <see cref="RCDSystem.GetPrototypeName"/> instead of using this directly.
     /// </remarks>
     [DataField("name"), ViewVariables(VVAccess.ReadOnly)]
     public LocId? SetName { get; private set; }

--- a/Content.Shared/RCD/RCDPrototype.cs
+++ b/Content.Shared/RCD/RCDPrototype.cs
@@ -23,7 +23,7 @@ public sealed partial class RCDPrototype : IPrototype
     /// <summary>
     /// The name associated with the prototype.
     /// If null, uses the prototype's name, if it exists.
-    /// Defaults to the <c>rcd-unknown</c> LocId otherwise.
+    /// Defaults to the <c>generic-unknown-title</c> LocId otherwise.
     /// </summary>
     /// <remarks>
     /// Use <see cref="RCDSystem.GetPrototypeName"/> instead of using this directly.

--- a/Content.Shared/RCD/RCDPrototype.cs
+++ b/Content.Shared/RCD/RCDPrototype.cs
@@ -25,6 +25,9 @@ public sealed partial class RCDPrototype : IPrototype
     /// If null, uses the prototype's name, if it exists.
     /// Defaults to the rcd-unknown LocId otherwise.
     /// </summary>
+    /// <remarks>
+    /// Use <see cref="RcdSystem.GetPrototypeName"/> instead of using this directly.
+    /// </remarks>
     [DataField("name"), ViewVariables(VVAccess.ReadOnly)]
     public LocId? SetName { get; private set; }
 

--- a/Content.Shared/RCD/RCDPrototype.cs
+++ b/Content.Shared/RCD/RCDPrototype.cs
@@ -21,10 +21,12 @@ public sealed partial class RCDPrototype : IPrototype
     public RcdMode Mode { get; private set; } = RcdMode.Invalid;
 
     /// <summary>
-    /// The name associated with the prototype
+    /// The name associated with the prototype.
+    /// If null, uses the prototype's name, if it exists.
+    /// Defaults to the rcd-unknown LocId otherwise.
     /// </summary>
     [DataField("name"), ViewVariables(VVAccess.ReadOnly)]
-    public string SetName { get; private set; } = "Unknown";
+    public LocId? SetName { get; private set; }
 
     /// <summary>
     /// The name of the radial container that this prototype will be listed under on the RCD menu

--- a/Content.Shared/RCD/RCDPrototype.cs
+++ b/Content.Shared/RCD/RCDPrototype.cs
@@ -23,7 +23,7 @@ public sealed partial class RCDPrototype : IPrototype
     /// <summary>
     /// The name associated with the prototype.
     /// If null, uses the prototype's name, if it exists.
-    /// Defaults to the rcd-unknown LocId otherwise.
+    /// Defaults to the <c>rcd-unknown</c> LocId otherwise.
     /// </summary>
     /// <remarks>
     /// Use <see cref="RCDSystem.GetPrototypeName"/> instead of using this directly.

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -49,6 +49,7 @@ public sealed partial class RCDSystem : EntitySystem
     private readonly ProtoId<RCDPrototype> _deconstructTileProto = "DeconstructTile";
     private readonly ProtoId<RCDPrototype> _deconstructLatticeProto = "DeconstructLattice";
     private static readonly ProtoId<TagPrototype> CatwalkTag = "Catwalk";
+    private static readonly LocId DefaultRecipeLocId = "rcd-unknown";
 
     private HashSet<EntityUid> _intersectingEntities = new();
 
@@ -63,6 +64,19 @@ public sealed partial class RCDSystem : EntitySystem
         SubscribeLocalEvent<RCDComponent, DoAfterAttemptEvent<RCDDoAfterEvent>>(OnDoAfterAttempt);
         SubscribeLocalEvent<RCDComponent, RCDSystemMessage>(OnRCDSystemMessage);
         SubscribeNetworkEvent<RCDConstructionGhostRotationEvent>(OnRCDconstructionGhostRotationEvent);
+    }
+
+    /// <summary>
+    /// Gets the display name of a given RCDPrototype.
+    /// </summary>
+    public string GetPrototypeName(RCDPrototype prototype)
+    {
+        if (prototype.SetName != null)
+            return Loc.GetString(prototype.SetName);
+        else if (prototype.Prototype != null)
+            return ProtoMan.Index(prototype.Prototype).Name; // already localized
+        else
+            return Loc.GetString(DefaultRecipeLocId);
     }
 
     #region Event handling
@@ -106,18 +120,14 @@ public sealed partial class RCDSystem : EntitySystem
 
         var prototype = ProtoMan.Index(component.ProtoId);
 
-        var msg = Loc.GetString("rcd-component-examine-mode-details", ("mode", Loc.GetString(prototype.SetName)));
+        var displayName = GetPrototypeName(prototype);
+
+        string msg;
 
         if (prototype.Mode == RcdMode.ConstructTile || prototype.Mode == RcdMode.ConstructObject)
-        {
-            var name = Loc.GetString(prototype.SetName);
-
-            if (prototype.Prototype != null &&
-                ProtoMan.TryIndex(prototype.Prototype, out var proto)) // don't use Resolve because this can be a tile
-                name = proto.Name;
-
-            msg = Loc.GetString("rcd-component-examine-build-details", ("name", name));
-        }
+            msg = Loc.GetString("rcd-component-examine-build-details", ("name", displayName));
+        else
+            msg = Loc.GetString("rcd-component-examine-mode-details", ("mode", displayName));
 
         args.PushMarkup(msg);
     }

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -49,7 +49,7 @@ public sealed partial class RCDSystem : EntitySystem
     private readonly ProtoId<RCDPrototype> _deconstructTileProto = "DeconstructTile";
     private readonly ProtoId<RCDPrototype> _deconstructLatticeProto = "DeconstructLattice";
     private static readonly ProtoId<TagPrototype> CatwalkTag = "Catwalk";
-    private static readonly LocId DefaultPrototypeNameLocId = "rcd-unknown";
+    private static readonly LocId DefaultPrototypeNameLocId = "generic-unknown-title";
 
     private HashSet<EntityUid> _intersectingEntities = new();
 

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -49,7 +49,7 @@ public sealed partial class RCDSystem : EntitySystem
     private readonly ProtoId<RCDPrototype> _deconstructTileProto = "DeconstructTile";
     private readonly ProtoId<RCDPrototype> _deconstructLatticeProto = "DeconstructLattice";
     private static readonly ProtoId<TagPrototype> CatwalkTag = "Catwalk";
-    private static readonly LocId DefaultRecipeLocId = "rcd-unknown";
+    private static readonly LocId DefaultPrototypeNameLocId = "rcd-unknown";
 
     private HashSet<EntityUid> _intersectingEntities = new();
 
@@ -76,7 +76,7 @@ public sealed partial class RCDSystem : EntitySystem
         else if (prototype.Prototype != null)
             return ProtoMan.Index(prototype.Prototype).Name; // already localized
         else
-            return Loc.GetString(DefaultRecipeLocId);
+            return Loc.GetString(DefaultPrototypeNameLocId);
     }
 
     #region Event handling

--- a/Resources/Locale/en-US/rcd/components/rcd-component.ftl
+++ b/Resources/Locale/en-US/rcd/components/rcd-component.ftl
@@ -4,6 +4,7 @@
 rcd-component-examine-mode-details = It's currently set to '{$mode}' mode.
 rcd-component-examine-build-details = It's currently set to build {MAKEPLURAL($name)}.
 
+
 ### Interaction Messages
 
 # Mode change

--- a/Resources/Locale/en-US/rcd/components/rcd-component.ftl
+++ b/Resources/Locale/en-US/rcd/components/rcd-component.ftl
@@ -4,6 +4,7 @@
 rcd-component-examine-mode-details = It's currently set to '{$mode}' mode.
 rcd-component-examine-build-details = It's currently set to build {MAKEPLURAL($name)}.
 
+rcd-unknown = Unknown
 
 ### Interaction Messages
 

--- a/Resources/Locale/en-US/rcd/components/rcd-component.ftl
+++ b/Resources/Locale/en-US/rcd/components/rcd-component.ftl
@@ -4,8 +4,6 @@
 rcd-component-examine-mode-details = It's currently set to '{$mode}' mode.
 rcd-component-examine-build-details = It's currently set to build {MAKEPLURAL($name)}.
 
-rcd-unknown = Unknown
-
 ### Interaction Messages
 
 # Mode change


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Adds a method for RCD prototype name lookup in RCDSystem, uses this instead of relying on RCDPrototype.SetName directly.

## Why / Balance

Resolves #45145.

## Technical details

Adds a new method to RCDSystem, GetPrototypeName, which returns a localized, human readable name for a given RCDPrototype.

Replaces uses of RCDPrototype.SetName with this new method (consistently!) - all prototypes will use their display name, if given, then their entity's name (if there is one), then rcd-unknown.

RCDPrototype.SetName changed from a `string` to a `LocId?`.

## Test plan
Open RCD menu
View submenus.
Check the debug console.
No warnings!

## Media

https://github.com/user-attachments/assets/475ffc6c-4289-404e-86ea-5d0830b7f47c

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

`RCDPrototype.SetName` is now a `LocId?` instead of a `string`.  Use `RCDSystem.GetPrototypeName()` vs. reading this value directly.

## Changelog
no!