### PR TITLE
Replace repeated #1B1B1E panel backgrounds with shared styles

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml
@@ -1,7 +1,6 @@
 <ui:FancyWindow xmlns="https://spacestation14.io"
             xmlns:x="http://schemas.microsoft.com/winfx/2007/xaml"
             xmlns:ui="clr-namespace:Content.Client.UserInterface.Controls"
-            xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
             MinSize="500 500" Resizable="True" Title="{Loc air-alarm-ui-title}">
     <BoxContainer Orientation="Vertical" Margin="5 5 5 5">
         <!-- Status (pressure, temperature, alarm state, device total, address, etc) -->
@@ -41,30 +40,21 @@
         <!-- Gas/Device Data -->
         <TabContainer Name="CTabContainer" VerticalExpand="True" Margin="0 0 0 2">
             <!-- Vent devices -->
-            <PanelContainer VerticalExpand="True">
-                <PanelContainer.PanelOverride>
-                    <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                </PanelContainer.PanelOverride>
+            <PanelContainer VerticalExpand="True" StyleClasses="PanelDeep">
 
                 <ScrollContainer>
                     <BoxContainer Name="CVentContainer" Orientation="Vertical"/>
                 </ScrollContainer>
             </PanelContainer>
             <!-- Scrubber devices -->
-            <PanelContainer VerticalExpand="True">
-                <PanelContainer.PanelOverride>
-                    <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                </PanelContainer.PanelOverride>
+            <PanelContainer VerticalExpand="True" StyleClasses="PanelDeep">
 
                 <ScrollContainer>
                     <BoxContainer Name="CScrubberContainer" Orientation="Vertical"/>
                 </ScrollContainer>
             </PanelContainer>
             <!-- Sensors -->
-            <PanelContainer VerticalExpand="True">
-                <PanelContainer.PanelOverride>
-                    <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                </PanelContainer.PanelOverride>
+            <PanelContainer VerticalExpand="True" StyleClasses="PanelDeep">
 
                 <ScrollContainer>
                     <BoxContainer Name="CSensorContainer" Orientation="Vertical"/>

--- a/Content.Client/Cargo/UI/CargoBountyMenu.xaml
+++ b/Content.Client/Cargo/UI/CargoBountyMenu.xaml
@@ -1,5 +1,4 @@
 ﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       Title="{Loc 'bounty-console-menu-title'}"
                       SetSize="550 420"
@@ -7,10 +6,7 @@
     <BoxContainer Orientation="Vertical"
                   VerticalExpand="True"
                   HorizontalExpand="True">
-        <PanelContainer VerticalExpand="True" HorizontalExpand="True" Margin="10">
-            <PanelContainer.PanelOverride>
-                <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-            </PanelContainer.PanelOverride>
+        <PanelContainer VerticalExpand="True" HorizontalExpand="True" Margin="10" StyleClasses="PanelDeep">
             <TabContainer Name="MasterTabContainer" VerticalExpand="True" HorizontalExpand="True">
                 <ScrollContainer HScrollEnabled="False"
                                  HorizontalExpand="True"

--- a/Content.Client/Cargo/UI/FundingAllocationMenu.xaml
+++ b/Content.Client/Cargo/UI/FundingAllocationMenu.xaml
@@ -1,6 +1,5 @@
 ﻿<controls:FancyWindow xmlns="https://spacestation14.io"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                      xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       Title="{Loc 'cargo-funding-alloc-console-menu-title'}">
     <BoxContainer Orientation="Vertical"
                   VerticalExpand="True"
@@ -13,10 +12,7 @@
             <SpinBox Name="LockboxCut"/>
         </TableContainer>
         <Label Name="HelpLabel" HorizontalAlignment="Center" StyleClasses="LabelSubText" Margin="0 10"/>
-        <PanelContainer VerticalExpand="True" HorizontalExpand="True" VerticalAlignment="Top" MaxHeight="250">
-            <PanelContainer.PanelOverride>
-                <graphics:StyleBoxFlat BackgroundColor="#1B1B1E"/>
-            </PanelContainer.PanelOverride>
+        <PanelContainer VerticalExpand="True" HorizontalExpand="True" VerticalAlignment="Top" MaxHeight="250" StyleClasses="PanelDeep">
             <TableContainer Name="EntriesContainer" Columns="4" HorizontalExpand="True" VerticalExpand="True" Margin="5 0">
                 <RichTextLabel Text="{Loc 'cargo-funding-alloc-console-label-account'}" HorizontalAlignment="Center"/>
                 <RichTextLabel Text="{Loc 'cargo-funding-alloc-console-label-code'}" HorizontalAlignment="Center"/>

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -1,7 +1,6 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
                 xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                 MinSize="620 670"
                 Title="{Loc 'chem-master-bound-user-interface-title'}">
     <TabContainer Name="Tabs" Margin="5 5 7 5">
@@ -13,10 +12,7 @@
                 <Button MinSize="80 0" Name="InputEjectButton" Access="Public" Text="{Loc 'chem-master-window-eject-button'}" />
             </BoxContainer>
 
-            <PanelContainer VerticalExpand="True" MinSize="0 200">
-                <PanelContainer.PanelOverride>
-                    <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                </PanelContainer.PanelOverride>
+            <PanelContainer VerticalExpand="True" MinSize="0 200" StyleClasses="PanelDeep">
 
                 <ScrollContainer HorizontalExpand="True" MinSize="0 200">
                     <!-- Initially empty, when server sends state data this will have container contents and fill volume.-->
@@ -39,10 +35,7 @@
             </BoxContainer>
 
             <!-- Buffer info -->
-            <PanelContainer VerticalExpand="True" MinSize="0 200">
-                <PanelContainer.PanelOverride>
-                    <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                </PanelContainer.PanelOverride>
+            <PanelContainer VerticalExpand="True" MinSize="0 200" StyleClasses="PanelDeep">
 
                 <ScrollContainer HorizontalExpand="True" MinSize="0 200">
                     <!-- Buffer reagent list -->
@@ -61,10 +54,7 @@
                 <Button MinSize="80 0" Name="OutputEjectButton" Access="Public" Text="{Loc 'chem-master-window-eject-button'}" />
             </BoxContainer>
 
-            <PanelContainer VerticalExpand="True" MinSize="0 200">
-                <PanelContainer.PanelOverride>
-                    <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                </PanelContainer.PanelOverride>
+            <PanelContainer VerticalExpand="True" MinSize="0 200" StyleClasses="PanelDeep">
 
                 <ScrollContainer HorizontalExpand="True" MinSize="0 200">
                     <!-- Initially empty, when server sends state data this will have container contents and fill volume.-->
@@ -89,10 +79,7 @@
             </BoxContainer>
 
             <!-- Wrap the packaging info-->
-            <PanelContainer>
-                <PanelContainer.PanelOverride>
-                    <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                </PanelContainer.PanelOverride>
+            <PanelContainer StyleClasses="PanelDeep">
 
                 <!-- Packaging Info -->
                 <BoxContainer Orientation="Vertical" Margin="4" HorizontalExpand="True" VerticalExpand="True" SeparationOverride="5">

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
@@ -1,7 +1,5 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                      xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
                       xmlns:ui="clr-namespace:Content.Client.Chemistry.UI"
                       Title="{Loc 'reagent-dispenser-bound-user-interface-title'}"
                       MinSize="600 300"
@@ -61,10 +59,7 @@
                              HorizontalExpand="True"
                              VerticalExpand="True"
                              MinHeight="50">
-                <PanelContainer VerticalExpand="True">
-                    <PanelContainer.PanelOverride>
-                        <gfx:StyleBoxFlat BackgroundColor="#1b1b1e" />
-                    </PanelContainer.PanelOverride>
+                <PanelContainer VerticalExpand="True" StyleClasses="PanelDeep">
                     <BoxContainer Name="ContainerInfo"
                                   Orientation="Vertical"
                                   HorizontalExpand="True"

--- a/Content.Client/Construction/UI/FlatpackCreatorMenu.xaml
+++ b/Content.Client/Construction/UI/FlatpackCreatorMenu.xaml
@@ -1,6 +1,5 @@
 <controls:FancyWindow
     xmlns="https://spacestation14.io"
-    xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:ui="clr-namespace:Content.Client.Materials.UI"
     Title="{Loc 'flatpacker-ui-title'}"
@@ -16,10 +15,7 @@
             <BoxContainer Orientation="Vertical" VerticalExpand="True" RectClipContent="True">
                 <Label Name="CostHeaderLabel" Text="{Loc 'flatpacker-ui-cost-label'}" HorizontalAlignment="Left"/>
                 <PanelContainer VerticalExpand="True"
-                                HorizontalExpand="True">
-                    <PanelContainer.PanelOverride>
-                        <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                    </PanelContainer.PanelOverride>
+                                HorizontalExpand="True" StyleClasses="PanelDeep">
                     <BoxContainer Orientation="Vertical" VerticalAlignment="Center">
                         <RichTextLabel Name="CostLabel" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                         <RichTextLabel Name="InsertLabel" HorizontalAlignment="Center" VerticalAlignment="Center"/>
@@ -33,10 +29,7 @@
             <PanelContainer
                 VerticalExpand="True"
                 HorizontalExpand="True"
-                RectClipContent="True">
-                <PanelContainer.PanelOverride>
-                    <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                </PanelContainer.PanelOverride>
+                RectClipContent="True" StyleClasses="PanelDeep">
                 <ui:MaterialStorageControl Name="MaterialStorageControl"/>
             </PanelContainer>
         </BoxContainer>

--- a/Content.Client/Humanoid/LayerMarkingItem.xaml
+++ b/Content.Client/Humanoid/LayerMarkingItem.xaml
@@ -1,14 +1,10 @@
 <BoxContainer xmlns="https://spacestation14.io"
-        xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
         Orientation="Vertical"
         HorizontalExpand="True"
         MouseFilter="Pass">
 
     <BoxContainer Orientation="Horizontal" SeparationOverride="4">
-        <PanelContainer SetSize="64 64" HorizontalAlignment="Right" MouseFilter="Ignore">
-            <PanelContainer.PanelOverride>
-                <graphics:StyleBoxFlat BackgroundColor="#1B1B1E" />
-            </PanelContainer.PanelOverride>
+        <PanelContainer SetSize="64 64" HorizontalAlignment="Right" MouseFilter="Ignore" StyleClasses="PanelDeep">
             <LayeredTextureRect TextureScale="2 2" Name="MarkingTexture" />
         </PanelContainer>
 

--- a/Content.Client/Lathe/UI/LatheMenu.xaml
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml
@@ -1,7 +1,6 @@
 <controls:FancyWindow
     xmlns="https://spacestation14.io"
     xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-    xmlns:system="clr-namespace:System;assembly=System.Runtime"
     xmlns:ui="clr-namespace:Content.Client.Materials.UI"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     Title="{Loc 'lathe-menu-title'}"
@@ -38,10 +37,7 @@
                     VerticalExpand="True"
                     HorizontalExpand="True"
                     SizeFlagsStretchRatio="4">
-                    <PanelContainer VerticalExpand="True">
-                        <PanelContainer.PanelOverride>
-                            <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                        </PanelContainer.PanelOverride>
+                    <PanelContainer VerticalExpand="True" StyleClasses="PanelDeep">
                         <ScrollContainer VerticalExpand="True" HScrollEnabled="False">
                             <BoxContainer
                                 Name="RecipeList"
@@ -137,10 +133,7 @@
             HorizontalExpand="True"
             Orientation="Vertical">
             <Label Text="{Loc 'lathe-menu-materials-title'}" Margin="5 5 5 5" HorizontalAlignment="Center"/>
-            <PanelContainer VerticalExpand="True">
-                <PanelContainer.PanelOverride>
-                    <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                </PanelContainer.PanelOverride>
+            <PanelContainer VerticalExpand="True" StyleClasses="PanelDeep">
                 <BoxContainer
                     Orientation="Vertical"
                     VerticalExpand="True"

--- a/Content.Client/Lobby/UI/Loadouts/LoadoutContainer.xaml
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutContainer.xaml
@@ -1,15 +1,11 @@
 <BoxContainer Name="Container" xmlns="https://spacestation14.io"
          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-         xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
          Orientation="Horizontal"
          HorizontalExpand="True"
          MouseFilter="Ignore"
          Margin="0 0 0 5">
     <Button Name="SelectButton" ToggleMode="True" Margin="0 0 5 0" HorizontalExpand="True"/>
-    <PanelContainer SetSize="64 64" HorizontalAlignment="Right">
-        <PanelContainer.PanelOverride>
-            <graphics:StyleBoxFlat BackgroundColor="#1B1B1E" />
-        </PanelContainer.PanelOverride>
+    <PanelContainer SetSize="64 64" HorizontalAlignment="Right" StyleClasses="PanelDeep">
         <SpriteView Name="Sprite" Scale="4 4" MouseFilter="Stop"/>
     </PanelContainer>
 </BoxContainer>

--- a/Content.Client/Lobby/UI/Loadouts/LoadoutWindow.xaml
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutWindow.xaml
@@ -1,16 +1,12 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
          xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-         xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
          SetSize="800 800"
          MinSize="800 128">
     <BoxContainer Orientation="Vertical" VerticalExpand="True">
         <BoxContainer Name="RoleNameBox" Orientation="Vertical" Margin="10">
             <Label Name="LoadoutNameLabel"/>
-            <PanelContainer HorizontalExpand="True" SetHeight="24">
-                <PanelContainer.PanelOverride>
-                    <graphics:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                </PanelContainer.PanelOverride>
+            <PanelContainer HorizontalExpand="True" SetHeight="24" StyleClasses="PanelDeep">
                 <LineEdit Name="RoleNameEdit" VerticalExpand="True" HorizontalExpand="True"/>
             </PanelContainer>
         </BoxContainer>

--- a/Content.Client/Materials/UI/OreSiloMenu.xaml
+++ b/Content.Client/Materials/UI/OreSiloMenu.xaml
@@ -1,6 +1,5 @@
 ﻿<controls:FancyWindow xmlns="https://spacestation14.io"
                      xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                     xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                      xmlns:ui="clr-namespace:Content.Client.Materials.UI"
                      Title="{Loc 'ore-silo-ui-title'}"
                      MinSize="400 260"
@@ -14,10 +13,7 @@
                       Orientation="Vertical"
                       SizeFlagsStretchRatio="3">
             <Label Text="{Loc 'ore-silo-ui-label-clients'}" Margin="5 5 5 5" HorizontalAlignment="Center" StyleClasses="LabelKeyText"/>
-            <PanelContainer VerticalExpand="True">
-                <PanelContainer.PanelOverride>
-                    <graphics:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                </PanelContainer.PanelOverride>
+            <PanelContainer VerticalExpand="True" StyleClasses="PanelDeep">
                 <ItemList Name="ClientList" SelectMode="Button" VerticalExpand="True"/>
             </PanelContainer>
         </BoxContainer>
@@ -26,10 +22,7 @@
                       Orientation="Vertical"
                       SizeFlagsStretchRatio="2">
             <Label Text="{Loc 'ore-silo-ui-label-mats'}" Margin="5 5 5 5" HorizontalAlignment="Center" StyleClasses="LabelKeyText"/>
-            <PanelContainer VerticalExpand="True">
-                <PanelContainer.PanelOverride>
-                    <graphics:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                </PanelContainer.PanelOverride>
+            <PanelContainer VerticalExpand="True" StyleClasses="PanelDeep">
                 <BoxContainer
                     Orientation="Vertical"
                     VerticalExpand="True"

--- a/Content.Client/Mech/Ui/MechMenu.xaml
+++ b/Content.Client/Mech/Ui/MechMenu.xaml
@@ -1,5 +1,4 @@
 ﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       Title="{Loc 'mech-menu-title'}"
                       MinSize="350 440"
@@ -47,10 +46,7 @@
             </SpriteView>
         </BoxContainer>
         <BoxContainer VerticalExpand="True" Margin="10 0 10 10" Orientation="Vertical">
-            <PanelContainer VerticalExpand="True" MinSize="0 200">
-                <PanelContainer.PanelOverride>
-                    <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                </PanelContainer.PanelOverride>
+            <PanelContainer VerticalExpand="True" MinSize="0 200" StyleClasses="PanelDeep">
                 <ScrollContainer
                     HScrollEnabled="False"
                     HorizontalExpand="True"

--- a/Content.Client/Research/UI/ResearchConsoleMenu.xaml
+++ b/Content.Client/Research/UI/ResearchConsoleMenu.xaml
@@ -1,5 +1,4 @@
 ﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
                       Title="{Loc 'research-console-menu-title'}"
@@ -35,10 +34,7 @@
                           MinWidth="175">
                 <Label Text="{Loc 'research-console-available-text'}" HorizontalAlignment="Center"/>
                 <customControls:HSeparator StyleClasses="LowDivider" Margin="0 0 0 10"/>
-                <PanelContainer VerticalExpand="True">
-                    <PanelContainer.PanelOverride>
-                        <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                    </PanelContainer.PanelOverride>
+                <PanelContainer VerticalExpand="True" StyleClasses="PanelDeep">
                     <ScrollContainer
                         HScrollEnabled="False"
                         HorizontalExpand="True"
@@ -53,10 +49,7 @@
                 <Control MinHeight="10"/>
                 <Label Text="{Loc 'research-console-unlocked-text'}" HorizontalAlignment="Center"/>
                 <customControls:HSeparator StyleClasses="LowDivider" Margin="0 0 0 10"/>
-                <PanelContainer VerticalExpand="True">
-                    <PanelContainer.PanelOverride>
-                        <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                    </PanelContainer.PanelOverride>
+                <PanelContainer VerticalExpand="True" StyleClasses="PanelDeep">
                     <ScrollContainer
                         HScrollEnabled="False"
                         HorizontalExpand="True"
@@ -74,10 +67,7 @@
                           HorizontalExpand="True"
                           SizeFlagsStretchRatio="3"
                           Margin="0 0 10 10">
-                <PanelContainer VerticalExpand="True" MinSize="0 200">
-                    <PanelContainer.PanelOverride>
-                        <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                    </PanelContainer.PanelOverride>
+                <PanelContainer VerticalExpand="True" MinSize="0 200" StyleClasses="PanelDeep">
                     <ScrollContainer
                         HScrollEnabled="False"
                         HorizontalExpand="True"

--- a/Content.Client/Salvage/UI/SalvageJobBoardMenu.xaml
+++ b/Content.Client/Salvage/UI/SalvageJobBoardMenu.xaml
@@ -17,10 +17,7 @@
             <RichTextLabel Text="{Loc 'job-board-ui-label-rank'}" Margin="0 0 5 0"/>
             <RichTextLabel Text="{Loc 'salvage-job-rank-title-0'}" Name="RankLabel"/>
         </BoxContainer>
-        <PanelContainer VerticalExpand="True" HorizontalExpand="True" Margin="10">
-            <PanelContainer.PanelOverride>
-                <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-            </PanelContainer.PanelOverride>
+        <PanelContainer VerticalExpand="True" HorizontalExpand="True" Margin="10" StyleClasses="PanelDeep">
             <ScrollContainer HScrollEnabled="False"
                              HorizontalExpand="True"
                              VerticalExpand="True">

--- a/Content.Client/Silicons/Borgs/BorgMenu.xaml
+++ b/Content.Client/Silicons/Borgs/BorgMenu.xaml
@@ -1,5 +1,4 @@
 ﻿<controls:FancyWindow xmlns="https://spacestation14.io"
-                      xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
                       Title="{Loc 'borg-ui-menu-title'}"
@@ -17,10 +16,7 @@
                 <Button Name="EjectBatteryButton" Text="{Loc 'borg-ui-remove-battery'}" StyleClasses="OpenLeft"/>
             </BoxContainer>
             <customControls:HSeparator Margin="0 10 0 10"/>
-            <PanelContainer VerticalExpand="True">
-                <PanelContainer.PanelOverride>
-                    <gfx:StyleBoxFlat BackgroundColor="#1B1B1E"/>
-                </PanelContainer.PanelOverride>
+            <PanelContainer VerticalExpand="True" StyleClasses="PanelDeep">
                 <BoxContainer HorizontalAlignment="Center" VerticalAlignment="Center">
                     <SpriteView Name="BorgSprite" Scale="5 5"/>
                 </BoxContainer>
@@ -38,10 +34,7 @@
         <customControls:VSeparator/>
         <BoxContainer Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True" Margin="15 10 15 15">
             <Label Text="{Loc 'borg-ui-modules-label'}" Margin="0 0 0 5"/>
-            <PanelContainer VerticalExpand="True">
-                <PanelContainer.PanelOverride>
-                    <gfx:StyleBoxFlat BackgroundColor="#1B1B1E"/>
-                </PanelContainer.PanelOverride>
+            <PanelContainer VerticalExpand="True" StyleClasses="PanelDeep">
                 <BoxContainer VerticalExpand="True" Orientation="Vertical">
                     <ScrollContainer HScrollEnabled="False" HorizontalExpand="True" VerticalExpand="True">
                         <BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True" Name="ModuleContainer" RectClipContent="True"/>

--- a/Content.Client/Silicons/Laws/Ui/SiliconLawMenu.xaml
+++ b/Content.Client/Silicons/Laws/Ui/SiliconLawMenu.xaml
@@ -1,7 +1,6 @@
 <controls:FancyWindow
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-    xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
     Title="{Loc 'laws-ui-menu-title'}"
     MinSize="450 225"
     SetSize="450 525">
@@ -26,10 +25,7 @@
                 MaxSize="256 64"
                 StyleClasses="OpenLeft" />
         </BoxContainer>
-        <PanelContainer VerticalExpand="True" Margin="10 10 10 5">
-            <PanelContainer.PanelOverride>
-                <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-            </PanelContainer.PanelOverride>
+        <PanelContainer VerticalExpand="True" Margin="10 10 10 5" StyleClasses="PanelDeep">
             <ScrollContainer
                 HScrollEnabled="False"
                 HorizontalExpand="True"

--- a/Content.Client/Silicons/StationAi/StationAiFixerConsoleWindow.xaml
+++ b/Content.Client/Silicons/StationAi/StationAiFixerConsoleWindow.xaml
@@ -11,10 +11,7 @@
             <BoxContainer VerticalExpand="True" HorizontalExpand="True" Orientation="Vertical" MinWidth="225" Margin="20 15 20 20">
 
                 <!-- AI panel -->
-                <PanelContainer>
-                    <PanelContainer.PanelOverride>
-                        <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
-                    </PanelContainer.PanelOverride>
+                <PanelContainer StyleClasses="PanelDeep">
 
                     <BoxContainer Orientation="Vertical">
                         <!-- AI name -->

--- a/Content.Client/Stylesheets/CommonStylesheet.cs
+++ b/Content.Client/Stylesheets/CommonStylesheet.cs
@@ -24,6 +24,8 @@ public abstract class CommonStylesheet : PalettedStylesheet, IButtonConfig, IWin
 
     ResPath IPanelConfig.GeometricPanelBorderPath => new("geometric_panel_border.svg.96dpi.png");
     ResPath IPanelConfig.BlackPanelDarkThinBorderPath => new("black_panel_dark_thin_border.png");
+    Color IPanelConfig.DeepPanelBackgroundColor => Color.FromHex("#1B1B1E");
+    Color IPanelConfig.DeepPanelBorderColor => Color.FromHex("#25252A");
 
     ResPath ITooltipConfig.TooltipBoxPath => new("tooltip.png");
     ResPath ITooltipConfig.WhisperBoxPath => new("whisper.png");

--- a/Content.Client/Stylesheets/SheetletConfigs/IPanelConfig.cs
+++ b/Content.Client/Stylesheets/SheetletConfigs/IPanelConfig.cs
@@ -6,4 +6,6 @@ public interface IPanelConfig : ISheetletConfig
 {
     public ResPath GeometricPanelBorderPath { get; }
     public ResPath BlackPanelDarkThinBorderPath { get; }
+    public Color DeepPanelBackgroundColor { get; }
+    public Color DeepPanelBorderColor { get; }
 }

--- a/Content.Client/Stylesheets/Sheetlets/PanelSheetlet.cs
+++ b/Content.Client/Stylesheets/Sheetlets/PanelSheetlet.cs
@@ -11,8 +11,6 @@ public sealed class PanelSheetlet<T> : Sheetlet<T> where T : PalettedStylesheet,
 {
     public override StyleRule[] GetRules(T sheet, object config)
     {
-        IPanelConfig panelCfg = sheet;
-
         var boxLight = new StyleBoxFlat
         {
             BackgroundColor = sheet.SecondaryPalette.BackgroundLight
@@ -29,12 +27,12 @@ public sealed class PanelSheetlet<T> : Sheetlet<T> where T : PalettedStylesheet,
         };
         var boxDeep = new StyleBoxFlat
         {
-            BackgroundColor = panelCfg.DeepPanelBackgroundColor
+            BackgroundColor = sheet.DeepPanelBackgroundColor
         };
         var boxInsetDeep = new StyleBoxFlat
         {
-            BackgroundColor = panelCfg.DeepPanelBackgroundColor,
-            BorderColor = panelCfg.DeepPanelBorderColor,
+            BackgroundColor = sheet.DeepPanelBackgroundColor,
+            BorderColor = sheet.DeepPanelBorderColor,
             BorderThickness = new Thickness(2f)
         };
 

--- a/Content.Client/Stylesheets/Sheetlets/PanelSheetlet.cs
+++ b/Content.Client/Stylesheets/Sheetlets/PanelSheetlet.cs
@@ -27,6 +27,16 @@ public sealed class PanelSheetlet<T> : Sheetlet<T> where T : PalettedStylesheet,
             BorderColor = sheet.PrimaryPalette.Background,
             BorderThickness = new Thickness(2f),
         };
+        var boxDeep = new StyleBoxFlat
+        {
+            BackgroundColor = Color.FromHex("#1B1B1E"),
+        };
+        var boxInsetDeep = new StyleBoxFlat
+        {
+            BackgroundColor = Color.FromHex("#1B1B1E"),
+            BorderColor = Color.FromHex("#25252A"),
+            BorderThickness = new Thickness(2f)
+        };
 
         var boxPositive = new StyleBoxFlat { BackgroundColor = sheet.PositivePalette.Background };
         var boxNegative = new StyleBoxFlat { BackgroundColor = sheet.NegativePalette.Background };
@@ -42,8 +52,10 @@ public sealed class PanelSheetlet<T> : Sheetlet<T> where T : PalettedStylesheet,
         [
             E<PanelContainer>().Class(StyleClass.PanelLight).Panel(boxLight),
             E<PanelContainer>().Class(StyleClass.PanelDark).Panel(boxDark),
+            E<PanelContainer>().Class(StyleClass.PanelDeep).Panel(boxDeep),
             E<PanelContainer>().Class(StyleClass.PanelDropTarget).Panel(boxDropTarget),
             E<PanelContainer>().Class(StyleClass.PanelInsetDark).Panel(boxInsetDark),
+            E<PanelContainer>().Class(StyleClass.PanelInsetDeep).Panel(boxInsetDeep),
 
             E<PanelContainer>().Class(StyleClass.Positive).Panel(boxPositive),
             E<PanelContainer>().Class(StyleClass.Negative).Panel(boxNegative),

--- a/Content.Client/Stylesheets/Sheetlets/PanelSheetlet.cs
+++ b/Content.Client/Stylesheets/Sheetlets/PanelSheetlet.cs
@@ -7,34 +7,34 @@ using static Content.Client.Stylesheets.StylesheetHelpers;
 namespace Content.Client.Stylesheets.Sheetlets;
 
 [CommonSheetlet]
-public sealed class PanelSheetlet<T> : Sheetlet<T> where T : PalettedStylesheet, IButtonConfig
+public sealed class PanelSheetlet<T> : Sheetlet<T> where T : PalettedStylesheet, IButtonConfig, IPanelConfig
 {
     public override StyleRule[] GetRules(T sheet, object config)
     {
-        IButtonConfig buttonCfg = sheet;
+        IPanelConfig panelCfg = sheet;
 
-        var boxLight = new StyleBoxFlat()
+        var boxLight = new StyleBoxFlat
         {
-            BackgroundColor = sheet.SecondaryPalette.BackgroundLight,
+            BackgroundColor = sheet.SecondaryPalette.BackgroundLight
         };
-        var boxDark = new StyleBoxFlat()
+        var boxDark = new StyleBoxFlat
         {
-            BackgroundColor = sheet.SecondaryPalette.BackgroundDark,
+            BackgroundColor = sheet.SecondaryPalette.BackgroundDark
         };
-        var boxInsetDark = new StyleBoxFlat()
+        var boxInsetDark = new StyleBoxFlat
         {
             BackgroundColor = sheet.SecondaryPalette.BackgroundDark,
             BorderColor = sheet.PrimaryPalette.Background,
-            BorderThickness = new Thickness(2f),
+            BorderThickness = new Thickness(2f)
         };
         var boxDeep = new StyleBoxFlat
         {
-            BackgroundColor = Color.FromHex("#1B1B1E"),
+            BackgroundColor = panelCfg.DeepPanelBackgroundColor
         };
         var boxInsetDeep = new StyleBoxFlat
         {
-            BackgroundColor = Color.FromHex("#1B1B1E"),
-            BorderColor = Color.FromHex("#25252A"),
+            BackgroundColor = panelCfg.DeepPanelBackgroundColor,
+            BorderColor = panelCfg.DeepPanelBorderColor,
             BorderThickness = new Thickness(2f)
         };
 
@@ -82,7 +82,7 @@ public sealed class PanelSheetlet<T> : Sheetlet<T> where T : PalettedStylesheet,
             E()
                 .Class(StyleClass.BackgroundPanelOpenRight)
                 .Prop(PanelContainer.StylePropertyPanel, StyleBoxHelpers.OpenRightStyleBox(sheet))
-                .Modulate(sheet.SecondaryPalette.Background),
+                .Modulate(sheet.SecondaryPalette.Background)
         ];
     }
 }

--- a/Content.Client/Stylesheets/StyleClass.cs
+++ b/Content.Client/Stylesheets/StyleClass.cs
@@ -51,9 +51,11 @@ public static class StyleClass
     public const string BackgroundPanelOpenRight = "BackgroundPanelOpenRight"; // replaces `BackgroundOpenRight`
 
     public const string PanelDark = "PanelDark";
+    public const string PanelDeep = "PanelDeep";
     public const string PanelLight = "PanelLight";
     public const string PanelDropTarget = "PanelDropTarget";
     public const string PanelInsetDark = "PanelInsetDark";
+    public const string PanelInsetDeep = "PanelInsetDeep";
 
     public const string ButtonOpenRight = "OpenRight";
     public const string ButtonOpenLeft = "OpenLeft";


### PR DESCRIPTION
## About the PR
Adds reusable deep panel styles and replaces repeated `#1B1B1E` panel backgrounds with them
I originally wanted to call it PanelBlack, but it’s not black at all...

## Why / Balance
`#1B1B1E` is used as a panel background across many UIs. This centralizes it instead of defining the same `StyleBoxFlat` in each XAML file
No balance changes

## Technical details
Added `PanelDeep` and `PanelInsetDeep` to the shared panel styles
The colors are provided through `IPanelConfig`, with `#1B1B1E` used for the background and `#25252A` for the inset border
Replaced existing plain `#1B1B1E` panel backgrounds with `PanelDeep` and cleaned up unused XAML namespaces in the touched files
An alternative would be to use the existing `Neutral` palette instead, which would avoid fixed colors entirely. However, its shades differ from the existing `#1B1B1E` appearance. Palette reference: https://codepen.io/aspiringLich/pen/VwOXdjd?editors=1000

## Test plan
- Open affected UIs and verify the migrated panels retain their expected appearance.

## Media
Not needed

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

## Changelog
No player-facing changes