### PR TITLE
Bugfix: SharedForensicsSystem: correct entity in Resolve, cleanup

### DIFF
--- a/Content.Server/Cloning/CloningSystem.Subscriptions.cs
+++ b/Content.Server/Cloning/CloningSystem.Subscriptions.cs
@@ -42,7 +42,7 @@ public sealed partial class CloningSystem
     [Dependency] private SharedChameleonClothingSystem _chameleonClothing = default!;
     [Dependency] private PullingSystem _pulling = default!;
     [Dependency] private BloodstreamSystem _bloodstream = default!;
-    [Dependency] private SharedForensicsSystem _forensics = default!;
+    [Dependency] private ForensicsSystem _forensics = default!;
 
     public override void Initialize()
     {

--- a/Content.Server/Nutrition/EntitySystems/SmokingSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SmokingSystem.cs
@@ -34,7 +34,7 @@ namespace Content.Server.Nutrition.EntitySystems
         [Dependency] private SharedItemSystem _items = default!;
         [Dependency] private SharedContainerSystem _container = default!;
         [Dependency] private SharedAppearanceSystem _appearance = default!;
-        [Dependency] private SharedForensicsSystem _forensics = default!;
+        [Dependency] private ForensicsSystem _forensics = default!;
 
         private const float UpdateTimer = 3f;
 

--- a/Content.Shared/Changeling/Systems/ChangelingClonerSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingClonerSystem.cs
@@ -27,7 +27,7 @@ public sealed partial class ChangelingClonerSystem : EntitySystem
     [Dependency] private SharedCloningSystem _cloning = default!;
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SharedChangelingIdentitySystem _changelingIdentity = default!;
-    [Dependency] private SharedForensicsSystem _forensics = default!;
+    [Dependency] private ForensicsSystem _forensics = default!;
     [Dependency] private SharedVisualBodySystem _visualBody = default!;
 
     public override void Initialize()

--- a/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
@@ -33,7 +33,7 @@ public sealed partial class InjectorSystem : EntitySystem
 {
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
-    [Dependency] private SharedForensicsSystem _forensics = default!;
+    [Dependency] private ForensicsSystem _forensics = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
     [Dependency] private OpenableSystem _openable = default!;
     [Dependency] private SharedPopupSystem _popup = default!;

--- a/Content.Shared/Forensics/Systems/ForensicPadSystem.cs
+++ b/Content.Shared/Forensics/Systems/ForensicPadSystem.cs
@@ -15,7 +15,7 @@ public sealed partial class ForensicPadSystem : EntitySystem
 {
     [Dependency] private SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private SharedPopupSystem _popupSystem = default!;
-    [Dependency] private SharedForensicsSystem _forensics = default!;
+    [Dependency] private ForensicsSystem _forensics = default!;
     [Dependency] private LabelSystem _label = default!;
 
     [SubscribeLocalEvent]

--- a/Content.Shared/Forensics/Systems/ForensicsSystem.cs
+++ b/Content.Shared/Forensics/Systems/ForensicsSystem.cs
@@ -31,13 +31,13 @@ public sealed partial class ForensicsSystem : EntitySystem
     [Dependency] private SharedPopupSystem _popupSystem = default!;
     [Dependency] private SharedSolutionContainerSystem _solutionContainerSystem = default!;
 
-    [Dependency] private EntityQuery<DnaComponent> _dnaQuery;
-    [Dependency] private EntityQuery<FiberComponent> _fiberQuery;
-    [Dependency] private EntityQuery<FingerprintComponent> _fingerprintQuery;
-    [Dependency] private EntityQuery<ForensicsComponent> _forensicsQuery;
-    [Dependency] private EntityQuery<IgnoresFingerprintsComponent> _ignoresFingerprintsQuery;
-    [Dependency] private EntityQuery<InventoryComponent> _inventoryQuery;
-    [Dependency] private EntityQuery<ResidueComponent> _residueQuery;
+    [Dependency] private EntityQuery<DnaComponent> _dnaQuery = default!;
+    [Dependency] private EntityQuery<FiberComponent> _fiberQuery = default!;
+    [Dependency] private EntityQuery<FingerprintComponent> _fingerprintQuery = default!;
+    [Dependency] private EntityQuery<ForensicsComponent> _forensicsQuery = default!;
+    [Dependency] private EntityQuery<IgnoresFingerprintsComponent> _ignoresFingerprintsQuery = default!;
+    [Dependency] private EntityQuery<InventoryComponent> _inventoryQuery = default!;
+    [Dependency] private EntityQuery<ResidueComponent> _residueQuery = default!;
 
     [SubscribeLocalEvent]
     private void OnSolutionChanged(Entity<DnaSubstanceTraceComponent> ent, ref SolutionChangedEvent ev)

--- a/Content.Shared/Forensics/Systems/SharedForensicScannerSystem.cs
+++ b/Content.Shared/Forensics/Systems/SharedForensicScannerSystem.cs
@@ -28,7 +28,7 @@ public sealed partial class SharedForensicScannerSystem : EntitySystem
     [Dependency] private SharedHandsSystem _handsSystem = default!;
     [Dependency] private SharedAudioSystem _audioSystem = default!;
     [Dependency] private MetaDataSystem _metaData = default!;
-    [Dependency] private SharedForensicsSystem _forensicsSystem = default!;
+    [Dependency] private ForensicsSystem _forensicsSystem = default!;
     [Dependency] private TagSystem _tag = default!;
 
     private static readonly ProtoId<TagPrototype> DNASolutionScannableTag = "DNASolutionScannable";

--- a/Content.Shared/Forensics/Systems/SharedForensicsSystem.cs
+++ b/Content.Shared/Forensics/Systems/SharedForensicsSystem.cs
@@ -171,10 +171,8 @@ public sealed partial class SharedForensicsSystem : EntitySystem
         {
             foreach (var data in reagent.Reagent.EnsureReagentData())
             {
-                if (data is not DnaData dnaData)
-                    continue;
-
-                list.Add(dnaData.DNA);
+                if (data is DnaData dnaData)
+                    list.Add(dnaData.DNA);
             }
         }
         return list;

--- a/Content.Shared/Forensics/Systems/SharedForensicsSystem.cs
+++ b/Content.Shared/Forensics/Systems/SharedForensicsSystem.cs
@@ -222,7 +222,7 @@ public sealed partial class SharedForensicsSystem : EntitySystem
     /// <returns>True if the target can be cleaned and has some sort of DNA or fingerprints / fibers and false otherwise.</returns>
     public bool TryStartCleaning(Entity<CleansForensicsComponent> cleanForensicsEntity, EntityUid user, EntityUid target)
     {
-        if (!TryComp<ForensicsComponent>(target, out var forensicsComp))
+        if (!_forensicsQuery.TryComp(target, out var forensicsComp))
         {
             _popupSystem.PopupEntity(Loc.GetString("forensics-cleaning-cannot-clean", ("target", Identity.Entity(target, EntityManager))), user, user, PopupType.MediumCaution);
             return false;

--- a/Content.Shared/Forensics/Systems/SharedForensicsSystem.cs
+++ b/Content.Shared/Forensics/Systems/SharedForensicsSystem.cs
@@ -31,13 +31,13 @@ public sealed partial class ForensicsSystem : EntitySystem
     [Dependency] private SharedPopupSystem _popupSystem = default!;
     [Dependency] private SharedSolutionContainerSystem _solutionContainerSystem = default!;
 
-    [Dependency] EntityQuery<DnaComponent> _dnaQuery;
-    [Dependency] EntityQuery<FiberComponent> _fiberQuery;
-    [Dependency] EntityQuery<FingerprintComponent> _fingerprintQuery;
-    [Dependency] EntityQuery<ForensicsComponent> _forensicsQuery;
-    [Dependency] EntityQuery<IgnoresFingerprintsComponent> _ignoresFingerprintsQuery;
-    [Dependency] EntityQuery<InventoryComponent> _inventoryQuery;
-    [Dependency] EntityQuery<ResidueComponent> _residueQuery;
+    [Dependency] private EntityQuery<DnaComponent> _dnaQuery;
+    [Dependency] private EntityQuery<FiberComponent> _fiberQuery;
+    [Dependency] private EntityQuery<FingerprintComponent> _fingerprintQuery;
+    [Dependency] private EntityQuery<ForensicsComponent> _forensicsQuery;
+    [Dependency] private EntityQuery<IgnoresFingerprintsComponent> _ignoresFingerprintsQuery;
+    [Dependency] private EntityQuery<InventoryComponent> _inventoryQuery;
+    [Dependency] private EntityQuery<ResidueComponent> _residueQuery;
 
     [SubscribeLocalEvent]
     private void OnSolutionChanged(Entity<DnaSubstanceTraceComponent> ent, ref SolutionChangedEvent ev)

--- a/Content.Shared/Forensics/Systems/SharedForensicsSystem.cs
+++ b/Content.Shared/Forensics/Systems/SharedForensicsSystem.cs
@@ -23,7 +23,7 @@ namespace Content.Shared.Forensics.Systems;
 /// <summary>
 /// A system for storing forensics data on entities, and transferring them between entities when interacting.
 /// </summary>
-public sealed partial class SharedForensicsSystem : EntitySystem
+public sealed partial class ForensicsSystem : EntitySystem
 {
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private InventorySystem _inventory = default!;

--- a/Content.Shared/Forensics/Systems/SharedForensicsSystem.cs
+++ b/Content.Shared/Forensics/Systems/SharedForensicsSystem.cs
@@ -9,17 +9,20 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
-using Content.Shared.Popups;
-using Content.Shared.Verbs;
 using Content.Shared.Gibbing;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Nutrition.EntitySystems;
+using Content.Shared.Popups;
+using Content.Shared.Verbs;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Forensics.Systems;
 
+/// <summary>
+/// A system for storing forensics data on entities, and transferring them between entities when interacting.
+/// </summary>
 public sealed partial class SharedForensicsSystem : EntitySystem
 {
     [Dependency] private IRobustRandom _random = default!;
@@ -27,6 +30,14 @@ public sealed partial class SharedForensicsSystem : EntitySystem
     [Dependency] private SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private SharedPopupSystem _popupSystem = default!;
     [Dependency] private SharedSolutionContainerSystem _solutionContainerSystem = default!;
+
+    [Dependency] EntityQuery<DnaComponent> _dnaQuery;
+    [Dependency] EntityQuery<FiberComponent> _fiberQuery;
+    [Dependency] EntityQuery<FingerprintComponent> _fingerprintQuery;
+    [Dependency] EntityQuery<ForensicsComponent> _forensicsQuery;
+    [Dependency] EntityQuery<IgnoresFingerprintsComponent> _ignoresFingerprintsQuery;
+    [Dependency] EntityQuery<InventoryComponent> _inventoryQuery;
+    [Dependency] EntityQuery<ResidueComponent> _residueQuery;
 
     [SubscribeLocalEvent]
     private void OnSolutionChanged(Entity<DnaSubstanceTraceComponent> ent, ref SolutionChangedEvent ev)
@@ -76,7 +87,7 @@ public sealed partial class SharedForensicsSystem : EntitySystem
     {
         var dna = Loc.GetString("forensics-dna-unknown");
 
-        if (TryComp(ent, out DnaComponent? dnaComp) && dnaComp.DNA != null)
+        if (_dnaQuery.TryComp(ent, out var dnaComp) && dnaComp.DNA != null)
             dna = dnaComp.DNA;
 
         foreach (var part in args.Giblets)
@@ -98,7 +109,7 @@ public sealed partial class SharedForensicsSystem : EntitySystem
 
         foreach (var hitEntity in args.HitEntities)
         {
-            if (TryComp<DnaComponent>(hitEntity, out var hitEntityComp) && hitEntityComp.DNA != null)
+            if (_dnaQuery.TryComp(hitEntity, out var hitEntityComp) && hitEntityComp.DNA != null)
                 weapon.Comp.DNAs.Add(hitEntityComp.DNA);
         }
         Dirty(weapon);
@@ -116,10 +127,8 @@ public sealed partial class SharedForensicsSystem : EntitySystem
     /// </summary>
     public void CopyForensicsFrom(Entity<ForensicsComponent?> src, EntityUid target)
     {
-        if (!Resolve(target, ref src.Comp, false))
-        {
+        if (!Resolve(src, ref src.Comp, false))
             return;
-        }
 
         var targetComp = EnsureComp<ForensicsComponent>(target);
         foreach (var dna in src.Comp.DNAs)
@@ -162,10 +171,10 @@ public sealed partial class SharedForensicsSystem : EntitySystem
         {
             foreach (var data in reagent.Reagent.EnsureReagentData())
             {
-                if (data is DnaData)
-                {
-                    list.Add(((DnaData) data).DNA);
-                }
+                if (data is not DnaData dnaData)
+                    continue;
+
+                list.Add(dnaData.DNA);
             }
         }
         return list;
@@ -253,7 +262,7 @@ public sealed partial class SharedForensicsSystem : EntitySystem
         if (args.Handled || args.Cancelled || args.Args.Target == null)
             return;
 
-        if (!TryComp<ForensicsComponent>(args.Target, out var targetComp))
+        if (!_forensicsQuery.TryComp(args.Target, out var targetComp))
             return;
 
         targetComp.Fibers = [];
@@ -263,10 +272,10 @@ public sealed partial class SharedForensicsSystem : EntitySystem
             targetComp.DNAs = [];
 
         // leave behind evidence it was cleaned
-        if (TryComp<FiberComponent>(args.Used, out var fiber))
+        if (_fiberQuery.TryComp(args.Used, out var fiber))
             targetComp.Fibers.Add(string.IsNullOrEmpty(fiber.FiberColor) ? Loc.GetString("forensic-fibers", ("material", fiber.FiberMaterial)) : Loc.GetString("forensic-fibers-colored", ("color", fiber.FiberColor), ("material", fiber.FiberMaterial)));
 
-        if (TryComp<ResidueComponent>(args.Used, out var residue))
+        if (_residueQuery.TryComp(args.Used, out var residue))
             targetComp.Residues.Add(string.IsNullOrEmpty(residue.ResidueColor) ? Loc.GetString("forensic-residue", ("adjective", residue.ResidueAdjective)) : Loc.GetString("forensic-residue-colored", ("color", residue.ResidueColor), ("adjective", residue.ResidueAdjective)));
 
         Dirty(args.Target.Value, targetComp);
@@ -282,29 +291,29 @@ public sealed partial class SharedForensicsSystem : EntitySystem
     public string GenerateDNA()
     {
         var letters = new[] { "A", "C", "G", "T" };
-        var DNA = string.Empty;
+        var dna = string.Empty;
 
         for (var i = 0; i < 16; i++)
         {
-            DNA += letters[_random.Next(letters.Length)];
+            dna += letters[_random.Next(letters.Length)];
         }
 
-        return DNA;
+        return dna;
     }
 
     private void ApplyEvidence(EntityUid user, EntityUid target)
     {
-        if (HasComp<IgnoresFingerprintsComponent>(target))
+        if (_ignoresFingerprintsQuery.HasComp(target))
             return;
 
         var component = EnsureComp<ForensicsComponent>(target);
         if (_inventory.TryGetSlotEntity(user, "gloves", out var gloves))
         {
-            if (TryComp<FiberComponent>(gloves, out var fiber) && !string.IsNullOrEmpty(fiber.FiberMaterial))
+            if (_fiberQuery.TryComp(gloves, out var fiber) && !string.IsNullOrEmpty(fiber.FiberMaterial))
                 component.Fibers.Add(string.IsNullOrEmpty(fiber.FiberColor) ? Loc.GetString("forensic-fibers", ("material", fiber.FiberMaterial)) : Loc.GetString("forensic-fibers-colored", ("color", fiber.FiberColor), ("material", fiber.FiberMaterial)));
         }
 
-        if (TryComp<FingerprintComponent>(user, out var fingerprint) && CanAccessFingerprint(user, out _))
+        if (_fingerprintQuery.TryComp(user, out var fingerprint) && CanAccessFingerprint(user, out _))
             component.Fingerprints.Add(fingerprint.Fingerprint ?? "");
 
         Dirty(target, component);
@@ -341,7 +350,7 @@ public sealed partial class SharedForensicsSystem : EntitySystem
     /// <param name="canDnaBeCleaned">If this DNA be cleaned off of the recipient. e.g. cleaning a knife vs cleaning a puddle of blood</param>
     public void TransferDna(EntityUid recipient, EntityUid donor, bool canDnaBeCleaned = true)
     {
-        if (!TryComp<DnaComponent>(donor, out var donorComp) || donorComp.DNA == null)
+        if (!_dnaQuery.TryComp(donor, out var donorComp) || donorComp.DNA == null)
             return;
 
         EnsureComp<ForensicsComponent>(recipient, out var recipientComp);
@@ -361,7 +370,7 @@ public sealed partial class SharedForensicsSystem : EntitySystem
         var ev = new TryAccessFingerprintEvent();
 
         RaiseLocalEvent(target, ev);
-        if (!ev.Cancelled && TryComp<InventoryComponent>(target, out var inv))
+        if (!ev.Cancelled && _inventoryQuery.TryComp(target, out var inv))
             _inventory.RelayEvent((target, inv), ev);
 
         blocker = ev.Blocker;

--- a/Content.Shared/Implants/SharedImplanterSystem.cs
+++ b/Content.Shared/Implants/SharedImplanterSystem.cs
@@ -34,7 +34,7 @@ public abstract partial class SharedImplanterSystem : EntitySystem
     [Dependency] private SharedContainerSystem _container = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
-    [Dependency] private SharedForensicsSystem _forensics = default!;
+    [Dependency] private ForensicsSystem _forensics = default!;
     [Dependency] private SharedUserInterfaceSystem _ui = default!;
 
     [Dependency] private EntityQuery<SubdermalImplantComponent> _implantCompQuery;

--- a/Content.Shared/Medical/VomitSystem.cs
+++ b/Content.Shared/Medical/VomitSystem.cs
@@ -27,7 +27,7 @@ public sealed partial class VomitSystem : EntitySystem
     [Dependency] private MovementModStatusSystem _movementMod = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private BloodstreamSystem _bloodstream = default!;
-    [Dependency] private SharedForensicsSystem _forensics = default!;
+    [Dependency] private ForensicsSystem _forensics = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedPuddleSystem _puddle = default!;
     [Dependency] private SatiationSystem _satiation = default!;

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -56,7 +56,7 @@ public sealed partial class IngestionSystem : EntitySystem
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedSolutionContainerSystem _solutionContainer = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
-    [Dependency] private SharedForensicsSystem _forensics = default!;
+    [Dependency] private ForensicsSystem _forensics = default!;
 
     // Body Component Dependencies
     [Dependency] private BodySystem _body = default!;

--- a/Content.Shared/Trigger/Systems/DnaScrambleOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/DnaScrambleOnTriggerSystem.cs
@@ -16,7 +16,7 @@ public sealed partial class DnaScrambleOnTriggerSystem : XOnTriggerSystem<DnaScr
     [Dependency] private HumanoidProfileSystem _humanoidProfile = default!;
     [Dependency] private SharedVisualBodySystem _visualBody = default!;
     [Dependency] private IdentitySystem _identity = default!;
-    [Dependency] private SharedForensicsSystem _forensics = default!;
+    [Dependency] private ForensicsSystem _forensics = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private INetManager _net = default!;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Fixes a bug in SharedForensicsSystem, does a few chores while we're there.

## Why / Balance

`!Resolve(target, ref src.Comp, false)`

Hey, that component's not yours...

## Technical details

Big one is the entity passed to Resolve on L130.  It should match.

EntityQuery pass over SharedForensicsSystem, IDE whitespace gripes.

## Test plan

Start growing a wheat plant in hydroponics.
When it's grown, clip it twice.
The second clip shouldn't trip a debug assertion.

## Media

<img width="373" height="461" alt="image" src="https://github.com/user-attachments/assets/a9b41aac-1fdb-425e-b99b-3892e6b1c799" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

`SharedForensicsSystem` has been renamed to `ForensicsSystem`.

## Changelog
nope!