### PR TITLE
Add spacelight

### DIFF
--- a/Content.Client/Light/RoofOverlay.cs
+++ b/Content.Client/Light/RoofOverlay.cs
@@ -20,6 +20,7 @@ public sealed partial class RoofOverlay : Overlay
     private readonly SharedMapSystem _mapSystem;
     private readonly SharedRoofSystem _roof = default!;
     private readonly SharedTransformSystem _xformSystem;
+    private readonly TurfSystem _turf;
 
     private List<Entity<MapGridComponent>> _grids = new();
 
@@ -36,6 +37,7 @@ public sealed partial class RoofOverlay : Overlay
         _mapSystem = _entManager.System<SharedMapSystem>();
         _roof = _entManager.System<SharedRoofSystem>();
         _xformSystem = _entManager.System<SharedTransformSystem>();
+        _turf = _entManager.System<TurfSystem>();
 
         ZIndex = ContentZIndex;
     }
@@ -81,6 +83,9 @@ public sealed partial class RoofOverlay : Overlay
 
                     while (tileEnumerator.MoveNext(out var tileRef))
                     {
+                        if (_turf.IsSpace(tileRef))
+                            continue;
+
                         var local = _lookup.GetLocalBounds(tileRef, grid.Comp.TileSize);
                         worldHandle.DrawRect(local, color);
                     }
@@ -112,6 +117,9 @@ public sealed partial class RoofOverlay : Overlay
                     // Due to stencilling we essentially draw on unrooved tiles
                     while (tileEnumerator.MoveNext(out var tileRef))
                     {
+                        if (_turf.IsSpace(tileRef))
+                            continue;
+
                         var color = _roof.GetColor(roofEnt, tileRef.GridIndices);
 
                         if (color == null)

--- a/Content.Server/Light/EntitySystems/SpaceLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/SpaceLightSystem.cs
@@ -1,0 +1,70 @@
+using Content.Server.GameTicking;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.Server.Light.EntitySystems;
+
+/// <summary>
+/// Applies `starlight` to space maps while preserving explicit per-map light setups.
+/// </summary>
+public sealed partial class SpaceLightSystem : EntitySystem
+{
+    // This really just exists to avoid doing mapping changes for all of them.
+
+    private Color _spaceLightColor;
+    private readonly HashSet<MapId> _spaceLightMaps = new();
+
+    [Dependency] private IConfigurationManager _cfg = default!;
+    [Dependency] private SharedMapSystem _map = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        Subs.CVar(_cfg, CCVars.SpaceLightColor, OnSpaceLightColorChanged, true);
+
+        SubscribeLocalEvent<PostGameMapLoad>(OnPostGameMapLoad);
+        SubscribeLocalEvent<MapRemovedEvent>(OnMapRemoved);
+    }
+
+    private void OnPostGameMapLoad(PostGameMapLoad ev)
+    {
+        if (!_map.TryGetMap(ev.Map, out var mapUid))
+            return;
+
+        // MapLight is often intentionally set for planet/salvage/arena maps, so don't overwrite it.
+        if (HasComp<MapLightComponent>(mapUid.Value))
+            return;
+
+        _spaceLightMaps.Add(ev.Map);
+        _map.SetAmbientLight(ev.Map, _spaceLightColor);
+    }
+
+    private void OnMapRemoved(MapRemovedEvent ev)
+    {
+        _spaceLightMaps.Remove(ev.MapId);
+    }
+
+    private void OnSpaceLightColorChanged(string value)
+    {
+        _spaceLightColor = ParseSpaceLightColor(value);
+
+        foreach (var mapId in _spaceLightMaps)
+        {
+            if (!_map.MapExists(mapId))
+                continue;
+
+            _map.SetAmbientLight(mapId, _spaceLightColor);
+        }
+    }
+
+    private static Color ParseSpaceLightColor(string value)
+    {
+        if (!Color.TryFromHex(value, out var color))
+            color = Color.FromHex(CCVars.DefaultSpaceLightColor);
+
+        return Color.FromSrgb(color);
+    }
+}

--- a/Content.Shared/CCVar/CCVars.Lighting.cs
+++ b/Content.Shared/CCVar/CCVars.Lighting.cs
@@ -4,6 +4,14 @@ namespace Content.Shared.CCVar;
 
 public sealed partial class CCVars
 {
+    public const string DefaultSpaceLightColor = "#8487db";
+
+    /// <summary>
+    /// Default space light color, in sRGB hex.
+    /// </summary>
+    public static readonly CVarDef<string> SpaceLightColor =
+        CVarDef.Create("light.space_light_color", DefaultSpaceLightColor, CVar.SERVERONLY);
+
     public static readonly CVarDef<bool> AmbientOcclusion =
         CVarDef.Create("light.ambient_occlusion", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 

--- a/Content.Shared/CCVar/CCVars.Lighting.cs
+++ b/Content.Shared/CCVar/CCVars.Lighting.cs
@@ -4,6 +4,7 @@ namespace Content.Shared.CCVar;
 
 public sealed partial class CCVars
 {
+    // SS13 uses #8589fa but it can come off as more harsh so we muted it a bit more.
     public const string DefaultSpaceLightColor = "#8487db";
 
     /// <summary>


### PR DESCRIPTION
SS13 parity that was kinda eh for a while but might as well PR it.

<img width="3840" height="2054" alt="2026-8-08_01 15 07" src="https://github.com/user-attachments/assets/9f966812-fda2-44d5-a5a5-8c5cb4737726" />

Not sure if it counts as BC.

## Changelog
:cl:
- add: Added ambient space light.
