### PR TITLE
Buffed the weakest xenoborg modules

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -555,7 +555,7 @@
   name: Jump boost
   components:
   - type: Action
-    useDelay: 16
+    useDelay: 8
   - type: Sprite
     sprite: Interface/Actions/actions_borg.rsi
     layers:

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -555,7 +555,7 @@
   name: Jump boost
   components:
   - type: Action
-    useDelay: 8
+    useDelay: 10
   - type: Sprite
     sprite: Interface/Actions/actions_borg.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1720,8 +1720,8 @@
         state: xenoborg_heavy_rad
       shader: unshaded
     - type: RadiationSource
-      intensity: 5
-      slope: 1.2
+      intensity: 4
+      slope: 1
     - type: AmbientSound
       range: 6
       volume: -3

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1599,7 +1599,7 @@
     - type: Electrified
       requirePower: false
       shockDamage: 15
-      shockDelay: 12
+      shockDelay: 6
       shockTime: 0.25
 
 - type: entity
@@ -1720,8 +1720,8 @@
         state: xenoborg_heavy_rad
       shader: unshaded
     - type: RadiationSource
-      intensity: 0.75
-      slope: 0.2
+      intensity: 5
+      slope: 1.2
     - type: AmbientSound
       range: 6
       volume: -3

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/nanite.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/nanite.yml
@@ -59,11 +59,11 @@
     damageOptions:
     - damage:
         types:
-          Blunt: -15
-          Piercing: -15
-          Slash: -15
-          Heat: -15
-          Shock: -15
+          Blunt: -20
+          Piercing: -20
+          Slash: -20
+          Heat: -20
+          Shock: -20
       whitelist:
         components:
         - BorgChassis

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/nanite.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/nanite.yml
@@ -51,19 +51,19 @@
     impactEffect: BulletImpactEffectNanite
     damage:
       types:
-        Piercing: 9
-        Poison: 3
+        Piercing: 10
+        Poison: 5
     soundHit:
       collection: NaniteBulletImpact
   - type: ComplexProjectileDamage
     damageOptions:
     - damage:
         types:
-          Blunt: -10
-          Piercing: -10
-          Slash: -10
-          Heat: -10
-          Shock: -10
+          Blunt: -15
+          Piercing: -15
+          Slash: -15
+          Heat: -15
+          Shock: -15
       whitelist:
         components:
         - BorgChassis


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- decreased delay of jump module from 16 seconds to 8 seconds
- decreased shock delay of the zap module from 12 seconds to 6 seconds
- increased the radiation of the radioactive module from 0.75 with a 0.2 slope to 5 with a 1.2 slope
- increased the healing of the nanite gun from 10 to 15.
- increased the damage of the nanite gun from 9 pierce and 3 poison to 10 pierce and 5 poison
<!-- What did you change? -->

## Why / Balance
these modules were very weak and not at all very useful
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
pure yml change
<!-- Summary of code changes for easier review. -->

## Test plan
- spawn: jump module, nanite gun module, zap module and radioactive module
- install them in the correct xenoborgs
- test to see if they still work
- they are a bit stronger than before
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
no need, is just number changes
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
no cl
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
