### PR TITLE
Flash Protection added to Syndicate Visors

### DIFF
--- a/Resources/Prototypes/Catalog/UplinkCatalog/wearables.yml
+++ b/Resources/Prototypes/Catalog/UplinkCatalog/wearables.yml
@@ -174,21 +174,6 @@
       - NukeOpsUplink
 
 - type: listing
-  id: UplinkClothingEyesHudSyndicate
-  name: uplink-clothing-eyes-hud-syndicate-name
-  description: uplink-clothing-eyes-hud-syndicate-desc
-  productEntity: ClothingEyesHudSyndicate
-  cost:
-    Telecrystal: 2
-  categories:
-    - UplinkWearables
-  conditions:
-    - !type:StoreWhitelistCondition
-      whitelist:
-        tags:
-          - NukeOpsUplink
-
-- type: listing
   id: UplinkBackpackSyndicate
   name: uplink-backpack-syndicate-name
   description: uplink-backpack-syndicate-desc

--- a/Resources/Prototypes/Catalog/UplinkCatalog/wearables.yml
+++ b/Resources/Prototypes/Catalog/UplinkCatalog/wearables.yml
@@ -174,6 +174,21 @@
       - NukeOpsUplink
 
 - type: listing
+  id: UplinkClothingEyesHudSyndicate
+  name: uplink-clothing-eyes-hud-syndicate-name
+  description: uplink-clothing-eyes-hud-syndicate-desc
+  productEntity: ClothingEyesHudSyndicate
+  cost:
+    Telecrystal: 2
+  categories:
+    - UplinkWearables
+  conditions:
+    - !type:StoreWhitelistCondition
+      whitelist:
+        tags:
+          - NukeOpsUplink
+
+- type: listing
   id: UplinkBackpackSyndicate
   name: uplink-backpack-syndicate-name
   description: uplink-backpack-syndicate-desc

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -246,24 +246,19 @@
     coverage: EYES
 
 - type: entity
-  parent: [ClothingEyesHudBase, ShowSecurityIcons, BaseSyndicateContraband]
+  parent: [ClothingEyesHudBase, ShowSecurityIcons, BaseSyndicateContraband, ClothingEyesHudSyndicate]
   id: ClothingEyesHudSyndicateAgent
   name: syndicate medical visor
   description: The Syndicate Corpsman's professional heads-up display, designed for quick diagnosis of their team's status.
   components:
-  - type: FlashImmunity
   - type: Sprite
     sprite: Clothing/Eyes/Hud/syndagent.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Hud/syndagent.rsi
-  - type: ShowSyndicateIcons
-  - type: ShowHealthBars
   - type: Tag
     tags:
-    - PetWearable
-    - WhitelistChameleon
-  - type: IdentityBlocker
-    coverage: EYES
+    - PetWearable # Manually added, for some reason this doesn't work when parented from ClothingEyesHudSyndicate..?
+  - type: ShowHealthBars
 
 - type: entity
   parent: [ClothingEyesGlassesSunglasses, ShowSecurityIcons]

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -232,6 +232,7 @@
   name: syndicate visor
   description: The syndicate's professional head-up display, designed for better detection of humanoids and their subsequent elimination.
   components:
+  - type: FlashImmunity
   - type: Sprite
     sprite: Clothing/Eyes/Hud/synd.rsi
   - type: Clothing
@@ -241,6 +242,8 @@
     tags:
     - PetWearable
     - WhitelistChameleon
+  - type: IdentityBlocker
+    coverage: EYES
 
 - type: entity
   parent: [ClothingEyesHudBase, ShowSecurityIcons, BaseSyndicateContraband]
@@ -248,6 +251,7 @@
   name: syndicate medical visor
   description: The Syndicate Corpsman's professional heads-up display, designed for quick diagnosis of their team's status.
   components:
+  - type: FlashImmunity
   - type: Sprite
     sprite: Clothing/Eyes/Hud/syndagent.rsi
   - type: Clothing
@@ -258,6 +262,8 @@
     tags:
     - PetWearable
     - WhitelistChameleon
+  - type: IdentityBlocker
+    coverage: EYES
 
 - type: entity
   parent: [ClothingEyesGlassesSunglasses, ShowSecurityIcons]

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -255,9 +255,6 @@
     sprite: Clothing/Eyes/Hud/syndagent.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Hud/syndagent.rsi
-  - type: Tag
-    tags:
-    - PetWearable # Manually added, for some reason this doesn't work when parented from ClothingEyesHudSyndicate..?
   - type: ShowHealthBars
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds flash protection to syndie visors, as well as eyes identity blocker ~~(as well as removes them from uplinks)~~
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The only thing that syndicate visors not having flash protection really causes is the inability to use interdynes on nukeops without running the risk of getting flashed which is just.. why? As well as syndie gas mask being 2tc already and it has weld prot, flash prot, *and* is a gas mask. Identity blocker added because it makes sense, engi goggles have them and they're see-through, visors are opaque and for some reason didn't have it. ~~Removed from uplink because I cannot think of a single reason to buy them from it. Reinforcements either can't wear them or are already geared with them, and they're free in nukie planet lockers.~~

## Technical details
<!-- Summary of code changes for easier review. -->
~6 lines added to ``hud.yml``, 5 removed.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Boot into a localhost,
2. Spawn in a syndicate visor or syndie med visor
3. Examine, has identity blocker for eyes as well as flash prot.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="485" height="230" alt="image" src="https://github.com/user-attachments/assets/4ce16b93-daa9-4f58-b35b-212bda443c0d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A
## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: jckspjf
- tweak: Syndicate Visors now have flash protection.
