### PR TITLE
Remove duplicate cmd-replay-toggleui-desc localization

### DIFF
--- a/Resources/Locale/en-US/replays/replays.ftl
+++ b/Resources/Locale/en-US/replays/replays.ftl
@@ -42,5 +42,3 @@ replay-verb-spectate = Spectate
 cmd-replay-spectate-help = replay_spectate [optional entity]
 cmd-replay-spectate-desc = Attaches or detaches the local player to a given entity uid.
 cmd-replay-spectate-hint = Optional EntityUid
-
-cmd-replay-toggleui-desc = Toggles the replay control UI.


### PR DESCRIPTION
## About the PR
Removes a duplicate localization entry:
<img width="982" height="41" alt="rider64_S2pkGA860q" src="https://github.com/user-attachments/assets/1407a567-49c6-4134-80b6-d03217585f65" />

## Why / Balance
The locale was moved to the engine (https://github.com/space-wizards/RobustToolbox/pull/6859), causing a duplicate localization warning in Content

## Technical details
Removed the now-redundant localization entry.

## Test plan
- Build Content.Client
- Verified the duplicate localization warning no longer appears :)

## Media
Not needed

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

## Changelog
No player-facing changes