### PR TITLE
Remove empty steps from construction menu.

### DIFF
--- a/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
+++ b/Content.Client/Construction/UI/ConstructionMenuPresenter.cs
@@ -258,6 +258,9 @@ namespace Content.Client.Construction.UI
 
             foreach (var entry in guide.Entries)
             {
+                if (entry.Empty())
+                    continue;
+
                 var text = entry.Arguments != null
                     ? Loc.GetString(entry.Localization, entry.Arguments)
                     : Loc.GetString(entry.Localization);

--- a/Content.Shared/Construction/ConstructionGuide.cs
+++ b/Content.Shared/Construction/ConstructionGuide.cs
@@ -1,26 +1,63 @@
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
-namespace Content.Shared.Construction
+namespace Content.Shared.Construction;
+
+/// <summary>
+/// A set of instructions on how to construct (or deconstruct) something.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class ConstructionGuide(ConstructionGuideEntry[] entries)
 {
-    [Serializable, NetSerializable]
-    public sealed class ConstructionGuide
-    {
-        public readonly ConstructionGuideEntry[] Entries;
+    /// <summary>
+    /// The set of entries (a step or a condition) describing how to build this.
+    /// </summary>
+    public readonly ConstructionGuideEntry[] Entries = entries;
+}
 
-        public ConstructionGuide(ConstructionGuideEntry[] entries)
-        {
-            Entries = entries;
-        }
-    }
+/// <summary>
+/// An individual entry in a set of instructions to build something.
+/// May represent a condition ("the tile this is on must be empty"),
+/// or an action ("add 2 steel sheets").
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class ConstructionGuideEntry
+{
+    /// <summary>
+    /// The number to display with this entry.
+    /// Normally 1-indexed.
+    /// </summary>
+    public int? EntryNumber { get; set; } = null;
 
-    [Serializable, NetSerializable]
-    public sealed class ConstructionGuideEntry
+    /// <summary>
+    /// The number of spaces to prefix this text with.
+    /// </summary>
+    public int Padding { get; set; } = 0;
+
+    /// <summary>
+    /// The localization ID of the string to print out for this entry.
+    /// </summary>
+    public LocId Localization { get; set; } = string.Empty;
+
+    /// <summary>
+    /// A set of arbitrary key/value data relating to this entry.
+    /// </summary>
+    public (string, object)[]? Arguments { get; set; } = null;
+
+    /// <summary>
+    /// An optional sprite to represent this entry.
+    /// </summary>
+    public SpriteSpecifier? Icon { get; set; } = null;
+
+    /// <summary>
+    /// Returns true if this entry contains no actual information.
+    /// </summary>
+    public bool Empty()
     {
-        public int? EntryNumber { get; set; } = null;
-        public int Padding { get; set; } = 0;
-        public string Localization { get; set; } = string.Empty;
-        public (string, object)[]? Arguments { get; set; } = null;
-        public SpriteSpecifier? Icon { get; set; } = null;
+        return EntryNumber == null
+            && Padding == 0
+            && Localization == string.Empty
+            && Arguments == null
+            && Icon == null;
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Removes steps with empty descriptions from construction guides, like SnapGrid.

Comments ConstructionGuide and ConstructionGuideEntry while we're there.

## Why / Balance

It doesn't make any sense to display this.  If you want more space between steps, great, but this isn't that.  If I added five steps without description, I'd get five lines.

## Technical details

Adds a new Empty call to ConstructionGuideEntry that checks if the values are defaulted.  If they are, there is no useful information to be displayed, and the step can be skipped.

Empty method isn't great, could also define Equals and compare against a default object.

## Test plan

Open construction menu, click on the airlock.
No huge space between "The tile must not be obstructed." and "It must be anchored."

## Media

On master:
<img width="400" height="310" alt="image" src="https://github.com/user-attachments/assets/7b7551e0-c040-4efc-a939-7260ebaecebb" />

On this PR:
<img width="672" height="558" alt="image" src="https://github.com/user-attachments/assets/b0a4f7e4-286d-400f-bd36-a8990a09b4f1" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
no >:(
