### PR TITLE
Fix light tube sprite

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -80,6 +80,8 @@
   parent: BaseReplacementLight
   id: BaseLightTube
   components:
+  - type: Sprite
+    sprite: Objects/Power/light_tube.rsi
   - type: Destructible
     thresholds:
     - trigger: *DamageTrigger10


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Right now, light tubes use the bulb sprite because nothing tells tubes to use the tube sprite.

## Technical details
<!-- Summary of code changes for easier review. -->
ya just gotta put a little
```yaml
  - type: Sprite
    sprite: Objects/Power/light_tube.rsi
```
into it

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
devmap
`aghost`
pull tube out of nearby fixture
observe it's a tube
throw it on the ground
observe it's a tube with the end broken off

tbh I don't know when the "burnt" sprite is used.
Maybe also try out other tube variants, idk

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
smol n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Light tubes look like tubes again, rather than like bulbs.
