### PR TITLE
Fix unbuckling from office chairs and being under them

### DIFF
--- a/Content.Client/Buckle/BuckleSystem.cs
+++ b/Content.Client/Buckle/BuckleSystem.cs
@@ -44,9 +44,14 @@ internal sealed partial class BuckleSystem : SharedBuckleSystem
         if (!_spriteQuery.TryComp(ent, out SpriteComponent? strapSprite))
             return;
 
-        var angle = _xformSystem.GetWorldRotation(ent) + _eye.CurrentEye.Rotation; // Get true screen position, or close enough
+        var newAngle = args.NewRotation + _eye.CurrentEye.Rotation;
+        var oldAngle = args.OldRotation + _eye.CurrentEye.Rotation;
 
-        var isNorth = angle.GetCardinalDir() == Direction.North;
+        if (newAngle.GetCardinalDir() == oldAngle.GetCardinalDir())
+            return;
+
+        var isNorth = newAngle.GetCardinalDir() == Direction.North;
+
         foreach (var buckledEntity in ent.Comp.BuckledEntities)
         {
             if (!TryComp<BuckleComponent>(buckledEntity, out var buckle))

--- a/Content.Client/Buckle/BuckleSystem.cs
+++ b/Content.Client/Buckle/BuckleSystem.cs
@@ -44,13 +44,13 @@ internal sealed partial class BuckleSystem : SharedBuckleSystem
         if (!_spriteQuery.TryComp(ent, out SpriteComponent? strapSprite))
             return;
 
-        var newAngle = args.NewRotation + _eye.CurrentEye.Rotation;
-        var oldAngle = args.OldRotation + _eye.CurrentEye.Rotation;
+        var newDir = (args.NewRotation + _eye.CurrentEye.Rotation).GetCardinalDir();
+        var oldDir = (args.OldRotation + _eye.CurrentEye.Rotation).GetCardinalDir();
 
-        if (newAngle.GetCardinalDir() == oldAngle.GetCardinalDir())
+        if (newDir == oldDir)
             return;
 
-        var isNorth = newAngle.GetCardinalDir() == Direction.North;
+        var isNorth = newDir == Direction.North;
 
         foreach (var buckledEntity in ent.Comp.BuckledEntities)
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I thought this was fixed, but it still happens if you click on your dude to unbuckle. Reason it happens is because clicking on your character will trigger a MoveEvent and that will overwrite anything that happens in `UnbuckledEvent`. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

`OnStrapMoveEvent` was updating draw depth regardless if the players direction actually changed, so I added a simple check to only update if we change direction. As far as I know you can't unbuckle in this manner while changing direction so this ends up fixing it while saving 1 whole TryComp

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
buckle yourself to office chair
unbuckle by clicking on yourself
you should now be above the chair

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

behold

https://github.com/user-attachments/assets/2e3c2273-6f74-4598-94d1-32bf39e656e9



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
