### PR TITLE
MapLight cvar in server_config.toml

### DIFF
--- a/Resources/ConfigPresets/server_config.toml
+++ b/Resources/ConfigPresets/server_config.toml
@@ -61,6 +61,10 @@ id = "unknown_server_id"
 # Controls if the game should run station events. (Meteors, Sleeper Syndicates, etc.)
 enabled = true
 
+[light]
+# Default ambient space light color for maps in hex
+space_light_color = "#404343"
+
 [shuttle]
 # Should the emergency shuttle be allowed to launch early by command staff?
 emergency_early_launch_allowed = false


### PR DESCRIPTION
## About the PR
Title
Moved the server config to new PR from #45208 
**WARNING:** It currently breaks default MapLight for maps without custom MapLight component (awaiting fix)
Kazne chose the default color 

## Why / Balance
default map light color from the code is awful, also better to have it costumizable

## Technical details
<!-- Summary of code changes for easier review. -->

## Test plan
go to map without custom parallax, see that it's birght outside

## Media
How it should look like:
<img width="1012" height="725" alt="image" src="https://github.com/user-attachments/assets/e60ecdc5-785a-41ac-a694-a3911bbace1f" />

How it looks right now:
<img width="1084" height="606" alt="image" src="https://github.com/user-attachments/assets/3930f990-c1ae-4d98-ab3b-e14ea287817e" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- tweak: Adjusted the default space light color