### PR TITLE
Add the fabled postinit test

### DIFF
--- a/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
+++ b/Content.IntegrationTests/Tests/SaveLoadSaveTest.cs
@@ -1,14 +1,18 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Content.IntegrationTests.Fixtures;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
+using Robust.Shared.EntitySerialization;
 using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Events;
 using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Sequence;
+using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Utility;
 
 namespace Content.IntegrationTests.Tests
@@ -88,6 +92,7 @@ namespace Content.IntegrationTests.Tests
         }
 
         private new const string TestMap = "Maps/bagel.yml";
+        private const string PostInitTestMap = "Maps/saltern.yml";
 
         /// <summary>
         ///     Loads the default map, runs it for 5 ticks, then assert that it did not change.
@@ -240,6 +245,261 @@ namespace Content.IntegrationTests.Tests
             await server.WaitPost(() => mapSys.DeleteMap(mapId1));
             await server.WaitPost(() => mapSys.DeleteMap(mapId2));
         }
+
+        /// <summary>
+        ///     Loads a map, map-initializes it, saves it, then loads and saves that post-mapinit save again.
+        /// </summary>
+        /// <remarks>
+        ///     Saving a post-mapinit map should produce a stable file. This catches systems that mutate serialized
+        ///     state while handling post-mapinit entities incorrectly.
+        /// </remarks>
+        [Test]
+        [Explicit("Because master is SO BROKEN it has to be explicit")]
+        // Ideally we'd get a global load / postinit / save / load diff test for all entities but baby steps.
+        public async Task LoadPostInitSaveLoadSaveSaltern()
+        {
+            var pair = Pair;
+            var server = pair.Server;
+
+            var mapLoader = server.System<MapLoaderSystem>();
+            var mapSys = server.System<SharedMapSystem>();
+            var userData = server.ResolveDependency<IResourceManager>().UserData;
+            var cfg = server.ResolveDependency<IConfigurationManager>();
+            Assert.That(cfg.GetCVar(CCVars.GridFill), Is.False);
+
+            var testSystem = server.System<SaveLoadSaveTestSystem>();
+            testSystem.Enabled = true;
+
+            var firstSave = new ResPath("/postinit saltern save 1.yml");
+            var secondSave = new ResPath("/postinit saltern save 2.yml");
+            var initialLoadOptions = DeserializationOptions.Default with
+            {
+                InitializeMaps = true,
+                PauseMaps = true,
+                StoreYamlUids = true
+            };
+            var reloadOptions = DeserializationOptions.Default with
+            {
+                StoreYamlUids = true
+            };
+
+            MapId mapId1 = default;
+            MapId mapId2 = default;
+
+            try
+            {
+                await server.WaitPost(() =>
+                {
+                    var path = new ResPath(PostInitTestMap);
+                    Assert.That(mapLoader.TryLoadMap(path, out var map, out _, initialLoadOptions),
+                        $"Failed to load test map {PostInitTestMap}");
+                    mapId1 = map!.Value.Comp.MapId;
+                    Assert.That(mapSys.IsInitialized(map.Value), Is.True);
+                    Assert.That(mapSys.IsPaused(map.Value), Is.True);
+                    Assert.That(mapLoader.TrySaveMap(mapId1, firstSave));
+                });
+
+                await server.WaitPost(() =>
+                {
+                    Assert.That(mapLoader.TryLoadMap(firstSave, out var map, out _, reloadOptions),
+                        $"Failed to reload post-mapinit save {firstSave}");
+                    mapId2 = map!.Value.Comp.MapId;
+                    Assert.That(mapSys.IsPaused(map.Value), Is.True);
+                    Assert.That(mapLoader.TrySaveMap(mapId2, secondSave));
+                });
+
+                await server.WaitIdleAsync();
+
+                var one = await ReadUserData(userData, firstSave);
+                var two = await ReadUserData(userData, secondSave);
+
+                Assert.Multiple(() =>
+                {
+                    if (two != one)
+                        TestContext.Error.WriteLine(BuildEntityDiff(mapLoader, firstSave, secondSave));
+
+                    Assert.That(two, Is.EqualTo(one));
+                    var failed = TestContext.CurrentContext.Result.Assertions.FirstOrDefault();
+                    if (failed != null)
+                    {
+                        var oneTmp = Path.GetTempFileName();
+                        var twoTmp = Path.GetTempFileName();
+
+                        File.WriteAllText(oneTmp, one);
+                        File.WriteAllText(twoTmp, two);
+
+                        TestContext.AddTestAttachment(oneTmp, "First post-mapinit save file");
+                        TestContext.AddTestAttachment(twoTmp, "Second post-mapinit save file");
+                        TestContext.Error.WriteLine("Complete output:");
+                        TestContext.Error.WriteLine(oneTmp);
+                        TestContext.Error.WriteLine(twoTmp);
+                    }
+                });
+            }
+            finally
+            {
+                testSystem.Enabled = false;
+                await server.WaitPost(() =>
+                {
+                    if (mapSys.MapExists(mapId1))
+                        mapSys.DeleteMap(mapId1);
+
+                    if (mapSys.MapExists(mapId2))
+                        mapSys.DeleteMap(mapId2);
+                });
+            }
+        }
+
+        private static async Task<string> ReadUserData(IWritableDirProvider userData, ResPath path)
+        {
+            await using var stream = userData.Open(path, FileMode.Open);
+            using var reader = new StreamReader(stream);
+            return await reader.ReadToEndAsync();
+        }
+
+        private static string BuildEntityDiff(MapLoaderSystem mapLoader, ResPath firstSave, ResPath secondSave)
+        {
+            if (!mapLoader.TryReadFile(firstSave, out var firstData))
+                return $"Failed to read {firstSave} for entity diff.";
+
+            if (!mapLoader.TryReadFile(secondSave, out var secondData))
+                return $"Failed to read {secondSave} for entity diff.";
+
+            var firstEntities = ReadSavedEntities(firstData);
+            var secondEntities = ReadSavedEntities(secondData);
+
+            var removed = firstEntities.Keys.Except(secondEntities.Keys).Order().ToArray();
+            var added = secondEntities.Keys.Except(firstEntities.Keys).Order().ToArray();
+            var changed = firstEntities.Keys
+                .Intersect(secondEntities.Keys)
+                .Where(uid => firstEntities[uid].Text != secondEntities[uid].Text)
+                .Order()
+                .ToArray();
+
+            using var writer = new StringWriter();
+            writer.WriteLine("Post-mapinit save/load/save entity diff:");
+            writer.WriteLine($"  First save entities: {firstEntities.Count}");
+            writer.WriteLine($"  Second save entities: {secondEntities.Count}");
+            writer.WriteLine($"  Added: {added.Length}");
+            writer.WriteLine($"  Removed: {removed.Length}");
+            writer.WriteLine($"  Changed: {changed.Length}");
+            WriteEntityList(writer, "Added entities", added, secondEntities);
+            WriteEntityList(writer, "Removed entities", removed, firstEntities);
+            WriteChangedEntityList(writer, changed, firstEntities, secondEntities);
+            return writer.ToString();
+        }
+
+        private static Dictionary<int, SavedEntity> ReadSavedEntities(MappingDataNode root)
+        {
+            var entities = new Dictionary<int, SavedEntity>();
+            var prototypeGroups = root.Get<SequenceDataNode>("entities");
+
+            foreach (var protoGroup in prototypeGroups.Cast<MappingDataNode>())
+            {
+                var proto = protoGroup.Get<ValueDataNode>("proto").Value;
+                var groupEntities = protoGroup.Get<SequenceDataNode>("entities");
+
+                foreach (var entityNode in groupEntities.Cast<MappingDataNode>())
+                {
+                    var uid = entityNode.Get<ValueDataNode>("uid").AsInt();
+                    entities[uid] = new SavedEntity(uid, proto, entityNode.ToString(), ReadComponents(entityNode));
+                }
+            }
+
+            return entities;
+        }
+
+        private static Dictionary<string, string> ReadComponents(MappingDataNode entityNode)
+        {
+            if (!entityNode.TryGet("components", out SequenceDataNode? components))
+                return new Dictionary<string, string>();
+
+            var result = new Dictionary<string, string>();
+            foreach (var component in components.Cast<MappingDataNode>())
+            {
+                var type = component.Get<ValueDataNode>("type").Value;
+                result[type] = component.ToString();
+            }
+
+            return result;
+        }
+
+        private static void WriteEntityList(
+            TextWriter writer,
+            string title,
+            int[] uids,
+            Dictionary<int, SavedEntity> entities)
+        {
+            if (uids.Length == 0)
+                return;
+
+            const int limit = 50;
+            writer.WriteLine($"  {title}:");
+            foreach (var uid in uids.Take(limit))
+            {
+                writer.WriteLine($"    {DescribeEntity(entities[uid])}");
+            }
+
+            if (uids.Length > limit)
+                writer.WriteLine($"    ... {uids.Length - limit} more");
+        }
+
+        private static void WriteChangedEntityList(
+            TextWriter writer,
+            int[] uids,
+            Dictionary<int, SavedEntity> firstEntities,
+            Dictionary<int, SavedEntity> secondEntities)
+        {
+            if (uids.Length == 0)
+                return;
+
+            const int limit = 50;
+            writer.WriteLine("  Changed entities:");
+            foreach (var uid in uids.Take(limit))
+            {
+                var first = firstEntities[uid];
+                var second = secondEntities[uid];
+                writer.WriteLine($"    {DescribeEntity(first)} -> {DescribeEntity(second)}");
+                WriteComponentDiff(writer, first, second);
+            }
+
+            if (uids.Length > limit)
+                writer.WriteLine($"    ... {uids.Length - limit} more");
+        }
+
+        private static void WriteComponentDiff(TextWriter writer, SavedEntity first, SavedEntity second)
+        {
+            var firstComponents = first.Components;
+            var secondComponents = second.Components;
+            var removed = firstComponents.Keys.Except(secondComponents.Keys).Order().ToArray();
+            var added = secondComponents.Keys.Except(firstComponents.Keys).Order().ToArray();
+            var changed = firstComponents.Keys
+                .Intersect(secondComponents.Keys)
+                .Where(type => firstComponents[type] != secondComponents[type])
+                .Order()
+                .ToArray();
+
+            if (first.Proto != second.Proto)
+                writer.WriteLine($"      proto: {first.Proto} -> {second.Proto}");
+
+            if (added.Length != 0)
+                writer.WriteLine($"      added components: {string.Join(", ", added)}");
+
+            if (removed.Length != 0)
+                writer.WriteLine($"      removed components: {string.Join(", ", removed)}");
+
+            if (changed.Length != 0)
+                writer.WriteLine($"      changed components: {string.Join(", ", changed)}");
+        }
+
+        private static string DescribeEntity(SavedEntity entity)
+            => $"{entity.Uid} ({entity.Proto})";
+
+        private sealed record SavedEntity(
+            int Uid,
+            string Proto,
+            string Text,
+            Dictionary<string, string> Components);
 
         /// <summary>
         /// Simple system that modifies the data saved to a yaml file by removing the timestamp.


### PR DESCRIPTION
So right now we have no test coverage of systems not misusing componentinit, this just adds an explicit test because so much stuff will need fixing.

Once saltern is fixed then we need a global entity spawner which will likely catch many more.