### PR TITLE
Betterer Bread Smite

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -516,7 +516,13 @@ public sealed partial class AdminVerbSystem
             Icon = new SpriteSpecifier.Rsi(new("/Textures/Objects/Consumable/Food/Baked/bread.rsi"), "plain"),
             Act = () =>
             {
-                _polymorphSystem.PolymorphEntity(args.Target, "AdminBreadSmite");
+                var breadedTarget = _polymorphSystem.PolymorphEntity(args.Target, "AdminBreadSmite");
+                if (breadedTarget.HasValue)
+                {
+                    EnsureComp<MumbleAccentComponent>(breadedTarget.Value);
+                    _transformSystem.SetNoLocalRotation(breadedTarget.Value, true);
+                    RemComp<InputMoverComponent>(breadedTarget.Value);
+                }
             },
             Impact = LogImpact.Extreme,
             Message = string.Join(": ", breadName, Loc.GetString("admin-smite-become-bread-description"))

--- a/Resources/Prototypes/Polymorphs/admin.yml
+++ b/Resources/Prototypes/Polymorphs/admin.yml
@@ -31,6 +31,11 @@
     forced: true
     inventory: Drop
     ignoreAllowRepeatedMorphs: true
+    transferName: false
+    revertOnDeath: false
+    revertOnEat: false
+    revertOnCrit: false
+
 
 - type: polymorph
   id: AdminInstrumentSmite

--- a/Resources/Prototypes/Polymorphs/admin.yml
+++ b/Resources/Prototypes/Polymorphs/admin.yml
@@ -36,7 +36,6 @@
     revertOnEat: false
     revertOnCrit: false
 
-
 - type: polymorph
   id: AdminInstrumentSmite
   configuration:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes bread smite betterer.

## Why / Balance
Smitten bread should not be able to talk, walk, or revert to human when eaten.

## Technical details
Removes walking from target and gives them mumble accent.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Breaded myself and confirmed no walk and talk.
2. Breaded Urist, ate him, and confirmed he did not revert.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="208" height="188" alt="image" src="https://github.com/user-attachments/assets/f4fb0ba0-3068-4d4b-b02a-e3233a075601" />


## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Pancake
ADMIN:
- tweak: Bread smite cannot be reverted.
- tweak: Smitten bread cannot walk or talk anymore. 
