### PR TITLE
Spiders now climb over obstacles

### DIFF
--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -210,6 +210,8 @@ public sealed partial class NPCSteeringSystem
                 ResetStuck(steering, ourCoordinates);
                 SteeringObstacleStatus status;
 
+                Array.Clear(steering.Interest);
+
                 // Breaking behaviours and the likes.
                 lock (_obstacles)
                 {

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Obstacles.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Obstacles.cs
@@ -141,7 +141,7 @@ public sealed partial class NPCSteeringSystem
                     foreach (var ent in obstacleEnts)
                     {
                         if (_climbableQuery.TryGetComponent(ent, out var table) &&
-                            _climb.CanVault(table, uid, uid, out _) &&
+                            _climb.CanVault(table, uid, ent, out _) &&
                             _climb.TryClimb(uid, uid, ent, out id, table, climbing))
                         {
                             component.DoAfterId = id;

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.NPC.Components;
 using Content.Server.NPC.Events;
 using Content.Server.NPC.Pathfinding;
 using Content.Shared.CCVar;
+using Content.Shared.Climbing.Components;
 using Content.Shared.Climbing.Systems;
 using Content.Shared.CombatMode;
 using Content.Shared.Interaction;
@@ -173,6 +174,10 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
             component.PathfindToken?.Cancel();
             component.PathfindToken = null;
             component.CurrentPath.Clear();
+
+            // Don't inherit the old targets failures
+            component.FailedPathCount = 0;
+            component.Status = SteeringStatus.Moving;
         }
         else
         {
@@ -324,6 +329,13 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
         // Can't move at all, just noop input.
         if (!mover.CanMove)
         {
+            // Climbing owns movement here, keep the path
+            if (TryComp<ClimbingComponent>(uid, out var climbing) && climbing.NextTransition != null)
+            {
+                SetDirection(uid, mover, steering, Vector2.Zero, false);
+                return;
+            }
+
             SetDirection(uid, mover, steering, Vector2.Zero);
             steering.Status = SteeringStatus.NoPath;
             return;
@@ -467,6 +479,9 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
 
             return;
         }
+
+        // We have a successful route, reset failure count
+        steering.FailedPathCount = 0;
 
         var targetPos = _transform.ToMapCoordinates(steering.Coordinates);
         var ourPos = _transform.GetMapCoordinates(uid, xform: xform);

--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -153,13 +153,15 @@ public sealed partial class ClimbSystem : VirtualController
         if (TryComp(args.Dragged, out ClimbingComponent? climbing) && climbing.IsClimbing)
             return;
 
-        var canVault = args.User == args.Dragged
+        var isSelfClimb = args.User == args.Dragged;
+
+        var canVault = isSelfClimb
             ? CanVault(component, args.User, uid, out _)
             : CanVault(component, args.User, args.Dragged, uid, out _);
 
         args.CanDrop = canVault;
 
-        if (!HasComp<HandsComponent>(args.User))
+        if (!isSelfClimb && !HasComp<HandsComponent>(args.User))
             args.CanDrop = false;
 
         args.Handled = true;

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2712,6 +2712,10 @@
     needsHands: false
   - type: NoSlip
   - type: Spider
+  - type: HTN
+    blackboard:
+      NavClimb: !type:Bool
+        true
   - type: IgnoreSpiderWeb
   - type: Bloodstream
     bloodReferenceSolution:

--- a/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
@@ -114,7 +114,7 @@
         fix1:
           shape:
             !type:PhysShapeAabb
-            bounds: "-0.3,-0.3,0.3,0.3"
+            bounds: "-0.45,-0.45,0.45,0.45"
           mask:
             - TableMask
           layer:
@@ -152,7 +152,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.3,-0.3,0.3,0.3"
+          bounds: "-0.45,-0.45,0.45,0.45"
         hard: true
         mask:
         - FullTileMask


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
* Spiders now have NavClimb so they can climb over obstructions like holobarriers / tables
* Fixed a wrong argument in the NPC climb check (CanVault was comparing the spider to itself instead of the obstacle)
* Player controlled handless mobs can now "click-drag" themselves over stuff (right-click -> Vault / alt+click already works)
* Increased the footprint of the holobarrier, otherwise spider gets stuck on the barrier after climbing
(path finding code seems to bug out on footprints less than tile size)

## Why / Balance
Tired of seeing chicken sec killing spiders behind holo barriers

## Test plan
* Try aggro spiders behind tables / barriers, they should climb over
* Control a spider and drag yourself on a table, should have same effect as alt-click

## Media
https://github.com/user-attachments/assets/db275ca6-af52-435b-b776-458379b21aed

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Spiders now climb obstacles

