### PR TITLE
Beds heal critical patients as if they're sleeping

### DIFF
--- a/Content.Shared/Bed/BedSystem.cs
+++ b/Content.Shared/Bed/BedSystem.cs
@@ -26,29 +26,16 @@ public sealed partial class BedSystem : EntitySystem
     [Dependency] private SharedPowerReceiverSystem _powerReceiver = default!;
     [Dependency] private SleepingSystem _sleepingSystem = default!;
 
-    [Dependency] private EntityQuery<SleepingComponent> _sleepingQuery = default!;
+    [Dependency] private EntityQuery<SleepingComponent> _sleepingQuery;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<HealOnBuckleComponent, MapInitEvent>(OnHealMapInit);
-        SubscribeLocalEvent<HealOnBuckleComponent, StrappedEvent>(OnStrapped);
-        SubscribeLocalEvent<HealOnBuckleComponent, UnstrappedEvent>(OnUnstrapped);
-
-        SubscribeLocalEvent<StasisBedComponent, StrappedEvent>(OnStasisStrapped);
-        SubscribeLocalEvent<StasisBedComponent, UnstrappedEvent>(OnStasisUnstrapped);
-        SubscribeLocalEvent<StasisBedComponent, GotEmaggedEvent>(OnStasisEmagged);
-        SubscribeLocalEvent<StasisBedComponent, PowerChangedEvent>(OnPowerChanged);
-        SubscribeLocalEvent<StasisBedBuckledComponent, GetMetabolicMultiplierEvent>(OnStasisGetMetabolicMultiplier);
-    }
-
+    [SubscribeLocalEvent]
     private void OnHealMapInit(Entity<HealOnBuckleComponent> ent, ref MapInitEvent args)
     {
         _actConts.EnsureAction(ent.Owner, ref ent.Comp.SleepAction, SleepingSystem.SleepActionId);
         Dirty(ent);
     }
 
+    [SubscribeLocalEvent]
     private void OnStrapped(Entity<HealOnBuckleComponent> bed, ref StrappedEvent args)
     {
         EnsureComp<HealOnBuckleHealingComponent>(bed);
@@ -60,6 +47,7 @@ public sealed partial class BedSystem : EntitySystem
         DebugTools.AssertEqual(args.Strap.Comp.BuckledEntities.Count, 1);
     }
 
+    [SubscribeLocalEvent]
     private void OnUnstrapped(Entity<HealOnBuckleComponent> bed, ref UnstrappedEvent args)
     {
         // If the entity being unbuckled is terminating, we shouldn't try to act upon it, as some components may be gone
@@ -72,18 +60,21 @@ public sealed partial class BedSystem : EntitySystem
         RemComp<HealOnBuckleHealingComponent>(bed);
     }
 
+    [SubscribeLocalEvent]
     private void OnStasisStrapped(Entity<StasisBedComponent> ent, ref StrappedEvent args)
     {
         EnsureComp<StasisBedBuckledComponent>(args.Buckle);
         _metabolizer.UpdateMetabolicMultiplier(args.Buckle);
     }
 
+    [SubscribeLocalEvent]
     private void OnStasisUnstrapped(Entity<StasisBedComponent> ent, ref UnstrappedEvent args)
     {
         RemComp<StasisBedBuckledComponent>(ent);
         _metabolizer.UpdateMetabolicMultiplier(args.Buckle);
     }
 
+    [SubscribeLocalEvent]
     private void OnStasisEmagged(Entity<StasisBedComponent> ent, ref GotEmaggedEvent args)
     {
         if (!_emag.CompareFlag(args.Type, EmagType.Interaction))
@@ -99,11 +90,13 @@ public sealed partial class BedSystem : EntitySystem
         args.Handled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnPowerChanged(Entity<StasisBedComponent> ent, ref PowerChangedEvent args)
     {
         UpdateMetabolisms(ent.Owner);
     }
 
+    [SubscribeLocalEvent]
     private void OnStasisGetMetabolicMultiplier(Entity<StasisBedBuckledComponent> ent, ref GetMetabolicMultiplierEvent args)
     {
         if (!TryComp<BuckleComponent>(ent, out var buckle) || buckle.BuckledTo is not { } buckledTo)
@@ -118,6 +111,7 @@ public sealed partial class BedSystem : EntitySystem
         args.Multiplier *= stasis.Multiplier;
     }
 
+    [SubscribeLocalEvent]
     private void UpdateMetabolisms(Entity<StrapComponent?> ent)
     {
         if (!Resolve(ent, ref ent.Comp, false))
@@ -153,7 +147,7 @@ public sealed partial class BedSystem : EntitySystem
 
                 var damage = bedComponent.Damage;
 
-                if (_sleepingQuery.HasComp(healedEntity))
+                if (_sleepingQuery.HasComp(healedEntity) || _mobStateSystem.IsCritical(healedEntity))
                     damage *= bedComponent.SleepMultiplier;
 
                 _damageableSystem.TryChangeDamage(healedEntity, damage, true, origin: uid);

--- a/Content.Shared/Bed/BedSystem.cs
+++ b/Content.Shared/Bed/BedSystem.cs
@@ -111,7 +111,6 @@ public sealed partial class BedSystem : EntitySystem
         args.Multiplier *= stasis.Multiplier;
     }
 
-    [SubscribeLocalEvent]
     private void UpdateMetabolisms(Entity<StrapComponent?> ent)
     {
         if (!Resolve(ent, ref ent.Comp, false))

--- a/Content.Shared/Bed/Components/HealOnBuckleComponent.cs
+++ b/Content.Shared/Bed/Components/HealOnBuckleComponent.cs
@@ -2,39 +2,39 @@ using Content.Shared.Damage;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
-namespace Content.Shared.Bed.Components
+namespace Content.Shared.Bed.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause, AutoGenerateComponentState]
+public sealed partial class HealOnBuckleComponent : Component
 {
-    [RegisterComponent, NetworkedComponent, AutoGenerateComponentPause, AutoGenerateComponentState]
-    public sealed partial class HealOnBuckleComponent : Component
-    {
-        /// <summary>
-        /// Damage to apply to entities that are strapped to this entity.
-        /// </summary>
-        [DataField(required: true)]
-        public DamageSpecifier Damage = default!;
+    /// <summary>
+    /// Damage to apply to entities that are strapped to this entity.
+    /// </summary>
+    [DataField(required: true)]
+    public DamageSpecifier Damage = default!;
 
-        /// <summary>
-        /// How frequently the damage should be applied, in seconds.
-        /// </summary>
-        [DataField(required: false)]
-        public float HealTime = 1f;
+    /// <summary>
+    /// How frequently the damage should be applied, in seconds.
+    /// </summary>
+    [DataField(required: false)]
+    public float HealTime = 1f;
 
-        /// <summary>
-        /// Damage multiplier that gets applied if the entity is sleeping.
-        /// </summary>
-        [DataField]
-        public float SleepMultiplier = 3f;
+    /// <summary>
+    /// Damage multiplier that gets applied if the entity is sleeping.
+    /// </summary>
+    [DataField]
+    public float SleepMultiplier = 3f;
 
-        /// <summary>
-        /// Next time that <see cref="Damage"/> will be applied.
-        /// </summary>
-        [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField, AutoNetworkedField]
-        public TimeSpan NextHealTime = TimeSpan.Zero; //Next heal
+    /// <summary>
+    /// Next time that <see cref="Damage"/> will be applied.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField, AutoNetworkedField]
+    public TimeSpan NextHealTime = TimeSpan.Zero;
 
-        /// <summary>
-        /// Action for the attached entity to be able to sleep.
-        /// </summary>
-        [DataField, AutoNetworkedField]
-        public EntityUid? SleepAction;
-    }
+    /// <summary>
+    /// Action for the attached entity to be able to sleep.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? SleepAction;
 }
+


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made critical patients profit from the same heal multiplier that sleeping patients get.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Critical patients can't sleep, but they're not awake either. Go heal more.
## Technical details
<!-- Summary of code changes for easier review. -->
Just one check for the mobstate. Also, namespaced the component and added the subscribeLocalEvent attributes.
## Test plan
Deal poison damage to a urist until crit.
Buckle them to a medical bed.
See their buckle healing tripled.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Critical Patients now count as sleeping and have the healing from the medical bed tripled!