### PR TITLE
Revert allowing nuke disks in plushies.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -224,8 +224,10 @@
     blacklist:
       components:
       - SecretStash # Prevents being able to insert plushies inside each other (infinite plush)!
+      - NukeDisk # Because a core mechanic of nukies should not be "where in this bag is the fucking disk"
       tags:
       - QuantumSpinInverter # It will cause issues with the grinder...
+      - FakeNukeDisk # For parity with NukeDisk
   - type: ToolOpenable
     openToolQualityNeeded: Slicing
     closeToolQualityNeeded: Slicing # Should probably be stitching or something if that gets added


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Nuke disks are no longer allowed in plushies

## Why / Balance
Some ridiculous storage stacking shenanigans can happen if you allow it, so... 
As said in the comments, a core mechanic of nukies should not be searching desperately in the captain's bag for the disk. There's already enough of that with nested storage, no need to allow more.

## Technical details
YAML!

## Test plan
1. Open Dev
2. Try put a (fake) nuke disk in a plushie

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- remove: Nuclear authentication disks can no longer be hidden in plushies.
