### PR TITLE
Paradox clones to basic antags, and remove derelicts from moderate antags

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -260,7 +260,7 @@
     duration: null
     occursDuringRoundEnd: false
     earliestStart: 20
-    reoccurrenceDelay: 20
+    reoccurrenceDelay: 30
     minimumPlayers: 15
   - type: ParadoxCloneRule
     objectiveBlacklist:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -31,6 +31,7 @@
     - id: ClosetSkeleton
     - id: KingRatMigration
     - id: RevenantSpawn
+    - id: ParadoxCloneSpawn
     - !type:NestedSelector
       tableId: DerelictBorgEventTable
 
@@ -40,13 +41,10 @@
     children:
     - id: DragonSpawn
     - id: NinjaSpawn
-    - id: ParadoxCloneSpawn
     - id: SleeperAgents
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
     - id: WizardSpawn
-    - !type:NestedSelector
-      tableId: DerelictBorgEventTable
 
 - type: entityTable
   id: DerelictBorgEventTable #For Derelict Borg spawns


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed derelict cyborgs from the possible moderate antagonist spawns table.
Removed Paradox clones from the possible moderate antagonist spawns table.

Added Paradox clones into the basic antagonist spawns table.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Derelict cyborgs being regarded as dangerous as a Dragon, Ninja, Sleeper Agents, Zombie Outbreak, Lone Operative or Wizard is quite frankly a bit silly.

I understand it can just be an antimov lawset and do a loose any% speedrun, but in that case why have it in the Basic Antagonist spawns table if we're gonna be treating it like a moderate antagonist?

Same thing with the Paradox clone, whose entire job is to usually kill one person, replace them, and then make it to central command. Of course it could be *literally any humanoid*, meaning this classification is a bit more fair if it so happened to land on another moderate antagonist. So I am more willing to negotiate with this one.

But a majority of the time it is a crew member, and with such a specific objective it usually doesn't allow for any significant collateral should they want to succeed. Though it could sometimes just have conflicting objectives with their original, like a DAGD, or a nuking of the station and the player might just say "screw it" and decide to cause as much damage as possible. To reduce this, their re-occurrence delay has been increased from 20 to 30.

## Technical details
Removed a nested selector for derelict cyborgs from the Moderate Antagonist events table in `events.yml`.
Moved the paradox clone to the Basic Antagonist events table in `events.yml`.
 
## Test plan
impossible to test in a solo environment, we have to put faith in the gamerules
I recommend a server with at least 20 population, on a survival round if you can replicate that

If testing for the paradox clone, it should appear at any time after the 20 minute mark assuming the station has 15 people on it in place of another basic antagonist spawn.

If testing for the derelict it should appear at any time after the 15 minute mark, assuming the station has 4 people on it as normal.
It just won't have the chance to replace a moderate antagonist spawn when those get spawned anymore.

If testing specifically for the derelict syndicate cyborg, it should appear after 25 minutes assuming the station has 15 people on it.

## Media

<img width="340" height="264" alt="image" src="https://github.com/user-attachments/assets/af5195f0-e406-4f78-8c7d-e18bb1bc6154" />
 
<img width="290" height="268" alt="image" src="https://github.com/user-attachments/assets/03fd2598-43f8-4be0-964f-c36899d92a44" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog

Don't think this is player facing enough
