### PR TITLE
Move edit button in PermissionsEui

### DIFF
--- a/Content.Client/Administration/UI/PermissionsEui.cs
+++ b/Content.Client/Administration/UI/PermissionsEui.cs
@@ -211,16 +211,7 @@ namespace Content.Client.Administration.UI
                 var al = _menu.AdminsList;
                 var name = admin.UserName ?? admin.UserId.ToString();
 
-                al.AddChild(new Label { Text = name });
-
-                var titleControl = new Label { Text = admin.Title ?? Loc.GetString("permissions-eui-edit-admin-title-control-text").ToLowerInvariant() };
-                if (admin.Title == null) // none
-                {
-                    titleControl.StyleClasses.Add(StyleClass.Italic);
-                }
-
-                al.AddChild(titleControl);
-
+                // Compute rank and combined flags first so we can create the edit button before other columns.
                 bool italic;
                 string rank;
                 var combinedFlags = admin.PosFlags;
@@ -237,6 +228,25 @@ namespace Content.Client.Administration.UI
                     rank = Loc.GetString("permissions-eui-edit-no-rank-text").ToLowerInvariant();
                 }
 
+                var editButton = new Button { Text = Loc.GetString("permissions-eui-edit-title-button") };
+                editButton.OnPressed += _ => OnEditPressed(admin);
+
+                // Add the edit button as the first column
+                al.AddChild(editButton);
+
+                // Name (C-key)
+                al.AddChild(new Label { Text = name });
+
+                // Prefix / Title
+                var titleControl = new Label { Text = admin.Title ?? Loc.GetString("permissions-eui-edit-admin-title-control-text").ToLowerInvariant() };
+                if (admin.Title == null) // none
+                {
+                    titleControl.StyleClasses.Add(StyleClass.Italic);
+                }
+
+                al.AddChild(titleControl);
+
+                // Rank
                 var rankControl = new Label { Text = rank };
                 if (italic)
                 {
@@ -245,6 +255,7 @@ namespace Content.Client.Administration.UI
 
                 al.AddChild(rankControl);
 
+                // Flags / Additional rights
                 var flagsText = AdminFlagsHelper.PosNegFlagsText(admin.PosFlags, admin.NegFlags);
 
                 al.AddChild(new Label
@@ -253,10 +264,6 @@ namespace Content.Client.Administration.UI
                     HorizontalExpand = true,
                     HorizontalAlignment = Control.HAlignment.Center,
                 });
-
-                var editButton = new Button { Text = Loc.GetString("permissions-eui-edit-title-button") };
-                editButton.OnPressed += _ => OnEditPressed(admin);
-                al.AddChild(editButton);
 
                 if (!_adminManager.HasFlag(combinedFlags))
                 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The Edit button in permissions window was moved from the far right to left, next to the C-key. Compute combined flags earlier so we can create the edit button before other columns.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Admin QoL. The Edit button used to be on the far right, so admins with many flags could push the button off-screen. That forced admins to either enlarge the window or scroll horizontally (until the C-key was out of view), making it hard to identify and edit the correct admin - especially when you have a long admin list. Moving the Edit button to the left keeps it immediately visible next to the C-key, improving discoverability and avoiding blind clicks or awkward window resizing.

## Technical details
<!-- Summary of code changes for easier review. -->
Moved the Edit button to the leftmost column of the admin row; combined rank+user flags are computed earlier so the button can be enabled/disabled correctly.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1258" height="232" alt="image" src="https://github.com/user-attachments/assets/04ab1205-c9f2-4256-a57e-59a9c6aae61a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun