### PR TITLE
Fix Airlock(Windoor) state on reconnect

### DIFF
--- a/Content.Client/Doors/AirlockSystem.cs
+++ b/Content.Client/Doors/AirlockSystem.cs
@@ -84,54 +84,57 @@ public sealed partial class AirlockSystem : SharedAirlockSystem
         if (args.Sprite == null)
             return;
 
-        var boltedVisible = false;
-        var emergencyLightsVisible = false;
-        var unlitVisible = false;
-
         if (!_appearanceSystem.TryGetData<DoorState>(uid, DoorVisuals.State, out var state, args.Component))
             state = DoorState.Closed;
 
-        if (_appearanceSystem.TryGetData<bool>(uid, PowerDeviceVisuals.Powered, out var powered, args.Component)
-            && powered)
-        {
-            boltedVisible = _appearanceSystem.TryGetData<bool>(uid, DoorVisuals.BoltLights, out var lights, args.Component)
-                            && lights && (state == DoorState.Closed || state == DoorState.Welded);
+        _appearanceSystem.TryGetData<bool>(uid, PowerDeviceVisuals.Powered, out var hasPower, args.Component);
 
-            emergencyLightsVisible = _appearanceSystem.TryGetData<bool>(uid, DoorVisuals.EmergencyLights, out var eaLights, args.Component) && eaLights;
-            unlitVisible =
-                    (state == DoorState.Closing
-                ||  state == DoorState.Opening
-                ||  state == DoorState.Denying
-                || (state == DoorState.Open && comp.OpenUnlitVisible)
-                || (_appearanceSystem.TryGetData<bool>(uid, DoorVisuals.ClosedLights, out var closedLights, args.Component) && closedLights))
-                    && !boltedVisible && !emergencyLightsVisible;
+        var showBaseUnlit = false;
+        var showBolted = false;
+        var showEmergency = false;
+
+        if (hasPower)
+        {
+            _appearanceSystem.TryGetData<bool>(uid, DoorVisuals.BoltLights, out var boltedVisible, args.Component);
+            showBolted = boltedVisible && (state == DoorState.Closed || state == DoorState.Welded);
+
+            _appearanceSystem.TryGetData<bool>(uid, DoorVisuals.EmergencyLights, out var emergencyVisible, args.Component);
+            showEmergency = emergencyVisible;
+
+            if (!showBolted && !showEmergency)
+            {
+                if (state == DoorState.Closing || state == DoorState.Opening || state == DoorState.Denying)
+                    showBaseUnlit = true;
+
+                if (state == DoorState.Open && comp.OpenUnlitVisible)
+                    showBaseUnlit = true;
+
+                _appearanceSystem.TryGetData<bool>(uid, DoorVisuals.ClosedLights, out var closedLightsVisible, args.Component);
+                if (state == DoorState.Closed && closedLightsVisible)
+                    showBaseUnlit = true;
+            }
         }
 
-        _sprite.LayerSetVisible((uid, args.Sprite), DoorVisualLayers.BaseUnlit, unlitVisible);
-        _sprite.LayerSetVisible((uid, args.Sprite), DoorVisualLayers.BaseBolted, boltedVisible);
+        _sprite.LayerSetVisible((uid, args.Sprite), DoorVisualLayers.BaseUnlit, showBaseUnlit);
+        _sprite.LayerSetVisible((uid, args.Sprite), DoorVisualLayers.BaseBolted, showBolted);
         if (comp.EmergencyAccessLayer)
         {
-            _sprite.LayerSetVisible(
-                (uid, args.Sprite),
-                DoorVisualLayers.BaseEmergencyAccess,
-                    emergencyLightsVisible
-                &&  state != DoorState.Open
-                &&  state != DoorState.Opening
-                &&  state != DoorState.Closing
-                && !boltedVisible
-            );
+            var isDoorIdle = state != DoorState.Open && state != DoorState.Opening && state != DoorState.Closing;
+            _sprite.LayerSetVisible((uid, args.Sprite), DoorVisualLayers.BaseEmergencyAccess,
+                showEmergency && isDoorIdle && !showBolted);
         }
 
-        switch (state)
+        if (comp.OpenUnlitVisible)
         {
-            case DoorState.Open:
-                _sprite.LayerSetRsiState((uid, args.Sprite), DoorVisualLayers.BaseUnlit, comp.ClosingSpriteState);
-                _sprite.LayerSetAnimationTime((uid, args.Sprite), DoorVisualLayers.BaseUnlit, 0);
-                break;
-            case DoorState.Closed:
-                _sprite.LayerSetRsiState((uid, args.Sprite), DoorVisualLayers.BaseUnlit, comp.OpeningSpriteState);
-                _sprite.LayerSetAnimationTime((uid, args.Sprite), DoorVisualLayers.BaseUnlit, 0);
-                break;
+            switch (state)
+            {
+                case DoorState.Open:
+                    _sprite.LayerSetRsiState((uid, args.Sprite), DoorVisualLayers.BaseUnlit, comp.OpenSpriteState);
+                    break;
+                case DoorState.Closed:
+                    _sprite.LayerSetRsiState((uid, args.Sprite), DoorVisualLayers.BaseUnlit, comp.ClosedSpriteState);
+                    break;
+            }
         }
     }
 }


### PR DESCRIPTION
## About the PR
Fixed airlock(windoor) sprites not restoring correctly after client reconnection (disconnect/reconnect) by correcting the sprite states set in `OnAppearanceChange`.

Previously, the `switch` statement in `OnAppearanceChange` incorrectly set:
- `DoorState.Open` → `ClosingSpriteState` (instead of `OpenSpriteState`)
- `DoorState.Closed` → `OpeningSpriteState` (instead of `ClosedSpriteState`)

This caused doors to display the wrong sprite after client reconnection, appearing as if they were constantly opening even when closed. A full client restart was required to fix the issue.

The PR also includes general code cleanup to improve readability and maintainability.

## Why / Balance
Fixes a visual bug affecting all airlocks(windoors). No gameplay balance changes.

## Technical details
- Fixed `switch` statement in `AirlockSystem` to use correct sprite states:
  - `DoorState.Open` → `OpenSpriteState`
  - `DoorState.Closed` → `ClosedSpriteState`
- Removed unnecessary `LayerSetAnimationTime` calls for static states
- Refactored logic for better readability with clear variable names and flat conditions

## Test plan
1. Spawn any `Windoor`
2. Open and close it - verify opening/closing sprite states are correct
3. Disconnect and reconnect to the same server
4. Open and close the windoor again - verify opening/closing sprite states are still correct after reconnection

**Before fix:** Closed sprites were broken after reconnection (stuck in animation frames)
**After fix:** Closed sprites restore correctly, no client restart needed

## Media
Shows windoor opening/closing normally, then after disconnect/reconnect the sprites break (stuck in closing animation)

https://github.com/user-attachments/assets/6bd6243c-59da-402d-b80e-fb2592063a52

Demonstrates that everything works correctly, the bug is fixed, and existing functionality remains unchanged

https://github.com/user-attachments/assets/6a1cbf4e-b2d9-4d9b-a9b8-b4259b12b229

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None. I don't like spaghetti

## Changelog
:cl:
- fix: Fixed airlock(windoor) displaying incorrect sprites after client reconnection