### PR TITLE
Pause passive regen for 5 seconds after taking damage

### DIFF
--- a/Content.Shared/Damage/Components/PassiveDamageComponent.cs
+++ b/Content.Shared/Damage/Components/PassiveDamageComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Damage.Components;
 /// <summary>
 /// Passively damages the entity on a specified interval.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class PassiveDamageComponent : Component
 {
     /// <summary>
@@ -27,7 +27,7 @@ public sealed partial class PassiveDamageComponent : Component
     /// Delay between damage events in seconds
     /// </summary>
     [DataField]
-    public float Interval = 1f;
+    public TimeSpan Interval = TimeSpan.FromSeconds(1);
 
     [DataField("nextDamage", customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
     public TimeSpan NextDamage = TimeSpan.Zero;
@@ -36,5 +36,5 @@ public sealed partial class PassiveDamageComponent : Component
     /// How long to pause the passive health change after damage has been taken.
     /// </summary>
     [DataField]
-    public float IntervalHaltOnDamageTaken;
+    public TimeSpan IntervalHaltOnDamageTaken = TimeSpan.Zero;
 }

--- a/Content.Shared/Damage/Components/PassiveDamageComponent.cs
+++ b/Content.Shared/Damage/Components/PassiveDamageComponent.cs
@@ -31,4 +31,10 @@ public sealed partial class PassiveDamageComponent : Component
 
     [DataField("nextDamage", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan NextDamage = TimeSpan.Zero;
+
+    /// <summary>
+    /// How long to pause the passive health change after damage has been taken.
+    /// </summary>
+    [DataField]
+    public float IntervalHaltOnDamageTaken;
 }

--- a/Content.Shared/Damage/Components/PassiveDamageComponent.cs
+++ b/Content.Shared/Damage/Components/PassiveDamageComponent.cs
@@ -8,33 +8,36 @@ namespace Content.Shared.Damage.Components;
 /// <summary>
 /// Passively damages the entity on a specified interval.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class PassiveDamageComponent : Component
 {
     /// <summary>
     /// The entitys' states that passive damage will apply in
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public List<MobState> AllowedStates = new();
 
     /// <summary>
     /// Damage / Healing per interval dealt to the entity every interval
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public DamageSpecifier Damage = new();
 
     /// <summary>
     /// Delay between damage events in seconds
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public TimeSpan Interval = TimeSpan.FromSeconds(1);
 
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
-    public TimeSpan NextDamage = TimeSpan.Zero;
+    /// <summary>
+    /// The next time the damage should occur at.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
+    public TimeSpan NextDamage;
 
     /// <summary>
     /// How long to pause the passive health change after damage has been taken.
     /// </summary>
-    [DataField]
-    public TimeSpan IntervalHaltOnDamageTaken = TimeSpan.Zero;
+    [DataField, AutoNetworkedField]
+    public TimeSpan IntervalHaltOnDamageTaken;
 }

--- a/Content.Shared/Damage/Components/PassiveDamageComponent.cs
+++ b/Content.Shared/Damage/Components/PassiveDamageComponent.cs
@@ -29,7 +29,7 @@ public sealed partial class PassiveDamageComponent : Component
     [DataField]
     public TimeSpan Interval = TimeSpan.FromSeconds(1);
 
-    [DataField("nextDamage", customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
     public TimeSpan NextDamage = TimeSpan.Zero;
 
     /// <summary>

--- a/Content.Shared/Damage/Components/PassiveDamageComponent.cs
+++ b/Content.Shared/Damage/Components/PassiveDamageComponent.cs
@@ -14,22 +14,22 @@ public sealed partial class PassiveDamageComponent : Component
     /// <summary>
     /// The entitys' states that passive damage will apply in
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public List<MobState> AllowedStates = new();
 
     /// <summary>
     /// Damage / Healing per interval dealt to the entity every interval
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public DamageSpecifier Damage = new();
 
     /// <summary>
     /// Delay between damage events in seconds
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float Interval = 1f;
 
-    [DataField("nextDamage", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
+    [DataField("nextDamage", customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
     public TimeSpan NextDamage = TimeSpan.Zero;
 
     /// <summary>

--- a/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
@@ -51,7 +51,7 @@ public sealed partial class PassiveDamageSystem : EntitySystem
 
             // Set the next time they can take damage
             comp.NextDamage = curTime + TimeSpan.FromSeconds(1f);
-            Dirty<PassiveDamageComponent>((uid, comp));
+            Dirty(uid, comp);
 
             // Damage them
             foreach (var allowedState in comp.AllowedStates)

--- a/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
@@ -9,17 +9,24 @@ public sealed partial class PassiveDamageSystem : EntitySystem
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private IGameTiming _timing = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
+    #region Subscriptions
 
-        SubscribeLocalEvent<PassiveDamageComponent, MapInitEvent>(OnPendingMapInit);
-    }
-
+    [SubscribeLocalEvent]
     private void OnPendingMapInit(EntityUid uid, PassiveDamageComponent component, MapInitEvent args)
     {
         component.NextDamage = _timing.CurTime + TimeSpan.FromSeconds(1f);
     }
+
+    [SubscribeLocalEvent]
+    private void OnDamageTaken(EntityUid ent, PassiveDamageComponent component, DamageDealtEvent args)
+    {
+        if (component.IntervalHaltOnDamageTaken == 0f || !args.Damage.AnyPositive())
+            return;
+
+        component.NextDamage = _timing.CurTime + TimeSpan.FromSeconds(1f + component.IntervalHaltOnDamageTaken);
+    }
+
+    #endregion
 
     // Every tick, attempt to damage entities
     public override void Update(float frameTime)

--- a/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
@@ -21,10 +21,10 @@ public sealed partial class PassiveDamageSystem : EntitySystem
     [SubscribeLocalEvent]
     private void OnDamageTaken(EntityUid ent, PassiveDamageComponent component, DamageDealtEvent args)
     {
-        if (component.IntervalHaltOnDamageTaken == 0f || !args.Damage.AnyPositive())
+        if (component.IntervalHaltOnDamageTaken == TimeSpan.Zero || !args.Damage.AnyPositive())
             return;
 
-        var proposedUpdateTime = _timing.CurTime + TimeSpan.FromSeconds(component.IntervalHaltOnDamageTaken);
+        var proposedUpdateTime = _timing.CurTime + component.IntervalHaltOnDamageTaken;
         if (proposedUpdateTime > component.NextDamage)
         {
             component.NextDamage = proposedUpdateTime;

--- a/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
@@ -27,6 +27,7 @@ public sealed partial class PassiveDamageSystem : EntitySystem
         if (proposedUpdateTime > component.NextDamage)
             component.NextDamage = proposedUpdateTime;
 
+        Dirty<PassiveDamageComponent>((ent, component));
     }
 
     #endregion

--- a/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
@@ -23,7 +23,10 @@ public sealed partial class PassiveDamageSystem : EntitySystem
         if (component.IntervalHaltOnDamageTaken == 0f || !args.Damage.AnyPositive())
             return;
 
-        component.NextDamage = _timing.CurTime + TimeSpan.FromSeconds(1f + component.IntervalHaltOnDamageTaken);
+        var proposedUpdateTime = _timing.CurTime + TimeSpan.FromSeconds(component.IntervalHaltOnDamageTaken);
+        if (proposedUpdateTime > component.NextDamage)
+            component.NextDamage = proposedUpdateTime;
+
     }
 
     #endregion

--- a/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
@@ -25,9 +25,11 @@ public sealed partial class PassiveDamageSystem : EntitySystem
 
         var proposedUpdateTime = _timing.CurTime + TimeSpan.FromSeconds(component.IntervalHaltOnDamageTaken);
         if (proposedUpdateTime > component.NextDamage)
+        {
             component.NextDamage = proposedUpdateTime;
+            Dirty<PassiveDamageComponent>((ent, component));
+        }
 
-        Dirty<PassiveDamageComponent>((ent, component));
     }
 
     #endregion

--- a/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
@@ -12,23 +12,23 @@ public sealed partial class PassiveDamageSystem : EntitySystem
     #region Subscriptions
 
     [SubscribeLocalEvent]
-    private void OnPendingMapInit(EntityUid uid, PassiveDamageComponent component, MapInitEvent args)
+    private void OnPendingMapInit(Entity<PassiveDamageComponent> ent, ref MapInitEvent args)
     {
-        component.NextDamage = _timing.CurTime + TimeSpan.FromSeconds(1f);
-        Dirty<PassiveDamageComponent>((uid, component));
+        ent.Comp.NextDamage = _timing.CurTime + TimeSpan.FromSeconds(1f);
+        Dirty(ent);
     }
 
     [SubscribeLocalEvent]
-    private void OnDamageTaken(EntityUid ent, PassiveDamageComponent component, DamageDealtEvent args)
+    private void OnDamageTaken(Entity<PassiveDamageComponent> ent, ref DamageDealtEvent args)
     {
-        if (component.IntervalHaltOnDamageTaken == TimeSpan.Zero || !args.Damage.AnyPositive())
+        if (ent.Comp.IntervalHaltOnDamageTaken == TimeSpan.Zero || !args.Damage.AnyPositive())
             return;
 
-        var proposedUpdateTime = _timing.CurTime + component.IntervalHaltOnDamageTaken;
-        if (proposedUpdateTime > component.NextDamage)
+        var proposedUpdateTime = _timing.CurTime + ent.Comp.IntervalHaltOnDamageTaken;
+        if (proposedUpdateTime > ent.Comp.NextDamage)
         {
-            component.NextDamage = proposedUpdateTime;
-            Dirty<PassiveDamageComponent>((ent, component));
+            ent.Comp.NextDamage = proposedUpdateTime;
+            Dirty(ent);
         }
 
     }

--- a/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
@@ -15,6 +15,7 @@ public sealed partial class PassiveDamageSystem : EntitySystem
     private void OnPendingMapInit(EntityUid uid, PassiveDamageComponent component, MapInitEvent args)
     {
         component.NextDamage = _timing.CurTime + TimeSpan.FromSeconds(1f);
+        Dirty<PassiveDamageComponent>((uid, component));
     }
 
     [SubscribeLocalEvent]
@@ -50,6 +51,7 @@ public sealed partial class PassiveDamageSystem : EntitySystem
 
             // Set the next time they can take damage
             comp.NextDamage = curTime + TimeSpan.FromSeconds(1f);
+            Dirty<PassiveDamageComponent>((uid, comp));
 
             // Damage them
             foreach (var allowedState in comp.AllowedStates)

--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -114,7 +114,7 @@
   - type: Damageable
     damageModifierSet: Slime
   - type: PassiveDamage # Around 8 damage a minute healed
-    intervalHaltOnDamageTaken: 5
+    intervalHaltOnDamageTaken: 5s
     allowedStates:
     - Alive
     damage:

--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -114,6 +114,7 @@
   - type: Damageable
     damageModifierSet: Slime
   - type: PassiveDamage # Around 8 damage a minute healed
+    intervalHaltOnDamageTaken: 5
     allowedStates:
     - Alive
     damage:

--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -197,7 +197,7 @@
   - type: PassiveDamage
     # Augment normal health regen to be able to tank some Poison damage
     # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.
-    intervalHaltOnDamageTaken: 5
+    intervalHaltOnDamageTaken: 5s
     allowedStates:
     - Alive
     damage:

--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -197,6 +197,7 @@
   - type: PassiveDamage
     # Augment normal health regen to be able to tank some Poison damage
     # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.
+    intervalHaltOnDamageTaken: 5
     allowedStates:
     - Alive
     damage:

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -178,6 +178,7 @@
         Blunt: 0.50
         Heat: 0.1
   - type: PassiveDamage
+    intervalHaltOnDamageTaken: 5
     allowedStates:
     - Alive
     damage:

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -178,7 +178,7 @@
         Blunt: 0.50
         Heat: 0.1
   - type: PassiveDamage
-    intervalHaltOnDamageTaken: 5
+    intervalHaltOnDamageTaken: 5s
     allowedStates:
     - Alive
     damage:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2720,7 +2720,7 @@
     useSound:
       path: /Audio/Items/crowbar.ogg
   - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute from base.yml.
-    intervalHaltOnDamageTaken: 5
+    intervalHaltOnDamageTaken: 5s
     allowedStates:
     - Alive
     damage:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2720,6 +2720,7 @@
     useSound:
       path: /Audio/Items/crowbar.ogg
   - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute from base.yml.
+    intervalHaltOnDamageTaken: 5
     allowedStates:
     - Alive
     damage:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
@@ -66,6 +66,7 @@
   - type: Injurable
     damageContainer: Inorganic
   - type: PassiveDamage
+    intervalHaltOnDamageTaken: 5
     allowedStates:
     - Alive
     damage:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
@@ -66,7 +66,7 @@
   - type: Injurable
     damageContainer: Inorganic
   - type: PassiveDamage
-    intervalHaltOnDamageTaken: 5
+    intervalHaltOnDamageTaken: 5s
     allowedStates:
     - Alive
     damage:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Passive regen on mobs now pauses for 5 seconds after taking damage.

## Why / Balance
To stop some thresholds from breaking arbitrarily. Also Vox micronerf :godo:

Also I updated the subscriptions to fit the modern style.

## Technical details
New datafield!!

## Test plan
1. Open dev
2. Spawn throwing knives kit
3. Urist should die in four hits with exactly 100 damage

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog

:cl:
- tweak: Passive health regeneration now pauses for five seconds after taking damage.
