### PR TITLE
Fix DamageThresholdsSerializer mutating on save / load

### DIFF
--- a/Content.Server/Destructible/DamageThresholdsSerializer.cs
+++ b/Content.Server/Destructible/DamageThresholdsSerializer.cs
@@ -18,7 +18,7 @@ public sealed class DamageThresholdsSerializer : ITypeSerializer<List<DamageThre
         IDependencyCollection dependencies,
         ISerializationContext context = null)
     {
-        var list = new List<ValidationNode>();
+        var list = new List<ValidationNode>(node.Count);
         foreach (var elem in node.Sequence)
         {
             list.Add(serializationManager.ValidateNode<DamageThreshold>(elem, context));
@@ -62,7 +62,6 @@ public sealed class DamageThresholdsSerializer : ITypeSerializer<List<DamageThre
             list.Add(item);
         }
 
-        list.Sort();
         return list;
     }
 
@@ -72,7 +71,7 @@ public sealed class DamageThresholdsSerializer : ITypeSerializer<List<DamageThre
         bool alwaysWrite = false,
         ISerializationContext context = null)
     {
-        var sequence = new SequenceDataNode();
+        var sequence = new SequenceDataNode(value.Count);
 
         foreach (var elem in value)
         {


### PR DESCRIPTION
The .Sort makes it unstable when producing yaml and can affect the actual code being run because the order matters.