### PR TITLE
Make interaction outline thickness constant in world-space

### DIFF
--- a/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
+++ b/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
@@ -1,9 +1,7 @@
 namespace Content.Client.Interactable.Components;
 
+/// <summary>
+/// Gives moused-over entities an interaction outline.
+/// </summary>
 [RegisterComponent]
-public sealed partial class InteractionOutlineComponent : Component
-{
-    public bool InRange;
-    public int LastRenderScale;
-    public bool Active;
-}
+public sealed partial class InteractionOutlineComponent : Component;

--- a/Content.Client/Outline/InteractionOutlineSystem.cs
+++ b/Content.Client/Outline/InteractionOutlineSystem.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+using System.Numerics;
 using Content.Client.ContextMenu.UI;
 using Content.Client.Gameplay;
 using Content.Client.Graphics;
@@ -14,26 +14,36 @@ using Robust.Client.State;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Configuration;
+using Robust.Shared.Graphics;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client.Outline;
 
+/// <summary>
+/// Gives moused-over entities an interaction outline.
+/// </summary>
 public sealed partial class InteractionOutlineSystem : EntitySystem
 {
-    private static readonly ProtoId<ShaderPrototype> ShaderInRange = "SelectionOutlineInrange";
-    private static readonly ProtoId<ShaderPrototype> ShaderOutOfRange = "SelectionOutline";
-    private const float DefaultWidth = 1;
-    private readonly Dictionary<(bool InRange, int RenderScale), ShaderInstance> _shaderCache = new();
-
     [Dependency] private IConfigurationManager _configManager = default!;
     [Dependency] private IEyeManager _eyeManager = default!;
     [Dependency] private IInputManager _inputManager = default!;
     [Dependency] private IPlayerManager _playerManager = default!;
+    [Dependency] private IPrototypeManager _prototype = default!;
+    [Dependency] private SpriteSystem _sprite = default!;
     [Dependency] private IStateManager _stateManager = default!;
     [Dependency] private IUserInterfaceManager _uiManager = default!;
     [Dependency] private SharedInteractionSystem _interactionSystem = default!;
-    [Dependency] private IPrototypeManager _prototypeManager = default!;
-    [Dependency] private SpriteSystem _sprite = default!;
+
+    [Dependency] private EntityQuery<InteractionOutlineComponent> _outlineQuery;
+    [Dependency] private EntityQuery<SpriteComponent> _spriteQuery;
+
+    private static readonly ProtoId<ShaderPrototype> ShaderInRange = "SelectionOutlineInrange";
+    private static readonly ProtoId<ShaderPrototype> ShaderOutOfRange = "SelectionOutline";
+
+    private ShaderInstance? _shaderInRange;
+    private ShaderInstance? _shaderOutOfRange;
+
+    private const float DesiredOutlineThickness = 1f;
 
     /// <summary>
     ///     Whether to currently draw the outline. The outline may be temporarily disabled by other systems
@@ -49,12 +59,8 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
 
     public override void Shutdown()
     {
-        foreach (var shader in _shaderCache.Values)
-        {
-            shader.Dispose();
-        }
-
-        _shaderCache.Clear();
+        _shaderInRange?.Dispose();
+        _shaderOutOfRange?.Dispose();
         base.Shutdown();
     }
 
@@ -63,10 +69,10 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
         base.Initialize();
 
         Subs.CVar(_configManager, CCVars.OutlineEnabled, SetCvarEnabled);
-        SubscribeLocalEvent<InteractionOutlineComponent, ComponentShutdown>(OnShutdown);
         UpdatesAfter.Add(typeof(SharedEyeSystem));
     }
 
+    [SubscribeLocalEvent]
     private void OnShutdown(Entity<InteractionOutlineComponent> ent, ref ComponentShutdown args)
     {
         RemoveOutline(ent);
@@ -87,7 +93,7 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
         if (_lastHoveredEntity == null || Deleted(_lastHoveredEntity))
             return;
 
-        if (TryComp(_lastHoveredEntity, out InteractionOutlineComponent? outline))
+        if (_outlineQuery.TryComp(_lastHoveredEntity, out var outline))
             RemoveOutline((_lastHoveredEntity.Value, outline));
     }
 
@@ -98,15 +104,16 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
 
         _enabled = enabled;
 
-        // clear last hover if required:
-
         if (enabled)
             return;
 
         if (_lastHoveredEntity == null || Deleted(_lastHoveredEntity))
+        {
+            _lastHoveredEntity = null;
             return;
+        }
 
-        if (TryComp(_lastHoveredEntity, out InteractionOutlineComponent? outline))
+        if (_outlineQuery.TryComp(_lastHoveredEntity, out var outline))
             RemoveOutline((_lastHoveredEntity.Value, outline));
     }
 
@@ -115,28 +122,31 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
         base.FrameUpdate(frameTime);
 
         if (!_enabled || !_cvarEnabled)
+        {
+            ClearOutline();
             return;
+        }
 
         // If there is no local player, there is no session, and therefore nothing to do here.
         var localSession = _playerManager.LocalSession;
         if (localSession == null)
+        {
+            ClearOutline();
             return;
-
-        // TODO InteractionOutlineComponent
-        // BUG: The logic that gets the renderScale here assumes that the entity is only visible in a single
-        // viewport. The entity will be highlighted in ALL viewport where it is visible, regardless of which
-        // viewport is being used to hover over it. If these Viewports have very different render scales, this may
-        // lead to extremely thick outlines in the other viewports. Fixing this probably requires changing how the
-        // hover outline works, so that it only highlights the entity in a single viewport.
+        }
 
         // GameScreen is still in charge of what entities are visible under a specific cursor position.
         // Potentially change someday? who knows.
         var currentState = _stateManager.CurrentState;
 
-        if (currentState is not GameplayStateBase screen) return;
+        if (currentState is not GameplayStateBase screen)
+        {
+            ClearOutline();
+            return;
+        }
 
         EntityUid? entityToClick = null;
-        var renderScale = 1;
+
         if (_uiManager.CurrentlyHovered is IViewportControl vp
             && _inputManager.MouseScreenPosition.IsValid)
         {
@@ -144,7 +154,6 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
 
             if (vp is ScalingViewport svp)
             {
-                renderScale = svp.CurrentRenderScale;
                 entityToClick = screen.GetClickedEntity(mousePosWorld, svp.Eye);
             }
             else
@@ -155,11 +164,6 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
         else if (_uiManager.CurrentlyHovered is EntityMenuElement element)
         {
             entityToClick = element.Entity;
-            // TODO InteractionOutlineComponent
-            // Currently we just take the renderscale from the main viewport. In the future, when the bug mentioned
-            // above is fixed, the viewport should probably be the one that was clicked on to open the entity menu
-            // in the first place.
-            renderScale = _eyeManager.MainViewport.GetRenderScale();
         }
 
         var inRange = false;
@@ -170,98 +174,105 @@ public sealed partial class InteractionOutlineSystem : EntitySystem
 
         if (entityToClick == _lastHoveredEntity)
         {
-            if (entityToClick != null && TryComp(entityToClick, out outline))
+            if (entityToClick != null && _outlineQuery.TryComp(entityToClick, out outline))
             {
-                UpdateOutline((entityToClick.Value, outline), inRange, renderScale);
+                UpdateOutline((entityToClick.Value, outline), inRange);
+            }
+            else
+            {
+                ClearOutline();
             }
 
             return;
         }
 
-        if (_lastHoveredEntity != null && !Deleted(_lastHoveredEntity) &&
-            TryComp(_lastHoveredEntity, out outline))
+        if (_lastHoveredEntity != null &&
+            !Deleted(_lastHoveredEntity) &&
+            _outlineQuery.TryComp(_lastHoveredEntity, out outline))
         {
             RemoveOutline((_lastHoveredEntity.Value, outline));
+        }
+        else
+        {
+            ClearOutline();
         }
 
         _lastHoveredEntity = entityToClick;
 
-        if (_lastHoveredEntity != null && TryComp(_lastHoveredEntity, out outline))
+        if (_lastHoveredEntity != null && _outlineQuery.TryComp(_lastHoveredEntity, out outline))
         {
-            AddOutline((_lastHoveredEntity.Value, outline), inRange, renderScale);
+            AddOutline((_lastHoveredEntity.Value, outline), inRange);
         }
     }
 
-    private void AddOutline(Entity<InteractionOutlineComponent> ent, bool inInteractionRange, int renderScale)
+    private void AddOutline(Entity<InteractionOutlineComponent> ent, bool inInteractionRange)
     {
-        ent.Comp.LastRenderScale = renderScale;
-        ent.Comp.InRange = inInteractionRange;
-        ent.Comp.Active = true;
-
-        if (!TryComp(ent.Owner, out SpriteComponent? sprite))
-            return;
-
-        SetOutlinePostShader((ent.Owner, sprite), inInteractionRange, renderScale);
+        SetPostShader(ent.Owner, inInteractionRange);
     }
 
     private void RemoveOutline(Entity<InteractionOutlineComponent> ent)
     {
-        if (TryComp(ent.Owner, out SpriteComponent? sprite))
-        {
+        if (_spriteQuery.TryComp(ent.Owner, out var sprite))
             _sprite.RemovePostShader((ent.Owner, sprite), ContentPostShaderIds.InteractionOutline);
-            sprite.RenderOrder = 0;
-        }
-
-        ent.Comp.Active = false;
     }
 
-    private void UpdateOutline(Entity<InteractionOutlineComponent> ent, bool inInteractionRange, int renderScale)
+    private void UpdateOutline(Entity<InteractionOutlineComponent> ent, bool inInteractionRange)
     {
-        if (!TryComp(ent.Owner, out SpriteComponent? sprite)
-            || !_sprite.HasPostShader((ent.Owner, sprite), ContentPostShaderIds.InteractionOutline)
-            || inInteractionRange == ent.Comp.InRange && ent.Comp.LastRenderScale == renderScale)
+        SetPostShader(ent.Owner, inInteractionRange);
+    }
+
+    private void ClearOutline()
+    {
+        if (_lastHoveredEntity != null &&
+            !Deleted(_lastHoveredEntity) &&
+            _spriteQuery.TryComp(_lastHoveredEntity, out var sprite))
         {
-            return;
+            _sprite.RemovePostShader((_lastHoveredEntity.Value, sprite), ContentPostShaderIds.InteractionOutline);
         }
-
-        ent.Comp.InRange = inInteractionRange;
-        ent.Comp.LastRenderScale = renderScale;
-
-        SetOutlinePostShader((ent.Owner, sprite), ent.Comp.InRange, ent.Comp.LastRenderScale);
     }
 
-    private void SetOutlinePostShader(Entity<SpriteComponent?> sprite, bool inRange, int renderScale)
+    private void SetPostShader(EntityUid uid, bool inInteractionRange)
     {
-        var shader = GetShader(inRange, renderScale);
+        if (!_spriteQuery.TryComp(uid, out var sprite))
+            return;
+
+        var shader = GetShader(inInteractionRange);
+
         if (_sprite.TryGetPostShader(sprite, ContentPostShaderIds.InteractionOutline, out var entry) &&
             entry.Shader == shader)
         {
             return;
         }
 
-        _sprite.SetPostShader(sprite, new SpriteComponent.PostShaderArgs(ContentPostShaderIds.InteractionOutline, shader)
+        _sprite.SetPostShader((uid, sprite), new SpriteComponent.PostShaderArgs(ContentPostShaderIds.InteractionOutline, shader)
         {
             After = ContentPostShaderIds.AfterBaseEffects,
+            RaiseShaderEvent = true,
         });
     }
 
-    private ShaderInstance GetShader(bool inRange, int renderScale)
+    private ShaderInstance GetShader(bool inRange)
     {
-        var key = (inRange, renderScale);
-        if (_shaderCache.TryGetValue(key, out var shader))
-            return shader;
+        var shader = inRange
+            ? _shaderInRange ??= _prototype.Index(ShaderInRange).InstanceUnique()
+            : _shaderOutOfRange ??= _prototype.Index(ShaderOutOfRange).InstanceUnique();
 
-        shader = MakeNewShader(inRange, renderScale);
-        _shaderCache.Add(key, shader);
+        shader.SetParameter("outline_width", DesiredOutlineThickness);
         return shader;
     }
 
-    private ShaderInstance MakeNewShader(bool inRange, int renderScale)
+    [SubscribeLocalEvent]
+    private void OnBeforePostShaderRender(Entity<InteractionOutlineComponent> ent, ref BeforePostShaderRenderEvent args)
     {
-        var shaderName = inRange ? ShaderInRange : ShaderOutOfRange;
+        if (args.Id != ContentPostShaderIds.InteractionOutline)
+            return;
 
-        var instance = _prototypeManager.Index(shaderName).InstanceUnique();
-        instance.SetParameter("outline_width", DefaultWidth * renderScale);
-        return instance;
+        var zoom = args.Viewport.Eye?.Zoom ?? Vector2.Zero;
+        var zoomLength = zoom.Length();
+
+        if (zoomLength < float.Epsilon)
+            return;
+
+        args.Shader.SetParameter("outline_width", DesiredOutlineThickness * args.Viewport.RenderScale.Length() / zoomLength);
     }
 }

--- a/Resources/Textures/Shaders/outline.swsl
+++ b/Resources/Textures/Shaders/outline.swsl
@@ -37,40 +37,43 @@ uniform highp float light_whitepoint; // = 1.0;
 void fragment() {
 	highp vec4 col = zTexture(UV);
 	highp vec2 ps = TEXTURE_PIXEL_SIZE;
+
+	// Width in screen-space terms
+	highp float width = outline_width;
 	highp float a;
 	highp float maxa = col.a;
 	highp float mina = col.a;
 
 	// note: these bypass zTexture because only alpha is queried.
-	a = texture2D(TEXTURE, UV + vec2(0.0, -outline_width)*ps).a;
+	a = texture2D(TEXTURE, UV + vec2(0.0, -width)*ps).a;
 	maxa = max(a, maxa);
 	mina = min(a, mina);
 
-    a = texture2D(TEXTURE, UV + vec2(-outline_width, -outline_width)*ps).a;
+    a = texture2D(TEXTURE, UV + vec2(-width, -width)*ps).a;
     maxa = max(a, maxa);
     mina = min(a, mina);
 
-	a = texture2D(TEXTURE, UV + vec2(0.0, outline_width)*ps).a;
+	a = texture2D(TEXTURE, UV + vec2(0.0, width)*ps).a;
 	maxa = max(a, maxa);
 	mina = min(a, mina);
 
-    a = texture2D(TEXTURE, UV + vec2(outline_width, -outline_width)*ps).a;
+    a = texture2D(TEXTURE, UV + vec2(width, -width)*ps).a;
     maxa = max(a, maxa);
     mina = min(a, mina);
 
-	a = texture2D(TEXTURE, UV + vec2(-outline_width,0.0)*ps).a;
+	a = texture2D(TEXTURE, UV + vec2(-width,0.0)*ps).a;
 	maxa = max(a, maxa);
 	mina = min(a, mina);
 
-    a = texture2D(TEXTURE, UV + vec2(-outline_width, outline_width)*ps).a;
+    a = texture2D(TEXTURE, UV + vec2(-width, width)*ps).a;
     maxa = max(a, maxa);
     mina = min(a, mina);
 
-	a = texture2D(TEXTURE, UV + vec2(outline_width, 0.0)*ps).a;
+	a = texture2D(TEXTURE, UV + vec2(width, 0.0)*ps).a;
 	maxa = max(a, maxa);
 	mina = min(a, mina);
 
-	a = texture2D(TEXTURE, UV + vec2(outline_width, outline_width)*ps).a;
+	a = texture2D(TEXTURE, UV + vec2(width, width)*ps).a;
 	maxa = max(a, maxa);
 	mina = min(a, mina);
 


### PR DESCRIPTION
Right now it has 2 issues:
1. It scales in screen-space so if you zoomed-in it stays the same thickness which looks weird.
2. Like the TODOs say it doesn't handle multiple viewports. I was considering an overlay but that had its own funkiness due to not quite being equivalent to a post-shader so just raising the event on every viewport render is much more workable.

Zoom 0.5:
<img width="3840" height="2054" alt="2026-8-15_14 24 33" src="https://github.com/user-attachments/assets/45958390-5379-4bc5-8f24-475aeaed4ffd" />

I tried lower zoom but the command is utterly cooked and I am too lazy to rebind my numpad zoom keys to something else.

## Breaking changes
InteractionOutlineComponent had its properties removed.

## Changelog
:cl:
- fix: Fix interaction outline not scaling with zoom.