### PR TITLE
XATInteractWith multiple-nodes bugfix

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/XAT/Components/XATInteractWithComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAT/Components/XATInteractWithComponent.cs
@@ -64,6 +64,13 @@ public sealed partial class XATInteractWithComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public int? Count;
+
+    /// <summary>
+    /// What to use in popup after an interaction was received but <see cref="MaxCount"/> is not met yet.
+    /// If null - no popup will be shown.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public LocId? InsufficientInteractionPopup = "interact-artifact-more";
 }
 
 /// <summary>

--- a/Content.Shared/Xenoarchaeology/Artifact/XAT/Components/XATInteractWithComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAT/Components/XATInteractWithComponent.cs
@@ -66,7 +66,7 @@ public sealed partial class XATInteractWithComponent : Component
     public int? Count;
 
     /// <summary>
-    /// What to use in popup after an interaction was received but <see cref="MaxCount"/> is not met yet.
+    /// What to show in popup after an interaction was received but <see cref="MaxCount"/> is not met yet.
     /// If null - no popup will be shown.
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Xenoarchaeology/Artifact/XAT/XATInteractWithSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAT/XATInteractWithSystem.cs
@@ -46,15 +46,11 @@ public sealed partial class XATInteractWithSystem : BaseXATSystem<XATInteractWit
     /// </summary>
     private void OnInteractUsing(Entity<XenoArtifactComponent> artifact, Entity<XATInteractWithComponent, XenoArtifactNodeComponent> node, ref InteractUsingEvent args)
     {
-        if (args.Handled)
-            return;
-
-        args.Handled = true;
-
         if (!_whitelistSystem.IsWhitelistPassOrNull(node.Comp1.Whitelist, args.Used)) // must be on the whitelist.
             return;
 
         _audio.PlayPredicted(node.Comp1.StartTriggerSound, artifact.Owner, args.User);
+
         _doAfter.TryStartDoAfter(
             new DoAfterArgs(
                 EntityManager,
@@ -107,7 +103,8 @@ public sealed partial class XATInteractWithSystem : BaseXATSystem<XATInteractWit
 
         if (node.Comp1.Count > 0)
         {
-            _popup.PopupEntity(Loc.GetString("interact-artifact-more"), artifact.Owner, args.User);
+            if (node.Comp1.InsufficientInteractionPopup != null)
+                _popup.PopupEntity(Loc.GetString(node.Comp1.InsufficientInteractionPopup), artifact.Owner, args.User);
             Dirty(node);
             return; // insufficient, still need to add more!
         }


### PR DESCRIPTION
## About the PR
Multiple nodes with the "Interact With" trigger system on the same layer were not functioning correctly, with them locking up. This PR fixes that.

## Why / Balance
I did an oopsie.

## Technical details
The System had a "handled" check at the start which would cancel out any future attempts of the event being raised. Meaning the system didn't function correctly.

Otherwise i took the opportunity to make the system's popup for when insufficient items were provided a customisable DataField to match the other systems.

## Test plan
Get an artifact with multiple nodes on the same level using the Interact With system (EG: Carbohydrate Intake, Protein Intake, Bureaucratic Approval, Knowledge Intake, or Bribery). Each can now be triggered by providing the appropriate entity.

## Media
https://github.com/user-attachments/assets/1ae11e7e-7f4f-43eb-a4cc-294e3d27ed0e

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
This is a bugfix, it's an unbreaking change.

## Changelog
:cl:
- fix: Entity Interaction artifact triggers now work properly when there are multiple of them as potential trigger candidates.
