### PR TITLE
Prevent StatusEffect relay "collection modified" error

### DIFF
--- a/Content.Shared/Speech/Muting/MutedStatusEffectSystem.cs
+++ b/Content.Shared/Speech/Muting/MutedStatusEffectSystem.cs
@@ -38,13 +38,7 @@ public sealed partial class MutedStatusEffectSystem : EntitySystem
         if (args.Args.Handled)
             return;
 
-        if (!TryComp<StatusEffectComponent>(ent, out var statusEffect))
-            return;
-
-        if (statusEffect.AppliedTo is not { } target)
-            return;
-
-        _popup.PopupEntity(Loc.GetString(ent.Comp.ActionPopup), target, target);
+        _popup.PopupEntity(Loc.GetString(ent.Comp.ActionPopup), args.AppliedTo, args.AppliedTo);
         args.Args.Handled = true;
     }
 

--- a/Content.Shared/Speech/Muting/MutedStatusEffectSystem.cs
+++ b/Content.Shared/Speech/Muting/MutedStatusEffectSystem.cs
@@ -2,7 +2,6 @@ using Content.Shared.Chat;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Popups;
 using Content.Shared.StatusEffectNew;
-using Content.Shared.StatusEffectNew.Components;
 
 namespace Content.Shared.Speech.Muting;
 

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -14,6 +14,7 @@ using Content.Shared.Speech;
 using Content.Shared.Speech.EntitySystems;
 using Content.Shared.StatusEffectNew.Components;
 using Content.Shared.Stunnable;
+using Robust.Shared.Collections;
 using Robust.Shared.Player;
 
 namespace Content.Shared.StatusEffectNew;
@@ -74,7 +75,7 @@ public sealed partial class StatusEffectsSystem
         var ev = new StatusEffectRelayedEvent<T>(args, statusEffect);
 
         // Prevent a collection modified enumeration error by copying the list in case a status adds another status
-        var list = new List<EntityUid>(originalCollection);
+        var list = new ValueList<EntityUid>(originalCollection);
         foreach (var activeEffect in list)
         {
             RaiseLocalEvent(activeEffect, ref ev);
@@ -92,7 +93,7 @@ public sealed partial class StatusEffectsSystem
         var ev = new StatusEffectRelayedEvent<T>(args, statusEffect);
 
         // Prevent a collection modified enumeration error by copying the list in case a status adds another status
-        var list = new List<EntityUid>(originalCollection);
+        var list = new ValueList<EntityUid>(originalCollection);
         foreach (var activeEffect in list)
         {
             RaiseLocalEvent(activeEffect, ref ev);

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -68,8 +68,11 @@ public sealed partial class StatusEffectsSystem
     public void RelayEvent<T>(Entity<StatusEffectContainerComponent> statusEffect, ref T args) where T : struct
     {
         // this copies the by-ref event if it is a struct
-        var ev = new StatusEffectRelayedEvent<T>(args);
-        foreach (var activeEffect in statusEffect.Comp.ActiveStatusEffects?.ContainedEntities ?? [])
+        var ev = new StatusEffectRelayedEvent<T>(args, statusEffect);
+
+        // Prevent a collection modified enumeration error by copying the list in case a status adds another status
+        var list = new List<EntityUid>(statusEffect.Comp.ActiveStatusEffects?.ContainedEntities ?? []);
+        foreach (var activeEffect in list)
         {
             RaiseLocalEvent(activeEffect, ref ev);
         }
@@ -80,8 +83,11 @@ public sealed partial class StatusEffectsSystem
     public void RelayEvent<T>(Entity<StatusEffectContainerComponent> statusEffect, T args) where T : class
     {
         // this copies the by-ref event if it is a struct
-        var ev = new StatusEffectRelayedEvent<T>(args);
-        foreach (var activeEffect in statusEffect.Comp.ActiveStatusEffects?.ContainedEntities ?? [])
+        var ev = new StatusEffectRelayedEvent<T>(args, statusEffect);
+
+        // Prevent a collection modified enumeration error by copying the list in case a status adds another status
+        var list = new List<EntityUid>(statusEffect.Comp.ActiveStatusEffects?.ContainedEntities ?? []);
+        foreach (var activeEffect in list)
         {
             RaiseLocalEvent(activeEffect, ref ev);
         }
@@ -92,4 +98,4 @@ public sealed partial class StatusEffectsSystem
 /// Event wrapper for relayed events.
 /// </summary>
 [ByRefEvent]
-public record struct StatusEffectRelayedEvent<TEvent>(TEvent Args);
+public record struct StatusEffectRelayedEvent<TEvent>(TEvent Args, EntityUid AppliedTo);

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -67,11 +67,14 @@ public sealed partial class StatusEffectsSystem
 
     public void RelayEvent<T>(Entity<StatusEffectContainerComponent> statusEffect, ref T args) where T : struct
     {
+        if(statusEffect.Comp.ActiveStatusEffects?.ContainedEntities is not {} originalCollection || originalCollection.Count == 0)
+            return;
+
         // this copies the by-ref event if it is a struct
         var ev = new StatusEffectRelayedEvent<T>(args, statusEffect);
 
         // Prevent a collection modified enumeration error by copying the list in case a status adds another status
-        var list = new List<EntityUid>(statusEffect.Comp.ActiveStatusEffects?.ContainedEntities ?? []);
+        var list = new List<EntityUid>(originalCollection);
         foreach (var activeEffect in list)
         {
             RaiseLocalEvent(activeEffect, ref ev);
@@ -82,11 +85,14 @@ public sealed partial class StatusEffectsSystem
 
     public void RelayEvent<T>(Entity<StatusEffectContainerComponent> statusEffect, T args) where T : class
     {
+        if (statusEffect.Comp.ActiveStatusEffects?.ContainedEntities is not { } originalCollection || originalCollection.Count == 0)
+            return;
+
         // this copies the by-ref event if it is a struct
         var ev = new StatusEffectRelayedEvent<T>(args, statusEffect);
 
         // Prevent a collection modified enumeration error by copying the list in case a status adds another status
-        var list = new List<EntityUid>(statusEffect.Comp.ActiveStatusEffects?.ContainedEntities ?? []);
+        var list = new List<EntityUid>(originalCollection);
         foreach (var activeEffect in list)
         {
             RaiseLocalEvent(activeEffect, ref ev);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR allows subscribers of a status effect event relay to add a status effect. It also adds a parameter to the relay event to more easily get the status's owner.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I ran into this while porting clumsy to status effects. Clumsiness wants to stun the clown when they fail certain actions, but this was causing an enumeration error as a new status effect was getting added during the relay. By making a new list of applied status effects before enumeration the collection doesn't get modified.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Works on a separate branch, hard to test on its own. See media.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


https://github.com/user-attachments/assets/d76a86dc-8b04-4099-bc9c-ce85024a9702

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->