### PR TITLE
Fix secret door drawdepth

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -12,6 +12,7 @@
   - type: Rotatable
   - type: Sprite
     sprite: Structures/Doors/Misc/secret-door.rsi
+    drawdepth: Walls
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]
@@ -38,6 +39,8 @@
     openTimeTwo: 0.2
     openingAnimationTime: 1.2
     closingAnimationTime: 1.2
+    openDrawDepth: Walls
+    closedDrawDepth: Walls
   - type: Appearance
   - type: Weldable
     time: 2

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -12,7 +12,6 @@
   - type: Rotatable
   - type: Sprite
     sprite: Structures/Doors/Misc/secret-door.rsi
-    drawdepth: Walls
     layers:
     - state: closed
       map: ["enum.DoorVisualLayers.Base"]


### PR DESCRIPTION
## About the PR

Fixes the secret door drawdepth, drawing it as though it's a wall, because it's supposed to be a wall.

## Why / Balance

Bug report at https://discord.com/channels/310555209753690112/1537751684569235466

## Technical details

DoorComponent sets the drawdepth of the door when it opens and closes.  We might as well keep it at wall depth, since it's a wall.

Open status _could_ be left at door depth, but passing under the sides of the walls feels odd.

<img width="215" height="211" alt="image" src="https://github.com/user-attachments/assets/87db9daa-80aa-4e9d-b91a-12fc896a413e" />

## Test plan

Walk up to a secret door from the north, your feet shouldn't slip under it as though it was a door.

## Media

Image showing the behaviour on master:

<img width="325" height="375" alt="image" src="https://github.com/user-attachments/assets/dd67c067-d088-463e-a481-c68f170489b3" />

Small video taken on the head of the branch:

https://github.com/user-attachments/assets/17a20c39-a913-4510-b2de-55be3cd53170

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- fix: Characters' feet no longer poke through the north side of secret doors.