### PR TITLE
checkCanSee for TargetActionComponent

### DIFF
--- a/Content.Shared/Actions/Components/TargetActionComponent.cs
+++ b/Content.Shared/Actions/Components/TargetActionComponent.cs
@@ -44,6 +44,20 @@ public sealed partial class TargetActionComponent : Component
     public CollisionGroup AccessMask = SharedInteractionSystem.InRangeUnobstructedMask;
 
     /// <summary>
+    ///     Whether the action system should block this action if the user does not have line of sight to the
+    ///     target (i.e. the target is behind an opaque occluder, such as a wall). Unlike <see cref="CheckCanAccess"/>,
+    ///     this uses the same occluder-based visibility check as examining, so it ignores things like closed
+    ///     containers or interaction blockers and is meant for long-range "you can see it, so you can target it"
+    ///     abilities (e.g. teleports).
+    /// </summary>
+    /// <remarks>
+    ///     Uses <see cref="Range"/> as the maximum raycast distance if it is positive; otherwise falls back to
+    ///     <see cref="SharedInteractionSystem.MaxRaycastRange"/>.
+    /// </remarks>
+    [DataField]
+    public bool CheckCanSee;
+
+    /// <summary>
     ///     The allowed range for a target to be. If zero or negative, the range check is skipped,
     ///     unless <see cref="CheckCanAccess"/> is true.
     /// </summary>

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -6,10 +6,12 @@ using Content.Shared.Actions.Events;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
+using Content.Shared.Examine;
 using Content.Shared.Hands;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Mind;
+using Content.Shared.Popups;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Whitelist;
 using Robust.Shared.Audio.Systems;
@@ -27,10 +29,12 @@ public abstract partial class SharedActionsSystem : EntitySystem
     [Dependency] private ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private ActionContainerSystem _actionContainer = default!;
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private ExamineSystemShared _examine = default!;
     [Dependency] private RotateToFaceSystem _rotateToFace = default!;
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedInteractionSystem _interaction = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
 
@@ -434,6 +438,9 @@ public abstract partial class SharedActionsSystem : EntitySystem
 
         var targetAction = Comp<TargetActionComponent>(uid);
 
+        if (!ValidateLineOfSight(user, target, targetAction))
+            return false;
+
         // not using the ValidateBaseTarget logic since its raycast fails if the target is e.g. a wall
         if (targetAction.CheckCanAccess)
             return _interaction.InRangeAndAccessible(user, target, targetAction.Range, targetAction.AccessMask);
@@ -456,6 +463,10 @@ public abstract partial class SharedActionsSystem : EntitySystem
     private bool ValidateBaseTarget(EntityUid user, EntityCoordinates coords, Entity<TargetActionComponent> ent)
     {
         var comp = ent.Comp;
+
+        if (!ValidateLineOfSight(user, coords, comp))
+            return false;
+
         if (comp.CheckCanAccess)
             return _interaction.InRangeUnobstructed(user, coords, range: comp.Range);
 
@@ -468,6 +479,32 @@ public abstract partial class SharedActionsSystem : EntitySystem
             return true;
 
         return _transform.InRange(coords, xform.Coordinates, comp.Range);
+    }
+
+    private bool ValidateLineOfSight(EntityUid user, EntityUid target, TargetActionComponent comp)
+    {
+        if (!comp.CheckCanSee)
+            return true;
+
+        var range = comp.Range > 0 ? comp.Range : SharedInteractionSystem.MaxRaycastRange;
+        if (_examine.InRangeUnOccluded(user, target, range))
+            return true;
+
+        _popup.PopupEntity(Loc.GetString("target-action-popup-cant-see"), user, user);
+        return false;
+    }
+
+    private bool ValidateLineOfSight(EntityUid user, EntityCoordinates target, TargetActionComponent comp)
+    {
+        if (!comp.CheckCanSee)
+            return true;
+
+        var range = comp.Range > 0 ? comp.Range : SharedInteractionSystem.MaxRaycastRange;
+        if (_examine.InRangeUnOccluded(user, target, range))
+            return true;
+
+        _popup.PopupEntity(Loc.GetString("target-action-popup-cant-see"), user, user);
+        return false;
     }
 
     private void OnInstantGetEvent(Entity<InstantActionComponent> ent, ref ActionGetEventEvent args)

--- a/Content.Shared/Teleportation/Systems/TeleportActionSystem.cs
+++ b/Content.Shared/Teleportation/Systems/TeleportActionSystem.cs
@@ -1,5 +1,3 @@
-using Content.Shared.Examine;
-using Content.Shared.Interaction;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Popups;
@@ -18,7 +16,6 @@ public sealed partial class TeleportActionSystem : EntitySystem
 {
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
-    [Dependency] private ExamineSystemShared _examine = default!;
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private PullingSystem _pulling = default!;
@@ -58,12 +55,8 @@ public sealed partial class TeleportActionSystem : EntitySystem
 
         var xform = Transform(user);
         var mapId = _transform.GetMapId(target);
-        if (xform.MapID != mapId ||
-            !_examine.InRangeUnOccluded(user, target, SharedInteractionSystem.MaxRaycastRange))
-        {
-            _popup.PopupEntity(Loc.GetString("teleport-action-popup-cant-see"), user, user);
+        if (xform.MapID != mapId)
             return false;
-        }
 
         var mapTarget = _transform.GetWorldPositionRotation(target.EntityId);
         var targetMapCoordinates = new MapCoordinates(mapTarget.WorldPosition + target.Position, mapId);

--- a/Resources/Locale/en-US/actions/actions/target-action.ftl
+++ b/Resources/Locale/en-US/actions/actions/target-action.ftl
@@ -1,0 +1,1 @@
+target-action-popup-cant-see = You cannot see the target.

--- a/Resources/Locale/en-US/teleportation/teleport-action.ftl
+++ b/Resources/Locale/en-US/teleportation/teleport-action.ftl
@@ -1,2 +1,1 @@
-teleport-action-popup-cant-see = You cannot see the destination.
 teleport-action-popup-blocked = There is no room at the destination.

--- a/Resources/Prototypes/Actions/ninja.yml
+++ b/Resources/Prototypes/Actions/ninja.yml
@@ -92,6 +92,7 @@
     - state: blink
   - type: TargetAction
     checkCanAccess: false
+    checkCanSee: true
     range: 0
   - type: WorldTargetAction
     event: !type:TeleportActionEvent

--- a/Resources/Prototypes/Magic/teleport_spells.yml
+++ b/Resources/Prototypes/Magic/teleport_spells.yml
@@ -18,6 +18,7 @@
     # ^ should probably add better validation that the clicked location is on the users screen somewhere,
     repeat: false
     checkCanAccess: false
+    checkCanSee: true
   - type: WorldTargetAction
     event: !type:TeleportActionEvent
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a `CheckCanSee` field to `TargetActionComponent` so target actions can require unobstructed line of sight to their target.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Ninja's Katana Dash and the wizard's Blink spell each hardcoded their own line-of-sight raycast inside `TeleportActionSystem`. This unifies that duplicated logic into a reusable `CheckCanSee` field any future target action can opt into.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
- Katana Dash and Blink still teleport when the destination is visible.
- Both are blocked with a "cannot see the target" popup when the destination is behind a wall.
- `Range` still caps Blink to 16 tiles; Dash remains effectively unlimited (falls back to `MaxRaycastRange`).

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

.
.
.
...
more boring refactors
