### PR TITLE
Localize hydroxysomnolene popups

### DIFF
--- a/Resources/Locale/en-US/reagents/hydroxysomnolene.ftl
+++ b/Resources/Locale/en-US/reagents/hydroxysomnolene.ftl
@@ -1,0 +1,3 @@
+hydroxysomnolene-effect-flavor = You feel a need for fizzy pink flavor.
+hydroxysomnolene-effect-another-hit = You could really use another hit.
+hydroxysomnolene-effect-sluggish = You feel sluggish and tired.

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -556,7 +556,10 @@
           max: 0.1
         type: Local
         visualType: MediumCaution
-        messages: [ "You feel a need for fizzy pink flavor" ]
+        messages:
+        - hydroxysomnolene-effect-flavor
+        - hydroxysomnolene-effect-another-hit
+        - hydroxysomnolene-effect-sluggish
         probability: 0.15
 
 - type: reagent


### PR DESCRIPTION
## About the PR

Localizes the popups from hydroxysomnolene.  Adds two extra messages.

## Why / Balance

Good for localizers.  Open RFC for other effect popups.

## Technical details

New FTL entries for hydroxysomnolene effects.

Adds two extras because why not.

Tried to resolve the metabolite TODOs but it was a pain.

## Test plan

Take strawberry ice.
Once it wears off, you should get your messages.

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
no >:(