### PR TITLE
Airlock pass: rotate on construction, consistent names, hide placeholder assemblies

### DIFF
--- a/Resources/Locale/en-US/construction/recipes/structures.ftl
+++ b/Resources/Locale/en-US/construction/recipes/structures.ftl
@@ -22,6 +22,6 @@ construction-recipe-fence-wood-t-junction-small = small wooden fence T-junction
 construction-recipe-fence-wood-gate-small = small wooden fence gate
 construction-recipe-pinion-airlock = clockwork airlock
 construction-recipe-pinion-airlock-glass = glass clockwork airlock
-construction-recipe-airlock-glass-shuttle = glass shuttle airlock
+construction-recipe-airlock-glass-shuttle = glass docking airlock
 construction-recipe-plastic-flaps-clear = plastic flaps (clear)
 construction-recipe-plastic-flaps-opaque = plastic flaps (opaque)

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -1159,7 +1159,7 @@
 - type: entity
   parent: AirlockShuttleSyndicate
   id: AirlockExternalShuttleSyndicateLocked
-  suffix: External, Docking, Syndicate, Locked
+  suffix: Syndicate, Docking, Locked
   components:
   - type: ContainerFill
     containers:
@@ -1168,7 +1168,7 @@
 - type: entity
   parent: AirlockShuttleSyndicate
   id: AirlockExternalShuttleNukeopLocked
-  suffix: External, Docking, Nukeop, Locked
+  suffix: Nukeop, Docking, Locked
   components:
   - type: ContainerFill
     containers:
@@ -1177,7 +1177,7 @@
 - type: entity
   parent: AirlockShuttleXenoborg
   id: AirlockGlassShuttleXenoborgLocked
-  suffix: External, Docking, Xenoborg, Locked
+  suffix: Xenoborg, Docking, Locked
   components:
   - type: StationAiWhitelist
     enabled: false
@@ -1188,7 +1188,7 @@
 - type: entity
   parent: AirlockGlassShuttle
   id: AirlockExternalGlassShuttleLocked
-  suffix: External, Glass, Docking, Locked
+  suffix: External, Docking, Glass
   components:
   - type: ContainerFill
     containers:
@@ -1197,7 +1197,7 @@
 - type: entity
   parent: AirlockGlassShuttleSyndicate
   id: AirlockExternalGlassShuttleSyndicateLocked
-  suffix: Syndicate, Locked, Glass
+  suffix: Syndicate, Docking, Glass
   components:
   - type: ContainerFill
     containers:
@@ -1206,7 +1206,7 @@
 - type: entity
   parent: AirlockGlassShuttleSyndicate
   id: AirlockExternalGlassShuttleNukeopLocked
-  suffix: Nukeop, Locked, Glass
+  suffix: Nukeop, Docking, Glass
   components:
   - type: ContainerFill
     containers:
@@ -1215,7 +1215,7 @@
 - type: entity
   parent: AirlockGlassShuttle
   id: AirlockExternalGlassShuttleEmergencyLocked
-  suffix: External, Emergency, Glass, Docking, Locked
+  suffix: External, Emergency, Docking, Glass
   components:
   - type: PriorityDock
     tag: DockEmergency
@@ -1224,10 +1224,10 @@
       board: [ DoorElectronicsExternal ]
 
 - type: entity
-  name: arrivals airlock
   parent: AirlockGlassShuttle
   id: AirlockExternalGlassShuttleArrivals
-  suffix: External, Arrivals, Glass, Docking
+  name: arrivals airlock
+  suffix: External, Arrivals, Docking, Glass
   components:
   - type: PriorityDock
     tag: DockArrivals
@@ -1240,10 +1240,10 @@
     dockLegendCategory: Arrivals
 
 - type: entity
-  name: cargo airlock
   parent: AirlockGlassShuttle
   id: AirlockExternalGlassShuttleCargo
-  suffix: External, Cargo, Glass, Docking
+  name: cargo airlock
+  suffix: External, Cargo, Docking, Glass
   components:
   - type: ContainerFill
     containers:
@@ -1256,7 +1256,7 @@
 - type: entity
   parent: AirlockGlassShuttle
   id: AirlockExternalGlassShuttleEscape
-  suffix: External, Escape 3x4, Glass, Docking
+  suffix: External, Escape 3x4, Docking, Glass
   components:
   - type: GridFill
     addComponents:

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/assembly.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/assembly.yml
@@ -78,7 +78,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyExternal
-  suffix: External
+  name: external airlock assembly
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/airlock-external.rsi
@@ -87,7 +87,8 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyExternalGlass
-  suffix: External, Glass
+  suffix: Glass
+  name: external airlock assembly
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Glass/airlock-external.rsi
@@ -227,25 +228,6 @@
     sprite: Structures/Doors/Airlocks/Glass/security-base.rsi
     state: "assembly"
 
-#Shuttle
-- type: entity
-  parent: AirlockAssembly
-  id: AirlockAssemblyShuttle
-  suffix: Shuttle
-  components:
-  - type: Sprite
-    sprite: Structures/Doors/Airlocks/Standard/shuttle-base.rsi
-    state: "assembly"
-
-- type: entity
-  parent: AirlockAssembly
-  id: AirlockAssemblyShuttleGlass
-  suffix: Shuttle, Glass
-  components:
-  - type: Sprite
-    sprite: Structures/Doors/Airlocks/Glass/shuttle-base.rsi
-    state: "assembly"
-
 #Virology
 - type: entity
   parent: AirlockAssembly
@@ -304,6 +286,7 @@
     state: "assembly"
 
 #Syndicate
+# NOTE: syndicate assembly assets exist, but are unused.
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblySyndicate
@@ -320,25 +303,6 @@
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Glass/syndicate-base.rsi
-    state: "assembly"
-
-#ShuttleSyndicate
-- type: entity
-  parent: AirlockAssembly
-  id: AirlockAssemblyShuttleSyndicate
-  suffix: ShuttleSyndicate
-  components:
-  - type: Sprite
-    sprite: Structures/Doors/Airlocks/Standard/shuttle-syndicate.rsi
-    state: "assembly"
-
-- type: entity
-  parent: AirlockAssembly
-  id: AirlockAssemblyShuttleSyndicateGlass
-  suffix: ShuttleSyndicate, Glass
-  components:
-  - type: Sprite
-    sprite: Structures/Doors/Airlocks/Glass/shuttle-syndicate.rsi
     state: "assembly"
 
 #High Security

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/assembly.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/assembly.yml
@@ -1,7 +1,11 @@
+# NOTE: all of these have been marked HideSpawnMenu pending additional construction graphs.
+#       They currently all construct into Airlock and deconstruct into AirlockAssembly, which is unintuitive.
+
 #Atmospherics
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyAtmospherics
+  categories: [HideSpawnMenu]
   suffix: Atmospherics
   components:
   - type: Sprite
@@ -11,6 +15,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyAtmosphericsGlass
+  categories: [HideSpawnMenu]
   suffix: Atmospherics, Glass
   components:
   - type: Sprite
@@ -21,6 +26,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyCargo
+  categories: [HideSpawnMenu]
   suffix: Cargo
   components:
   - type: Sprite
@@ -30,6 +36,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyCargoGlass
+  categories: [HideSpawnMenu]
   suffix: Cargo, Glass
   components:
   - type: Sprite
@@ -40,6 +47,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyCommand
+  categories: [HideSpawnMenu]
   suffix: Command
   components:
   - type: Sprite
@@ -49,6 +57,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyCommandGlass
+  categories: [HideSpawnMenu]
   suffix: Command, Glass
   components:
   - type: Sprite
@@ -59,6 +68,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyEngineering
+  categories: [HideSpawnMenu]
   suffix: Engineering
   components:
   - type: Sprite
@@ -68,6 +78,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyEngineeringGlass
+  categories: [HideSpawnMenu]
   suffix: Engineering, Glass
   components:
   - type: Sprite
@@ -78,6 +89,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyExternal
+  categories: [HideSpawnMenu]
   name: external airlock assembly
   components:
   - type: Sprite
@@ -87,8 +99,9 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyExternalGlass
-  suffix: Glass
+  categories: [HideSpawnMenu]
   name: external airlock assembly
+  suffix: Glass
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Glass/airlock-external.rsi
@@ -98,6 +111,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyGlass
+  categories: [HideSpawnMenu]
   suffix: Glass
   components:
   - type: Sprite
@@ -108,6 +122,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyFreezer
+  categories: [HideSpawnMenu]
   suffix: Freezer
   components:
   - type: Sprite
@@ -118,6 +133,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyHydroponics
+  categories: [HideSpawnMenu]
   suffix: Hydroponics
   components:
   - type: Sprite
@@ -127,6 +143,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyHydroponicsGlass
+  categories: [HideSpawnMenu]
   suffix: Hydroponics, Glass
   components:
   - type: Sprite
@@ -137,6 +154,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyMaintenance
+  categories: [HideSpawnMenu]
   suffix: Maintenance
   components:
   - type: Sprite
@@ -146,6 +164,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyMaintenanceGlass
+  categories: [HideSpawnMenu]
   suffix: Maintenance, Glass
   components:
   - type: Sprite
@@ -156,6 +175,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyMedical
+  categories: [HideSpawnMenu]
   suffix: Medical
   components:
   - type: Sprite
@@ -165,6 +185,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyMedicalGlass
+  categories: [HideSpawnMenu]
   suffix: Medical, Glass
   components:
   - type: Sprite
@@ -175,6 +196,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblySalvage
+  categories: [HideSpawnMenu]
   suffix: Salvage
   components:
   - type: Sprite
@@ -184,6 +206,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblySalvageGlass
+  categories: [HideSpawnMenu]
   suffix: Salvage, Glass
   components:
   - type: Sprite
@@ -194,6 +217,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyScience
+  categories: [HideSpawnMenu]
   suffix: Science
   components:
   - type: Sprite
@@ -203,6 +227,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyScienceGlass
+  categories: [HideSpawnMenu]
   suffix: Science, Glass
   components:
   - type: Sprite
@@ -213,6 +238,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblySecurity
+  categories: [HideSpawnMenu]
   suffix: Security
   components:
   - type: Sprite
@@ -222,16 +248,39 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblySecurityGlass
+  categories: [HideSpawnMenu]
   suffix: Security, Glass
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Glass/security-base.rsi
     state: "assembly"
 
+#Shuttle
+- type: entity
+  parent: AirlockAssembly
+  id: AirlockAssemblyShuttle
+  categories: [HideSpawnMenu]
+  suffix: Shuttle
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/shuttle-base.rsi
+    state: "assembly"
+
+- type: entity
+  parent: AirlockAssembly
+  id: AirlockAssemblyShuttleGlass
+  categories: [HideSpawnMenu]
+  suffix: Shuttle, Glass
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Glass/shuttle-base.rsi
+    state: "assembly"
+
 #Virology
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyVirology
+  categories: [HideSpawnMenu]
   suffix: Virology
   components:
   - type: Sprite
@@ -241,6 +290,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyVirologyGlass
+  categories: [HideSpawnMenu]
   suffix: Virology, Glass
   components:
   - type: Sprite
@@ -251,6 +301,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyCentralCommand
+  categories: [HideSpawnMenu]
   suffix: CentralCommand
   components:
   - type: Sprite
@@ -260,6 +311,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyCentralCommandGlass
+  categories: [HideSpawnMenu]
   suffix: CentralCommand, Glass
   components:
   - type: Sprite
@@ -270,6 +322,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyMining
+  categories: [HideSpawnMenu]
   suffix: Mining
   components:
   - type: Sprite
@@ -279,6 +332,7 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyMiningGlass
+  categories: [HideSpawnMenu]
   suffix: Mining, Glass
   components:
   - type: Sprite
@@ -286,10 +340,10 @@
     state: "assembly"
 
 #Syndicate
-# NOTE: syndicate assembly assets exist, but are unused.
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblySyndicate
+  categories: [HideSpawnMenu]
   suffix: Syndicate
   components:
   - type: Sprite
@@ -299,16 +353,39 @@
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblySyndicateGlass
+  categories: [HideSpawnMenu]
   suffix: Syndicate, Glass
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Glass/syndicate-base.rsi
     state: "assembly"
 
+#ShuttleSyndicate
+- type: entity
+  parent: AirlockAssembly
+  id: AirlockAssemblyShuttleSyndicate
+  categories: [HideSpawnMenu]
+  suffix: ShuttleSyndicate
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/shuttle-syndicate.rsi
+    state: "assembly"
+
+- type: entity
+  parent: AirlockAssembly
+  id: AirlockAssemblyShuttleSyndicateGlass
+  categories: [HideSpawnMenu]
+  suffix: ShuttleSyndicate, Glass
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Glass/shuttle-syndicate.rsi
+    state: "assembly"
+
 #High Security
 - type: entity
   parent: AirlockAssembly
   id: AirlockAssemblyHighSec
+  categories: [HideSpawnMenu]
   suffix: HighSec
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/assembly.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/assembly.yml
@@ -257,7 +257,7 @@
 
 #Shuttle
 - type: entity
-  parent: AirlockAssembly
+  parent: AirlockShuttleAssembly
   id: AirlockAssemblyShuttle
   categories: [HideSpawnMenu]
   suffix: Shuttle
@@ -267,7 +267,7 @@
     state: "assembly"
 
 - type: entity
-  parent: AirlockAssembly
+  parent: AirlockShuttleAssembly
   id: AirlockAssemblyShuttleGlass
   categories: [HideSpawnMenu]
   suffix: Shuttle, Glass
@@ -362,7 +362,7 @@
 
 #ShuttleSyndicate
 - type: entity
-  parent: AirlockAssembly
+  parent: AirlockShuttleAssembly
   id: AirlockAssemblyShuttleSyndicate
   categories: [HideSpawnMenu]
   suffix: ShuttleSyndicate
@@ -372,7 +372,7 @@
     state: "assembly"
 
 - type: entity
-  parent: AirlockAssembly
+  parent: AirlockShuttleAssembly
   id: AirlockAssemblyShuttleSyndicateGlass
   categories: [HideSpawnMenu]
   suffix: ShuttleSyndicate, Glass

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_assembly.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_assembly.yml
@@ -27,7 +27,7 @@
   - type: Pullable
   - type: Transform
     anchored: true
-    noRot: true
+  - type: Rotatable
   - type: Damageable
     damageModifierSet: SteelMod
   - type: RCDDeconstructable

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: AirlockRCDResistant
   id: AirlockExternal
-  suffix: External
+  name: external airlock
   description: It opens, it closes, it might crush you, and there might be only space behind it.
   components:
   - type: Door
@@ -61,7 +61,7 @@
 - type: entity
   parent: AirlockExternal
   id: AirlockExternalGlass
-  suffix: Glass, External
+  suffix: Glass
   components:
   - type: Door
     occludes: false

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -115,6 +115,7 @@
         layer:     #removed opaque from the layer, allowing lasers to pass through glass airlocks
         - GlassAirlockLayer
 
+# TODO: migrate into assembly with the others
 - type: entity
   id: AirlockShuttleAssembly
   parent: AirlockAssembly
@@ -122,8 +123,8 @@
   description: An incomplete structure necessary for connecting two space craft together.
   components:
   - type: Sprite
-    sprite: Structures/Doors/Airlocks/Glass/shuttle-base.rsi
-    state: closed
+    sprite: Structures/Doors/Airlocks/Standard/shuttle-base.rsi
+    state: "assembly"
     snapCardinals: false
   - type: Construction
     graph: AirlockShuttle
@@ -132,6 +133,7 @@
 - type: entity
   id: AirlockGlassShuttleSyndicate
   parent: AirlockGlassShuttle
+  suffix: Syndicate, Glass
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Glass/shuttle-syndicate.rsi
@@ -139,6 +141,7 @@
 - type: entity
   parent: AirlockShuttle
   id: AirlockShuttleSyndicate
+  suffix: Syndicate
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/shuttle-syndicate.rsi

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -1,8 +1,7 @@
 ﻿- type: entity
   parent: AirlockRCDResistant
   id: AirlockShuttle
-  suffix: Docking
-  name: external airlock
+  name: docking airlock
   description: Necessary for connecting two space craft together.
   components:
   - type: Docking
@@ -102,7 +101,7 @@
 - type: entity
   id: AirlockGlassShuttle
   parent: AirlockShuttle
-  suffix: Glass, Docking
+  suffix: Glass
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Glass/shuttle-base.rsi
@@ -119,14 +118,9 @@
 - type: entity
   id: AirlockShuttleAssembly
   parent: AirlockAssembly
-  name: external airlock assembly
-  suffix: Docking
+  name: docking airlock assembly
   description: An incomplete structure necessary for connecting two space craft together.
   components:
-  - type: Transform
-    anchored: true
-    noRot: false
-  - type: Rotatable
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Glass/shuttle-base.rsi
     state: closed
@@ -152,7 +146,7 @@
 - type: entity
   parent: AirlockShuttle
   id: AirlockShuttleXenoborg
-  name: external mechadermis airlock
+  name: docking mechadermis airlock
   components:
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/shuttle-xenoborg.rsi

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -293,7 +293,7 @@
 
 # region Firelocks
 - type: construction
-  parent: BaseStructureFullTile
+  parent: BaseStructureFullTileDirectional
   id: Firelock
   graph: Firelock
   targetNode: Firelock
@@ -308,7 +308,6 @@
   id: FirelockEdge
   name: construction-recipe-firelock-edge
   targetNode: FirelockEdge
-  canRotate: true
 # endregion Firelocks
 
 # region Shutters
@@ -480,7 +479,7 @@
 
 # region Airlocks
 - type: construction
-  parent: BaseStructureFullTile
+  parent: BaseStructureFullTileDirectional
   id: Airlock
   graph: Airlock
   targetNode: airlock
@@ -491,10 +490,9 @@
   targetNode: glassAirlock
 
 - type: construction
-  parent: BaseStructureFullTileDirectional
+  parent: Airlock
   id: AirlockShuttle
   graph: AirlockShuttle
-  targetNode: airlock
 
 - type: construction
   parent: AirlockShuttle
@@ -509,7 +507,6 @@
   id: Windoor
   graph: Windoor
   targetNode: windoor
-
 # endregion Windoors
 
 # region Lighting

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1126,8 +1126,3 @@ MeteorRockUranium: AsteroidRockUranium
 
 #2026-08-18
 DrinkNeurotoxinGlass: null
-
-#2026-08-19
-# TODO: reverse this when AirlockAssembly* has construction graphs.
-AirlockAssemblyShuttle: AirlockShuttleAssembly
-AirlockAssemblyShuttleGlass: AirlockShuttleAssembly

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1128,5 +1128,6 @@ MeteorRockUranium: AsteroidRockUranium
 DrinkNeurotoxinGlass: null
 
 #2026-08-19
+# TODO: reverse this when AirlockAssembly* has construction graphs.
 AirlockAssemblyShuttle: AirlockShuttleAssembly
 AirlockAssemblyShuttleGlass: AirlockShuttleAssembly

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1126,3 +1126,7 @@ MeteorRockUranium: AsteroidRockUranium
 
 #2026-08-18
 DrinkNeurotoxinGlass: null
+
+#2026-08-19
+AirlockAssemblyShuttle: AirlockShuttleAssembly
+AirlockAssemblyShuttleGlass: AirlockShuttleAssembly


### PR DESCRIPTION
## About the PR

A handful of changes related to airlocks and firelocks.

1. Airlocks and firelocks now rotate on construction, as do airlock assemblies (firelocks already fine).
2. Introduces a more consistent naming for airlocks.  The red airlocks used for two-stage external airlocks are renamed to "external airlock" (from "airlock"), and the airlocks used for docking are renamed to "docking airlock" (from "external airlock" and one "glass shuttle airlock" reference in the construction menu).
3. Marks all airlock assembly entities as HideSpawnMenu - these are still placeholders as-is, and they were used erroneously in a few maps - in master, they behave as regular airlock assemblies.  This fixes the parents of AirlockAssemblyShuttle/Glass and the syndicate versions, as they were mapped on abandoned_outpost and Plasma.

## Why / Balance

Rotation: quality of life, matches existing airlocks.
Naming: better consistency, arguably more intuitive names.
Assemblies: really unintuitive - if they're placeholders, that's great, but as-is they're a mapper trap

## Technical details

Rotation: Airlocks and firelocks have their ConstructionPrototype parent changed to BaseStructureFullTileDirectional, which allows for rotation.  Shuttle overrides removed, now they inherit the rotatability from their parent.

Hiding assemblies: there are already a few uses of AirlockAssemblyShuttle and AirlockAssemblyShuttleGlass in the maps as-is.  These will construct into Airlock, which is probably not intended!  While these were originally migrated on this branch, it is possible to reparent them to fix the existing maps - they'll now at least build into docking airlocks vs. regular airlocks if/when constructed.

Suffixes: slightly more consistent - Docking could be removed from all of the existing airlocks (save maybe cargo/arrivals airlocks), since now it's _in the name_.

## Test plan

Construct airlocks and firelocks, the ghosts should be rotatable, and the resulting assemblies should match the rotation of the ghosts.
Check the construction menu for "airlock", you should have four entries.

## Media

Various assemblies.
<img width="468" height="489" alt="image" src="https://github.com/user-attachments/assets/b04eb0ce-1094-430c-b540-f9990ab896d7" />

A video showing the placement and first step of the airlock construction.  Note that the assemblies maintain the rotation of the ghosts.

https://github.com/user-attachments/assets/85dc8e62-6ae8-48b6-8884-f135c1655187

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- tweak: The construction menu entries for dockable airlocks can now be found at "docking airlock" and "docking glass airlock".
