### PR TITLE
Give Xenoborgs EMP resistance

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -523,6 +523,8 @@
   - type: Xenoborg
   - type: BypassLock
     bypassDelay: 15 # We don't want people to easily be able to remove xenoborg brains.
+  - type: EmpResistance
+    strengthMultiplier: 0
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

EMPs too easily shut down xenoborgs, unfortunately due to various reasons of how EMPs work making them partly resistant just doesn't quite work. Even if we did get that working, it would be  trivial to just cook up more emp juice and then disable them that way.

[Screencast_20260807_210409.webm](https://github.com/user-attachments/assets/6804a21c-a180-4ec3-82e8-2c0627e6a1fd)

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Xenoborgs are now EMP resistant
