### PR TITLE
Cleanup: Resolve GetAnchoredEntitiesEnumerator, Get*TilesEnumerator warnings

### DIFF
--- a/Content.Client/IconSmoothing/IconSmoothSystem.cs
+++ b/Content.Client/IconSmoothing/IconSmoothSystem.cs
@@ -180,8 +180,8 @@ namespace Content.Client.IconSmoothing
             {
                 DirtyEntities(_mapSystem.GetAnchoredEntities(entityUid, grid, pos + Vector2i.UpRight));
                 DirtyEntities(_mapSystem.GetAnchoredEntities(entityUid, grid, pos + Vector2i.DownLeft));
-                DirtyEntities(_mapSystem.GetAnchoredEntities(entityUid, grid, pos + Vector2i.DownRight));
                 DirtyEntities(_mapSystem.GetAnchoredEntities(entityUid, grid, pos + Vector2i.UpLeft));
+                DirtyEntities(_mapSystem.GetAnchoredEntities(entityUid, grid, pos + Vector2i.DownRight));
             }
         }
 

--- a/Content.Client/IconSmoothing/IconSmoothSystem.cs
+++ b/Content.Client/IconSmoothing/IconSmoothSystem.cs
@@ -171,17 +171,17 @@ namespace Content.Client.IconSmoothing
             }
 
             // Yes, we updates ALL smoothing entities surrounding us even if they would never smooth with us.
-            DirtyEntities(_mapSystem.GetAnchoredEntitiesEnumerator(entityUid, grid, pos + new Vector2i(1, 0)));
-            DirtyEntities(_mapSystem.GetAnchoredEntitiesEnumerator(entityUid, grid, pos + new Vector2i(-1, 0)));
-            DirtyEntities(_mapSystem.GetAnchoredEntitiesEnumerator(entityUid, grid, pos + new Vector2i(0, 1)));
-            DirtyEntities(_mapSystem.GetAnchoredEntitiesEnumerator(entityUid, grid, pos + new Vector2i(0, -1)));
+            DirtyEntities(_mapSystem.GetAnchoredEntities(entityUid, grid, pos + Vector2i.Right));
+            DirtyEntities(_mapSystem.GetAnchoredEntities(entityUid, grid, pos + Vector2i.Left));
+            DirtyEntities(_mapSystem.GetAnchoredEntities(entityUid, grid, pos + Vector2i.Up));
+            DirtyEntities(_mapSystem.GetAnchoredEntities(entityUid, grid, pos + Vector2i.Down));
 
             if (comp.Mode is IconSmoothingMode.Corners or IconSmoothingMode.NoSprite or IconSmoothingMode.Diagonal)
             {
-                DirtyEntities(_mapSystem.GetAnchoredEntitiesEnumerator(entityUid, grid, pos + new Vector2i(1, 1)));
-                DirtyEntities(_mapSystem.GetAnchoredEntitiesEnumerator(entityUid, grid, pos + new Vector2i(-1, -1)));
-                DirtyEntities(_mapSystem.GetAnchoredEntitiesEnumerator(entityUid, grid, pos + new Vector2i(-1, 1)));
-                DirtyEntities(_mapSystem.GetAnchoredEntitiesEnumerator(entityUid, grid, pos + new Vector2i(1, -1)));
+                DirtyEntities(_mapSystem.GetAnchoredEntities(entityUid, grid, pos + Vector2i.UpRight));
+                DirtyEntities(_mapSystem.GetAnchoredEntities(entityUid, grid, pos + Vector2i.DownLeft));
+                DirtyEntities(_mapSystem.GetAnchoredEntities(entityUid, grid, pos + Vector2i.DownRight));
+                DirtyEntities(_mapSystem.GetAnchoredEntities(entityUid, grid, pos + Vector2i.UpLeft));
             }
         }
 
@@ -229,13 +229,13 @@ namespace Content.Client.IconSmoothing
 
                         gridEntity = (gridUid, grid);
 
-                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.North))))
+                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.North))))
                             directions |= DirectionFlag.North;
-                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.South))))
+                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.South))))
                             directions |= DirectionFlag.South;
-                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.East))))
+                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.East))))
                             directions |= DirectionFlag.East;
-                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.West))))
+                        if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.West))))
                             directions |= DirectionFlag.West;
                     }
 
@@ -312,7 +312,7 @@ namespace Content.Client.IconSmoothing
             for (var i = 0; i < neighbors.Length; i++)
             {
                 var neighbor = (Vector2i)rotation.RotateVec(neighbors[i]);
-                matching = matching && MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos + neighbor));
+                matching = matching && MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos + neighbor));
             }
 
             if (matching)
@@ -339,13 +339,13 @@ namespace Content.Client.IconSmoothing
             var grid = gridEntity.Value.Comp;
 
             var pos = _mapSystem.TileIndicesFor(gridUid, grid, xform.Coordinates);
-            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.North))))
+            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.North))))
                 dirs |= CardinalConnectDirs.North;
-            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.South))))
+            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.South))))
                 dirs |= CardinalConnectDirs.South;
-            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.East))))
+            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.East))))
                 dirs |= CardinalConnectDirs.East;
-            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.West))))
+            if (MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.West))))
                 dirs |= CardinalConnectDirs.West;
 
             _sprite.LayerSetRsiState(sprite.AsNullable(), 0, $"{smooth.StateBase}{(int)dirs}");
@@ -419,14 +419,14 @@ namespace Content.Client.IconSmoothing
             var grid = gridEntity.Comp;
 
             var pos = _mapSystem.TileIndicesFor(gridUid, grid, xform.Coordinates);
-            var n = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.North)));
-            var ne = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.NorthEast)));
-            var e = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.East)));
-            var se = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.SouthEast)));
-            var s = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.South)));
-            var sw = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.SouthWest)));
-            var w = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.West)));
-            var nw = MatchingEntity(smooth, _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, pos.Offset(Direction.NorthWest)));
+            var n = MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.North)));
+            var ne = MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.NorthEast)));
+            var e = MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.East)));
+            var se = MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.SouthEast)));
+            var s = MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.South)));
+            var sw = MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.SouthWest)));
+            var w = MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.West)));
+            var nw = MatchingEntity(smooth, _mapSystem.GetAnchoredEntities(gridUid, grid, pos.Offset(Direction.NorthWest)));
 
             // ReSharper disable InconsistentNaming
             var cornerNE = CornerFill.None;

--- a/Content.Client/Light/EntitySystems/GridStencilSystem.cs
+++ b/Content.Client/Light/EntitySystems/GridStencilSystem.cs
@@ -85,7 +85,7 @@ public sealed partial class GridStencilSystem : EntitySystem
                 foreach (var grid in _grids)
                 {
                     var worldToTextureMatrix = Matrix3x2.Multiply(_xform.GetWorldMatrix(grid.Owner), invMatrix);
-                    var tiles = _map.GetTilesEnumerator(grid.Owner, grid, worldBounds);
+                    var tiles = _map.GetTilesIntersecting(grid.Owner, grid, worldBounds);
                     worldHandle.SetTransform(worldToTextureMatrix);
                     _rects.Clear();
 
@@ -155,7 +155,7 @@ public sealed partial class GridStencilSystem : EntitySystem
                 {
                     var transform = _xform.GetWorldMatrix(grid.Owner);
                     var worldToTextureMatrix = Matrix3x2.Multiply(transform, invMatrix);
-                    var tiles = _map.GetTilesEnumerator(grid.Owner, grid, worldBounds);
+                    var tiles = _map.GetTilesIntersecting(grid.Owner, grid, worldBounds);
                     worldHandle.SetTransform(worldToTextureMatrix);
                     _rects.Clear();
 

--- a/Content.Client/Light/RoofOverlay.cs
+++ b/Content.Client/Light/RoofOverlay.cs
@@ -78,7 +78,7 @@ public sealed partial class RoofOverlay : Overlay
 
                     worldHandle.SetTransform(matty);
 
-                    var tileEnumerator = _mapSystem.GetTilesEnumerator(grid.Owner, grid, bounds);
+                    var tileEnumerator = _mapSystem.GetTilesIntersecting(grid.Owner, grid, bounds);
                     var color = roof.Color;
 
                     while (tileEnumerator.MoveNext(out var tileRef))
@@ -111,7 +111,7 @@ public sealed partial class RoofOverlay : Overlay
 
                     worldHandle.SetTransform(matty);
 
-                    var tileEnumerator = _mapSystem.GetTilesEnumerator(grid.Owner, grid, bounds);
+                    var tileEnumerator = _mapSystem.GetTilesIntersecting(grid.Owner, grid, bounds);
                     var roofEnt = (grid.Owner, grid.Comp, roof);
 
                     // Due to stencilling we essentially draw on unrooved tiles

--- a/Content.Client/Shuttles/FtlArrivalOverlay.cs
+++ b/Content.Client/Shuttles/FtlArrivalOverlay.cs
@@ -68,7 +68,7 @@ public sealed partial class FtlArrivalOverlay : Overlay
             args.WorldHandle.SetTransform(worldMatrix);
             var localAABB = invMatrix.TransformBox(args.WorldBounds);
 
-            var tilesEnumerator = _maps.GetLocalTilesEnumerator(grid, mapGrid, localAABB);
+            var tilesEnumerator = _maps.GetTilesIntersecting(grid, mapGrid, localAABB);
 
             while (tilesEnumerator.MoveNext(out var tile))
             {

--- a/Content.Client/Shuttles/FtlArrivalOverlay.cs
+++ b/Content.Client/Shuttles/FtlArrivalOverlay.cs
@@ -68,7 +68,7 @@ public sealed partial class FtlArrivalOverlay : Overlay
             args.WorldHandle.SetTransform(worldMatrix);
             var localAABB = invMatrix.TransformBox(args.WorldBounds);
 
-            var tilesEnumerator = _maps.GetTilesIntersecting(grid, mapGrid, localAABB);
+            var tilesEnumerator = _maps.GetLocalTilesIntersecting(grid, mapGrid, localAABB);
 
             while (tilesEnumerator.MoveNext(out var tile))
             {

--- a/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
@@ -117,7 +117,7 @@ public partial class BaseShuttleControl : MapGridControl
 
     protected void DrawGrid(DrawingHandleScreen handle, Matrix3x2 gridToView, Entity<MapGridComponent> grid, Color color, float alpha = 0.01f)
     {
-        var rator = Maps.GetAllTilesEnumerator(grid.Owner, grid.Comp);
+        var rator = Maps.GetAllTiles(grid.Owner, grid.Comp);
         var tileSize = grid.Comp.TileSize;
 
         // Check if we even have data

--- a/Content.Client/Wall/Systems/WallMountVisibilitySystem.cs
+++ b/Content.Client/Wall/Systems/WallMountVisibilitySystem.cs
@@ -17,6 +17,9 @@ public sealed partial class WallMountVisibilitySystem : EntitySystem
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private SpriteSystem _sprite = default!;
 
+    [Dependency] private EntityQuery<SpriteComponent> _spriteQuery;
+    [Dependency] private EntityQuery<WallComponent> _wallQuery;
+
     private WallMountVisibilityOverlay _overlayInstance = default!;
 
     /// <summary>
@@ -73,7 +76,7 @@ public sealed partial class WallMountVisibilitySystem : EntitySystem
         if (TerminatingOrDeleted(ent))
             return;
 
-        if (!TryComp<SpriteComponent>(ent, out var sprite))
+        if (!_spriteQuery.TryComp(ent, out var sprite))
             return;
 
         _sprite.SetVisible((ent, sprite), true);
@@ -88,7 +91,7 @@ public sealed partial class WallMountVisibilitySystem : EntitySystem
         if (ent.Comp.DirectionalVisibility)
             return;
 
-        if (!TryComp<SpriteComponent>(ent, out var sprite))
+        if (!_spriteQuery.TryComp(ent, out var sprite))
             return;
 
         _sprite.SetVisible((ent, sprite), true);
@@ -99,10 +102,10 @@ public sealed partial class WallMountVisibilitySystem : EntitySystem
     /// </summary>
     public bool IsTileBlocked(Entity<MapGridComponent> grid, Vector2i tile)
     {
-        var enumerator = _map.GetAnchoredEntitiesEnumerator(grid.Owner, grid, tile);
+        var enumerator = _map.GetAnchoredEntities(grid.Owner, grid, tile);
         while (enumerator.MoveNext(out var anchored))
         {
-            if (!HasComp<WallComponent>(anchored.Value))
+            if (!_wallQuery.HasComp(anchored.Value))
                 continue;
 
             return true;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
@@ -33,34 +33,34 @@ public sealed partial class AtmosphereSystem
     [AdminCommand(AdminFlags.Debug)]
     private void FixGridAtmosCommand(IConsoleShell shell, string argstr, string[] args)
     {
-       if (args.Length == 0)
-       {
-           shell.WriteError("Not enough arguments.");
-           return;
-       }
+        if (args.Length == 0)
+        {
+            shell.WriteError("Not enough arguments.");
+            return;
+        }
 
-       foreach (var arg in args)
-       {
-           if (!NetEntity.TryParse(arg, out var netEntity) || !TryGetEntity(netEntity, out var euid))
-           {
-               shell.WriteError($"Failed to parse euid '{arg}'.");
-               return;
-           }
+        foreach (var arg in args)
+        {
+            if (!NetEntity.TryParse(arg, out var netEntity) || !TryGetEntity(netEntity, out var euid))
+            {
+                shell.WriteError($"Failed to parse euid '{arg}'.");
+                return;
+            }
 
-           if (!TryComp(euid, out MapGridComponent? gridComp))
-           {
-               shell.WriteError($"Euid '{euid}' does not exist or is not a grid.");
-               return;
-           }
+            if (!TryComp(euid, out MapGridComponent? gridComp))
+            {
+                shell.WriteError($"Euid '{euid}' does not exist or is not a grid.");
+                return;
+            }
 
-           if (!TryComp(euid, out GridAtmosphereComponent? gridAtmosphere))
-           {
-               shell.WriteError($"Grid \"{euid}\" has no atmosphere component, try addatmos.");
-               continue;
-           }
+            if (!TryComp(euid, out GridAtmosphereComponent? gridAtmosphere))
+            {
+                shell.WriteError($"Grid \"{euid}\" has no atmosphere component, try addatmos.");
+                continue;
+            }
 
-           RebuildGridAtmosphere((euid.Value, gridAtmosphere, gridComp));
-       }
+            RebuildGridAtmosphere((euid.Value, gridAtmosphere, gridComp));
+        }
     }
 
     /// <summary>
@@ -116,12 +116,12 @@ public sealed partial class AtmosphereSystem
 
         foreach (var (indices, tile) in ent.Comp1.Tiles.ToArray())
         {
-            if (tile.Air is not {Immutable: false} air)
+            if (tile.Air is not { Immutable: false } air)
                 continue;
 
             air.Clear();
             var mixtureId = 0;
-            var enumerator = _mapSystem.GetAnchoredEntitiesEnumerator(grid, grid, indices);
+            var enumerator = _mapSystem.GetAnchoredEntities(grid, grid, indices);
             while (enumerator.MoveNext(out var entUid))
             {
                 if (_atmosFixMarkerQuery.TryComp(entUid, out var marker))
@@ -162,7 +162,7 @@ public sealed partial class AtmosphereSystem
         var volume = GetVolumeForTiles(ent);
         TryComp(ent.Comp4.MapUid, out MapAtmosphereComponent? mapAtmos);
 
-        var enumerator = _map.GetAllTilesEnumerator(ent, ent);
+        var enumerator = _map.GetAllTiles(ent, ent);
         while (enumerator.MoveNext(out var tileRef))
         {
             var tile = GetOrNewTile(ent, ent, tileRef.Value.GridIndices);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.GridAtmosphere.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.GridAtmosphere.cs
@@ -72,7 +72,7 @@ public sealed partial class AtmosphereSystem
                 newGridAtmos = AddComp<GridAtmosphereComponent>(newGrid);
 
             // We assume the tiles on the new grid have the same coordinates as they did on the old grid...
-            var enumerator = _mapSystem.GetAllTilesEnumerator(newGrid, mapGrid);
+            var enumerator = _mapSystem.GetAllTiles(newGrid, mapGrid);
 
             while (enumerator.MoveNext(out var tile))
             {
@@ -324,7 +324,7 @@ public sealed partial class AtmosphereSystem
             atmos.InvalidatedCoords.Add(indices);
         }
 
-        var enumerator = _map.GetAllTilesEnumerator(uid, grid);
+        var enumerator = _map.GetAllTiles(uid, grid);
         while (enumerator.MoveNext(out var tile))
         {
             atmos.InvalidatedCoords.Add(tile.Value.GridIndices);

--- a/Content.Server/Decals/DecalSystem.cs
+++ b/Content.Server/Decals/DecalSystem.cs
@@ -10,7 +10,6 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Map.Events;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
-using Robust.Shared.Utility;
 
 namespace Content.Server.Decals;
 
@@ -93,9 +92,9 @@ public sealed partial class DecalSystem : SharedDecalSystem
         var moved = new HashSet<DecalIndex>();
         var toMove = new List<(DecalIndex Id, Decal Decal)>();
 
-        foreach (var tile in _mapSystem.GetAllTilesEnumerator(ev.Grid, grid))
+        foreach (var tile in _mapSystem.GetAllTiles(ev.Grid, grid))
         {
-            var tilePos = (Vector2) tile.GridIndices;
+            var tilePos = (Vector2)tile.GridIndices;
             var bounds = new Box2(tilePos - _boundsMinExpansion, tilePos + _boundsMaxExpansion);
 
             foreach (var (id, decal) in GetDecalsIntersecting(ev.OldGrid, bounds))
@@ -371,7 +370,7 @@ public sealed partial class DecalSystem : SharedDecalSystem
                 if (chunk.Comp2.MaxDecalId >= DecalChunkComponent.MaxServerDecalId)
                     break;
 
-                next = (ushort) (chunk.Comp2.MaxDecalId + 1);
+                next = (ushort)(chunk.Comp2.MaxDecalId + 1);
             }
 
             if (chunk.Comp2.Decals.ContainsKey(next))

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Airtight.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Airtight.cs
@@ -97,7 +97,7 @@ public sealed partial class ExplosionSystem
         var tolerance = new FixedPoint2[_explosionTypes.Count];
         var blockedDirections = AtmosDirection.Invalid;
 
-        var anchoredEnumerator = _map.GetAnchoredEntitiesEnumerator(gridId, grid, tile);
+        var anchoredEnumerator = _map.GetAnchoredEntities(gridId, grid, tile);
 
         while (anchoredEnumerator.MoveNext(out var uid))
         {

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.cs
@@ -512,7 +512,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
 
         // Get normalized co-ordinate for spill location and spill it in the centre
         // TODO: Does SnapGrid or something else already do this?
-        var anchored = _map.GetAnchoredEntitiesEnumerator(gridId, mapGrid, tileRef.GridIndices);
+        var anchored = _map.GetAnchoredEntities(gridId, mapGrid, tileRef.GridIndices);
 
         while (anchored.MoveNext(out var ent))
         {
@@ -558,7 +558,7 @@ public sealed partial class PuddleSystem : SharedPuddleSystem
         if (!TryComp<MapGridComponent>(tile.GridUid, out var grid))
             return false;
 
-        var anc = _map.GetAnchoredEntitiesEnumerator(tile.GridUid, grid, tile.GridIndices);
+        var anc = _map.GetAnchoredEntities(tile.GridUid, grid, tile.GridIndices);
         while (anc.MoveNext(out var ent))
         {
             if (!_puddleQuery.HasComponent(ent.Value))

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -8,7 +8,6 @@ using Content.Server.Shuttles.Systems;
 using Content.Shared.Atmos;
 using Content.Shared.Ghost.Components;
 using Content.Shared.Decals;
-using Content.Shared.Ghost;
 using Content.Shared.Gravity;
 using Content.Shared.Light.Components;
 using Content.Shared.Parallax.Biomes;
@@ -593,7 +592,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
                     continue;
 
                 // Check if it's a valid spawn, if so then use it.
-                var enumerator = _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, node);
+                var enumerator = _mapSystem.GetAnchoredEntities(gridUid, grid, node);
                 enumerator.MoveNext(out var existing);
 
                 if (!forced && existing != null)
@@ -811,7 +810,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
                     continue;
 
                 // Don't mess with anything that's potentially anchored.
-                var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, indices);
+                var anchored = _mapSystem.GetAnchoredEntities(gridUid, grid, indices);
 
                 if (anchored.MoveNext(out _) || !TryGetEntity(indices, component, (gridUid, grid), out var entPrototype))
                     continue;
@@ -844,7 +843,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
                     continue;
 
                 // Don't mess with anything that's potentially anchored.
-                var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, indices);
+                var anchored = _mapSystem.GetAnchoredEntities(gridUid, grid, indices);
 
                 if (anchored.MoveNext(out _) || !TryGetDecals(indices, component.Layers, seed, (gridUid, grid), out var decals))
                     continue;
@@ -958,7 +957,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
                     continue;
 
                 // Don't mess with anything that's potentially anchored.
-                var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(gridUid, grid, indices);
+                var anchored = _mapSystem.GetAnchoredEntities(gridUid, grid, indices);
 
                 if (anchored.MoveNext(out _))
                 {

--- a/Content.Server/Pinpointer/NavMapSystem.cs
+++ b/Content.Server/Pinpointer/NavMapSystem.cs
@@ -269,7 +269,7 @@ public sealed partial class NavMapSystem : SharedNavMapSystem
         else
             tileData &= FloorMask;
 
-        var enumerator = _mapSystem.GetAnchoredEntitiesEnumerator(uid, mapGrid, tile);
+        var enumerator = _mapSystem.GetAnchoredEntities(uid, mapGrid, tile);
         while (enumerator.MoveNext(out var ent))
         {
             if (!_airtightQuery.TryComp(ent, out var airtight))

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.AutoCabling.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.AutoCabling.cs
@@ -26,7 +26,7 @@ public sealed partial class DungeonJob
         // Gather existing nodes
         foreach (var tile in allTiles)
         {
-            var anchored = _maps.GetAnchoredEntitiesEnumerator(_gridUid, _grid, tile);
+            var anchored = _maps.GetAnchoredEntities(_gridUid, _grid, tile);
 
             while (anchored.MoveNext(out var anc))
             {
@@ -93,7 +93,7 @@ public sealed partial class DungeonJob
 
             for (var i = 0; i < 4; i++)
             {
-                var dir = (Direction) (i * 2);
+                var dir = (Direction)(i * 2);
 
                 var neighbor = node + dir.ToIntVec();
                 var tileCost = 1f;
@@ -134,7 +134,7 @@ public sealed partial class DungeonJob
             if (reservedTiles.Contains(tile))
                 continue;
 
-            var anchored = _maps.GetAnchoredEntitiesEnumerator(_gridUid, _grid, tile);
+            var anchored = _maps.GetAnchoredEntities(_gridUid, _grid, tile);
             var found = false;
 
             while (anchored.MoveNext(out var anc))

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Biome.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Biome.cs
@@ -24,7 +24,7 @@ public sealed partial class DungeonJob
         var seed = random.Next();
         var xformQuery = _entManager.GetEntityQuery<TransformComponent>();
 
-        var tiles = _maps.GetAllTilesEnumerator(_gridUid, _grid);
+        var tiles = _maps.GetAllTiles(_gridUid, _grid);
         while (tiles.MoveNext(out var tileRef))
         {
             var node = tileRef.Value.GridIndices;

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.CorridorClutter.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.CorridorClutter.cs
@@ -14,14 +14,14 @@ public sealed partial class DungeonJob
     private async Task PostGen(CorridorClutterDunGen gen, Dungeon dungeon, HashSet<Vector2i> reservedTiles, IRobustRandom random)
     {
         var physicsQuery = _entManager.GetEntityQuery<PhysicsComponent>();
-        var count = (int) Math.Ceiling(dungeon.CorridorTiles.Count * gen.Chance);
+        var count = (int)Math.Ceiling(dungeon.CorridorTiles.Count * gen.Chance);
         var contents = _prototype.Index(gen.Contents);
 
         while (count > 0)
         {
             var tile = random.Pick(dungeon.CorridorTiles);
 
-            var enumerator = _maps.GetAnchoredEntitiesEnumerator(_gridUid, _grid, tile);
+            var enumerator = _maps.GetAnchoredEntities(_gridUid, _grid, tile);
             var blocked = false;
 
             while (enumerator.MoveNext(out var ent))

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.CorridorDecalSkirting.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.CorridorDecalSkirting.cs
@@ -31,10 +31,10 @@ public sealed partial class DungeonJob
             // Do corners the other step
             for (var i = 0; i < 4; i++)
             {
-                var dir = (DirectionFlag) Math.Pow(2, i);
+                var dir = (DirectionFlag)Math.Pow(2, i);
                 var neighbor = tile + dir.AsDir().ToIntVec();
 
-                var anc = _maps.GetAnchoredEntitiesEnumerator(_gridUid, _grid, neighbor);
+                var anc = _maps.GetAnchoredEntities(_gridUid, _grid, neighbor);
 
                 while (anc.MoveNext(out var ent))
                 {
@@ -58,10 +58,10 @@ public sealed partial class DungeonJob
 
                 for (var i = 1; i < 5; i++)
                 {
-                    var dir = (Direction) (i * 2 - 1);
+                    var dir = (Direction)(i * 2 - 1);
                     var neighbor = tile + dir.ToIntVec();
 
-                    var anc = _maps.GetAnchoredEntitiesEnumerator(_gridUid, _grid, neighbor);
+                    var anc = _maps.GetAnchoredEntities(_gridUid, _grid, neighbor);
 
                     while (anc.MoveNext(out var ent))
                     {

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Helpers.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Helpers.cs
@@ -12,7 +12,7 @@ public sealed partial class DungeonJob
 
     private bool HasWall(Vector2i tile)
     {
-        var anchored = _maps.GetAnchoredEntitiesEnumerator(_gridUid, _grid, tile);
+        var anchored = _maps.GetAnchoredEntities(_gridUid, _grid, tile);
 
         while (anchored.MoveNext(out var uid))
         {

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Ore.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Ore.cs
@@ -35,7 +35,7 @@ public sealed partial class DungeonJob
                     continue;
 
                 // Check if it's a valid spawn, if so then use it.
-                var enumerator = _maps.GetAnchoredEntitiesEnumerator(_gridUid, _grid, node);
+                var enumerator = _maps.GetAnchoredEntities(_gridUid, _grid, node);
                 var found = false;
 
                 // We use existing entities as a mark to spawn in place
@@ -75,7 +75,7 @@ public sealed partial class DungeonJob
             if (_prototype.Resolve(gen.Entity, out var proto) &&
                 proto.Components.TryGetComponent("EntityRemap", out var comps))
             {
-                var remappingComp = (EntityRemapComponent) comps;
+                var remappingComp = (EntityRemapComponent)comps;
                 remapping = remappingComp.Mask;
             }
 

--- a/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
@@ -331,11 +331,11 @@ public sealed partial class DockingSystem
             // If it's a map check no hard collidable anchored entities overlap
             if (isMap)
             {
-                var localTiles = _mapSystem.GetLocalTilesEnumerator(gridEntity.Owner, gridEntity.Comp, aabb);
+                var localTiles = _mapSystem.GetLocalTilesIntersecting(gridEntity.Owner, gridEntity.Comp, aabb);
 
                 while (localTiles.MoveNext(out var tile))
                 {
-                    var anchoredEnumerator = _mapSystem.GetAnchoredEntitiesEnumerator(gridEntity.Owner, gridEntity.Comp, tile.GridIndices);
+                    var anchoredEnumerator = _mapSystem.GetAnchoredEntities(gridEntity.Owner, gridEntity.Comp, tile.GridIndices);
 
                     while (anchoredEnumerator.MoveNext(out var anc))
                     {

--- a/Content.Server/Shuttles/Systems/ThrusterSystem.cs
+++ b/Content.Server/Shuttles/Systems/ThrusterSystem.cs
@@ -116,7 +116,7 @@ public sealed partial class ThrusterSystem : EntitySystem
                         continue;
 
                     var checkPos = tilePos + new Vector2i(x, y);
-                    var enumerator = _mapSystem.GetAnchoredEntitiesEnumerator(uid, grid, checkPos);
+                    var enumerator = _mapSystem.GetAnchoredEntities(uid, grid, checkPos);
 
                     while (enumerator.MoveNext(out var ent))
                     {

--- a/Content.Server/Spreader/SpreaderSystem.cs
+++ b/Content.Server/Spreader/SpreaderSystem.cs
@@ -190,7 +190,7 @@ public sealed partial class SpreaderSystem : EntitySystem
         var neighborTiles = new ValueList<(EntityUid entity, MapGridComponent grid, Vector2i Indices, AtmosDirection OtherDir, AtmosDirection OurDir)>();
 
         // Check if anything on our own tile blocking that direction.
-        var ourEnts = _map.GetAnchoredEntitiesEnumerator(comp.GridUid.Value, grid, tile);
+        var ourEnts = _map.GetAnchoredEntities(comp.GridUid.Value, grid, tile);
 
         while (ourEnts.MoveNext(out var ent))
         {
@@ -231,7 +231,7 @@ public sealed partial class SpreaderSystem : EntitySystem
         // Add the normal neighbors.
         for (var i = 0; i < 4; i++)
         {
-            var atmosDir = (AtmosDirection) (1 << i);
+            var atmosDir = (AtmosDirection)(1 << i);
             var neighborPos = tile.Offset(atmosDir);
             neighborTiles.Add((comp.GridUid.Value, grid, neighborPos, atmosDir, i.ToOppositeDir()));
         }
@@ -248,7 +248,7 @@ public sealed partial class SpreaderSystem : EntitySystem
             if (spreaderPrototype.PreventSpreadOnSpaced && _turf.IsSpace(tileRef))
                 continue;
 
-            var directionEnumerator = _map.GetAnchoredEntitiesEnumerator(neighborEnt, neighborGrid, neighborPos);
+            var directionEnumerator = _map.GetAnchoredEntities(neighborEnt, neighborGrid, neighborPos);
             var occupied = false;
 
             while (directionEnumerator.MoveNext(out var ent))
@@ -269,7 +269,7 @@ public sealed partial class SpreaderSystem : EntitySystem
                 continue;
 
             var oldCount = occupiedTiles.Count;
-            directionEnumerator = _map.GetAnchoredEntitiesEnumerator(neighborEnt, neighborGrid, neighborPos);
+            directionEnumerator = _map.GetAnchoredEntities(neighborEnt, neighborGrid, neighborPos);
 
             while (directionEnumerator.MoveNext(out var ent))
             {
@@ -315,7 +315,7 @@ public sealed partial class SpreaderSystem : EntitySystem
             (gridUid, tile) = position.Value;
         }
 
-        var anchored = _map.GetAnchoredEntitiesEnumerator(gridUid, gridComp, tile);
+        var anchored = _map.GetAnchoredEntities(gridUid, gridComp, tile);
         while (anchored.MoveNext(out var entity))
         {
             // Don't re-activate the terminating entity
@@ -330,9 +330,9 @@ public sealed partial class SpreaderSystem : EntitySystem
 
         for (var i = 0; i < Atmospherics.Directions; i++)
         {
-            var direction = (AtmosDirection) (1 << i);
+            var direction = (AtmosDirection)(1 << i);
             var adjacentTile = SharedMapSystem.GetDirection(tile, direction.ToDirection());
-            anchored = _map.GetAnchoredEntitiesEnumerator(gridUid, gridComp, adjacentTile);
+            anchored = _map.GetAnchoredEntities(gridUid, gridComp, adjacentTile);
 
             while (anchored.MoveNext(out var entity))
             {

--- a/Content.Server/Tiles/RequiresTileSystem.cs
+++ b/Content.Server/Tiles/RequiresTileSystem.cs
@@ -25,7 +25,7 @@ public sealed partial class RequiresTileSystem : EntitySystem
 
         foreach (var change in ev.Changes)
         {
-            var anchored = _maps.GetAnchoredEntitiesEnumerator(ev.Entity, grid, change.GridIndices);
+            var anchored = _maps.GetAnchoredEntities(ev.Entity, grid, change.GridIndices);
 
             while (anchored.MoveNext(out var ent))
             {

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -358,7 +358,7 @@ public sealed partial class AnchorableSystem : EntitySystem
     /// <param name="grid"></param>
     public bool TileFree(Entity<MapGridComponent> grid, Vector2i gridIndices, int collisionLayer = 0, int collisionMask = 0)
     {
-        var enumerator = _map.GetAnchoredEntitiesEnumerator(grid, grid.Comp, gridIndices);
+        var enumerator = _map.GetAnchoredEntities(grid, grid.Comp, gridIndices);
 
         while (enumerator.MoveNext(out var ent))
         {
@@ -403,7 +403,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         if (!TryComp<MapGridComponent>(gridUid, out var grid))
             return false;
 
-        var enumerator = _map.GetAnchoredEntitiesEnumerator(gridUid.Value, grid, _map.LocalToTile(gridUid.Value, grid, location));
+        var enumerator = _map.GetAnchoredEntities(gridUid.Value, grid, _map.LocalToTile(gridUid.Value, grid, location));
 
         while (enumerator.MoveNext(out var entity))
         {

--- a/Content.Shared/Construction/EntitySystems/BlockAnchorOnSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/BlockAnchorOnSystem.cs
@@ -65,7 +65,7 @@ public sealed partial class BlockAnchorOnSystem : EntitySystem
             return false;
 
         var indices = _map.TileIndicesFor(grid, gridComp, ent.Comp2.Coordinates);
-        var enumerator = _map.GetAnchoredEntitiesEnumerator(grid, gridComp, indices);
+        var enumerator = _map.GetAnchoredEntities(grid, gridComp, indices);
 
         while (enumerator.MoveNext(out var otherEnt))
         {

--- a/Content.Shared/EntityConditions/Conditions/Generic/NearbyTilesPercentConditionSystem.cs
+++ b/Content.Shared/EntityConditions/Conditions/Generic/NearbyTilesPercentConditionSystem.cs
@@ -37,7 +37,7 @@ public sealed partial class NearbyTilesPercentConditionSystem : EntityConditionS
             // Only consider collidable anchored (for reasons some subfloor stuff has physics but non-collidable)
             if (args.Condition.IgnoreAnchored)
             {
-                var gridEnum = _map.GetAnchoredEntitiesEnumerator(entity.Comp.GridUid.Value, grid, tile.GridIndices);
+                var gridEnum = _map.GetAnchoredEntities(entity.Comp.GridUid.Value, grid, tile.GridIndices);
                 var found = false;
 
                 while (gridEnum.MoveNext(out var ancUid))

--- a/Content.Shared/Fluids/SharedPuddleSystem.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.cs
@@ -196,7 +196,7 @@ public abstract partial class SharedPuddleSystem : EntitySystem
             if (!_turf.IsSpace(change.NewTile))
                 continue;
 
-            var anchored = _map.GetAnchoredEntitiesEnumerator(ev.Entity, ev.Entity.Comp, change.GridIndices);
+            var anchored = _map.GetAnchoredEntities(ev.Entity, ev.Entity.Comp, change.GridIndices);
             while (anchored.MoveNext(out var ent))
             {
                 if (!_puddleQuery.HasComponent(ent))

--- a/Content.Shared/Friction/TileFrictionController.cs
+++ b/Content.Shared/Friction/TileFrictionController.cs
@@ -156,7 +156,7 @@ namespace Content.Shared.Friction
                 return tileModifier;
 
             // Check for anchored ents that modify friction
-            var anc = _map.GetAnchoredEntitiesEnumerator(xform.GridUid.Value, grid, tile.GridIndices);
+            var anc = _map.GetAnchoredEntities(xform.GridUid.Value, grid, tile.GridIndices);
             while (anc.MoveNext(out var tileEnt))
             {
                 if (_frictionQuery.TryGetComponent(tileEnt, out var friction))

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -104,7 +104,7 @@ public abstract partial class SharedMoverController : VirtualController
 
     protected virtual void OnMoverStartup(Entity<InputMoverComponent> ent, ref ComponentStartup args)
     {
-       _blocker.UpdateCanMove(ent, ent.Comp);
+        _blocker.UpdateCanMove(ent, ent.Comp);
     }
 
     public override void Shutdown()
@@ -586,7 +586,7 @@ public abstract partial class SharedMoverController : VirtualController
 
         // If the coordinates have a FootstepModifier component
         // i.e. component that emit sound on footsteps emit that sound
-        var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(xform.GridUid.Value, grid, position);
+        var anchored = _mapSystem.GetAnchoredEntities(xform.GridUid.Value, grid, position);
 
         while (anchored.MoveNext(out var maybeFootstep))
         {

--- a/Content.Shared/Silicons/StationAi/StationAiVisionSystem.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiVisionSystem.cs
@@ -97,7 +97,7 @@ public sealed partial class StationAiVisionSystem : EntitySystem
         // Skip occluders step if we're just doing range checks.
         if (!fastPath)
         {
-            var tileEnumerator = _maps.GetLocalTilesEnumerator(grid, grid, expandedBounds, ignoreEmpty: false);
+            var tileEnumerator = _maps.GetLocalTilesIntersecting(grid, grid, expandedBounds, ignoreEmpty: false);
 
             // Get all other relevant tiles.
             while (tileEnumerator.MoveNext(out var tileRef))
@@ -182,7 +182,7 @@ public sealed partial class StationAiVisionSystem : EntitySystem
             return;
 
         // Get viewport tiles
-        var tileEnumerator = _maps.GetLocalTilesEnumerator(grid, grid, localAabb, ignoreEmpty: false);
+        var tileEnumerator = _maps.GetLocalTilesIntersecting(grid, grid, localAabb, ignoreEmpty: false);
 
         while (tileEnumerator.MoveNext(out var tileRef))
         {
@@ -194,7 +194,7 @@ public sealed partial class StationAiVisionSystem : EntitySystem
             _viewportTiles.Add(tileRef.GridIndices);
         }
 
-        tileEnumerator = _maps.GetLocalTilesEnumerator(grid, grid, enlargedLocalAabb, ignoreEmpty: false);
+        tileEnumerator = _maps.GetLocalTilesIntersecting(grid, grid, enlargedLocalAabb, ignoreEmpty: false);
 
         while (tileEnumerator.MoveNext(out var tileRef))
         {

--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -63,7 +63,7 @@ public sealed partial class StepTriggerSystem : EntitySystem
         if (component.Blacklist != null && TryComp<MapGridComponent>(transform.GridUid, out var grid))
         {
             var positon = _map.LocalToTile(transform.GridUid.Value, grid, transform.Coordinates);
-            var anch = _map.GetAnchoredEntitiesEnumerator(uid, grid, positon);
+            var anch = _map.GetAnchoredEntities(uid, grid, positon);
 
             while (anch.MoveNext(out var ent))
             {

--- a/Content.Shared/Weather/SharedWeatherSystem.cs
+++ b/Content.Shared/Weather/SharedWeatherSystem.cs
@@ -43,7 +43,7 @@ public abstract partial class SharedWeatherSystem : EntitySystem
         if (!tileDef.Weather)
             return false;
 
-        var anchoredEntities = _mapSystem.GetAnchoredEntitiesEnumerator(ent, ent.Comp1, tileRef.GridIndices);
+        var anchoredEntities = _mapSystem.GetAnchoredEntities(ent, ent.Comp1, tileRef.GridIndices);
 
         while (anchoredEntities.MoveNext(out var anchored))
         {


### PR DESCRIPTION
## About the PR

RT obsolescence pass.

Resolves a bunch of obsolete warnings about GetAnchoredEntitiesEnumerator, GetTilesEnumerator, GetLocalTilesEnumerator, and GetAllTilesEnumerator.

Replaces them with their wrapped calls in accordance with the warning text.

## Why / Balance

Idempotent functions!

Wink and a nod to #33279.

## Technical details

Also a few minor _minor_ cases of whitespace cleanup nearby.
Adds EntityQueries to WallmountSystem.
AtmosphereSystem.Commands.cs indentation fixed in a command.

GetTilesEnumerator->GetTilesIntersecting
GetLocalTilesEnumerator->GetLocalTilesIntersecting
GetAllTilesEnumerator->GetAllTiles
GetAnchoredEntitiesEnumerator->GetAnchoredEntities

## Test plan

Compile.  Run tests.  Fewer warnings.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
no :)