### PR TITLE
Make satiation able to increase over time & reframe satiation not assuming it decays by default

### DIFF
--- a/Content.IntegrationTests/Tests/Nutrition/SatiationTest.cs
+++ b/Content.IntegrationTests/Tests/Nutrition/SatiationTest.cs
@@ -32,7 +32,7 @@ public sealed class SatiationTest : GameTest
     private static readonly string SatiationPrototypes = $@"
 - type: satiation
   id: {TestSatiationId}
-  baseDecayRate: 1
+  baseChangeRate: -1
   maximumValue: {MaxValue}
   thresholds: # Intentionally out of ordinal order.
     {DeadKey}: 0
@@ -40,7 +40,7 @@ public sealed class SatiationTest : GameTest
     {MiddleKey}: {MiddleValue}
   startingValueMinimum: {StartingMin}
   startingValueMaximum: {StartingMax}
-  decayModifiers:
+  changeModifiers:
     25: 0.5
   alertCategory: Hunger
 
@@ -117,9 +117,11 @@ public sealed class SatiationTest : GameTest
                 TestSatiationType,
                 dict,
                 out var result,
+                out var nextHigher,
                 out var nextLower);
             Assert.That(res, Is.True);
             Assert.That(result, Is.EqualTo(100));
+            Assert.That(nextHigher, Is.EqualTo(100));
             Assert.That(nextLower, Is.EqualTo(80));
         }
 
@@ -130,9 +132,11 @@ public sealed class SatiationTest : GameTest
                 TestSatiationType,
                 dict,
                 out var result,
+                out var nextHigher,
                 out var nextLower);
             Assert.That(res, Is.True);
             Assert.That(result, Is.EqualTo(60));
+            Assert.That(nextHigher, Is.EqualTo(60));
             Assert.That(nextLower, Is.EqualTo(40));
         }
 
@@ -143,6 +147,7 @@ public sealed class SatiationTest : GameTest
                 TestSatiationType,
                 dict,
                 out var result,
+                out var nextHigher,
                 out var nextLower);
             Assert.That(res, Is.True);
             Assert.That(result, Is.Zero);
@@ -173,9 +178,11 @@ public sealed class SatiationTest : GameTest
                 TestSatiationType,
                 dict,
                 out var result,
+                out var nextHigher,
                 out var nextLower);
             Assert.That(res, Is.True);
             Assert.That(result, Is.Zero);
+            Assert.That(nextHigher, Is.EqualTo(MaxValue));
             Assert.That(nextLower, Is.EqualTo(MiddleValue));
         }
 
@@ -186,9 +193,11 @@ public sealed class SatiationTest : GameTest
                 TestSatiationType,
                 dict,
                 out var result,
+                out var nextHigher,
                 out var nextLower);
             Assert.That(res, Is.True);
             Assert.That(result, Is.Zero);
+            Assert.That(nextHigher, Is.EqualTo(MaxValue));
             Assert.That(nextLower, Is.EqualTo(MiddleValue));
         }
 
@@ -199,9 +208,11 @@ public sealed class SatiationTest : GameTest
                 TestSatiationType,
                 dict,
                 out var result,
+                out var nextHigher,
                 out var nextLower);
             Assert.That(res, Is.True);
             Assert.That(result, Is.EqualTo(40));
+            Assert.That(nextHigher, Is.EqualTo(MiddleValue));
             Assert.That(nextLower, Is.Zero);
         }
 
@@ -212,9 +223,11 @@ public sealed class SatiationTest : GameTest
                 TestSatiationType,
                 dict,
                 out var result,
+                out var nextHigher,
                 out var nextLower);
             Assert.That(res, Is.True);
             Assert.That(result, Is.EqualTo(20));
+            Assert.That(nextHigher, Is.Zero);
             Assert.That(nextLower, Is.Null);
         }
     }

--- a/Content.Server/Nutrition/Unsatiate.cs
+++ b/Content.Server/Nutrition/Unsatiate.cs
@@ -71,7 +71,7 @@ public sealed partial class Unsatiate : LocalizedEntityCommands
         // Check all of the types given before modifying any of them.
         foreach (var arg in args)
         {
-            if (_protoMan.TryIndex<SatiationPrototype>(arg, out var satiationType) && entity.Comp.Has(satiationType.ID))
+            if (_protoMan.TryIndex<SatiationTypePrototype>(arg, out var satiationType) && entity.Comp.Has(satiationType.ID))
                 continue;
 
             shell.WriteLine(Loc.GetString("shell-target-entity-does-not-have-message",

--- a/Content.Shared/Nutrition/Components/SatiationComponent.cs
+++ b/Content.Shared/Nutrition/Components/SatiationComponent.cs
@@ -22,6 +22,12 @@ namespace Content.Shared.Nutrition.Components;
 [Access(typeof(SatiationSystem))]
 public sealed partial class SatiationComponent : Component
 {
+    // TODO Satiations being stored in a bespoke dictionary wrapper type is a hack. See the remark on `SatiationDictionary`.
+    //   When the engine issue is resolved, `_satiations` should swap to the signature `public Dictionary<...> Satiations`,
+    //   the existing `Satiations` field should be removed, existing references to `Satiations` should be retargetted to
+    //   the actual actual `Dictionary` field, and `SatiationFieldName` should be replaced with `nameof(Satiation)` and
+    //   inlined wherever it's used.
+
     /// <summary>
     /// The actual <see cref="Satiation"/>s this entity has, keyed by their <see cref="SatiationTypePrototype">type</see>.
     /// </summary>
@@ -32,6 +38,12 @@ public sealed partial class SatiationComponent : Component
     /// <inheritdoc cref="_satiations"/>
     // Hide `SatiationDictionary` from public API
     public Dictionary<ProtoId<SatiationTypePrototype>, Satiation> Satiations => _satiations.Data;
+
+    /// <summary>
+    /// The C# code name of the backing field of <see cref="Satiations"/>, used for field deltas in
+    /// <see cref="SatiationSystem"/>.
+    /// </summary>
+    public const string SatiationFieldName = nameof(_satiations);
 
     /// <summary>
     /// Checks if this has a <see cref="Satiation"/> of the specified <paramref name="type"/>.
@@ -45,18 +57,13 @@ public sealed partial class SatiationComponent : Component
     /// </summary>
     [Access(Other = AccessPermissions.Execute)]
     public Satiation? GetOrNull(ProtoId<SatiationTypePrototype> type) => Satiations.GetValueOrDefault(type);
-
-    /// <summary>
-    /// The C# code name of the backing field of <see cref="Satiations"/>, used for field deltas in
-    /// <see cref="SatiationSystem"/>.
-    /// </summary>
-    public const string SatiationFieldName = nameof(_satiations);
 }
 
 /// <summary>
 /// A specialized <c>Dictionary&lt;ProtoId&lt;SatiationTypePrototype&gt;, Satiation&gt;</c> that exists just to
 /// implement <see cref="IRobustCloneable{T}"/>.
 /// </summary>
+/// <remarks>TODO This existing at all is a hack to work around https://github.com/space-wizards/RobustToolbox/issues/6972 . When the engine supports generating this, this should be removed.</remarks>
 [Serializable, NetSerializable, Access(typeof(SatiationDictionarySerializer))]
 public sealed partial class SatiationDictionary : IRobustCloneable<SatiationDictionary>
 {
@@ -75,11 +82,16 @@ public sealed partial class SatiationDictionary : IRobustCloneable<SatiationDict
     }
 }
 
+/// <summary>
+/// The serializer for <see cref="SatiationDictionary"/>. It just delegates to the standard dictionary serializer.
+/// </summary>
+/// <remarks>TODO This is a hack. See the remark on <see cref="SatiationDictionary"/></remarks>
 [TypeSerializer]
 public sealed partial class SatiationDictionarySerializer : ITypeSerializer<SatiationDictionary, MappingDataNode>
 {
     private static readonly DictionarySerializer<ProtoId<SatiationTypePrototype>, Satiation> Delegate = new();
 
+    /// <inheritdoc/>
     public ValidationNode Validate(
         ISerializationManager serializationManager,
         MappingDataNode node,
@@ -87,6 +99,7 @@ public sealed partial class SatiationDictionarySerializer : ITypeSerializer<Sati
         ISerializationContext? context = null
     ) => Delegate.Validate(serializationManager, node, dependencies, context);
 
+    /// <inheritdoc/>
     public SatiationDictionary Read(
         ISerializationManager serializationManager,
         MappingDataNode node,
@@ -106,6 +119,7 @@ public sealed partial class SatiationDictionarySerializer : ITypeSerializer<Sati
         ),
     };
 
+    /// <inheritdoc/>
     public DataNode Write(
         ISerializationManager serializationManager,
         SatiationDictionary value,

--- a/Content.Shared/Nutrition/Components/SatiationComponent.cs
+++ b/Content.Shared/Nutrition/Components/SatiationComponent.cs
@@ -2,6 +2,13 @@ using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Nutrition.Prototypes;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown;
+using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
 namespace Content.Shared.Nutrition.Components;
 
@@ -18,9 +25,13 @@ public sealed partial class SatiationComponent : Component
     /// <summary>
     /// The actual <see cref="Satiation"/>s this entity has, keyed by their <see cref="SatiationTypePrototype">type</see>.
     /// </summary>
-    [DataField(required: true)]
+    [DataField("satiations", required: true)]
     [AutoNetworkedField]
-    public Dictionary<ProtoId<SatiationTypePrototype>, Satiation> Satiations = [];
+    private SatiationDictionary _satiations = new();
+
+    /// <inheritdoc cref="_satiations"/>
+    // Hide `SatiationDictionary` from public API
+    public Dictionary<ProtoId<SatiationTypePrototype>, Satiation> Satiations => _satiations.Data;
 
     /// <summary>
     /// Checks if this has a <see cref="Satiation"/> of the specified <paramref name="type"/>.
@@ -34,4 +45,72 @@ public sealed partial class SatiationComponent : Component
     /// </summary>
     [Access(Other = AccessPermissions.Execute)]
     public Satiation? GetOrNull(ProtoId<SatiationTypePrototype> type) => Satiations.GetValueOrDefault(type);
+
+    /// <summary>
+    /// The C# code name of the backing field of <see cref="Satiations"/>, used for field deltas in
+    /// <see cref="SatiationSystem"/>.
+    /// </summary>
+    public const string SatiationFieldName = nameof(_satiations);
+}
+
+/// <summary>
+/// A specialized <c>Dictionary&lt;ProtoId&lt;SatiationTypePrototype&gt;, Satiation&gt;</c> that exists just to
+/// implement <see cref="IRobustCloneable{T}"/>.
+/// </summary>
+[Serializable, NetSerializable, Access(typeof(SatiationDictionarySerializer))]
+public sealed partial class SatiationDictionary : IRobustCloneable<SatiationDictionary>
+{
+    public Dictionary<ProtoId<SatiationTypePrototype>, Satiation> Data = new();
+
+    /// <inheritdoc/>
+    public SatiationDictionary Clone()
+    {
+        var clone = new SatiationDictionary();
+        foreach (var (proto, satiation) in Data)
+        {
+            clone.Data[proto] = satiation.Clone();
+        }
+
+        return clone;
+    }
+}
+
+[TypeSerializer]
+public sealed partial class SatiationDictionarySerializer : ITypeSerializer<SatiationDictionary, MappingDataNode>
+{
+    private static readonly DictionarySerializer<ProtoId<SatiationTypePrototype>, Satiation> Delegate = new();
+
+    public ValidationNode Validate(
+        ISerializationManager serializationManager,
+        MappingDataNode node,
+        IDependencyCollection dependencies,
+        ISerializationContext? context = null
+    ) => Delegate.Validate(serializationManager, node, dependencies, context);
+
+    public SatiationDictionary Read(
+        ISerializationManager serializationManager,
+        MappingDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<SatiationDictionary>? instanceProvider = null
+    ) => new()
+    {
+        Data = Delegate.Read(
+            serializationManager,
+            node,
+            dependencies,
+            hookCtx,
+            context,
+            (ISerializationManager.InstantiationDelegate<Dictionary<ProtoId<SatiationTypePrototype>, Satiation>>?)null
+        ),
+    };
+
+    public DataNode Write(
+        ISerializationManager serializationManager,
+        SatiationDictionary value,
+        IDependencyCollection dependencies,
+        bool alwaysWrite = false,
+        ISerializationContext? context = null
+    ) => Delegate.Write(serializationManager, value.Data, dependencies, alwaysWrite, context);
 }

--- a/Content.Shared/Nutrition/Components/SatiationSpeedModifierComponent.cs
+++ b/Content.Shared/Nutrition/Components/SatiationSpeedModifierComponent.cs
@@ -17,5 +17,5 @@ public sealed partial class SatiationSpeedModifierComponent : Component
     /// keyed by the <see cref="SatiationTypePrototype">satiation types</see> they are thresholds for.
     /// </summary>
     [DataField(required: true), AutoNetworkedField]
-    public Dictionary<ProtoId<SatiationTypePrototype>, SatiationThresholds<float>> Satiations;
+    public Dictionary<ProtoId<SatiationTypePrototype>, SatiationThresholds<float>> Satiations = [];
 }

--- a/Content.Shared/Nutrition/EntitySystems/BaseSatiationEffectSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/BaseSatiationEffectSystem.cs
@@ -21,8 +21,9 @@ namespace Content.Shared.Nutrition.EntitySystems;
 /// <remarks>Note that this <b>is not</b> related to <see cref="EntityEffects"/></remarks>
 public abstract partial class BaseSatiationEffectSystem<TComp, T> : EntitySystem where TComp : Component
 {
-    [Dependency] private SatiationSystem _satiation = default!;
     [Dependency] private IGameTiming _timing = default!;
+
+    [Dependency] private SatiationSystem _satiation = default!;
 
     [Dependency] private EntityQuery<SatiationComponent> _satiationQuery;
 

--- a/Content.Shared/Nutrition/EntitySystems/BaseSatiationEffectSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/BaseSatiationEffectSystem.cs
@@ -22,8 +22,9 @@ namespace Content.Shared.Nutrition.EntitySystems;
 public abstract partial class BaseSatiationEffectSystem<TComp, T> : EntitySystem where TComp : Component
 {
     [Dependency] private SatiationSystem _satiation = default!;
-    [Dependency] private EntityQuery<SatiationComponent> _satiationQuery;
     [Dependency] private IGameTiming _timing = default!;
+
+    [Dependency] private EntityQuery<SatiationComponent> _satiationQuery;
 
     /// <summary>
     /// How to access <see cref="SatiationThresholds{T}"/> via a <typeparamref name="TComp"/>.
@@ -89,30 +90,26 @@ public abstract partial class BaseSatiationEffectSystem<TComp, T> : EntitySystem
     /// </summary>
     private void UpdateSatiation(Entity<TComp> entity, SatiationComponent comp, ProtoId<SatiationTypePrototype> type)
     {
-        // Get the current satiation value...
         if (!GetThresholds(entity.Comp).TryGetValue(type, out var thresholds))
             return;
+        var satiation = new Entity<SatiationComponent>(entity, comp);
 
-        // ... and then use it to get the appropriate threshold T value.
-        if (_satiation.TryGetValueByThreshold(
-                (entity, comp),
-                type,
-                thresholds.Thresholds,
-                out var result,
-                out var nextLowerThreshold))
-        {
-            thresholds.Current = result ?? DefaultValue();
+        _satiation.TryGetValueByThreshold(
+            satiation,
+            type,
+            thresholds.Thresholds,
+            out var result,
+            out var nextHigherThreshold,
+            out var nextLowerThreshold
+        );
 
-            // Predict when our satiation will decay to the next threshold down.
-            thresholds.ProjectedThresholdChangeTime = nextLowerThreshold is { } lower
-                ? _satiation.GetTimeToDecay((entity, comp), type, lower)
-                : null;
-        }
-        else
-        {
-            thresholds.Current = DefaultValue();
-            thresholds.ProjectedThresholdChangeTime = null;
-        }
+        thresholds.Current = result ?? DefaultValue();
+        thresholds.ProjectedThresholdChangeTime = _satiation.GetTimeToBound(
+            satiation,
+            type,
+            nextHigherThreshold,
+            nextLowerThreshold
+        );
 
         Dirty(entity);
 

--- a/Content.Shared/Nutrition/EntitySystems/BaseSatiationEffectSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/BaseSatiationEffectSystem.cs
@@ -96,7 +96,7 @@ public abstract partial class BaseSatiationEffectSystem<TComp, T> : EntitySystem
             return;
         var satiation = new Entity<SatiationComponent>(entity, comp);
 
-        _satiation.TryGetValueByThreshold(
+        var gotThreshold = _satiation.TryGetValueByThreshold(
             satiation,
             type,
             thresholds.Thresholds,
@@ -105,7 +105,7 @@ public abstract partial class BaseSatiationEffectSystem<TComp, T> : EntitySystem
             out var nextLowerThreshold
         );
 
-        thresholds.Current = result ?? DefaultValue();
+        thresholds.Current = gotThreshold ? result ?? DefaultValue() : DefaultValue();
         thresholds.ProjectedThresholdChangeTime = _satiation.GetTimeToBound(
             satiation,
             type,

--- a/Content.Shared/Nutrition/EntitySystems/BaseSatiationEffectSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/BaseSatiationEffectSystem.cs
@@ -56,7 +56,8 @@ public abstract partial class BaseSatiationEffectSystem<TComp, T> : EntitySystem
         {
             foreach (var (type, thresholds) in GetThresholds(comp))
             {
-                if (_timing.CurTime < thresholds.ProjectedThresholdChangeTime)
+                if (thresholds.ProjectedThresholdChangeTime == null ||
+                    _timing.CurTime < thresholds.ProjectedThresholdChangeTime)
                     continue;
 
                 UpdateSatiation((ent, comp), satiation, type);

--- a/Content.Shared/Nutrition/EntitySystems/Satiation.cs
+++ b/Content.Shared/Nutrition/EntitySystems/Satiation.cs
@@ -21,7 +21,7 @@ namespace Content.Shared.Nutrition.EntitySystems;
 /// concepts which should be familiar to anyone working in Robust C#.
 /// </remarks>
 [DataDefinition, Serializable, NetSerializable, Access(typeof(SatiationSystem))]
-public sealed partial class Satiation
+public sealed partial class Satiation : IRobustCloneable<Satiation>
 {
     /// <summary>
     /// This satiation's <see cref="SatiationTypePrototype"/>.
@@ -70,6 +70,19 @@ public sealed partial class Satiation
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan? NextAlertUpdateTime;
+
+    /// <inheritdoc/>
+    [Access(typeof(SatiationDictionary))]
+    public Satiation Clone() => new()
+    {
+        SatiationType = SatiationType,
+        Prototype = Prototype,
+        LastAuthoritativeValue = LastAuthoritativeValue,
+        LastAuthoritativeChangeTime = LastAuthoritativeChangeTime,
+        ActualChangeRate = ActualChangeRate,
+        NextChangeRateModUpdateTime = NextChangeRateModUpdateTime,
+        NextAlertUpdateTime = NextAlertUpdateTime,
+    };
 }
 
 /// <summary>
@@ -97,8 +110,9 @@ public sealed partial class SatiationThresholds<T>
     /// When this satiation is expected to change from its current threshold to a different one. This is null when the
     /// current linear change is zero or there is no threshold in the direction of the expected change.
     /// </summary>
+    // Initialize to zero to force an update as soon as possible on load
     [ViewVariables]
-    public TimeSpan? ProjectedThresholdChangeTime = TimeSpan.Zero; // Initialize to zero to force an update as soon as possible on load
+    public TimeSpan? ProjectedThresholdChangeTime = TimeSpan.Zero;
 
     /// <summary>
     /// The current <typeparamref name="T"/> value, at least when maintained by something like

--- a/Content.Shared/Nutrition/EntitySystems/Satiation.cs
+++ b/Content.Shared/Nutrition/EntitySystems/Satiation.cs
@@ -97,12 +97,14 @@ public sealed partial class SatiationThresholds<T>
     /// When this satiation is expected to change from its current threshold to a different one. This is null when the
     /// current linear change is zero or there is no threshold in the direction of the expected change.
     /// </summary>
-    public TimeSpan? ProjectedThresholdChangeTime;
+    [ViewVariables]
+    public TimeSpan? ProjectedThresholdChangeTime = TimeSpan.Zero; // Initialize to zero to force an update as soon as possible on load
 
     /// <summary>
     /// The current <typeparamref name="T"/> value, at least when maintained by something like
     /// <see cref="BaseSatiationEffectSystem{TComp,T}"/>
     /// </summary>
+    [ViewVariables]
     public T Current;
 }
 

--- a/Content.Shared/Nutrition/EntitySystems/Satiation.cs
+++ b/Content.Shared/Nutrition/EntitySystems/Satiation.cs
@@ -52,15 +52,15 @@ public sealed partial class Satiation
     public TimeSpan LastAuthoritativeChangeTime;
 
     /// <summary>
-    /// The rate at which this satiation value is expected to. It is a combination of
+    /// The rate at which this satiation value is expected to change. It is a combination of
     /// <see cref="SatiationPrototype.BaseChangeRate"/> and modifiers.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadOnly)]
     public float ActualChangeRate;
 
     /// <summary>
-    /// When <see cref="ActualChangeRate"/> is expected to change, if nothing but normal linear evolution affects this
-    /// satiation. This is used to predict satiation updates on clients.
+    /// When <see cref="ActualChangeRate"/> is expected to change, if nothing but time affects this satiation. This is
+    /// used to predict satiation updates on clients.
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan? NextChangeRateModUpdateTime;

--- a/Content.Shared/Nutrition/EntitySystems/Satiation.cs
+++ b/Content.Shared/Nutrition/EntitySystems/Satiation.cs
@@ -6,6 +6,8 @@ using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Implementations;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 
@@ -99,40 +101,73 @@ public sealed partial class Satiation : IRobustCloneable<Satiation>
 [DataDefinition, Serializable]
 public sealed partial class SatiationThresholds<T>
 {
+    // They're not redundant if I have to implement the serializer manually! :^)
+#pragma warning disable RA0027
     /// <summary>
     /// The <typeparamref name="T"/> values keyed by the satiation values at or below which the T value becomes "active".
     /// </summary>
     /// <seealso cref="SatiationSystem.TryGetValueByThreshold"/>
-    [IncludeDataField]
+    [DataField(ThresholdsTag)]
     public Dictionary<SatiationValue, T> Thresholds = [];
 
     /// <summary>
     /// When this satiation is expected to change from its current threshold to a different one. This is null when the
     /// current linear change is zero or there is no threshold in the direction of the expected change.
     /// </summary>
-    // Initialize to zero to force an update as soon as possible on load
-    [ViewVariables]
-    public TimeSpan? ProjectedThresholdChangeTime = TimeSpan.Zero;
+    [DataField(ProjectedThresholdChangeTimeTag)]
+#pragma warning restore RA0027
+    public TimeSpan? ProjectedThresholdChangeTime;
 
     /// <summary>
     /// The current <typeparamref name="T"/> value, at least when maintained by something like
     /// <see cref="BaseSatiationEffectSystem{TComp,T}"/>
     /// </summary>
+    // TODO This OUGHT to be serialized, but something in the generated state management code chokes on the `T` type
+    //  parameter. So, instead, we immediately calculate this value in `BaseSatiationEffectSystem.OnMapInit`.
     [ViewVariables]
     public T Current;
+
+    public const string ThresholdsTag = "thresholds";
+    public const string ProjectedThresholdChangeTimeTag = "projectedThresholdChangeTime";
 }
 
+/// <summary>
+/// The serializer for <see cref="SatiationThresholds{T}"/>. Manually implemented because scary generic <c>T</c>.
+/// </summary>
 [TypeSerializer]
-public sealed partial class SatiationThresholdsSerializer<T> : ITypeSerializer<SatiationThresholds<T>, MappingDataNode>,
-    ITypeCopier<SatiationThresholds<T>>
+public sealed partial class SatiationThresholdsSerializer<T> : ITypeSerializer<SatiationThresholds<T>, MappingDataNode>
 {
+    // ReSharper disable once StaticMemberInGenericType // I mean, it's one immutable reference, ReSharper! What could it cost? 100 bytes?
+    private static readonly TimespanSerializer TimeSpanSerializer = new();
+
+    /// <inheritdoc/>
     public ValidationNode Validate(
         ISerializationManager serializationManager,
         MappingDataNode node,
         IDependencyCollection dependencies,
         ISerializationContext? context = null
-    ) => serializationManager.ValidateNode<Dictionary<SatiationValue, T>>(node, context);
+    )
+    {
+        var ret = new Dictionary<ValidationNode, ValidationNode>();
 
+        if (node.TryGetValue(SatiationThresholds<T>.ThresholdsTag, out var thresholds))
+        {
+            ret[new ValidatedValueNode(node.GetKeyNode(SatiationThresholds<T>.ThresholdsTag))] =
+                serializationManager.ValidateNode<Dictionary<SatiationValue, T>>(thresholds, context);
+        }
+
+        if (node.TryGetValue(SatiationThresholds<T>.ProjectedThresholdChangeTimeTag, out var changeTime))
+        {
+            ret[new ValidatedValueNode(node.GetKeyNode(SatiationThresholds<T>.ProjectedThresholdChangeTimeTag))] =
+                changeTime is ValueDataNode v
+                    ? serializationManager.ValidateNode(TimeSpanSerializer, v, context)
+                    : new ErrorNode(changeTime, $"Expected {typeof(ValueDataNode)}, got {changeTime.GetType()}");
+        }
+
+        return new ValidatedMappingNode(ret);
+    }
+
+    /// <inheritdoc/>
     public SatiationThresholds<T> Read(
         ISerializationManager serializationManager,
         MappingDataNode node,
@@ -142,29 +177,44 @@ public sealed partial class SatiationThresholdsSerializer<T> : ITypeSerializer<S
         ISerializationManager.InstantiationDelegate<SatiationThresholds<T>>? instanceProvider = null
     ) => new()
     {
-        Thresholds = serializationManager.Read<Dictionary<SatiationValue, T>>(
-            node,
-            context,
-            hookCtx.SkipHooks,
-            instanceProvider is { } ip ? () => ip().Thresholds : null,
-            true
-        ),
+        Thresholds = node.TryGetValue(SatiationThresholds<T>.ThresholdsTag, out var thresholdsNode)
+            ? serializationManager.Read<Dictionary<SatiationValue, T>>(
+                thresholdsNode,
+                context,
+                notNullableOverride: true
+            )
+            : [],
+        ProjectedThresholdChangeTime =
+            node.TryGetValue(SatiationThresholds<T>.ProjectedThresholdChangeTimeTag, out var changeTime)
+                ? serializationManager.Read(TimeSpanSerializer, (ValueDataNode)changeTime, context)
+                : null,
     };
 
+    /// <inheritdoc/>
     public DataNode Write(
         ISerializationManager serializationManager,
         SatiationThresholds<T> value,
         IDependencyCollection dependencies,
         bool alwaysWrite = false,
         ISerializationContext? context = null
-    ) => serializationManager.WriteValue(value.Thresholds, alwaysWrite, context, true);
+    )
+    {
+        var ret = new Dictionary<string, DataNode>
+        {
+            [SatiationThresholds<T>.ThresholdsTag] =
+                serializationManager.WriteValue(value.Thresholds, alwaysWrite, context, true),
+        };
 
-    public void CopyTo(
-        ISerializationManager serializationManager,
-        SatiationThresholds<T> source,
-        ref SatiationThresholds<T> target,
-        IDependencyCollection dependencies,
-        SerializationHookContext hookCtx,
-        ISerializationContext? context = null
-    ) => serializationManager.CopyTo(source.Thresholds, ref target.Thresholds, context, true, true);
+        if (value.ProjectedThresholdChangeTime is { } changeTime)
+        {
+            ret[SatiationThresholds<T>.ProjectedThresholdChangeTimeTag] = serializationManager.WriteValue(
+                TimeSpanSerializer,
+                changeTime,
+                alwaysWrite,
+                context
+            );
+        }
+
+        return new MappingDataNode(ret);
+    }
 }

--- a/Content.Shared/Nutrition/EntitySystems/Satiation.cs
+++ b/Content.Shared/Nutrition/EntitySystems/Satiation.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Nutrition.Components;
 using Content.Shared.Nutrition.Prototypes;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -11,8 +12,14 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 namespace Content.Shared.Nutrition.EntitySystems;
 
 /// <summary>
-/// A need whose value decays over time. Examples include Thirst and Hunger.
+/// A need whose value changes over time. Examples include Thirst and Hunger.
 /// </summary>
+/// <remarks>
+/// While public, this type should not be used in <see cref="SatiationSystem"/> API methods. Instead, pass
+/// <see cref="SatiationComponent"/> and a <see cref="SatiationTypePrototype"/> (or its <see cref="ProtoId{T}"/>).
+/// This is to allow people unfamiliar with the internals of satiation to work with a component and a prototype,
+/// concepts which should be familiar to anyone working in Robust C#.
+/// </remarks>
 [DataDefinition, Serializable, NetSerializable, Access(typeof(SatiationSystem))]
 public sealed partial class Satiation
 {
@@ -45,21 +52,21 @@ public sealed partial class Satiation
     public TimeSpan LastAuthoritativeChangeTime;
 
     /// <summary>
-    /// The rate at which this satiation value is expected to decay. It is a combination of
-    /// <see cref="SatiationPrototype.BaseDecayRate"/> and modifiers.
+    /// The rate at which this satiation value is expected to. It is a combination of
+    /// <see cref="SatiationPrototype.BaseChangeRate"/> and modifiers.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadOnly)]
-    public float ActualDecayRate;
+    public float ActualChangeRate;
 
     /// <summary>
-    /// When <see cref="ActualDecayRate"/> is expected to change, if nothing but normal decay affects this satiation.
-    /// This is used to predict satiation updates on clients.
+    /// When <see cref="ActualChangeRate"/> is expected to change, if nothing but normal linear evolution affects this
+    /// satiation. This is used to predict satiation updates on clients.
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
-    public TimeSpan? NextDecayRateModUpdateTime;
+    public TimeSpan? NextChangeRateModUpdateTime;
 
     /// <summary>
-    /// <see cref="NextDecayRateModUpdateTime"/>, but for satiation alerts.
+    /// <see cref="NextChangeRateModUpdateTime"/>, but for satiation alerts.
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan? NextAlertUpdateTime;
@@ -87,8 +94,8 @@ public sealed partial class SatiationThresholds<T>
     public Dictionary<SatiationValue, T> Thresholds = [];
 
     /// <summary>
-    /// When this satiation is expected to decay from its current threshold to the next lower threshold. This
-    /// is null when there is no lower threshold to decay to.
+    /// When this satiation is expected to change from its current threshold to a different one. This is null when the
+    /// current linear change is zero or there is no threshold in the direction of the expected change.
     /// </summary>
     public TimeSpan? ProjectedThresholdChangeTime;
 

--- a/Content.Shared/Nutrition/EntitySystems/SatiationSystem.Proxy.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SatiationSystem.Proxy.cs
@@ -185,8 +185,8 @@ public sealed partial class SatiationSystem
 
         if (currentValue > valuesByDescendingThreshold.Current.Item1)
         {
-            // `currentSatiation` is higher than all thresholds, so we don't have a value nor higher threshold, but we
-            // can return a next lower threshold.
+            // `currentSatiation` is higher than all thresholds, so we have neither a value nor a higher threshold, but
+            // we can return the next lower threshold.
             result = default;
             nextHigherThreshold = null;
             nextLowerThreshold = valuesByDescendingThreshold.Current.Item1;

--- a/Content.Shared/Nutrition/EntitySystems/SatiationSystem.Proxy.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SatiationSystem.Proxy.cs
@@ -128,17 +128,20 @@ public sealed partial class SatiationSystem
     }
 
     /// <summary>
-    /// This function returns a value from <see cref="valuesByThreshold"/> based on the current value of
-    /// <paramref name="entity"/>'s satiation of the given <paramref name="type"/>. The value in
-    /// <paramref name="valuesByThreshold"/> with the lowest key greater than the current satiation value is returned.
+    /// Returns the <typeparamref name="T"/> value for <paramref name="entity"/>'s current satiation value of the given
+    /// <paramref name="type"/>, as informed by <paramref name="valuesByThreshold"/>.
     /// </summary>
     /// <param name="entity">The entity whose satiation is considered</param>
     /// <param name="type">The type of satiation to consider</param>
     /// <param name="valuesByThreshold">The values, keyed by <see cref="SatiationValue"/> thresholds</param>
     /// <param name="result">The value selected from <paramref name="valuesByThreshold"/></param>
+    /// <param name="nextHigherThreshold">
+    /// The keying-threshold-value of the next threshold above the selected value. Most consumers will not have a use
+    /// for this value, but it is used by <see cref="BaseSatiationEffectSystem{TComp,T}"/>'s prediction of value change.
+    /// </param>
     /// <param name="nextLowerThreshold">
     /// The keying-threshold-value of the next threshold below the selected value. Most consumers will not have a use
-    /// for this value, but it is used by <see cref="BaseSatiationEffectSystem{TComp,T}"/>'s prediction of value decay.
+    /// for this value, but it is used by <see cref="BaseSatiationEffectSystem{TComp,T}"/>'s prediction of value change.
     /// </param>
     /// <typeparam name="T">The type of values in <paramref name="valuesByThreshold"/></typeparam>
     /// <returns>
@@ -151,14 +154,18 @@ public sealed partial class SatiationSystem
         [ForbidLiteral] ProtoId<SatiationTypePrototype> type,
         Dictionary<SatiationValue, T> valuesByThreshold,
         out T? result,
+        out int? nextHigherThreshold,
         out int? nextLowerThreshold
     )
     {
-        result = default;
-        nextLowerThreshold = null;
         if (GetValueOrNull(entity, type) is not { } currentValue ||
             GetAndResolveSatiationOfType(entity, type) is not var (_, proto))
+        {
+            result = default;
+            nextHigherThreshold = null;
+            nextLowerThreshold = null;
             return false;
+        }
 
         using var valuesByDescendingThreshold = valuesByThreshold
             // Resolve keys to threshold integers, discarding any keys which cannot be resolved.
@@ -171,15 +178,17 @@ public sealed partial class SatiationSystem
         {
             // `values` is empty, so there are no values to return.
             result = default;
+            nextHigherThreshold = null;
             nextLowerThreshold = null;
             return false;
         }
 
         if (currentValue > valuesByDescendingThreshold.Current.Item1)
         {
-            // `currentSatiation` is higher than all thresholds, so we don't have a value, but we can return a next
-            // lower threshold.
+            // `currentSatiation` is higher than all thresholds, so we don't have a value nor higher threshold, but we
+            // can return a next lower threshold.
             result = default;
+            nextHigherThreshold = null;
             nextLowerThreshold = valuesByDescendingThreshold.Current.Item1;
             return false;
         }
@@ -192,6 +201,7 @@ public sealed partial class SatiationSystem
             {
                 // The current value is below `nextHigher` and above `nextLower`, so `nextHigher` is the correct threshold.
                 result = nextHigher.Item2;
+                nextHigherThreshold = nextHigher.Item1;
                 nextLowerThreshold = nextLower.Item1;
                 return true;
             }
@@ -202,9 +212,25 @@ public sealed partial class SatiationSystem
 
         // We've run out of thresholds below.
         result = nextHigher.Item2;
+        nextHigherThreshold = nextHigher.Item1;
         nextLowerThreshold = null;
         return true;
     }
+
+    /// <summary>
+    /// Calculates when the given <paramref name="entity"/>'s satiation of the given <paramref name="type"/> will
+    /// evolve to either <paramref name="upperBound"/> or <paramref name="lowerBound"/>. Returns null if the given
+    /// entity does not have the given satiation or when the given satiation will not never evolve to one of the given
+    /// values. A null bound is treated as unreachable.
+    /// </summary>
+    public TimeSpan? GetTimeToBound(
+        Entity<SatiationComponent> entity,
+        ProtoId<SatiationTypePrototype> type,
+        int? upperBound,
+        int? lowerBound
+    ) => GetAndResolveSatiationOfType(entity, type) is var (satiation, proto)
+        ? EvolvesToBoundAt(satiation, proto, upperBound, lowerBound)
+        : null;
 
     /// <summary>
     /// Looks up the <see cref="StatusIconPrototype"/> appropriate for the given entity's <see cref="Satiation"/> of the
@@ -221,7 +247,7 @@ public sealed partial class SatiationSystem
             !ProtoMan.Resolve(satiation.Prototype, out var proto))
             return null;
 
-        TryGetValueByThreshold(entity, type, proto.Icons, out var iconProtoId, out _);
+        TryGetValueByThreshold(entity, type, proto.Icons, out var iconProtoId, out _, out _);
         return ProtoMan.Resolve(iconProtoId, out var icon) ? icon : null;
     }
 

--- a/Content.Shared/Nutrition/EntitySystems/SatiationSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SatiationSystem.cs
@@ -70,7 +70,7 @@ public sealed partial class SatiationSystem : EntitySystem
             SetAuthoritativeValue(entity, satiation, proto, value);
         }
 
-        DirtyField(entity.AsNullable(), nameof(SatiationComponent.Satiations));
+        DirtyField(entity.AsNullable(), SatiationComponent.SatiationFieldName);
     }
 
     /// <summary>
@@ -228,7 +228,7 @@ public sealed partial class SatiationSystem : EntitySystem
         var updateEvent = new SatiationUpdateEvent(satiation.SatiationType);
         RaiseLocalEvent(entity, ref updateEvent);
 
-        DirtyField(entity.AsNullable(), nameof(SatiationComponent.Satiations));
+        DirtyField(entity.AsNullable(), SatiationComponent.SatiationFieldName);
     }
 
     private void UpdateAlerts(
@@ -261,7 +261,7 @@ public sealed partial class SatiationSystem : EntitySystem
             nextHigherThreshold,
             nextLowerThreshold
         );
-        DirtyField(entity.AsNullable(), nameof(SatiationComponent.Satiations));
+        DirtyField(entity.AsNullable(), SatiationComponent.SatiationFieldName);
     }
 }
 

--- a/Content.Shared/Nutrition/EntitySystems/SatiationSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SatiationSystem.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Timing;
 namespace Content.Shared.Nutrition.EntitySystems;
 
 /// <summary>
-/// This system manages the <see cref="SatiationComponent"/>. Broadly, what that means is that it handles the decay of
+/// This system manages <see cref="SatiationComponent"/>. Broadly, what that means is that it handles the change of
 /// satiations in <see cref="Update"/>, and external changes to satiations through accessors like
 /// <see cref="ModifyValue"/>.
 /// </summary>
@@ -17,8 +17,6 @@ public sealed partial class SatiationSystem : EntitySystem
 {
     [Dependency] private AlertsSystem _alerts = default!;
     [Dependency] private IGameTiming _timing = default!;
-
-    [Dependency] private EntityQuery<SatiationComponent> _satiationQuery;
 
     /// <summary>
     /// The ID of the <c>Hunger</c> satiation type. Provided because it is so commonly used in Content.
@@ -44,7 +42,7 @@ public sealed partial class SatiationSystem : EntitySystem
                     UpdateAlerts(entity, satiation, proto);
                 }
 
-                if (_timing.CurTime >= satiation.NextDecayRateModUpdateTime)
+                if (_timing.CurTime >= satiation.NextChangeRateModUpdateTime)
                 {
                     SetAuthoritativeValue(entity, satiation, proto, CalculateCurrentValue(satiation, proto));
                 }
@@ -99,6 +97,19 @@ public sealed partial class SatiationSystem : EntitySystem
         }
     }
 
+    /// <remarks>
+    /// This is basically a special-case reimplementation of <see cref="BaseSatiationEffectSystem{TComp,T}.OnSatiationUpdate"/>.
+    /// </remarks>
+    [SubscribeLocalEvent]
+    private void UpdateAlertsOnSatiationUpdated(Entity<SatiationComponent> entity, ref SatiationUpdateEvent args)
+    {
+        if (entity.Comp.GetOrNull(args.Type) is not { } satiation ||
+            !ProtoMan.Resolve(satiation.Prototype, out var proto))
+            return;
+
+        UpdateAlerts(entity, satiation, proto);
+    }
+
     /// <summary>
     /// This helper resolves <paramref name="type"/> and returns the corresponding <see cref="Satiation"/> from
     /// <paramref name="satiations"/> along with its <see cref="SatiationPrototype"/>.
@@ -134,13 +145,47 @@ public sealed partial class SatiationSystem : EntitySystem
     /// <summary>
     /// Calculates the current value of the given <see cref="Satiation"/> by linearly extrapolating the change of the
     /// value based on <see cref="Satiation.LastAuthoritativeValue"/>, <see cref="Satiation.LastAuthoritativeChangeTime"/>
-    /// and <see cref="Satiation.ActualDecayRate"/>
+    /// and <see cref="Satiation.ActualChangeRate"/>
     /// </summary>
     private float CalculateCurrentValue(Satiation satiation, SatiationPrototype proto)
     {
         var dt = _timing.CurTime - satiation.LastAuthoritativeChangeTime;
-        var value = satiation.LastAuthoritativeValue - (float)dt.TotalSeconds * satiation.ActualDecayRate;
+        var value = satiation.LastAuthoritativeValue + (float)dt.TotalSeconds * satiation.ActualChangeRate;
         return proto.ClampSatiationWithinThresholds(value);
+    }
+
+    /// <summary>
+    /// Calculates when <paramref name="satiation"/>'s value reach either <paramref name="upperBound"/> or
+    /// <paramref name="lowerBound"/>, or <c>null</c> if neither will happen based on the current expected linear
+    /// evolution of the satiation value. A null bound is treated as unreachable, so if both bounds are null, this
+    /// this function returns null.
+    /// </summary>
+    /// <seealso cref="EvolvesToTargetAt"/>
+    private TimeSpan? EvolvesToBoundAt(
+        Satiation satiation,
+        SatiationPrototype proto,
+        int? upperBound,
+        int? lowerBound
+    ) => satiation.ActualChangeRate switch
+    {
+        > 0 when upperBound is { } t => EvolvesToTargetAt(satiation, proto, t),
+        < 0 when lowerBound is { } t => EvolvesToTargetAt(satiation, proto, t),
+        // Change rate is zero or there's no threshold to decay/grow into: we'll never change without outside modification
+        _ => null,
+    };
+
+    /// <summary>
+    /// Calculates when <paramref name="satiation"/>'s value will reach <paramref name="target"/>, or <c>null</c> if
+    /// the current linear evolution will not reach that value.
+    /// </summary>
+    /// <seealso cref="EvolvesToBoundAt"/>
+    private TimeSpan? EvolvesToTargetAt(Satiation satiation, SatiationPrototype proto, int target)
+    {
+        var seconds = (target - CalculateCurrentValue(satiation, proto)) / satiation.ActualChangeRate;
+        if (!seconds.IsValid() || seconds < 0f)
+            return null;
+
+        return _timing.CurTime + TimeSpan.FromSeconds(seconds);
     }
 
     /// <summary>
@@ -163,43 +208,27 @@ public sealed partial class SatiationSystem : EntitySystem
         if (!TryGetValueByThreshold(
                 entity,
                 satiation.SatiationType,
-                proto.DecayModifiers,
-                out var currentDecayMod,
+                proto.ChangeModifiers,
+                out var currentChangeMod,
+                out var nextHigherThreshold,
                 out var nextLowerThreshold
             ))
         {
-            currentDecayMod = 1f;
+            currentChangeMod = 1f;
         }
 
-        satiation.ActualDecayRate = proto.BaseDecayRate * currentDecayMod;
-
-        if (nextLowerThreshold is { } t)
-        {
-            satiation.NextDecayRateModUpdateTime =
-                _timing.CurTime + TimeSpan.FromSeconds((value - t) / satiation.ActualDecayRate);
-        }
-        else
-        {
-            satiation.NextDecayRateModUpdateTime = null;
-        }
+        satiation.ActualChangeRate = proto.BaseChangeRate * currentChangeMod;
+        satiation.NextChangeRateModUpdateTime = EvolvesToBoundAt(
+            satiation,
+            proto,
+            nextHigherThreshold,
+            nextLowerThreshold
+        );
 
         var updateEvent = new SatiationUpdateEvent(satiation.SatiationType);
         RaiseLocalEvent(entity, ref updateEvent);
 
         DirtyField(entity.AsNullable(), nameof(SatiationComponent.Satiations));
-    }
-
-    /// <remarks>
-    /// This is basically a reimplementation of <see cref="BaseSatiationEffectSystem{TComp,T}.OnSatiationUpdate"/>.
-    /// </remarks>
-    [SubscribeLocalEvent]
-    private void UpdateAlertsOnSatiationUpdated(Entity<SatiationComponent> entity, ref SatiationUpdateEvent args)
-    {
-        if (entity.Comp.GetOrNull(args.Type) is not { } satiation ||
-            !ProtoMan.Resolve(satiation.Prototype, out var proto))
-            return;
-
-        UpdateAlerts(entity, satiation, proto);
     }
 
     private void UpdateAlerts(
@@ -208,46 +237,39 @@ public sealed partial class SatiationSystem : EntitySystem
         SatiationPrototype proto
     )
     {
-        if (TryGetValueByThreshold(
-                entity,
-                satiation.SatiationType,
-                proto.Alerts,
-                out var result,
-                out var nextLowerThreshold))
+        TryGetValueByThreshold(
+            entity,
+            satiation.SatiationType,
+            proto.Alerts,
+            out var result,
+            out var nextHigherThreshold,
+            out var nextLowerThreshold
+        );
+
+        if (result is { } alert)
         {
-            if (result is { } alert)
-            {
-                _alerts.ShowAlert(entity.Owner, alert);
-                satiation.NextAlertUpdateTime = nextLowerThreshold is { } lower
-                    ? GetTimeToDecay(entity, satiation.SatiationType, lower)
-                    : null;
-            }
-            else
-            {
-                _alerts.ClearAlertCategory(entity.Owner, proto.AlertCategory);
-                satiation.NextAlertUpdateTime = null;
-            }
+            _alerts.ShowAlert(entity.Owner, alert);
         }
         else
         {
             _alerts.ClearAlertCategory(entity.Owner, proto.AlertCategory);
-            satiation.NextAlertUpdateTime = null;
         }
-    }
 
-    public TimeSpan? GetTimeToDecay(Entity<SatiationComponent> entity,
-        ProtoId<SatiationTypePrototype> type,
-        int threshold
-    )
-    {
-        if (GetValueOrNull(entity, type) is not { } value ||
-            entity.Comp.GetOrNull(type) is not { } satiation)
-            return null;
-
-        return _timing.CurTime + TimeSpan.FromSeconds((value - threshold) / satiation.ActualDecayRate);
+        satiation.NextAlertUpdateTime = EvolvesToBoundAt(
+            satiation,
+            proto,
+            nextHigherThreshold,
+            nextLowerThreshold
+        );
     }
 }
 
-// Best effort on change to authoritative value or decay rate
+/// <summary>
+/// This event is raised entities with <see cref="SatiationComponent"/> when their satiation of <paramref name="Type"/>
+/// is directly set or when the <see cref="Satiation.ActualChangeRate">rate of change</see> to that satiation is changed.
+/// </summary>
+/// <remarks>
+/// This event is raised in a best-effort manner, meaning it may be raised even when no change has occurred.
+/// </remarks>
 [ByRefEvent]
 public readonly record struct SatiationUpdateEvent(ProtoId<SatiationTypePrototype> Type);

--- a/Content.Shared/Nutrition/EntitySystems/SatiationSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/SatiationSystem.cs
@@ -9,14 +9,14 @@ using Robust.Shared.Timing;
 namespace Content.Shared.Nutrition.EntitySystems;
 
 /// <summary>
-/// This system manages <see cref="SatiationComponent"/>. Broadly, what that means is that it handles the change of
-/// satiations in <see cref="Update"/>, and external changes to satiations through accessors like
-/// <see cref="ModifyValue"/>.
+/// This system manages <see cref="SatiationComponent"/>. It handles the change of satiations in <see cref="Update"/>
+/// and external changes to satiations through accessors like <see cref="ModifyValue"/>.
 /// </summary>
 public sealed partial class SatiationSystem : EntitySystem
 {
-    [Dependency] private AlertsSystem _alerts = default!;
     [Dependency] private IGameTiming _timing = default!;
+
+    [Dependency] private AlertsSystem _alerts = default!;
 
     /// <summary>
     /// The ID of the <c>Hunger</c> satiation type. Provided because it is so commonly used in Content.
@@ -155,7 +155,7 @@ public sealed partial class SatiationSystem : EntitySystem
     }
 
     /// <summary>
-    /// Calculates when <paramref name="satiation"/>'s value reach either <paramref name="upperBound"/> or
+    /// Calculates when <paramref name="satiation"/>'s value will reach either <paramref name="upperBound"/> or
     /// <paramref name="lowerBound"/>, or <c>null</c> if neither will happen based on the current expected linear
     /// evolution of the satiation value. A null bound is treated as unreachable, so if both bounds are null, this
     /// this function returns null.
@@ -261,15 +261,14 @@ public sealed partial class SatiationSystem : EntitySystem
             nextHigherThreshold,
             nextLowerThreshold
         );
+        DirtyField(entity.AsNullable(), nameof(SatiationComponent.Satiations));
     }
 }
 
 /// <summary>
-/// This event is raised entities with <see cref="SatiationComponent"/> when their satiation of <paramref name="Type"/>
+/// This event is raised on entities with <see cref="SatiationComponent"/> when their satiation of <paramref name="Type"/>
 /// is directly set or when the <see cref="Satiation.ActualChangeRate">rate of change</see> to that satiation is changed.
 /// </summary>
-/// <remarks>
-/// This event is raised in a best-effort manner, meaning it may be raised even when no change has occurred.
-/// </remarks>
+/// <remarks> This event may be raised even when no change has occurred.</remarks>
 [ByRefEvent]
 public readonly record struct SatiationUpdateEvent(ProtoId<SatiationTypePrototype> Type);

--- a/Content.Shared/Nutrition/Prototypes/SatiationPrototype.cs
+++ b/Content.Shared/Nutrition/Prototypes/SatiationPrototype.cs
@@ -29,10 +29,10 @@ public sealed partial class SatiationPrototype : IPrototype, IInheritingPrototyp
     public bool Abstract { get; private set; }
 
     /// <summary>
-    /// The base rate at which this satiation decreases per second.
+    /// The base rate at which this satiation changes per second.
     /// </summary>
     [DataField(required: true)]
-    public float BaseDecayRate;
+    public float BaseChangeRate;
 
     /// <summary>
     /// The highest value this satiation can have. Increases beyond this value are clamped to this value.
@@ -71,11 +71,11 @@ public sealed partial class SatiationPrototype : IPrototype, IInheritingPrototyp
     public int StartingValueMaximum => GetValueOrNull(_startingValueMaximum) ?? MaximumValue;
 
     /// <summary>
-    /// Modifiers to <see cref="BaseDecayRate"/> based on the current threshold.
+    /// Modifiers to <see cref="BaseChangeRate"/> based on the current threshold.
     /// </summary>
-    /// <seealso cref="Satiation.ActualDecayRate"/>
+    /// <seealso cref="Satiation.ActualChangeRate"/>
     [DataField(customTypeSerializer: typeof(DictionarySerializer<SatiationValue, float>))]
-    public Dictionary<SatiationValue, float> DecayModifiers = [];
+    public Dictionary<SatiationValue, float> ChangeModifiers = [];
 
     #region Alerts
 

--- a/Resources/Prototypes/Body/Satiation/Hunger/examination.yml
+++ b/Resources/Prototypes/Body/Satiation/Hunger/examination.yml
@@ -5,8 +5,9 @@
   - type: ExaminableSatiation
     satiations:
       Hunger:
-        Dead: "examinable-satiation-component-examine-hunger-desperate"
-        Starving: "examinable-satiation-component-examine-hunger-desperate"
-        Peckish: "examinable-satiation-component-examine-hunger-concerned"
-        Okay: "examinable-satiation-component-examine-hunger-okay"
-        Overfed: "examinable-satiation-component-examine-hunger-full"
+        thresholds:
+          Dead: "examinable-satiation-component-examine-hunger-desperate"
+          Starving: "examinable-satiation-component-examine-hunger-desperate"
+          Peckish: "examinable-satiation-component-examine-hunger-concerned"
+          Okay: "examinable-satiation-component-examine-hunger-okay"
+          Overfed: "examinable-satiation-component-examine-hunger-full"

--- a/Resources/Prototypes/Body/Satiation/Hunger/hunger.yml
+++ b/Resources/Prototypes/Body/Satiation/Hunger/hunger.yml
@@ -1,6 +1,6 @@
 - type: satiation
   id: NormalSatiationHunger
-  baseDecayRate: 0.01666666666
+  baseChangeRate: -0.01666666666
   maximumValue: 200
   thresholds:
     Overfed: 200
@@ -10,7 +10,7 @@
     Dead: 0
   startingValueMinimum: Peckish
   startingValueMaximum: Okay
-  decayModifiers:
+  changeModifiers:
     Overfed: 1.2
     Okay: 1.0
     Peckish: 0.8
@@ -33,7 +33,7 @@
     Okay: 50
     Peckish: 25
     Starving: 10
-  baseDecayRate: 0.00925925925926 # it is okay for animals to eat and drink less than humans, but more frequently
+  baseChangeRate: -0.00925925925926 # it is okay for animals to eat and drink less than humans, but more frequently
   maximumValue: 100
 
 - type: satiation
@@ -44,13 +44,13 @@
     Okay: 25
     Peckish: 15
     Starving: 10
-  baseDecayRate: 0.1
+  baseChangeRate: -0.1
   maximumValue: 35
 
 - type: satiation
   id: CockroachHunger
   parent: SimpleMobBaseHunger
-  baseDecayRate: 0.25
+  baseChangeRate: -0.25
 
 - type: satiation
   id: MouseHunger
@@ -60,18 +60,18 @@
     Okay: 25
     Peckish: 15
     Starving: 10
-  baseDecayRate: 0.5 # I'm very hungry! Give me. The cheese.
+  baseChangeRate: -0.5 # I'm very hungry! Give me. The cheese.
   maximumValue: 35
 
 - type: satiation
   id: MouseAdmemeHunger
   parent: MouseHunger
-  baseDecayRate: 10 # always hungry
+  baseChangeRate: -10 # always hungry
 
 - type: satiation
   id: HamsterHunger
   parent: SimpleMobBaseHunger
-  baseDecayRate: 0.3
+  baseChangeRate: -0.3
 
 - type: satiation
   id: RegalRatHunger
@@ -81,18 +81,18 @@
     Okay: 150
     Peckish: 100
     Starving: 50
-  baseDecayRate: 0.01666666666
+  baseChangeRate: -0.01666666666
   maximumValue: 200
 
 - type: satiation
   id: ScurretHunger
   parent: SimpleMobBaseHunger
-  baseDecayRate: 0.05 # They get a lil' hungy
+  baseChangeRate: -0.05 # They get a lil' hungy
 
 - type: satiation
   id: DionaHunger
   parent: NormalSatiationHunger
-  baseDecayRate: 0.0083
+  baseChangeRate: -0.0083
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Body/Satiation/Hunger/hunger.yml
+++ b/Resources/Prototypes/Body/Satiation/Hunger/hunger.yml
@@ -93,12 +93,3 @@
   id: DionaHunger
   parent: NormalSatiationHunger
   baseChangeRate: -0.0083
-
-- type: entity
-  abstract: true
-  id: BaseHungerSlowdown
-  component:
-  - type: SatiationSpeedModifier
-    satiations:
-      Hunger:
-        Peckish: 0.75

--- a/Resources/Prototypes/Body/Satiation/Thirst/thirst.yml
+++ b/Resources/Prototypes/Body/Satiation/Thirst/thirst.yml
@@ -1,6 +1,6 @@
 - type: satiation
   id: NormalSatiationThirst
-  baseDecayRate: 0.1
+  baseChangeRate: -0.1
   maximumValue: 600
   thresholds:
     Overhydrated: 600
@@ -10,7 +10,7 @@
     Dead: 0
   startingValueMinimum: Thirsty
   startingValueMaximum: Okay
-  decayModifiers:
+  changeModifiers:
     Overhydrated: 1.2
     Okay: 1.0
     Thirsty: 0.8
@@ -28,7 +28,7 @@
 - type: satiation
   id: MouseThirst
   parent: NormalSatiationThirst
-  baseDecayRate: 0.04
+  baseChangeRate: -0.04
   maximumValue: 35
   thresholds:
     Overhydrated: 35
@@ -40,12 +40,12 @@
 - type: satiation
   id: MouseAdmemeThirst
   parent: MouseThirst
-  baseDecayRate: 10
+  baseChangeRate: -10
 
 - type: satiation
   id: SimpleMobBaseThirst
   parent: NormalSatiationThirst
-  baseDecayRate: 0.04
+  baseChangeRate: -0.04
   maximumValue: 200
   thresholds:
     Overhydrated: 200
@@ -57,7 +57,7 @@
 - type: satiation
   id: DionaThirst
   parent: NormalSatiationThirst
-  baseDecayRate: 0.0083
+  baseChangeRate: -0.0083
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Body/Satiation/Thirst/thirst.yml
+++ b/Resources/Prototypes/Body/Satiation/Thirst/thirst.yml
@@ -62,8 +62,9 @@
 - type: entity
   abstract: true
   id: BaseThirstSlowdown
-  component:
+  components:
   - type: SatiationSpeedModifier
     satiations:
       Thirst:
-        Parched: 0.75
+        thresholds:
+          Parched: 0.75

--- a/Resources/Prototypes/Body/Satiation/base.yml
+++ b/Resources/Prototypes/Body/Satiation/base.yml
@@ -1,0 +1,12 @@
+- type: entity
+  abstract: true
+  id: BaseHungerThirstSlowdown
+  components:
+  - type: SatiationSpeedModifier
+    satiations:
+      Hunger:
+        thresholds:
+          Peckish: 0.75
+      Thirst:
+        thresholds:
+          Parched: 0.75

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -161,8 +161,7 @@
   - MobFlammable
   - BaseSpeciesMob
   - BaseMobDestructible
-  - BaseHungerSlowdown
-  - BaseThirstSlowdown
+  - BaseHungerThirstSlowdown # TODO CENT
   id: BaseSpeciesMobOrganic
   save: false
   components:

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -161,7 +161,7 @@
   - MobFlammable
   - BaseSpeciesMob
   - BaseMobDestructible
-  - BaseHungerThirstSlowdown # TODO CENT
+  - BaseHungerThirstSlowdown
   id: BaseSpeciesMobOrganic
   save: false
   components:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -39,8 +39,7 @@
   - MobBloodstream
   - MobFlammable
   - BaseMobAnimal
-  - BaseHungerSlowdown
-  - BaseThirstSlowdown
+  - BaseHungerThirstSlowdown
   id: SimpleSpaceMobBase # Mob without barotrauma, freezing and asphyxiation (for space carps!?)
   suffix: AI
   components:
@@ -69,8 +68,7 @@
   - MobRespirator
   - MobAtmosStandard
   - SimpleSpaceMobBase
-  - BaseHungerSlowdown
-  - BaseThirstSlowdown
+  - BaseHungerThirstSlowdown
   id: SimpleMobBase # for air breathers
   suffix: AI
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
@ScarKy0 wants satiation that naturally grows over time. The existing satiation system assumes the opposite, that it decays over time, and there're a handful of assumptions baked into the implementation based on that. Namely:
- `decay` is used all over, and the protos assign a positive value to decay. So when Scar went to make changeling biopoints or whatever, he made it so that it was like `decay: -1`, which is jank.
- certain things in the implementation assume the only way the value would go up is with an authoritative setting of the value, so negative decay completely broke all of the threshold prediction stuff

### @ScarKy0 found a bug
Basically, there's an issue with client prediction where things which modify satiation values on the client, for example metabolism ticks, will suffer from the same basic issue that was solved for solutions in https://github.com/space-wizards/space-station-14/pull/34838 . He and I tried to solve the issue by making `Satiation` cloneable, but that didn't resolve the issue, with my hypothesis being that because the satiation objects are in a dictionary, they don't get cloned -- like the dict isn't getting deeply cloned. Unsure.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
see above

## Technical details
<!-- Summary of code changes for easier review. -->
- Change `decay` in various places to `change`
- the threshold stuff was solved by way of tracking the next HIGHEST threshold in various places, too, so it can detect "intersection" with thresholds both above and below the current value
- a few easy proto changes to uptake the above

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
devmap
become the urist
`unsatiate`
eat and drink stuff
observe you get satiated
;
leave the game running for like a billion years and see it went back down
;
vv `satiation component` on the server
watch it move around funkily as things manipulate the values

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
#### `SatiationPrototype.BaseDecayRate` is removed
`SatiationPrototype.BaseChangeRate` is added and is basically the same as the old decay rate, but negated.
Uptake by changing the name and adding `-` in front of the value.

#### `SatiationPrototype.DecayModifiers` is renamed to `ChangeModifiers`
There is no change in behavior.

#### `SatiationSystem.TryGetValueByThreshold` has a new `out` parameter
Check the doc for what it does, but you probably just want to `out _` it.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Nothing player facing.