### PR TITLE
Movement Modifier Status Effect fix

### DIFF
--- a/Content.Shared/Movement/Components/MovementModStatusEffectComponent.cs
+++ b/Content.Shared/Movement/Components/MovementModStatusEffectComponent.cs
@@ -6,7 +6,6 @@ namespace Content.Shared.Movement.Components;
 /// <summary>
 /// This is used to store a movement speed modifier attached to a status effect entity so it can be applied via statuses.
 /// To be used in conjunction with <see cref="MovementModStatusSystem"/>.
-/// See <see cref="MovementModStatusComponent"/> for the component applied to the entity.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(MovementModStatusSystem))]
 public sealed partial class MovementModStatusEffectComponent : Component

--- a/Content.Shared/Movement/Systems/MovementModStatusSystem.cs
+++ b/Content.Shared/Movement/Systems/MovementModStatusSystem.cs
@@ -30,16 +30,28 @@ public sealed partial class MovementModStatusSystem : EntitySystem
 
     public override void Initialize()
     {
+        SubscribeLocalEvent<MovementModStatusEffectComponent, StatusEffectAppliedEvent>(OnMovementModApplied);
         SubscribeLocalEvent<MovementModStatusEffectComponent, StatusEffectRemovedEvent>(OnMovementModRemoved);
         SubscribeLocalEvent<MovementModStatusEffectComponent, StatusEffectRelayedEvent<RefreshMovementSpeedModifiersEvent>>(OnRefreshRelay);
+        SubscribeLocalEvent<FrictionStatusEffectComponent, StatusEffectAppliedEvent>(OnFrictionStatusEffectApplied);
         SubscribeLocalEvent<FrictionStatusEffectComponent, StatusEffectRemovedEvent>(OnFrictionStatusEffectRemoved);
         SubscribeLocalEvent<FrictionStatusEffectComponent, StatusEffectRelayedEvent<RefreshFrictionModifiersEvent>>(OnRefreshFrictionStatus);
         SubscribeLocalEvent<FrictionStatusEffectComponent, StatusEffectRelayedEvent<TileFrictionEvent>>(OnRefreshTileFrictionStatus);
     }
 
+    private void OnMovementModApplied(Entity<MovementModStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
+    {
+        _movementSpeedModifier.RefreshMovementSpeedModifiers(args.Target);
+    }
+
     private void OnMovementModRemoved(Entity<MovementModStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
     {
         TryUpdateMovementStatus(args.Target, (ent, ent), 1f);
+    }
+
+    private void OnFrictionStatusEffectApplied(Entity<FrictionStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
+    {
+        _movementSpeedModifier.RefreshFrictionModifiers(args.Target);
     }
 
     private void OnFrictionStatusEffectRemoved(Entity<FrictionStatusEffectComponent> entity, ref StatusEffectRemovedEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`MovementModStatusEffectComponent` and `FrictionStatusEffectComponent` now refresh movement speed/friction on status effect application (`StatusEffectAppliedEvent`), not just on removal.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Previously, the speed refresh on application only happened when calling code went through the `MovementModStatusSystem.TryAdd/TryUpdateMovementSpeedModDuration` wrapper. If the effect was applied directly via `StatusEffectsSystem` (e.g. via a generic `ModifyStatusEffect` on a reagent), the modifier values were set but movement speed was never recalculated until some unrelated refresh happened elsewhere

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
To test this, you’ll need to create a status effect like this:
```yml
- type: entity
  id: StatusEffectSlowdown
  name: slowdown
  components:
  - type: StatusEffect
  - type: MovementModStatusEffect
    sprintSpeedModifier: 0.1
    walkSpeedModifier: 0.1
  ```
and apply it to the entity using some generic method, such as EntityEffect. As a result, the entity will slow down (which wasn’t the case before).
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
