### PR TITLE
fix radial menus not opening where expected

### DIFF
--- a/Content.Client/Changeling/UI/ChangelingTransformBoundUserInterface.cs
+++ b/Content.Client/Changeling/UI/ChangelingTransformBoundUserInterface.cs
@@ -5,12 +5,16 @@ using Content.Shared.Changeling.Systems;
 using JetBrains.Annotations;
 using Robust.Client.UserInterface;
 using Robust.Shared.Utility;
+using Robust.Shared.Configuration;
+using Content.Shared.CCVar;
 
 namespace Content.Client.Changeling.UI;
 
 [UsedImplicitly]
 public sealed partial class ChangelingTransformBoundUserInterface(EntityUid owner, Enum uiKey) : BoundUserInterface(owner, uiKey)
 {
+    [Dependency] private IConfigurationManager _cfg = default!;
+
     private SimpleRadialMenu? _menu;
     private static readonly Color SelectedOptionBackground = Palettes.Green.Element.WithAlpha(128);
     private static readonly Color DisabledOptionBackground = Palettes.Slate.Element.WithAlpha(128);
@@ -22,6 +26,8 @@ public sealed partial class ChangelingTransformBoundUserInterface(EntityUid owne
         base.Open();
 
         _menu = this.CreateWindow<SimpleRadialMenu>();
+        if (!_cfg.GetCVar(CCVars.ControlRadialLocation))
+            _menu.Track(Owner);
         Update();
         _menu.OpenOverMouseScreenPosition();
     }

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -161,6 +161,7 @@ namespace Content.Client.Options.UI.Tabs
             AddToggleCvarCheckBox("ui-options-hotkey-keymap", CVars.DisplayUSQWERTYHotkeys);
             AddToggleCvarCheckBox("ui-options-hold-to-attack-melee", CCVars.ControlHoldToAttackMelee);
             AddToggleCvarCheckBox("ui-options-hold-to-attack-ranged", CCVars.ControlHoldToAttackRanged);
+            AddToggleCvarCheckBox("ui-options-radial-menu-location-preference", CCVars.ControlRadialLocation);
 
             AddHeader("ui-options-header-movement");
             AddButton(EngineKeyFunctions.MoveUp);

--- a/Content.Client/RCD/RCDMenuBoundUserInterface.cs
+++ b/Content.Client/RCD/RCDMenuBoundUserInterface.cs
@@ -46,7 +46,6 @@ public sealed partial class RCDMenuBoundUserInterface : BoundUserInterface
             return;
 
         _menu = this.CreateWindow<SimpleRadialMenu>();
-        _menu.Track(Owner);
         var models = ConvertToButtons(rcd.AvailablePrototypes);
         _menu.SetButtons(models);
 

--- a/Content.Client/RCD/RCDMenuBoundUserInterface.cs
+++ b/Content.Client/RCD/RCDMenuBoundUserInterface.cs
@@ -9,6 +9,8 @@ using Robust.Shared.Collections;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Robust.Shared.Configuration;
+using Content.Shared.CCVar;
 
 namespace Content.Client.RCD;
 
@@ -19,6 +21,8 @@ public sealed partial class RCDMenuBoundUserInterface : BoundUserInterface
     [Dependency] private ISharedPlayerManager _playerManager = default!;
     [Dependency] private PopupSystem _popup = default!;
     [Dependency] private RCDSystem _rcd = default!;
+    [Dependency] private IConfigurationManager _cfg = default!;
+
 
     private const string TopLevelActionCategory = "Main";
 
@@ -46,6 +50,8 @@ public sealed partial class RCDMenuBoundUserInterface : BoundUserInterface
             return;
 
         _menu = this.CreateWindow<SimpleRadialMenu>();
+        if (!_cfg.GetCVar(CCVars.ControlRadialLocation))
+            _menu.Track(Owner);
         var models = ConvertToButtons(rcd.AvailablePrototypes);
         _menu.SetButtons(models);
 

--- a/Content.Client/Remotes/UI/DoorRemoteBoundUserInterface.cs
+++ b/Content.Client/Remotes/UI/DoorRemoteBoundUserInterface.cs
@@ -3,11 +3,15 @@ using Content.Client.UserInterface.Controls;
 using Content.Shared.Remotes.Components;
 using Content.Shared.Remotes.EntitySystems;
 using Robust.Client.UserInterface;
+using Robust.Shared.Configuration;
+using Content.Shared.CCVar;
 
 namespace Content.Client.Remotes.UI;
 
 public sealed class DoorRemoteBoundUserInterface(EntityUid owner, Enum uiKey) : BoundUserInterface(owner, uiKey)
 {
+    [Dependency] private IConfigurationManager _cfg = default!;
+
     private static readonly Color SelectedOptionColor = Palettes.Green.Element.WithAlpha(128);
     private static readonly Color SelectedOptionHoverColor = Palettes.Green.HoveredElement.WithAlpha(128);
 
@@ -21,6 +25,8 @@ public sealed class DoorRemoteBoundUserInterface(EntityUid owner, Enum uiKey) : 
             return;
 
         _menu = this.CreateWindow<SimpleRadialMenu>();
+        if (!_cfg.GetCVar(CCVars.ControlRadialLocation))
+            _menu.Track(Owner);
         var models = CreateButtons(remote.Mode, remote.Options);
         _menu.SetButtons(models);
 

--- a/Content.Client/Remotes/UI/DoorRemoteBoundUserInterface.cs
+++ b/Content.Client/Remotes/UI/DoorRemoteBoundUserInterface.cs
@@ -8,7 +8,7 @@ using Content.Shared.CCVar;
 
 namespace Content.Client.Remotes.UI;
 
-public sealed class DoorRemoteBoundUserInterface(EntityUid owner, Enum uiKey) : BoundUserInterface(owner, uiKey)
+public sealed partial class DoorRemoteBoundUserInterface(EntityUid owner, Enum uiKey) : BoundUserInterface(owner, uiKey)
 {
     [Dependency] private IConfigurationManager _cfg = default!;
 

--- a/Content.Shared/CCVar/CCVars.Interactions.cs
+++ b/Content.Shared/CCVar/CCVars.Interactions.cs
@@ -83,4 +83,9 @@ public sealed partial class CCVars
     public static readonly CVarDef<bool> ControlHoldToAttackRanged =
         CVarDef.Create("control.hold_to_attack_ranged", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 
+    /// <summary>
+    ///     If enabled, radial menus will open at the mouse location, rather than on the character.
+    /// </summary>
+    public static readonly CVarDef<bool> ControlRadialLocation =
+        CVarDef.Create("control.radial_menu_location", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -116,6 +116,7 @@ ui-options-sharpness = Sharpness:
 
 ui-options-hold-to-attack-melee = Hold to attack (melee)
 ui-options-hold-to-attack-ranged = Hold to attack (ranged)
+ui-options-radial-menu-location-preference = Radial Menu Open on Mouse
 
 ui-options-binds-reset-all = Reset ALL keybinds
 ui-options-binds-explanation = Click to change binding, right-click to clear


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
fixed a logic error that caused the radial menu for the RCD opening on the player character rather than at the mouse location, added a config option for choosing UI popup location
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
the entire point of a radial menu is to have it ~~on your mouse~~ where you want it to be
## Technical details
<!-- Summary of code changes for easier review. -->
config option to either track the player or open on mouse
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
i hold RCD in my hand and use the activate in hand button
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


https://github.com/user-attachments/assets/4afc43dd-7416-41df-830b-9282edaa7ca9




## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: radial menus are now consistent in their opening positions, with a new config option