### PR TITLE
Rebalance mothership modules

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
@@ -179,12 +179,10 @@
     moduleWhitelist:
       tags:
       - MothershipModule
-      - BorgModuleEngineering
   - type: ContainerFill
     containers:
       borg_module:
       - MothershipModule
-      - BorgModuleAdvancedTool
   - type: ContainerContainer
     containers:
       cell_slot: !type:ContainerSlot { }

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1441,6 +1441,10 @@
         whitelist:
           components:
           - PowerCell
+    - item: JawsOfLife
+    - item: PowerDrill
+    - item: WelderExperimental
+    - item: Multitool
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-module-module }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Mothership had two tool modules and it wasn't really necessary. The issue is switching between them was frustrating as you really need tools from both when creating new borgs. Combing them into one makes this process a lot smoother

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="522" height="1020" alt="image" src="https://github.com/user-attachments/assets/6b604f31-b17c-4a33-90ce-4cb07dbf47c1" />

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Motherships tool modules have been combined into one

