### PR TITLE
Survival boxes now contain a utility knife

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -14,7 +14,7 @@
   parent: BaseBoxSurvival
   id: BoxSurvival
   name: O2 survival box
-  description: A small box containing a breath mask, an emergency oxygen tank, and an emergency medipen. Standard-issue for most oxygen-breathing crew.
+  description: A small box containing a breath mask, an emergency oxygen tank, an emergency medipen, a flare, and a utility knife. Standard-issue for most oxygen-breathing crew.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -24,6 +24,7 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
+        - id: UtilityKnife
   - type: Sprite
     layers:
     - state: internals
@@ -33,7 +34,7 @@
   parent: BaseBoxSurvival
   id: BoxSurvivalNitrogen
   name: N2 survival box
-  description: A small box containing a breath mask, an emergency nitrogen tank, and an emergency medipen. Standard-issue for most nitrogen-breathing crew.
+  description: A small box containing a breath mask, an emergency nitrogen tank, an emergency medipen, a flare, and a utility knife. Standard-issue for most nitrogen-breathing crew.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -43,6 +44,7 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
+        - id: UtilityKnife
   - type: Sprite
     layers:
     - state: internals
@@ -52,7 +54,7 @@
   parent: BoxSurvival
   id: BoxSurvivalEngineering
   name: extended-capacity O2 survival box
-  description: A small box containing a breath mask, an extended-capacity emergency oxygen tank, and an emergency medipen. Issued to oxygen-breathing crew whose job responsibilities often take them to places with no atmosphere.
+  description: A small box containing a breath mask, an extended-capacity emergency oxygen tank, an emergency medipen, a flare, and a utility knife. Issued to oxygen-breathing crew whose job responsibilities often take them to places with no atmosphere.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -62,6 +64,7 @@
         - id: ExtendedEmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
+        - id: UtilityKnife
   - type: Sprite
     layers:
     - state: internals
@@ -71,7 +74,7 @@
   parent: BoxSurvivalNitrogen
   id: BoxSurvivalEngineeringNitrogen
   name: extended-capacity N2 survival box
-  description: A small box containing a breath mask, an extended-capacity emergency nitrogen tank, and an emergency medipen. Issued to nitrogen-breathing crew whose job responsibilities often take them to places with no atmosphere.
+  description: A small box containing a breath mask, an extended-capacity emergency nitrogen tank, an emergency medipen, a flare, and a utility knife. Issued to nitrogen-breathing crew whose job responsibilities often take them to places with no atmosphere.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -81,6 +84,7 @@
         - id: ExtendedEmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
+        - id: UtilityKnife
   - type: Sprite
     layers:
     - state: internals
@@ -90,7 +94,7 @@
   parent: BoxSurvival
   id: BoxSurvivalSecurity
   name: security O2 survival box
-  description: A small box containing a gas mask, an emergency oxygen tank, and an emergency medipen. Issued to oxygen-breathing members of the security staff.
+  description: A small box containing a gas mask, an emergency oxygen tank, an emergency medipen, a flare, and a utility knife. Issued to oxygen-breathing members of the security staff.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -100,12 +104,13 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
+        - id: UtilityKnife
 
 - type: entity
   parent: BoxSurvivalNitrogen
   id: BoxSurvivalSecurityNitrogen
   name: security N2 survival box
-  description: A small box containing a gas mask, an emergency nitrogen tank, and an emergency medipen. Issued to nitrogen-breathing members of the security staff.
+  description: A small box containing a gas mask, an emergency nitrogen tank, an emergency medipen, a flare, and a utility knife. Issued to nitrogen-breathing members of the security staff.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -115,6 +120,7 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
+        - id: UtilityKnife
   - type: Sprite
     layers:
     - state: internals
@@ -124,7 +130,7 @@
   parent: BoxSurvival
   id: BoxSurvivalMedical
   name: medical O2 survival box
-  description: A small box containing a medical mask, an emergency oxygen tank, and an emergency medipen. Issued to oxygen-breathing members of the medical staff.
+  description: A small box containing a medical mask, an emergency oxygen tank, an emergency medipen, a flare, and a utility knife. Issued to oxygen-breathing members of the medical staff.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -134,12 +140,13 @@
         - id: EmergencyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
+        - id: UtilityKnife
 
 - type: entity
   parent: BoxSurvivalNitrogen
   id: BoxSurvivalMedicalNitrogen
   name: medical N2 survival box
-  description: A small box containing a medical mask, an emergency nitrogen tank, and an emergency medipen. Issued to nitrogen-breathing members of the medical staff.
+  description: A small box containing a medical mask, an emergency nitrogen tank, an emergency medipen, a flare, and a utility knife. Issued to nitrogen-breathing members of the medical staff.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -149,6 +156,7 @@
         - id: EmergencyNitrogenTankFilled
         - id: EmergencyMedipen
         - id: Flare
+        - id: UtilityKnife
   - type: Sprite
     layers:
     - state: internals
@@ -167,6 +175,7 @@
         - id: EmergencyFunnyOxygenTankFilled
         - id: EmergencyMedipen
         - id: Flare
+        - id: UtilityKnife
 
 - type: entity
   parent: BoxSurvivalHug
@@ -181,6 +190,7 @@
         - id: EmergencyNitrogenTankFilled # This should probably be replaced by an equivalent to the funny emergency oxygen tank, once that exists
         - id: EmergencyMedipen
         - id: Flare
+        - id: UtilityKnife
 
 # Primarily intended for antagonists that spawn outside the station (e.g ninjas, wizards)
 # Contains food and water because, unlike normal crew, we don't want to force them to seek food mid-round.
@@ -189,7 +199,7 @@
   parent: BoxCardboard
   id: BoxSurvivalDeluxeExtended
   name: deluxe extended-capacity O2 survival box
-  description: A deluxe survival box containing a breath mask, an extended-capacity emergency oxygen tank, an emergency medipen, an emergency flare, and a bit of food and water.
+  description: A deluxe survival box containing a breath mask, an extended-capacity emergency oxygen tank, an emergency medipen, a flare, and a bit of food and water.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -210,7 +220,7 @@
   parent: BoxSurvivalDeluxeExtended
   id: BoxSurvivalDeluxeExtendedNitrogen
   name: deluxe extended-capacity N2 survival box
-  description: A deluxe survival box containing a breath mask, an extended-capacity emergency oxygen tank, an emergency medipen, an emergency flare, and a bit of food and water.
+  description: A deluxe survival box containing a breath mask, an extended-capacity emergency oxygen tank, an emergency medipen, a flare, and a bit of food and water.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -234,7 +244,7 @@
   parent: BoxCardboard
   id: BoxSurvivalSyndicate
   name: syndicate O2 survival box
-  description: A Syndicate-designed survival box containing a syndicate gas mask, an extended-capacity emergency oxygen tank, an emergency medipen, an emergency flare, and a bit of food.
+  description: A Syndicate-designed survival box containing a syndicate gas mask, an extended-capacity emergency oxygen tank, an emergency medipen, a flare, and a bit of food.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -254,7 +264,7 @@
   parent: BoxSurvivalSyndicate
   id: BoxSurvivalSyndicateNitrogen
   name: syndicate N2 survival box
-  description: A Syndicate-designed survival box containing a syndicate gas mask, an extended-capacity emergency nitrogen tank, an emergency medipen, an emergency flare, and a bit of food.
+  description: A Syndicate-designed survival box containing a syndicate gas mask, an extended-capacity emergency nitrogen tank, an emergency medipen, a flare, and a bit of food.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -277,7 +287,7 @@
   parent: BoxCardboardSmall
   id: BoxSurvivalMilitaryDouble
   name: military O2 survival box
-  description: A military-grade survival box containing a double-capacity emergency oxygen tank, an emergency medipen, and an emergency flare.
+  description: A military-grade survival box containing a double-capacity emergency oxygen tank, an emergency medipen, and a flare.
   components:
   - type: EntityTableContainerFill
     containers:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
All standard crew survival boxes now contain a utility knife, in addition to their other contents.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
#44948 resized survival boxes to 2x3 in order to re-add the flare they used to contain. This means we now have exactly one tile of empty space in the survival boxes, which is a bit awkward. Utility knives were one of the proposed uses for this empty space in that PR's discussion, since they would be the kind of thing that'd be useful to have in a survival situation without being especially dangerous for the entire crew to be armed with (they do less damage than just punching/clawing with your bare hands). Hopefully this will also mean less tiders ripping out light fixtures to smash them for glass shards when they need to butcher something.

## Technical details
<!-- Summary of code changes for easier review. -->
Just YAML changes to add the utility knife to survival boxes, as well as updates to the boxes' descriptions.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Open Dev. Spawn survival boxes, check to see if they have utility knives in them.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="106" height="110" alt="tempknif" src="https://github.com/user-attachments/assets/2bcb9fc1-c714-4100-965d-ac31fd7bf9e7" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Nanotrasen's standard-issue survival boxes now contain utility knives.