### PR TITLE
Make DamageableSystem not call ReloadAllReagentPrototypes 4 times in Initialize

### DIFF
--- a/Content.Shared/Damage/Systems/DamageableSystem.Events.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.Events.cs
@@ -12,8 +12,11 @@ namespace Content.Shared.Damage.Systems;
 
 public sealed partial class DamageableSystem
 {
+    private bool _initializing = true;
+
     public override void Initialize()
     {
+        _initializing = true;
         RebuildContainerCache();
 
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
@@ -32,8 +35,12 @@ public sealed partial class DamageableSystem
             value =>
             {
                 UniversalAllDamageModifier = value;
-                _chemistryGuideData.ReloadAllReagentPrototypes();
-                _explosion.ReloadMap();
+
+                if (!_initializing)
+                {
+                    _chemistryGuideData.ReloadAllReagentPrototypes();
+                    _explosion.ReloadMap();
+                }
             },
             true
         );
@@ -43,7 +50,9 @@ public sealed partial class DamageableSystem
             value =>
             {
                 UniversalAllHealModifier = value;
-                _chemistryGuideData.ReloadAllReagentPrototypes();
+
+                if (!_initializing)
+                    _chemistryGuideData.ReloadAllReagentPrototypes();
             },
             true
         );
@@ -77,7 +86,9 @@ public sealed partial class DamageableSystem
             value =>
             {
                 UniversalReagentDamageModifier = value;
-                _chemistryGuideData.ReloadAllReagentPrototypes();
+
+                if (!_initializing)
+                    _chemistryGuideData.ReloadAllReagentPrototypes();
             },
             true
         );
@@ -87,7 +98,9 @@ public sealed partial class DamageableSystem
             value =>
             {
                 UniversalReagentHealModifier = value;
-                _chemistryGuideData.ReloadAllReagentPrototypes();
+
+                if (!_initializing)
+                    _chemistryGuideData.ReloadAllReagentPrototypes();
             },
             true
         );
@@ -119,6 +132,10 @@ public sealed partial class DamageableSystem
             value => UniversalMobDamageModifier = value,
             true
         );
+
+        _initializing = false;
+        _chemistryGuideData.ReloadAllReagentPrototypes();
+        _explosion.ReloadMap();
     }
 
     private void OnPrototypesReloaded(PrototypesReloadedEventArgs ev)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
4 trips to the loc bundle mines is bad for the economy
Was top 5 in EntitySystemManager.Initialize

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
