### PR TITLE
Fix initial display of turret control window

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/DeviceNetworkSystem.cs
@@ -145,7 +145,10 @@ namespace Content.Server.DeviceNetwork.Systems
                 _configurator.OnDeviceShutdown(list, (uid, component));
             }
 
-            GetNetwork(component.DeviceNetId).Remove(component);
+            if (GetNetwork(component.DeviceNetId).Remove(component))
+            {
+                RaiseLocalEvent(uid, new DeviceNetworkDisconnectedEvent());
+            }
         }
 
         /// <summary>
@@ -157,7 +160,12 @@ namespace Content.Server.DeviceNetwork.Systems
             if (!Resolve(uid, ref device, false))
                 return false;
 
-            return GetNetwork(device.DeviceNetId).Add(device);
+            if (GetNetwork(device.DeviceNetId).Add(device))
+            {
+                RaiseLocalEvent(uid, new DeviceNetworkConnectedEvent());
+                return true;
+            }
+            return false;
         }
 
         /// <summary>
@@ -172,7 +180,12 @@ namespace Content.Server.DeviceNetwork.Systems
             if (preventAutoConnect)
                 device.AutoConnect = false;
 
-            return GetNetwork(device.DeviceNetId).Remove(device);
+            if (GetNetwork(device.DeviceNetId).Remove(device))
+            {
+                RaiseLocalEvent(uid, new DeviceNetworkDisconnectedEvent());
+                return true;
+            }
+            return false;
         }
 
         /// <summary>

--- a/Content.Server/TurretController/DeployableTurretControllerSystem.cs
+++ b/Content.Server/TurretController/DeployableTurretControllerSystem.cs
@@ -34,6 +34,31 @@ public sealed partial class DeployableTurretControllerSystem : SharedDeployableT
         SubscribeLocalEvent<DeployableTurretControllerComponent, DeviceNetworkPacketEvent>(OnPacketReceived);
     }
 
+    [SubscribeLocalEvent]
+    private void OnNetworkConnection(Entity<DeployableTurretControllerComponent> ent, ref DeviceNetworkConnectedEvent args)
+    {
+        if (!TryComp<DeviceNetworkComponent>(ent, out var device))
+            return;
+
+        // On a new network, so find new connected devices
+        ent.Comp.LinkedTurrets = new();
+
+        var payload = new NetworkPayload
+        {
+            [DeviceNetworkConstants.Command] = DeviceNetworkConstants.CmdUpdatedState,
+        };
+
+        _deviceNetwork.QueuePacket(ent, null, payload, device: device);
+        UpdateUIState(ent);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnNetworkDisconnect(Entity<DeployableTurretControllerComponent> ent, ref DeviceNetworkDisconnectedEvent args)
+    {
+        ent.Comp.LinkedTurrets = new();
+        UpdateUIState(ent);
+    }
+
     private void OnBUIOpened(Entity<DeployableTurretControllerComponent> ent, ref BoundUIOpenedEvent args)
     {
         UpdateUIState(ent);

--- a/Content.Server/Turrets/DeployableTurretSystem.cs
+++ b/Content.Server/Turrets/DeployableTurretSystem.cs
@@ -45,6 +45,12 @@ public sealed partial class DeployableTurretSystem : SharedDeployableTurretSyste
         SubscribeLocalEvent<DeployableTurretComponent, BeforeBroadcastAttemptEvent>(OnBeforeBroadcast);
     }
 
+    [SubscribeLocalEvent]
+    private void OnNetworkConnection(Entity<DeployableTurretComponent> ent, ref DeviceNetworkConnectedEvent args)
+    {
+        SendStateUpdateToDeviceNetwork(ent);
+    }
+
     private void OnAmmoShot(Entity<DeployableTurretComponent> ent, ref AmmoShotEvent args)
     {
         UpdateAmmoStatus(ent);

--- a/Content.Shared/DeviceNetwork/Events/ConnectionEvents.cs
+++ b/Content.Shared/DeviceNetwork/Events/ConnectionEvents.cs
@@ -1,0 +1,15 @@
+namespace Content.Shared.DeviceNetwork.Events;
+
+/// <summary>
+/// Event raised when a device is connected to a network
+/// </summary>
+public sealed class DeviceNetworkConnectedEvent : EntityEventArgs
+{
+}
+
+/// <summary>
+/// Event raised when a device is disconnected from a network
+/// </summary>
+public sealed class DeviceNetworkDisconnectedEvent : EntityEventArgs
+{
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

When you open the turret control window the first time, you're presented with:

<img width="590" height="569" alt="2026-08-16_15-04" src="https://github.com/user-attachments/assets/5dca4d9b-e3da-4f61-a469-b51394bae0b5" />

Note that it claims "No linked devices" - the UI will report this even if there *are* linked devices. After pressing one of the inactive/stun/lethal buttons, the linked devices list will be populated.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bugfix

## Technical details
<!-- Summary of code changes for easier review. -->

Turret control only kept track of connected devices if they sent a status update. Now, when connecting a turret to the device network, they can send a status update so the controller is aware of them. When the controller is connected, request a status update from all devices on the network.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

`forcemap packed`
`startround`

Move to AI room, open a turret control panel, observe that there are non-empty "linked devices".

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
