### PR TITLE
fix: insufficient avalanche in PredictedRandom

### DIFF
--- a/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
+++ b/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
@@ -190,6 +190,17 @@ namespace Content.Shared.Random.Helpers
             return hash;
         }
 
+        private static int Fmix32(int seed)
+        {
+            uint h = (uint)seed;
+            h ^= h >> 16;
+            h *= 0x85ebca6b;
+            h ^= h >> 13;
+            h *= 0xc2b2ae35;
+            h ^= h >> 16;
+            return (int)h;
+        }
+
         // TODO: REPLACE ALL OF THIS WITH PREDICTED RANDOM WHEN ENGINE PR IS MERGED
         /// <summary>
         /// Creates an instance of IRobustRandom that will be the same for both the server and client.
@@ -207,7 +218,7 @@ namespace Content.Shared.Random.Helpers
         {
             var seed = HashCodeCombine((int)timing.CurTick.Value, netEnt.Id, netEnt2?.Id ?? 0);
             var random = new RobustRandom();
-            random.SetSeed(seed);
+            random.SetSeed(Fmix32(seed));
             return random;
         }
 

--- a/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
+++ b/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
@@ -190,6 +190,8 @@ namespace Content.Shared.Random.Helpers
             return hash;
         }
 
+        // the well-known public domain murmurhash32 finalization mix function by Austin Appleby
+        // source: https://github.com/aappleby/smhasher/blob/07bb4de10a63e8cc2e1724865454eba635742383/src/MurmurHash3.cpp#L68
         private static int Fmix32(int seed)
         {
             uint h = (uint)seed;


### PR DESCRIPTION
## About the PR
`MetabolizerSystem` and others (anything using `PredictedRandom`) are not consistently getting random numbers because synchronized seeds are very close together due to only the tick value changing. The underlying PRNG has very high output correlation when initialized with poorly distributed seeds.

## Why / Balance
`MetabolizerSystem` has long runs of non-random continuous changes in values, triggering effects much more often or much less often than they should trigger. Other systems using `PredictedRandom` presumably have issues too. Currently, this happens:

```
[INFO] system.metabolizer: metabolizer: Mannitol 0.41469988 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.40093657 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.38717324 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.3734099 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.35964656 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.34588322 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.33211988 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.31835657 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.30459324 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.2908299 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.27706656 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.26330322 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.2495399 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.23577657 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.22201324 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.2082499 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.19448657 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.18072324 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.1669599 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.15319657 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.13943323 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.12566991 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.11190657 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.09814324 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.084379904 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.07061657 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.056853242 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.043089908 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.029326577 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.015563244 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.0017999108 < 0.2 = True
[INFO] system.metabolizer: metabolizer: Mannitol 0.9880366 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.97427326 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.9605099 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.9467466 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.9329832 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.9192199 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.9054566 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.89169323 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.8779299 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.86416656 < 0.2 = False
[INFO] system.metabolizer: metabolizer: Mannitol 0.85040325 < 0.2 = False
```

## Technical details
`PredictedRandom` is used in `MetabolizerSystem` and others to allow client prediction using a synchronized seed. Unfortunately the hash function [used for the seed](https://github.com/space-wizards/space-station-14/blob/68de6b6dcf7a9890202ab656bd1e60b163b275a7/Content.Shared/Random/Helpers/SharedRandomExtensions.cs#L183) (djb2) exhibits no avalanche effect, and the underlying PRNG does not mix the seed, nor have good avalanche properties with poorly distributed seeds. Consequently, seeds that are near in value produce highly correlated PRNG state -  very much not random.

Seeds derived from the game tick with otherwise unchanging `EntityUID`s via `PredictedRandom`'s [constructor](https://github.com/space-wizards/space-station-14/blob/68de6b6dcf7a9890202ab656bd1e60b163b275a7/Content.Shared/Random/Helpers/SharedRandomExtensions.cs#L208) will therefore have relatively continuous periodic outputs over a sequence of adjacent ticks.

It's worth noting that the default seeded `System.Random(N)` constructor's implementation has been kept for [backwards compatibility](https://github.com/dotnet/runtime/issues/23198) and is known to have [other serious flaws](https://gist.github.com/fuglede/772402ecc3997ada82a03ce65361781b).

This PR simply mixes the seed with MurmurHash3's finalizer algorithm, but probably the underlying PRNG should also be switched out at some point given the links above.

## Test plan
1. apply [this patch](https://gist.githubusercontent.com/avosirenfal/66cd61366154d0b3f7138937768823eb/raw) on top of `master` for logging
    ```
    curl https://gist.githubusercontent.com/avosirenfal/66cd61366154d0b3f7138937768823eb/raw | git apply -v
    ```
2. start the server and client
3. to isolate a single metabolism for testing, delete all mobs with toolshed
    ```
    entities with MobState delete
    ```
4. spawn a human, two bottles of mannitol and a bluespace syringe
5. draw from the bottles, inject the human
6. look at the server logs and note that the logged values for `if (rand.NextFloat() >= effect.Probability)` are moving in a continuous fashion rather than randomly
7. kill the server and client, pull this pr, repeat and observe that the values now move randomly

## Media
Before (note the linear decrease in values)
<img width="970" height="1298" alt="before" src="https://github.com/user-attachments/assets/24123242-4363-44a5-abaf-9081f1f0fa46" />

After
<img width="970" height="1298" alt="after" src="https://github.com/user-attachments/assets/05c04afe-820c-4fb8-8a43-9ec8489c0cfe" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- fix: predicted system ticks were not reliably using random values
