### PR TITLE
Configure Russian defaults and disable votes

### DIFF
--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -10,7 +10,8 @@ namespace Content.Shared.Localizations
         [Dependency] private ILocalizationManager _loc = default!;
 
         // If you want to change your codebase's language, do it here.
-        private const string Culture = "en-US";
+        private const string Culture = "ru-RU";
+        private const string FallbackCulture = "en-US";
 
         /// <summary>
         /// Custom format strings used for parsing and displaying minutes:seconds timespans.
@@ -26,8 +27,27 @@ namespace Content.Shared.Localizations
         public void Initialize()
         {
             var culture = new CultureInfo(Culture);
+            var fallbackCulture = new CultureInfo(FallbackCulture);
 
             _loc.LoadCulture(culture);
+            _loc.LoadCulture(fallbackCulture);
+            _loc.SetCulture(culture);
+            _loc.SetFallbackCluture(fallbackCulture);
+            AddLocalizationFunctions(culture);
+            AddLocalizationFunctions(fallbackCulture);
+
+
+            /*
+             * The following language functions are specific to the english localization. When working on your own
+             * localization you should NOT modify these, instead add new functions specific to your language/culture.
+             * This ensures the english translations continue to work as expected when fallbacks are needed.
+             */
+            _loc.AddFunction(fallbackCulture, "MAKEPLURAL", FormatMakePlural);
+        }
+
+        private void AddLocalizationFunctions(CultureInfo culture)
+        {
+            _loc.AddFunction(culture, "MANY", FormatMany);
             _loc.AddFunction(culture, "PRESSURE", FormatPressure);
             _loc.AddFunction(culture, "POWERWATTS", FormatPowerWatts);
             _loc.AddFunction(culture, "POWERJOULES", FormatPowerJoules);
@@ -39,17 +59,6 @@ namespace Content.Shared.Localizations
             _loc.AddFunction(culture, "NATURALFIXED", FormatNaturalFixed);
             _loc.AddFunction(culture, "NATURALPERCENT", FormatNaturalPercent);
             _loc.AddFunction(culture, "PLAYTIME", FormatPlaytime);
-
-
-            /*
-             * The following language functions are specific to the english localization. When working on your own
-             * localization you should NOT modify these, instead add new functions specific to your language/culture.
-             * This ensures the english translations continue to work as expected when fallbacks are needed.
-             */
-            var cultureEn = new CultureInfo("en-US");
-
-            _loc.AddFunction(cultureEn, "MAKEPLURAL", FormatMakePlural);
-            _loc.AddFunction(cultureEn, "MANY", FormatMany);
         }
 
         private ILocValue FormatMany(LocArgs args)

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -1,8 +1,14 @@
 ﻿[game]
-# Straight in-game baby
-lobbyenabled = false
-# Dev map for faster loading & convenience
-map = "Dev"
+lobbyenabled = true
+defaultpreset = "SpaceArena"
+map = "SpaceArenaHub"
+
+[vote]
+enabled = false
+restart_enabled = false
+preset_enabled = false
+map_enabled = false
+votekick_enabled = false
 role_timers = false
 admin_job_tracking = true
 role_loadout_timers = false
@@ -44,7 +50,8 @@ see_own_notes = true
 new_player_threshold = 120
 
 [ic]
-random_characters = true
+random_characters = false
+restricted_names = false
 random_species_weights = ""
 ssd_sleep_time = 3600
 

--- a/Resources/ConfigPresets/server_config.toml
+++ b/Resources/ConfigPresets/server_config.toml
@@ -25,6 +25,16 @@ max_connections = 256
 hostname = "MyServer"
 # Description of the server. This is what will be displayed in the server list.
 desc = "Just another server, don't mind me!"
+lobbyenabled = true
+defaultpreset = "SpaceArena"
+map = "SpaceArenaHub"
+
+[vote]
+enabled = false
+restart_enabled = false
+preset_enabled = false
+map_enabled = false
+votekick_enabled = false
 # The maximum number of players that can connect to the server. (Exluding admins)
 soft_max_players = 30
 # Controls the lobby timer in seconds.
@@ -40,6 +50,8 @@ ipintel_contact_email = ""
 ipintel_bad_rating = 0.95
 
 [ic]
+random_characters = false
+restricted_names = false
 # Allows visibility and editing of flavor text (character descriptions)
 flavor_text = false
 


### PR DESCRIPTION
## About the PR

Configure SpaceArena to start with Russian localization, the SpaceArena preset and SpaceArenaHub map. Disable player voting on the server.

## Why / Balance

This changes server defaults and localization only. No gameplay balance changes.

## Technical details

- Set `ru-RU` as the default content culture with English fallback.
- Set `SpaceArena` as the default preset.
- Set `SpaceArenaHub` as the default map.
- Disabled restart, preset, map and votekick votes.

## Test plan

- Build:
  `dotnet build Content.Shared/Content.Shared.csproj --no-restore`
- Start the server and verify that the SpaceArenaHub map and SpaceArena preset load automatically.
- Verify that the interface starts in Russian.
- Verify that vote commands are unavailable.
- The language can be checked manually with:
  `localization_set_culture ru-RU`

## Media

Not required. This PR contains configuration and localization changes only.

## Requirements

- [X] I have read and am following the Pull Request and Changelog Guidelines.
- [X] I have tested this pull request and written instructions on how to test it.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

## Changelog

:cl:
- tweak: Russian is now the default language.
- tweak: SpaceArena starts with its hub map and preset by default.
- tweak: Player voting is disabled on the server.