### PR TITLE
Update drawdepths to bytes

### DIFF
--- a/Content.Client/Botany/PlantVisualizerSystem.cs
+++ b/Content.Client/Botany/PlantVisualizerSystem.cs
@@ -19,7 +19,7 @@ public sealed partial class PlantVisualizerSystem : VisualizerSystem<PlantVisual
             return;
 
         // Ensure they always render above the tray sprite.
-        SpriteSystem.SetDrawDepth((uid, sprite), (int)DrawDepth.SmallObjects);
+        SpriteSystem.SetDrawDepth((uid, sprite), (byte)DrawDepth.SmallObjects);
         SpriteSystem.LayerMapReserve((uid, sprite), PlantLayers.Plant);
         SpriteSystem.LayerSetVisible((uid, sprite), PlantLayers.Plant, false);
     }

--- a/Content.Client/Buckle/BuckleSystem.cs
+++ b/Content.Client/Buckle/BuckleSystem.cs
@@ -64,7 +64,7 @@ internal sealed partial class BuckleSystem : SharedBuckleSystem
             {
                 // This will only assign if empty, it won't get overwritten by new depth on multiple calls, which do happen easily
                 buckle.OriginalDrawDepth ??= buckledSprite.DrawDepth;
-                _sprite.SetDrawDepth((buckledEntity, buckledSprite), strapSprite.DrawDepth - 1);
+                _sprite.SetDrawDepth((buckledEntity, buckledSprite), (byte) (strapSprite.DrawDepth - 1));
             }
             else if (buckle.OriginalDrawDepth.HasValue)
             {
@@ -105,7 +105,7 @@ internal sealed partial class BuckleSystem : SharedBuckleSystem
             return;
 
         ent.Comp.OriginalDrawDepth ??= buckledSprite.DrawDepth;
-        _sprite.SetDrawDepth((ent.Owner, buckledSprite), strapSprite.DrawDepth - 1);
+        _sprite.SetDrawDepth((ent.Owner, buckledSprite), (byte) (strapSprite.DrawDepth - 1));
     }
 
     /// <summary>

--- a/Content.Client/DamageState/DamageStateVisualizerSystem.cs
+++ b/Content.Client/DamageState/DamageStateVisualizerSystem.cs
@@ -40,10 +40,10 @@ public sealed class DamageStateVisualizerSystem : VisualizerSystem<DamageStateVi
         // So they don't draw over mobs anymore
         if (data == MobState.Dead)
         {
-            if (sprite.DrawDepth > (int)DrawDepth.DeadMobs)
+            if (sprite.DrawDepth > (byte)DrawDepth.DeadMobs)
             {
                 component.OriginalDrawDepth = sprite.DrawDepth;
-                SpriteSystem.SetDrawDepth((uid, sprite), (int)DrawDepth.DeadMobs);
+                SpriteSystem.SetDrawDepth((uid, sprite), (byte)DrawDepth.DeadMobs);
             }
         }
         else if (component.OriginalDrawDepth != null)

--- a/Content.Client/DamageState/DamageStateVisualsComponent.cs
+++ b/Content.Client/DamageState/DamageStateVisualsComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Client.DamageState;
 [RegisterComponent]
 public sealed partial class DamageStateVisualsComponent : Component
 {
-    public int? OriginalDrawDepth;
+    public byte? OriginalDrawDepth;
 
     [DataField("states")] public Dictionary<MobState, Dictionary<DamageStateVisualLayers, string>> States = new();
 }

--- a/Content.Client/Holopad/HolopadSystem.cs
+++ b/Content.Client/Holopad/HolopadSystem.cs
@@ -99,7 +99,7 @@ public sealed partial class HolopadSystem : SharedHolopadSystem
         // Override specific values
         _sprite.SetColor((hologram, hologramSprite), Color.White);
         _sprite.SetOffset((hologram, hologramSprite), holopadhologram.Offset);
-        _sprite.SetDrawDepth((hologram, hologramSprite), (int)DrawDepth.Mobs);
+        _sprite.SetDrawDepth((hologram, hologramSprite), (byte)DrawDepth.Mobs);
         hologramSprite.NoRotation = true;
         hologramSprite.DirectionOverride = Direction.South;
         hologramSprite.EnableDirectionOverride = true;

--- a/Content.Client/Interaction/DragDropSystem.cs
+++ b/Content.Client/Interaction/DragDropSystem.cs
@@ -254,7 +254,7 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
             dragSprite.RenderOrder = EntityManager.CurrentTick.Value;
             _sprite.SetColor((_dragShadow.Value, dragSprite), dragSprite.Color.WithAlpha(0.7f));
             // keep it on top of everything
-            _sprite.SetDrawDepth((_dragShadow.Value, dragSprite), (int)DrawDepth.Overlays);
+            _sprite.SetDrawDepth((_dragShadow.Value, dragSprite), (byte)DrawDepth.Overlays);
             if (!dragSprite.NoRotation)
             {
                 _transformSystem.SetWorldRotationNoLerp(_dragShadow.Value, _transformSystem.GetWorldRotation(_draggedEntity.Value));

--- a/Content.Client/Mech/MechSystem.cs
+++ b/Content.Client/Mech/MechSystem.cs
@@ -42,6 +42,6 @@ public sealed partial class MechSystem : SharedMechSystem
         }
 
         _sprite.LayerSetRsiState((uid, args.Sprite), MechVisualLayers.Base, state);
-        _sprite.SetDrawDepth((uid, args.Sprite), (int)drawDepth);
+        _sprite.SetDrawDepth((uid, args.Sprite), (byte)drawDepth);
     }
 }

--- a/Content.Client/Pointing/PointingSystem.cs
+++ b/Content.Client/Pointing/PointingSystem.cs
@@ -66,7 +66,7 @@ public sealed partial class PointingSystem
     private void OnArrowStartup(EntityUid uid, PointingArrowComponent component, ComponentStartup args)
     {
         if (TryComp<SpriteComponent>(uid, out var sprite))
-            _sprite.SetDrawDepth((uid, sprite), (int)DrawDepth.Overlays);
+            _sprite.SetDrawDepth((uid, sprite), (byte)DrawDepth.Overlays);
 
         BeginPointAnimation(uid, component.StartPosition, component.Offset, component.AnimationKey);
     }
@@ -75,7 +75,7 @@ public sealed partial class PointingSystem
     {
         if (TryComp<SpriteComponent>(uid, out var sprite))
         {
-            _sprite.SetDrawDepth((uid, sprite), (int)DrawDepth.Overlays);
+            _sprite.SetDrawDepth((uid, sprite), (byte)DrawDepth.Overlays);
             sprite.NoRotation = false;
         }
     }

--- a/Content.Client/Storage/Visualizers/EntityStorageVisualsComponent.cs
+++ b/Content.Client/Storage/Visualizers/EntityStorageVisualsComponent.cs
@@ -36,11 +36,11 @@ public sealed partial class EntityStorageVisualsComponent : Component
     /// The drawdepth the object has when it's open
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public int? OpenDrawDepth;
+    public byte? OpenDrawDepth;
 
     /// <summary>
     /// The drawdepth the object has when it's closed
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public int? ClosedDrawDepth;
+    public byte? ClosedDrawDepth;
 }

--- a/Content.Client/SubFloor/SubFloorHideSystem.cs
+++ b/Content.Client/SubFloor/SubFloorHideSystem.cs
@@ -91,8 +91,8 @@ public sealed partial class SubFloorHideSystem : SharedSubFloorHideSystem
         {
             // Allows sandbox mode to make wires visible over other stuff.
             component.OriginalDrawDepth ??= args.Sprite.DrawDepth;
-            var drawDepthDifference = Shared.DrawDepth.DrawDepth.ThickPipe - (Shared.DrawDepth.DrawDepth.Overdoors + 1);
-            _sprite.SetDrawDepth((uid, args.Sprite), args.Sprite.DrawDepth - drawDepthDifference);
+            var drawDepthDifference = (int) Shared.DrawDepth.DrawDepth.ThickPipe - ((int) Shared.DrawDepth.DrawDepth.Overdoors + 1);
+            _sprite.SetDrawDepth((uid, args.Sprite), (byte) (args.Sprite.DrawDepth - drawDepthDifference));
         }
         else if (scannerRevealed)
         {
@@ -100,8 +100,8 @@ public sealed partial class SubFloorHideSystem : SharedSubFloorHideSystem
             if (component.OriginalDrawDepth is not null)
                 return;
             component.OriginalDrawDepth = args.Sprite.DrawDepth;
-            var drawDepthDifference = Shared.DrawDepth.DrawDepth.ThickPipe - (Shared.DrawDepth.DrawDepth.Puddles + 1);
-            _sprite.SetDrawDepth((uid, args.Sprite), args.Sprite.DrawDepth - drawDepthDifference);
+            var drawDepthDifference = (int) Shared.DrawDepth.DrawDepth.ThickPipe - ((int) Shared.DrawDepth.DrawDepth.Puddles + 1);
+            _sprite.SetDrawDepth((uid, args.Sprite), (byte) (args.Sprite.DrawDepth - drawDepthDifference));
         }
         else if (component.OriginalDrawDepth.HasValue)
         {

--- a/Content.Client/Tabletop/TabletopSystem.cs
+++ b/Content.Client/Tabletop/TabletopSystem.cs
@@ -225,7 +225,7 @@ namespace Content.Client.Tabletop
 
             if (_appearance.TryGetData<int>(uid, TabletopItemVisuals.DrawDepth, out var drawDepth, args.Component))
             {
-                _sprite.SetDrawDepth((uid, args.Sprite), drawDepth);
+                _sprite.SetDrawDepth((uid, args.Sprite), (byte) drawDepth);
             }
         }
 

--- a/Content.Shared/Buckle/Components/BuckleComponent.cs
+++ b/Content.Shared/Buckle/Components/BuckleComponent.cs
@@ -69,7 +69,7 @@ public sealed partial class BuckleComponent : Component
     /// <summary>
     /// Used for client rendering
     /// </summary>
-    [ViewVariables] public int? OriginalDrawDepth;
+    [ViewVariables] public byte? OriginalDrawDepth;
 }
 
 public sealed partial class UnbuckleAlertEvent : BaseAlertEvent;

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -315,11 +315,11 @@ public sealed partial class DoorComponent : Component
     [DataField]
     public bool AllowMachineLayer;
 
-    [DataField(customTypeSerializer: typeof(ConstantSerializer<DrawDepthTag>))]
-    public int OpenDrawDepth = (int) DrawDepth.DrawDepth.Doors;
+    [DataField(customTypeSerializer: typeof(ByteConstantSerializer<DrawDepthTag>))]
+    public byte OpenDrawDepth = (byte) DrawDepth.DrawDepth.Doors;
 
-    [DataField(customTypeSerializer: typeof(ConstantSerializer<DrawDepthTag>))]
-    public int ClosedDrawDepth = (int) DrawDepth.DrawDepth.Doors;
+    [DataField(customTypeSerializer: typeof(ByteConstantSerializer<DrawDepthTag>))]
+    public byte ClosedDrawDepth = (byte) DrawDepth.DrawDepth.Doors;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/DrawDepth/DrawDepth.cs
+++ b/Content.Shared/DrawDepth/DrawDepth.cs
@@ -4,134 +4,136 @@ using DrawDepthTag = Robust.Shared.GameObjects.DrawDepth;
 namespace Content.Shared.DrawDepth
 {
     [ConstantsFor(typeof(DrawDepthTag))]
-    public enum DrawDepth
+    public enum DrawDepth : byte
     {
+        ContentDefault = 32,
+
         /// <summary>
         ///     This is for sub-floors, the floors you see after prying off a tile.
         /// </summary>
-        LowFloors = DrawDepthTag.Default - 22,
+        LowFloors = ContentDefault - 22,
 
         // various entity types that require different
         // draw depths, as to avoid hiding
         // If updating this set, update the gaps above Puddles and Overdoors.
         #region SubfloorEntities
-        ThickPipe = DrawDepthTag.Default - 21,
-        ThickWire = DrawDepthTag.Default - 20,
-        ThinPipeAlt2 = DrawDepthTag.Default - 19,
-        ThinPipeAlt1 = DrawDepthTag.Default - 18,
-        ThinPipe = DrawDepthTag.Default - 17,
-        ThinWire = DrawDepthTag.Default - 16,
+        ThickPipe = ContentDefault - 21,
+        ThickWire = ContentDefault - 20,
+        ThinPipeAlt2 = ContentDefault - 19,
+        ThinPipeAlt1 = ContentDefault - 18,
+        ThinPipe = ContentDefault - 17,
+        ThinWire = ContentDefault - 16,
         #endregion
 
         /// <summary>
         ///     Things that are beneath regular floors.
         /// </summary>
-        BelowFloor = DrawDepthTag.Default - 15,
+        BelowFloor = ContentDefault - 15,
 
         /// <summary>
         ///     Used for entities like carpets.
         /// </summary>
-        FloorTiles = DrawDepthTag.Default - 14,
+        FloorTiles = ContentDefault - 14,
 
         /// <summary>
         ///     Things that are actually right on the floor, like ice crust or atmos devices. This does not mean objects like
         ///     tables, even though they are technically "on the floor".
         /// </summary>
-        FloorObjects = DrawDepthTag.Default - 13,
+        FloorObjects = ContentDefault - 13,
 
         /// <summary>
-        //     Discrete drawdepth to avoid z-fighting with other FloorObjects but also above floor entities.
+        ///     Discrete drawdepth to avoid z-fighting with other FloorObjects but also above floor entities.
         /// </summary>
-        Puddles = DrawDepthTag.Default - 12,
+        Puddles = ContentDefault - 12,
 
         // NOTE: There's a gap for subfloor entities to retain relative draw depth when revealed by a t-ray scanner (need 6 layers in between).
 
         /// <summary>
-        //     Objects that are on the floor, but should render above puddles. This includes kudzu, holopads, telepads and levers.
+        ///     Objects that are on the floor, but should render above puddles. This includes kudzu, holopads, telepads and levers.
         /// </summary>
-        HighFloorObjects = DrawDepthTag.Default - 5,
+        HighFloorObjects = ContentDefault - 5,
 
-        DeadMobs = DrawDepthTag.Default - 4,
+        DeadMobs = ContentDefault - 4,
 
         /// <summary>
         ///     Allows small mobs like mice and drones to render under tables and chairs but above puddles and vents
         /// </summary>
-        SmallMobs = DrawDepthTag.Default - 3,
+        SmallMobs = ContentDefault - 3,
 
-        Walls = DrawDepthTag.Default - 2,
+        Walls = ContentDefault - 2,
 
         /// <summary>
         ///     Used for windows (grilles use walls) and misc signage. Useful if you want to have an APC in the middle
         ///     of some wall-art or something.
         /// </summary>
-        WallTops = DrawDepthTag.Default - 1,
+        WallTops = ContentDefault - 1,
 
         /// <summary>
         ///     Furniture, crates, tables. etc. If an entity should be drawn on top of a table, it needs a draw depth
         ///     that is higher than this.
         /// </summary>
-        Objects = DrawDepthTag.Default,
+        Objects = ContentDefault,
 
         /// <summary>
         ///     In-between an furniture and an item. Useful for entities that need to appear on top of tables, but are
         ///     not items. E.g., power cell chargers. Also useful for pizza boxes, which appear above crates, but not
         ///     above the pizza itself.
         /// </summary>
-        SmallObjects = DrawDepthTag.Default + 1,
+        SmallObjects = ContentDefault + 1,
 
         /// <summary>
         ///     Posters, APCs, air alarms, etc. This also includes most lights & lamps.
         /// </summary>
-        WallMountedItems = DrawDepthTag.Default + 2,
+        WallMountedItems = ContentDefault + 2,
 
         /// <summary>
         ///     To use for objects that would usually fall under SmallObjects, but appear taller than 1 tile. For example: Reagent Grinder
         /// </summary>
-        LargeObjects = DrawDepthTag.Default + 3,
+        LargeObjects = ContentDefault + 3,
 
         /// <summary>
         ///     Generic items. Things that should be above crates & tables, but underneath mobs.
         /// </summary>
-        Items = DrawDepthTag.Default + 4,
+        Items = ContentDefault + 4,
         /// <summary>
         /// Stuff that should be drawn below mobs, but on top of items. Like muzzle flash.
         /// </summary>
-        BelowMobs = DrawDepthTag.Default + 5,
+        BelowMobs = ContentDefault + 5,
 
-        Mobs = DrawDepthTag.Default + 6,
+        Mobs = ContentDefault + 6,
 
-        OverMobs = DrawDepthTag.Default + 7,
+        OverMobs = ContentDefault + 7,
 
-        Doors = DrawDepthTag.Default + 8,
+        Doors = ContentDefault + 8,
 
         /// <summary>
         /// Blast doors and shutters which go over the usual doors.
         /// </summary>
-        BlastDoors = DrawDepthTag.Default + 9,
+        BlastDoors = ContentDefault + 9,
 
         /// <summary>
         /// Stuff that needs to draw over most things, but not effects, like Kudzu.
         /// </summary>
-        Overdoors = DrawDepthTag.Default + 10,
+        Overdoors = ContentDefault + 10,
 
         // NOTE: There's a gap here for subfloor layers in mapping mode (need 6 layers in between)
 
         /// <summary>
         ///     Visible atmos gas.
         /// </summary>
-        Gasses = DrawDepthTag.Default + 17,
+        Gasses = ContentDefault + 17,
 
         /// <summary>
         ///     Explosions, fire, melee swings. Whatever.
         /// </summary>
-        Effects = DrawDepthTag.Default + 18,
+        Effects = ContentDefault + 18,
 
-        Ghosts = DrawDepthTag.Default + 19,
+        Ghosts = ContentDefault + 19,
 
         /// <summary>
         ///    Use this selectively if it absolutely needs to be drawn above (almost) everything else. Examples include
         ///    the pointing arrow, the drag & drop ghost-entity, and some debug tools.
         /// </summary>
-        Overlays = DrawDepthTag.Default + 20,
+        Overlays = ContentDefault + 20,
     }
 }

--- a/Content.Shared/DrawDepth/DrawDepth.cs
+++ b/Content.Shared/DrawDepth/DrawDepth.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.DrawDepth
     [ConstantsFor(typeof(DrawDepthTag))]
     public enum DrawDepth : byte
     {
-        ContentDefault = 32,
+        ContentDefault = DrawDepthTag.Default,
 
         /// <summary>
         ///     This is for sub-floors, the floors you see after prying off a tile.

--- a/Content.Shared/Sticky/Components/StickyVisualizerComponent.cs
+++ b/Content.Shared/Sticky/Components/StickyVisualizerComponent.cs
@@ -14,13 +14,13 @@ public sealed partial class StickyVisualizerComponent : Component
     /// What sprite draw depth gets set to when stuck to something.
     /// </summary>
     [DataField]
-    public int StuckDrawDepth = (int) DrawDepth.Overdoors;
+    public byte StuckDrawDepth = (byte) DrawDepth.Overdoors;
 
     /// <summary>
     /// The sprite's original draw depth before being stuck.
     /// </summary>
     [DataField]
-    public int OriginalDrawDepth;
+    public byte OriginalDrawDepth;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/SubFloor/SubFloorHideComponent.cs
+++ b/Content.Shared/SubFloor/SubFloorHideComponent.cs
@@ -49,6 +49,6 @@ namespace Content.Shared.SubFloor
         /// e.g. when a t-ray revealed cable is drawn above a carpet.
         /// </summary>
         [DataField]
-        public int? OriginalDrawDepth;
+        public byte? OriginalDrawDepth;
     }
 }


### PR DESCRIPTION
Requires https://github.com/space-wizards/RobustToolbox/pull/7002

## Breaking changes
- Sprite drawdepths are now stored as bytes.
- Default drawdepth was moved to 128.