### PR TITLE
Admin remarks notification

### DIFF
--- a/Content.Client/Options/UI/EscapeMenu.xaml
+++ b/Content.Client/Options/UI/EscapeMenu.xaml
@@ -1,4 +1,4 @@
-﻿<ui1:EscapeMenu xmlns="https://spacestation14.io"
+<ui1:EscapeMenu xmlns="https://spacestation14.io"
                 xmlns:changelog="clr-namespace:Content.Client.Changelog"
                 xmlns:ui="clr-namespace:Content.Client.Voting.UI"
                 xmlns:ui1="clr-namespace:Content.Client.Options.UI"
@@ -13,7 +13,8 @@
         <Button Access="Public" Name="GuidebookButton" Text="{Loc 'ui-escape-guidebook'}" StyleClasses="OpenBoth" />
         <Button Access="Public" Name="WikiButton" Text="{Loc 'ui-escape-wiki'}" StyleClasses="OpenBoth" />
         <changelog:ChangelogButton Access="Public" Name="ChangelogButton" StyleClasses="OpenBoth"/>
-        <Button Access="Public" Name="FeedbackButton" Text="{Loc 'ui-escape-feedback'}" StyleClasses="OpenRight"/>
+        <Button Access="Public" Name="FeedbackButton" Text="{Loc 'ui-escape-feedback'}" StyleClasses="OpenBoth"/>
+        <Button Access="Public" Name="AdminRemarksButton" Text="{Loc 'ui-escape-remarks'}" StyleClasses="OpenRight"/>
         <PanelContainer StyleClasses="LowDivider" Margin="0 2.5 0 2.5" />
         <Button Access="Public" Name="OptionsButton" Text="{Loc 'ui-escape-options'}" />
         <PanelContainer StyleClasses="LowDivider" Margin="0 2.5 0 2.5" />

--- a/Content.Client/UserInterface/Systems/EscapeMenu/EscapeUIController.cs
+++ b/Content.Client/UserInterface/Systems/EscapeMenu/EscapeUIController.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client.FeedbackPopup;
+using Content.Client.FeedbackPopup;
 using Content.Client.Gameplay;
 using Content.Client.UserInterface.Controls;
 using Content.Client.UserInterface.Systems.Guidebook;
@@ -101,6 +101,12 @@ public sealed partial class EscapeUIController : UIController, IOnStateEntered<G
             _console.ExecuteCommand("quit");
         };
 
+        _escapeWindow.AdminRemarksButton.OnPressed += _ =>
+        {
+            CloseEscapeWindow();
+            _console.ExecuteCommand("adminremarks");
+        };
+
         _escapeWindow.WikiButton.OnPressed += _ =>
         {
             _uri.OpenUri(_cfg.GetCVar(CCVars.InfoLinksWiki));
@@ -113,6 +119,7 @@ public sealed partial class EscapeUIController : UIController, IOnStateEntered<G
 
         // Hide wiki button if we don't have a link for it.
         _escapeWindow.WikiButton.Visible = _cfg.GetCVar(CCVars.InfoLinksWiki) != "";
+        _escapeWindow.AdminRemarksButton.Disabled = !_cfg.GetCVar(CCVars.SeeOwnNotes);
 
         CommandBinds.Builder
             .Bind(EngineKeyFunctions.EscapeMenu,

--- a/Content.Client/UserInterface/Systems/EscapeMenu/EscapeUIController.cs
+++ b/Content.Client/UserInterface/Systems/EscapeMenu/EscapeUIController.cs
@@ -27,6 +27,7 @@ public sealed partial class EscapeUIController : UIController, IOnStateEntered<G
     [Dependency] private OptionsUIController _options = default!;
     [Dependency] private GuidebookUIController _guidebook = default!;
     [Dependency] private FeedbackPopupUIController _feedback = null!;
+    [Dependency] private ILocalizationManager _loc = default!;
 
     private Options.UI.EscapeMenu? _escapeWindow;
 
@@ -119,7 +120,8 @@ public sealed partial class EscapeUIController : UIController, IOnStateEntered<G
 
         // Hide wiki button if we don't have a link for it.
         _escapeWindow.WikiButton.Visible = _cfg.GetCVar(CCVars.InfoLinksWiki) != "";
-        _escapeWindow.AdminRemarksButton.Disabled = !_cfg.GetCVar(CCVars.SeeOwnNotes);
+
+        _cfg.OnValueChanged(CCVars.SeeOwnNotes, OnSeeOwnNotesChanged, true);
 
         CommandBinds.Builder
             .Bind(EngineKeyFunctions.EscapeMenu,
@@ -129,6 +131,8 @@ public sealed partial class EscapeUIController : UIController, IOnStateEntered<G
 
     public void OnStateExited(GameplayState state)
     {
+        _cfg.UnsubValueChanged(CCVars.SeeOwnNotes, OnSeeOwnNotesChanged);
+
         if (_escapeWindow != null)
         {
             _escapeWindow.Dispose();
@@ -136,6 +140,17 @@ public sealed partial class EscapeUIController : UIController, IOnStateEntered<G
         }
 
         CommandBinds.Unregister<EscapeUIController>();
+    }
+
+    private void OnSeeOwnNotesChanged(bool seeOwnNotes)
+    {
+        if (_escapeWindow == null)
+            return;
+
+        _escapeWindow.AdminRemarksButton.Disabled = !seeOwnNotes;
+        _escapeWindow.AdminRemarksButton.ToolTip = !seeOwnNotes
+            ? _loc.GetString("ui-escape-remarks-button-disabled")
+            : null;
     }
 
     private void EscapeButtonOnOnPressed(ButtonEventArgs obj)

--- a/Content.Server/Administration/Notes/AdminNotesManager.cs
+++ b/Content.Server/Administration/Notes/AdminNotesManager.cs
@@ -172,11 +172,11 @@ public sealed partial class AdminNotesManager : IAdminNotesManager, IPostInjectI
         );
         NoteAdded?.Invoke(note);
 
-        if (_player.TryGetSessionById(netUserId, out var session) && !secret
-            && type == NoteType.Note)
+        // Send a notification to the player that they received a non-secret note.
+        if (_player.TryGetSessionById(netUserId, out var session) && !secret && type == NoteType.Note)
         {
-            var notifMessage = _config.GetCVar(CCVars.SeeOwnNotes) ? "Your account has received an administration note, for more information, run the command \"adminremarks.\"" +
-                " in the console." : "Your account has received an administration note.";
+            var notifMessage = _config.GetCVar(CCVars.SeeOwnNotes) ? _loc.GetString("admin-notes-manager-note-notification")
+                : _loc.GetString("admin-notes-manager-note-notification-no-cvar");
             var notifAudio = new SoundPathSpecifier("/Audio/Effects/adminhelp.ogg");
             var audioSystem = _systems.GetEntitySystem<SharedAudioSystem>();
 

--- a/Content.Server/Administration/Notes/AdminNotesManager.cs
+++ b/Content.Server/Administration/Notes/AdminNotesManager.cs
@@ -174,8 +174,8 @@ public sealed partial class AdminNotesManager : IAdminNotesManager, IPostInjectI
         NoteAdded?.Invoke(note);
 
         // Send a notification to the player that they received a non-secret note.
-        if (_player.TryGetSessionById(netUserId, out var session) && !secret && type == NoteType.Note
-            && _config.GetCVar(CCVars.SeeOwnNotes))
+        if (!secret && type == NoteType.Note
+            && _player.TryGetSessionById(netUserId, out var session) && _config.GetCVar(CCVars.SeeOwnNotes))
         {
             _systems.TryGetEntitySystem(out SharedAudioSystem? audio);
             var notifMessage = _loc.GetString("admin-notes-manager-note-notification");

--- a/Content.Server/Administration/Notes/AdminNotesManager.cs
+++ b/Content.Server/Administration/Notes/AdminNotesManager.cs
@@ -33,11 +33,14 @@ public sealed partial class AdminNotesManager : IAdminNotesManager, IPostInjectI
 
     public const string SawmillId = "admin.notes";
 
+    private readonly SoundPathSpecifier _noteNotificationSound = new("/Audio/Effects/adminhelp.ogg");
+
     public event Action<SharedAdminNote>? NoteAdded;
     public event Action<SharedAdminNote>? NoteModified;
     public event Action<SharedAdminNote>? NoteDeleted;
 
     private ISawmill _sawmill = default!;
+
 
     public bool CanCreate(ICommonSession admin)
     {
@@ -176,12 +179,11 @@ public sealed partial class AdminNotesManager : IAdminNotesManager, IPostInjectI
         if (_player.TryGetSessionById(netUserId, out var session) && !secret && type == NoteType.Note)
         {
             var audioSystem = _systems.GetEntitySystem<SharedAudioSystem>();
-            var notifAudio = new SoundPathSpecifier("/Audio/Effects/adminhelp.ogg");
             var notifMessage = _config.GetCVar(CCVars.SeeOwnNotes) ? _loc.GetString("admin-notes-manager-note-notification")
                 : _loc.GetString("admin-notes-manager-note-notification-no-cvar");
 
             _chat.DispatchServerMessage(session, notifMessage);
-            audioSystem.PlayGlobal(notifAudio, Filter.SinglePlayer(session), false, AudioParams.Default.AddVolume(-7f));
+            audioSystem.PlayGlobal(_noteNotificationSound, Filter.SinglePlayer(session), false, AudioParams.Default.AddVolume(-7f));
         }
     }
 

--- a/Content.Server/Administration/Notes/AdminNotesManager.cs
+++ b/Content.Server/Administration/Notes/AdminNotesManager.cs
@@ -182,7 +182,7 @@ public sealed partial class AdminNotesManager : IAdminNotesManager, IPostInjectI
             var notifSound = new SoundPathSpecifier(_config.GetCVar(CCVars.AHelpSound));
 
             _chat.DispatchServerMessage(session, notifMessage);
-            audio?.PlayGlobal(notifSound, Filter.SinglePlayer(session), false, AudioParams.Default.AddVolume(-7f));
+            audio?.PlayGlobal(notifSound, session, AudioParams.Default.AddVolume(-7f));
         }
     }
 

--- a/Content.Server/Administration/Notes/AdminNotesManager.cs
+++ b/Content.Server/Administration/Notes/AdminNotesManager.cs
@@ -33,8 +33,6 @@ public sealed partial class AdminNotesManager : IAdminNotesManager, IPostInjectI
 
     public const string SawmillId = "admin.notes";
 
-    private readonly SoundPathSpecifier _noteNotificationSound = new("/Audio/Effects/adminhelp.ogg");
-
     public event Action<SharedAdminNote>? NoteAdded;
     public event Action<SharedAdminNote>? NoteModified;
     public event Action<SharedAdminNote>? NoteDeleted;
@@ -176,14 +174,15 @@ public sealed partial class AdminNotesManager : IAdminNotesManager, IPostInjectI
         NoteAdded?.Invoke(note);
 
         // Send a notification to the player that they received a non-secret note.
-        if (_player.TryGetSessionById(netUserId, out var session) && !secret && type == NoteType.Note)
+        if (_player.TryGetSessionById(netUserId, out var session) && !secret && type == NoteType.Note
+            && _config.GetCVar(CCVars.SeeOwnNotes))
         {
-            var audioSystem = _systems.GetEntitySystem<SharedAudioSystem>();
-            var notifMessage = _config.GetCVar(CCVars.SeeOwnNotes) ? _loc.GetString("admin-notes-manager-note-notification")
-                : _loc.GetString("admin-notes-manager-note-notification-no-cvar");
+            _systems.TryGetEntitySystem(out SharedAudioSystem? audio);
+            var notifMessage = _loc.GetString("admin-notes-manager-note-notification");
+            var notifSound = new SoundPathSpecifier(_config.GetCVar(CCVars.AHelpSound));
 
             _chat.DispatchServerMessage(session, notifMessage);
-            audioSystem.PlayGlobal(_noteNotificationSound, Filter.SinglePlayer(session), false, AudioParams.Default.AddVolume(-7f));
+            audio?.PlayGlobal(notifSound, Filter.SinglePlayer(session), false, AudioParams.Default.AddVolume(-7f));
         }
     }
 

--- a/Content.Server/Administration/Notes/AdminNotesManager.cs
+++ b/Content.Server/Administration/Notes/AdminNotesManager.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Threading.Tasks;
 using Content.Server.Administration.Managers;
+using Content.Server.Chat.Managers;
 using Content.Server.Database;
 using Content.Server.EUI;
 using Content.Server.GameTicking;
@@ -9,6 +10,9 @@ using Content.Shared.Administration.Notes;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
 using Content.Shared.Players.PlayTimeTracking;
+using Robust.Server.Player;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
@@ -23,6 +27,9 @@ public sealed partial class AdminNotesManager : IAdminNotesManager, IPostInjectI
     [Dependency] private EuiManager _euis = default!;
     [Dependency] private IEntitySystemManager _systems = default!;
     [Dependency] private IConfigurationManager _config = default!;
+    [Dependency] private IPlayerManager _player = default!;
+    [Dependency] private ILocalizationManager _loc = default!;
+    [Dependency] private IChatManager _chat = default!;
 
     public const string SawmillId = "admin.notes";
 
@@ -70,12 +77,13 @@ public sealed partial class AdminNotesManager : IAdminNotesManager, IPostInjectI
 
     public async Task AddAdminRemark(ICommonSession createdBy, Guid player, NoteType type, string message, NoteSeverity? severity, bool secret, DateTime? expiryTime)
     {
+        var netUserId = (NetUserId)player;
         message = message.Trim();
 
         // There's a foreign key constraint in place here. If there's no player record, it will fail.
         // Not like there's much use in adding notes on accounts that have never connected.
         // You can still ban them just fine, which is why we should allow admins to view their bans with the notes panel
-        if (await _db.GetPlayerRecordByUserId((NetUserId) player) is null)
+        if (await _db.GetPlayerRecordByUserId(netUserId) is null)
             return;
 
         var sb = new StringBuilder($"{createdBy.Name} added a");
@@ -163,6 +171,18 @@ public sealed partial class AdminNotesManager : IAdminNotesManager, IPostInjectI
             seen
         );
         NoteAdded?.Invoke(note);
+
+        if (_player.TryGetSessionById(netUserId, out var session) && !secret
+            && type == NoteType.Note)
+        {
+            var notifMessage = _config.GetCVar(CCVars.SeeOwnNotes) ? "Your account has received an administration note, for more information, run the command \"adminremarks.\"" +
+                " in the console." : "Your account has received an administration note.";
+            var notifAudio = new SoundPathSpecifier("/Audio/Effects/adminhelp.ogg");
+            var audioSystem = _systems.GetEntitySystem<SharedAudioSystem>();
+
+            _chat.DispatchServerMessage(session, notifMessage);
+            audioSystem.PlayGlobal(notifAudio, Filter.SinglePlayer(session), false, AudioParams.Default.AddVolume(-7f));
+        }
     }
 
     private async Task<SharedAdminNote?> GetAdminRemark(int id, NoteType type)

--- a/Content.Server/Administration/Notes/AdminNotesManager.cs
+++ b/Content.Server/Administration/Notes/AdminNotesManager.cs
@@ -175,10 +175,10 @@ public sealed partial class AdminNotesManager : IAdminNotesManager, IPostInjectI
         // Send a notification to the player that they received a non-secret note.
         if (_player.TryGetSessionById(netUserId, out var session) && !secret && type == NoteType.Note)
         {
+            var audioSystem = _systems.GetEntitySystem<SharedAudioSystem>();
+            var notifAudio = new SoundPathSpecifier("/Audio/Effects/adminhelp.ogg");
             var notifMessage = _config.GetCVar(CCVars.SeeOwnNotes) ? _loc.GetString("admin-notes-manager-note-notification")
                 : _loc.GetString("admin-notes-manager-note-notification-no-cvar");
-            var notifAudio = new SoundPathSpecifier("/Audio/Effects/adminhelp.ogg");
-            var audioSystem = _systems.GetEntitySystem<SharedAudioSystem>();
 
             _chat.DispatchServerMessage(session, notifMessage);
             audioSystem.PlayGlobal(notifAudio, Filter.SinglePlayer(session), false, AudioParams.Default.AddVolume(-7f));

--- a/Content.Shared/CCVar/CCVars.Admin.Ahelp.cs
+++ b/Content.Shared/CCVar/CCVars.Admin.Ahelp.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Configuration;
+using Robust.Shared.Configuration;
 
 namespace Content.Shared.CCVar;
 
@@ -38,4 +38,11 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<int> AhelpQuickInfoStartWordSize =
         CVarDef.Create("ahelp.quick_info_start_word_size", 4, CVar.SERVERONLY);
+
+    /// <summary>
+    /// The path to the sound played on some admin interactions to the client.
+    /// </summary>
+    /// <seealso cref="CCVars.BwoinkSoundEnabled"/>
+    public static readonly CVarDef<string> AHelpSound =
+        CVarDef.Create("audio.ahelp_sound", "/Audio/Effects/adminhelp.ogg", CVar.SERVER | CVar.REPLICATED | CVar.ARCHIVE);
 }

--- a/Content.Shared/CCVar/CCVars.Sounds.cs
+++ b/Content.Shared/CCVar/CCVars.Sounds.cs
@@ -31,7 +31,4 @@ public sealed partial class CCVars
 
     public static readonly CVarDef<float> AdminChatSoundVolume =
         CVarDef.Create("audio.admin_chat_sound_volume", -5f, CVar.ARCHIVE | CVar.CLIENT | CVar.REPLICATED);
-
-    public static readonly CVarDef<string> AHelpSound =
-        CVarDef.Create("audio.ahelp_sound", "/Audio/Effects/adminhelp.ogg", CVar.SERVER | CVar.REPLICATED | CVar.ARCHIVE);
 }

--- a/Content.Shared/CCVar/CCVars.Sounds.cs
+++ b/Content.Shared/CCVar/CCVars.Sounds.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Configuration;
+using Robust.Shared.Configuration;
 
 namespace Content.Shared.CCVar;
 
@@ -33,5 +33,5 @@ public sealed partial class CCVars
         CVarDef.Create("audio.admin_chat_sound_volume", -5f, CVar.ARCHIVE | CVar.CLIENT | CVar.REPLICATED);
 
     public static readonly CVarDef<string> AHelpSound =
-        CVarDef.Create("audio.ahelp_sound", "/Audio/Effects/adminhelp.ogg", CVar.ARCHIVE | CVar.CLIENTONLY);
+        CVarDef.Create("audio.ahelp_sound", "/Audio/Effects/adminhelp.ogg", CVar.SERVER | CVar.REPLICATED | CVar.ARCHIVE);
 }

--- a/Resources/Locale/en-US/administration/managers/admin-notes-manager.ftl
+++ b/Resources/Locale/en-US/administration/managers/admin-notes-manager.ftl
@@ -1,1 +1,1 @@
-admin-notes-manager-note-notification = Your account has received an administration note, for more information run the command "adminremarks" in the console.
+admin-notes-manager-note-notification = Your account has received an administrative note. For further information, open the admin remarks panel via the escape menu.

--- a/Resources/Locale/en-US/administration/managers/admin-notes-manager.ftl
+++ b/Resources/Locale/en-US/administration/managers/admin-notes-manager.ftl
@@ -1,0 +1,2 @@
+admin-notes-manager-note-notification = Your account has received an administration note, for more information run the command "adminremarks" in the console.
+admin-notes-manager-note-notification-no-cvar = Your account has received an administration note.

--- a/Resources/Locale/en-US/administration/managers/admin-notes-manager.ftl
+++ b/Resources/Locale/en-US/administration/managers/admin-notes-manager.ftl
@@ -1,2 +1,1 @@
 admin-notes-manager-note-notification = Your account has received an administration note, for more information run the command "adminremarks" in the console.
-admin-notes-manager-note-notification-no-cvar = Your account has received an administration note.

--- a/Resources/Locale/en-US/escape-menu/ui/escape-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/escape-menu.ftl
@@ -9,3 +9,5 @@ ui-escape-disconnect = Disconnect
 ui-escape-quit = Quit
 ui-escape-feedback = Feedback
 ui-escape-remarks = Admin Remarks
+
+ui-escape-remarks-button-disabled = This functionality has been disabled by the server.

--- a/Resources/Locale/en-US/escape-menu/ui/escape-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/escape-menu.ftl
@@ -8,3 +8,4 @@ ui-escape-wiki = Wiki
 ui-escape-disconnect = Disconnect
 ui-escape-quit = Quit
 ui-escape-feedback = Feedback
+ui-escape-remarks = Admin Remarks


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I added a sound cue and message that the player receives when their account receives an admin note, also added a button in the escape menu that opens the admin remarks panel.

## Why / Balance
Right now, the only way for a player to know if they received an administration note is via communication in ahelps, or by keeping the admin remarks popup open. This change improves transparency between player and admin, for example in case the admin forgets to notify the player themselves, and adds a useful button to the escape menu.

## Technical details
Logic is pretty straightforward, the admin remarks button is greyed out if `CCVars.SeeOwnNotes` is false, making sure that it is unselectable should the server require it. `CCVar.AhelpSound` is now server authoritative and synched between client and server.

## Test plan
1) Run two clients.
2) Give an admin note to your second client from the first one.
3) Listen to the audio cue and read the message in chat.

## Media


https://github.com/user-attachments/assets/3b4d77cd-fbdd-4c28-af62-2824d184532b


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
- add: New sound cue and notification dispatched to the chat when a player receives an administration note.
- add: New button in the escape button that opens the admin remarks panel.
