### PR TITLE
Ignore space tiles for rooves

### DIFF
--- a/Content.Client/Light/RoofOverlay.cs
+++ b/Content.Client/Light/RoofOverlay.cs
@@ -20,6 +20,7 @@ public sealed partial class RoofOverlay : Overlay
     private readonly SharedMapSystem _mapSystem;
     private readonly SharedRoofSystem _roof = default!;
     private readonly SharedTransformSystem _xformSystem;
+    private readonly TurfSystem _turf;
 
     private List<Entity<MapGridComponent>> _grids = new();
 
@@ -36,6 +37,7 @@ public sealed partial class RoofOverlay : Overlay
         _mapSystem = _entManager.System<SharedMapSystem>();
         _roof = _entManager.System<SharedRoofSystem>();
         _xformSystem = _entManager.System<SharedTransformSystem>();
+        _turf = _entManager.System<TurfSystem>();
 
         ZIndex = ContentZIndex;
     }
@@ -81,6 +83,9 @@ public sealed partial class RoofOverlay : Overlay
 
                     while (tileEnumerator.MoveNext(out var tileRef))
                     {
+                        if (_turf.IsSpace(tileRef))
+                            continue;
+
                         var local = _lookup.GetLocalBounds(tileRef, grid.Comp.TileSize);
                         worldHandle.DrawRect(local, color);
                     }
@@ -112,6 +117,9 @@ public sealed partial class RoofOverlay : Overlay
                     // Due to stencilling we essentially draw on unrooved tiles
                     while (tileEnumerator.MoveNext(out var tileRef))
                     {
+                        if (_turf.IsSpace(tileRef))
+                            continue;
+
                         var color = _roof.GetColor(roofEnt, tileRef.GridIndices);
 
                         if (color == null)


### PR DESCRIPTION
If we get spacelight this looks better, look at the lattices.

<img width="2688" height="1920" alt="image" src="https://github.com/user-attachments/assets/415faec6-0a80-4dc1-93d4-de6bf31001f0" />