### PR TITLE
Give the Syndicate Assault Borg a screwdriver

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1289,6 +1289,7 @@
     - type: ItemBorgModule
       hands:
       - item: Crowbar
+      - item: Screwdriver
       - item: Emag
       - item: AccessBreaker
       - item: PinpointerSyndicateNuclear


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gives the Syndicate Assault Borg and Derelict Assault Borg a screwdriver in the basic operative module.

## Why / Balance
Since the tool used to open a Borg's panel was changed from a crowbar to a screwdriver, Syndicate Borgs have been unable to emag regular Borgs without help from Nukies. This simply gives them a screwdriver so that they can do so themselves.

## Technical details
one line YAML change

## Test plan
Spawn a Syndicate assault Borg and any other Borg
Take control of Syndicate Assault Borg
Use access breaker to unlock the Borg
Use screwdriver to open and emag the Borg

## Media

https://github.com/user-attachments/assets/6369ac1f-6271-4ff2-b6f4-0a75f00de105


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
>

## Changelog
:cl:
- tweak: The Syndicate Assault Borg's Operative module now comes with a screwdriver.
