### PR TITLE
Changeling Transformation Automatic Drop

### DIFF
--- a/Content.Client/Changeling/UI/ChangelingTransformBoundUserInterface.cs
+++ b/Content.Client/Changeling/UI/ChangelingTransformBoundUserInterface.cs
@@ -33,15 +33,21 @@ public sealed partial class ChangelingTransformBoundUserInterface(EntityUid owne
 
         if (!EntMan.TryGetComponent<ChangelingIdentityComponent>(Owner, out var lingIdentity))
             return;
+        
+        var manualDrop = true;
 
-        var models = ConvertToButtons(lingIdentity.ConsumedIdentities, lingIdentity.CurrentIdentity);
+        if (EntMan.TryGetComponent<ChangelingTransformComponent>(Owner, out var lingTransform))
+            manualDrop = lingTransform.ManualDrop;
+            
+        var models = ConvertToButtons(lingIdentity.ConsumedIdentities, lingIdentity.CurrentIdentity, manualDrop);
 
         _menu.SetButtons(models);
     }
 
     private IEnumerable<RadialMenuOptionBase> ConvertToButtons(
         IEnumerable<ChangelingIdentityData> identities,
-        EntityUid? currentIdentity
+        EntityUid? currentIdentity,
+        bool canDrop
     )
     {
         var buttons = new List<RadialMenuOptionBase>();
@@ -62,6 +68,9 @@ public sealed partial class ChangelingTransformBoundUserInterface(EntityUid owne
             };
             buttons.Add(option);
 
+            if (!canDrop)
+                continue;
+
             // Options for dropping identities.
             var dropOption = new RadialMenuActionOption<NetEntity>(SendIdentityDrop, EntMan.GetNetEntity(identity.Identity.Value))
             {
@@ -74,14 +83,17 @@ public sealed partial class ChangelingTransformBoundUserInterface(EntityUid owne
             };
             dropButtons.Add(dropOption);
         }
-
-        // Menu category for dropping identities.
-        var dropMenuButton = new RadialMenuNestedLayerOption(dropButtons)
+        
+        if (canDrop)
         {
-            IconSpecifier = RadialMenuIconSpecifier.With(new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/delete.svg.192dpi.png"))),
-            ToolTip = Loc.GetString("changeling-transform-bui-drop-identity-menu")
-        };
-        buttons.Add(dropMenuButton);
+            // Menu category for dropping identities.
+            var dropMenuButton = new RadialMenuNestedLayerOption(dropButtons)
+            {
+                IconSpecifier = RadialMenuIconSpecifier.With(new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/delete.svg.192dpi.png"))),
+                ToolTip = Loc.GetString("changeling-transform-bui-drop-identity-menu")
+            };
+            buttons.Add(dropMenuButton);
+        }
 
         return buttons;
     }

--- a/Content.Shared/Changeling/Components/ChangelingTransformComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingTransformComponent.cs
@@ -51,5 +51,11 @@ public sealed partial class ChangelingTransformComponent : Component
     public ProtoId<CloningSettingsPrototype> TransformCloningSettings = "ChangelingCloningSettings";
 
     public override bool SendOnlyToOwner => true;
+
+    /// <summary>
+    /// If true, then the changeling can manually drop identities. If false, then whenever they transform, the changeling will drop their former identity.
+    /// </summary>
+    [DataField]
+    public bool ManualDrop = true;
 }
 

--- a/Content.Shared/Changeling/Components/ChangelingTransformComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingTransformComponent.cs
@@ -55,7 +55,7 @@ public sealed partial class ChangelingTransformComponent : Component
     /// <summary>
     /// If true, then the changeling can manually drop identities. If false, then whenever they transform, the changeling will drop their former identity.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool ManualDrop = true;
 }
 

--- a/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
@@ -106,8 +106,8 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
 
         if (!TryComp<ChangelingIdentityComponent>(ent, out var identity))
             return;
-        
-        if (ent.Comp.ManualDrop)
+
+        if (!ent.Comp.ManualDrop)
             return; // can't drop identities in this mode
 
         if (identity.CurrentIdentity == targetIdentity)

--- a/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
@@ -106,6 +106,9 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
 
         if (!TryComp<ChangelingIdentityComponent>(ent, out var identity))
             return;
+        
+        if (ent.Comp.ManualDrop)
+            return; // can't drop identities in this mode
 
         if (identity.CurrentIdentity == targetIdentity)
             return; // don't drop our current identity
@@ -180,6 +183,11 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
         if (args.Target is not { } targetIdentity)
             return;
 
+        EntityUid? previousIdentity = null;
+
+        if (TryComp<ChangelingIdentityComponent>(ent.Owner, out var identityComp) && ent.Comp.ManualDrop)
+            previousIdentity = identityComp.CurrentIdentity;
+
         var beforeTransformEvent = new BeforeChangelingTransformEvent(targetIdentity);
         RaiseLocalEvent(args.User, beforeTransformEvent);
 
@@ -208,6 +216,9 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
 
         var afterTransformEvent = new AfterChangelingTransformEvent(targetIdentity);
         RaiseLocalEvent(args.User, afterTransformEvent);
+
+        if (previousIdentity != null)
+            _changelingIdentity.DropStoredIdentity(ent.Owner, previousIdentity.Value);
     }
 
     private void StorageBeforeTransform(Entity<StorageComponent> ent, ref BeforeChangelingTransformEvent args)

--- a/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingTransformSystem.cs
@@ -185,7 +185,7 @@ public sealed partial class ChangelingTransformSystem : EntitySystem
 
         EntityUid? previousIdentity = null;
 
-        if (TryComp<ChangelingIdentityComponent>(ent.Owner, out var identityComp) && ent.Comp.ManualDrop)
+        if (TryComp<ChangelingIdentityComponent>(ent.Owner, out var identityComp) && !ent.Comp.ManualDrop)
             previousIdentity = identityComp.CurrentIdentity;
 
         var beforeTransformEvent = new BeforeChangelingTransformEvent(targetIdentity);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

`ManualDrop` field in `ChangelingTransformComponent`. When true, the changeling enjoys the normal transformation / dropping behaviour. When false, the changeling cannot manually drop identities and automatically drops their last identity on transform.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

To playtest 13-style lings.

## Technical details
<!-- Summary of code changes for easier review. -->


`ManualDrop`, is both a datafield and autonetworked (because it'll probably be modified in the runtime by admins since this is mainly intended to playtest 13-like changelings).

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Launch, make yourself a changeling, vedit the `ManualDrop` field to false and see that you can no longer manually drop identities & that identities are dropped when transforming.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

None really needed.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

Nothing ever happens.