### PR TITLE
Fix `GuidebookDataSystem` late MsgEntity warning

### DIFF
--- a/Content.Client/Guidebook/GuidebookDataSystem.cs
+++ b/Content.Client/Guidebook/GuidebookDataSystem.cs
@@ -17,9 +17,6 @@ public sealed class GuidebookDataSystem : EntitySystem
         base.Initialize();
 
         SubscribeNetworkEvent<UpdateGuidebookDataEvent>(OnServerUpdated);
-
-        // Request data from the server
-        RaiseNetworkEvent(new RequestGuidebookDataEvent());
     }
 
     private void OnServerUpdated(UpdateGuidebookDataEvent args)

--- a/Content.Server/Guidebook/GuidebookDataSystem.cs
+++ b/Content.Server/Guidebook/GuidebookDataSystem.cs
@@ -1,5 +1,8 @@
 using System.Reflection;
 using Content.Shared.Guidebook;
+using Robust.Server.Player;
+using Robust.Shared.Enums;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
@@ -11,6 +14,8 @@ namespace Content.Server.Guidebook;
 /// </summary>
 public sealed partial class GuidebookDataSystem : EntitySystem
 {
+    [Dependency] private IPlayerManager _player = default!;
+
     private readonly Dictionary<string, List<MemberInfo>> _tagged = [];
     private GuidebookData _cachedData = new();
 
@@ -18,18 +23,21 @@ public sealed partial class GuidebookDataSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeNetworkEvent<RequestGuidebookDataEvent>(OnRequestRules);
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
+        _player.PlayerStatusChanged += OnPlayerStatusChanged;
 
         // Build initial cache
         GatherData(ref _cachedData);
     }
 
-    private void OnRequestRules(RequestGuidebookDataEvent ev, EntitySessionEventArgs args)
+    private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e)
     {
-        // Send cached data to requesting client
+        if (e.NewStatus != SessionStatus.Connected)
+            return;
+
+        // Send cached data to newly-connected client.
         var sendEv = new UpdateGuidebookDataEvent(_cachedData);
-        RaiseNetworkEvent(sendEv, args.SenderSession);
+        RaiseNetworkEvent(sendEv, e.Session);
     }
 
     private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)

--- a/Content.Shared/Guidebook/Events.cs
+++ b/Content.Shared/Guidebook/Events.cs
@@ -3,14 +3,8 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.Guidebook;
 
 /// <summary>
-/// Raised by the client on GuidebookDataSystem Initialize to request a
-/// full set of guidebook data from the server.
-/// </summary>
-[Serializable, NetSerializable]
-public sealed class RequestGuidebookDataEvent : EntityEventArgs { }
-
-/// <summary>
-/// Raised by the server at a specific client in response to <see cref="RequestGuidebookDataEvent"/>.
+/// Sends all extracted prototype data needed by GuidebookDataSystem.
+/// Raised by the server directed at newly-connected clients.
 /// Also raised by the server at ALL clients when prototype data is hot-reloaded.
 /// </summary>
 [Serializable, NetSerializable]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The client's `GuidebookDataSystem` no longer sends a net message during initialization, which is counted as late by the server.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Prevents having to see
```
SERVER: 3.996s [WARN] net.ent: Got late MsgEntity! Diff: -50462, msgT: 6, cT: 50468, player: integration_61, msg: Content.Shared.Guidebook.RequestGuidebookDataEvent
```
in the server log when a player connects.

## Technical details
<!-- Summary of code changes for easier review. -->
`GuidebookDataSystem` was raising a `RequestGuidebookDataEvent` network event in its `Initialize` method, which is a bad place to do that, since the client is not yet in sync with the server's current tick.
This PR removes the unnecessary extra step of having the client request the data; instead the server simply sends the data when a client connects.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
- Start server and client, connect.
- Observe console logs to see that the warning is no longer raised.
- Open guidebook to engineering page about portable generators and ensure that generator output wattages are still reported, indicating that the data was received by the client.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`RequestGuidebookDataEvent` has been removed.