### PR TITLE
Fix UI Window Memory Leak in `CloseRecentWindowUIController`

### DIFF
--- a/Content.Client/UserInterface/Systems/CloseWindow/CloseRecentWindowUIController.cs
+++ b/Content.Client/UserInterface/Systems/CloseWindow/CloseRecentWindowUIController.cs
@@ -27,6 +27,7 @@ public sealed partial class CloseRecentWindowUIController : UIController
         // (Does not need to be unlistened since UIControllers live forever)
         _uiManager.OnKeyBindDown += OnKeyBindDown;
         _uiManager.WindowRoot.OnChildAdded += OnRootChildAdded;
+        _uiManager.WindowRoot.OnChildRemoved += OnRootChildRemoved;
 
         _inputManager.SetInputCommand(EngineKeyFunctions.WindowCloseRecent,
             InputCmdHandler.FromDelegate(session => CloseMostRecentWindow()));
@@ -119,6 +120,14 @@ public sealed partial class CloseRecentWindowUIController : UIController
         {
             // On new window open, add to tracking
             SetMostRecentlyInteractedWindow((BaseWindow) control);
+        }
+    }
+
+    private void OnRootChildRemoved(Control control)
+    {
+        if (control is BaseWindow window)
+        {
+            recentlyInteractedWindows.Remove(window);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Client memory leak bad

## Technical details
<!-- Summary of code changes for easier review. -->
Moffstation, beautiful gremlin that it can be, had users reporting of a memory leak where clients would grow up to 10GB after a few rounds of play. I had some suspicions and the smoke seemed to be coming from a new, heavy vending machine UI that was added recently.

Doing some `dotnet-dump` analysis, it was in fact the vending machine windows that were leaked (like 14k instances of some UI controls sitting around), and using `gcroot`, all of them seemed to be held onto by `CloseRecentWindowUIController`'s `recentlyInteractedWindows`.

Looking at the work that controller does, I noticed there's a handler for `_uiManager.WindowRoot.OnChildAdded` which adds items to the list mentioned above, but no handler at all for `_uiManager.WindowRoot.OnChildRemoved`.
I added a symmetric removal handler and took my dumps again, and as if by magic, there were no leaked control instances.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Recreate the `dotnet-dump` analysis I described above, I guess.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
n/a