### PR TITLE
[Hotfix] Increase Server Population limit to 80

### DIFF
--- a/Resources/ConfigPresets/WizardsDen/vulture.toml
+++ b/Resources/ConfigPresets/WizardsDen/vulture.toml
@@ -3,7 +3,7 @@
 [game]
 hostname = "[EN][Testing] Wizard's Den Vulture [NA East]"
 desc = "Official English testing server for Space Station 14.\nVanilla, roleplay ruleset.\n\nYou can play with the newest changes to the game here, but these changes may not be final or stable, and may be reverted before the next stable release.\nPlease report bugs on our GitHub, forum, or community Discord."
-soft_max_players = 67
+soft_max_players = 80
 panic_bunker.enabled = false
 panic_bunker.disable_with_admins = false
 panic_bunker.enable_without_admins = false

--- a/Resources/ConfigPresets/WizardsDen/vulture.toml
+++ b/Resources/ConfigPresets/WizardsDen/vulture.toml
@@ -3,7 +3,6 @@
 [game]
 hostname = "[EN][Testing] Wizard's Den Vulture [NA East]"
 desc = "Official English testing server for Space Station 14.\nVanilla, roleplay ruleset.\n\nYou can play with the newest changes to the game here, but these changes may not be final or stable, and may be reverted before the next stable release.\nPlease report bugs on our GitHub, forum, or community Discord."
-soft_max_players = 80
 panic_bunker.enabled = false
 panic_bunker.disable_with_admins = false
 panic_bunker.enable_without_admins = false

--- a/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
+++ b/Resources/ConfigPresets/WizardsDen/wizardsDen.toml
@@ -4,7 +4,7 @@
 [game]
 desc             = "Official English Space Station 14 servers. Vanilla, roleplay ruleset."
 lobbyenabled     = true
-soft_max_players = 65
+soft_max_players = 80
 lobbyduration    = 300 # 5 minutes lobby timer
 panic_bunker.enabled = true
 panic_bunker.min_overall_minutes = 120


### PR DESCRIPTION
## About the PR
Config Presets reset to earlier defaults of 80.

At this point, the intent is to keep #44996 's changes and it's follow up fixes.
This change only increases the overall population cap for the servers.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
