### PR TITLE
Examinable doafters

### DIFF
--- a/Content.Shared/Anomaly/Components/AnomalyScannerComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyScannerComponent.cs
@@ -35,4 +35,7 @@ public sealed partial class AnomalyScannerComponent : Component
     /// </summary>
     [DataField]
     public bool IgnoreSecret;
+
+    [DataField]
+    public LocId DoAfterExamineText = "anomaly-scanner-doafter-examine";
 }

--- a/Content.Shared/Anomaly/SharedAnomalyScannerSystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalyScannerSystem.cs
@@ -65,7 +65,8 @@ public abstract partial class SharedAnomalyScannerSystem : EntitySystem
             used: uid
         )
         {
-            DistanceThreshold = 2f
+            DistanceThreshold = 2f,
+            ExamineText = component.DoAfterExamineText,
         };
         _doAfter.TryStartDoAfter(doAfterArgs);
     }

--- a/Content.Shared/Anomaly/SharedAnomalyScannerSystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalyScannerSystem.cs
@@ -66,7 +66,7 @@ public abstract partial class SharedAnomalyScannerSystem : EntitySystem
         )
         {
             DistanceThreshold = 2f,
-            ExamineText = component.DoAfterExamineText,
+            ExamineText = Loc.GetString(component.DoAfterExamineText, ("user", args.User)),
         };
         _doAfter.TryStartDoAfter(doAfterArgs);
     }

--- a/Content.Shared/DoAfter/DoAfterArgs.cs
+++ b/Content.Shared/DoAfter/DoAfterArgs.cs
@@ -46,6 +46,12 @@ public sealed partial class DoAfterArgs
     [DataField]
     public bool Hidden;
 
+    /// <summary>
+    ///     LocId of the text that will be added to the examine window of the entity.
+    /// </summary>
+    [DataField]
+    public LocId? ExamineText;
+
     #region Event options
     /// <summary>
     ///     The event that will get raised when the DoAfter has finished. If null, this will simply raise a <see cref="SimpleDoAfterEvent"/>
@@ -248,6 +254,7 @@ public sealed partial class DoAfterArgs
         Target = other.Target;
         Used = other.Used;
         Hidden = other.Hidden;
+        ExamineText = other.ExamineText;
         EventTarget = other.EventTarget;
         Broadcast = other.Broadcast;
         NeedHand = other.NeedHand;

--- a/Content.Shared/DoAfter/DoAfterArgs.cs
+++ b/Content.Shared/DoAfter/DoAfterArgs.cs
@@ -47,10 +47,10 @@ public sealed partial class DoAfterArgs
     public bool Hidden;
 
     /// <summary>
-    ///     LocId of the text that will be added to the examine window of the entity.
+    ///     String that will be added to the examine window of the entity.
     /// </summary>
     [DataField]
-    public LocId? ExamineText;
+    public string? ExamineText;
 
     #region Event options
     /// <summary>

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -184,7 +184,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             return;
 
         var msg = new FormattedMessage();
-        var examined = new HashSet<string>();
+        var examined = new HashSet<string>(ent.Comp.DoAfters.Count);
 
         foreach (var doAfter in ent.Comp.DoAfters.Values)
         {

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Damage.Systems;
+using Content.Shared.Examine;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Movement.Events;
@@ -39,6 +40,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         SubscribeLocalEvent<DoAfterComponent, ComponentGetState>(OnDoAfterGetState);
         SubscribeLocalEvent<DoAfterComponent, ComponentHandleState>(OnDoAfterHandleState);
         SubscribeLocalEvent<DoAfterComponent, EffectiveMoverChangedEvent>(OnEffectiveMoverChanged);
+        SubscribeLocalEvent<DoAfterComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<GetInteractingEntitiesEvent>(OnGetInteractingEntities);
     }
 
@@ -173,6 +175,18 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
                 if (doAfter.Args.Target == args.Target)
                     args.InteractingEntities.Add(doAfter.Args.User);
             }
+        }
+    }
+
+    private void OnExamined(Entity<DoAfterComponent> ent, ref ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        foreach (var doAfter in ent.Comp.DoAfters.Values)
+        {
+            if (doAfter.Args.ExamineText is not null)
+                args.PushMarkup(Loc.GetString(doAfter.Args.ExamineText));
         }
     }
 

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -184,15 +184,12 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             return;
 
         var msg = new FormattedMessage();
-        var examined = new List<string>();
+        var examined = new HashSet<string>();
 
         foreach (var doAfter in ent.Comp.DoAfters.Values)
         {
-            if (doAfter.Args.ExamineText is not null &&
-                !examined.Contains(doAfter.Args.ExamineText))
-            {
+            if (doAfter.Args.ExamineText is not null)
                 examined.Add(doAfter.Args.ExamineText);
-            }
         }
 
         foreach (var entry in examined)

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -183,11 +183,25 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         if (!args.IsInDetailsRange)
             return;
 
+        var msg = new FormattedMessage();
+        var examined = new List<string>();
+
         foreach (var doAfter in ent.Comp.DoAfters.Values)
         {
-            if (doAfter.Args.ExamineText is not null)
-                args.PushMarkup(Loc.GetString(doAfter.Args.ExamineText), -5);
+            if (doAfter.Args.ExamineText is not null &&
+                !examined.Contains(doAfter.Args.ExamineText))
+            {
+                examined.Add(doAfter.Args.ExamineText);
+            }
         }
+
+        foreach (var entry in examined)
+        {
+            msg.AddMarkupOrThrow(entry);
+            msg.PushNewline();
+        }
+
+        args.PushMessage(msg, -5);
     }
 
     #region Creation

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -186,7 +186,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         foreach (var doAfter in ent.Comp.DoAfters.Values)
         {
             if (doAfter.Args.ExamineText is not null)
-                args.PushMarkup(Loc.GetString(doAfter.Args.ExamineText));
+                args.PushMarkup(Loc.GetString(doAfter.Args.ExamineText), -5);
         }
     }
 

--- a/Resources/Locale/en-US/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/anomaly/anomaly.ftl
@@ -32,6 +32,7 @@ anomaly-scanner-particle-unstable-unknown = - [color=plum]Unstable type:[/color]
 anomaly-scanner-particle-containment-unknown = - [color=goldenrod]Containment type:[/color] [color=red]ERROR[/color]
 anomaly-scanner-particle-transformation-unknown = - [color=#6b75fa]Transformation type:[/color] [color=red]ERROR[/color]
 anomaly-scanner-pulse-timer = Time until next pulse: [color=gray]{$time}[/color]
+anomaly-scanner-doafter-examine = {CAPITALIZE{THE({SUBJECT($target)}}} {CONJUGATE-BE($target)} [color=plum]scanning anomaly[/color]
 
 anomaly-gorilla-core-slot-name = Anomaly core
 anomaly-gorilla-charge-none = It has no [bold]anomaly core[/bold] inside of it.

--- a/Resources/Locale/en-US/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/anomaly/anomaly.ftl
@@ -32,7 +32,7 @@ anomaly-scanner-particle-unstable-unknown = - [color=plum]Unstable type:[/color]
 anomaly-scanner-particle-containment-unknown = - [color=goldenrod]Containment type:[/color] [color=red]ERROR[/color]
 anomaly-scanner-particle-transformation-unknown = - [color=#6b75fa]Transformation type:[/color] [color=red]ERROR[/color]
 anomaly-scanner-pulse-timer = Time until next pulse: [color=gray]{$time}[/color]
-anomaly-scanner-doafter-examine = {CAPITALIZE{THE({SUBJECT($target)}}} {CONJUGATE-BE($target)} [color=plum]scanning anomaly[/color]
+anomaly-scanner-doafter-examine = { CAPITALIZE(SUBJECT($user)) } {CONJUGATE-BE($user)} [color=plum]scanning anomaly[/color].
 
 anomaly-gorilla-core-slot-name = Anomaly core
 anomaly-gorilla-charge-none = It has no [bold]anomaly core[/bold] inside of it.

--- a/Resources/Locale/en-US/anomaly/anomaly.ftl
+++ b/Resources/Locale/en-US/anomaly/anomaly.ftl
@@ -32,7 +32,7 @@ anomaly-scanner-particle-unstable-unknown = - [color=plum]Unstable type:[/color]
 anomaly-scanner-particle-containment-unknown = - [color=goldenrod]Containment type:[/color] [color=red]ERROR[/color]
 anomaly-scanner-particle-transformation-unknown = - [color=#6b75fa]Transformation type:[/color] [color=red]ERROR[/color]
 anomaly-scanner-pulse-timer = Time until next pulse: [color=gray]{$time}[/color]
-anomaly-scanner-doafter-examine = { CAPITALIZE(SUBJECT($user)) } {CONJUGATE-BE($user)} [color=plum]scanning anomaly[/color].
+anomaly-scanner-doafter-examine = { CAPITALIZE(SUBJECT($user)) } {CONJUGATE-BE($user)} [color=plum]scanning an anomaly[/color].
 
 anomaly-gorilla-core-slot-name = Anomaly core
 anomaly-gorilla-charge-none = It has no [bold]anomaly core[/bold] inside of it.


### PR DESCRIPTION
## About the PR
This pr allows the creation of the examinable doafters alongside a simple example of this: the anomaly scanner doafter is now examinable because the anomaly scanner doafter is pretty obvious (the player literally holds the scanner) and located at the head of the shared file system.

## Why / Balance
I always thought that doafters are really strange; they block players from the instant actions and allow other players to interrupt them. But without context, you don't understand what these actions are. 
For example, you see a passenger with a pretty long doafter near the bridge, but you haven't seen the start of the doafter, so you can't actually say what they are doing. They can build one-sided tourniquets, they can use a topical, they can uncuff themselves, and they can drink from the puddle. And I don't want to interrupt them. What if they are doing something useful? But then why do doafters even exist if you don't know what they are doing without context?
This is optional; if you see how someone with scissors just walks to you and attempts to do some doafters with sus sounds, you don't need to examine anything. Obviously, they are attempting to change your hair. But what if, for example, I'm playing without sound?

## Technical details
One new subscrition method to the `Content.Shared/DoAfter/SharedDoAfterSystem.cs`

## Test plan
1. Start server and client
2. Spawn anomaly and scanner
3. Scan anomaly and examine your character

## Media
<img width="800" height="450" alt="ss14" src="https://github.com/user-attachments/assets/2185f532-84fa-443e-95da-d33055615523" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
N/A

## Changelog
Probably should be added later. Not really player facing right now.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
