### PR TITLE
publish pipeline now commits changelog, READY FOR STABLE

### DIFF
--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Update changelog
       run: |
-        dotnet tool install --global SpaceWizards.ChangelogTool --version 1.0.2
+        dotnet tool install --global SpaceWizards.ChangelogTool --version 1.0.7
         ss14-changelog update -d Resources/Changelog
       env:
         REPO: ${{ github.repository }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,8 @@ jobs:
     - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
+        fetch-depth: 0
+        filter: blob:none
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
       with:
@@ -36,6 +38,41 @@ jobs:
 
     - name: Install dependencies
       run: dotnet restore
+
+    - name: Update changelog
+      run: |
+        dotnet tool install --global SpaceWizards.ChangelogTool --version 1.0.7
+        ss14-changelog update -d Resources/Changelog
+      env:
+        REPO: ${{ github.repository }}
+        BRANCH: stable
+        CHANGELOG_REPO_PATH: Resources/Changelog
+        EXTRA_CATEGORIES: Admin,Maps,Rules
+        GITHUB_TOKEN: ${{ secrets.CL_ACCESS_TOKEN }}
+
+    - name: Commit and push changelog changes
+      id: changelog
+      run: |
+        git config user.name "Space-Wizards-Bot"
+        git config user.email "support@spacestation14.com"
+        if [ -n "$(git status --porcelain Resources/Changelog)" ]; then
+          git add Resources/Changelog
+          git commit -m "Update changelog"
+          git remote set-url origin "https://x-access-token:${CL_ACCESS_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+          echo "committed=true" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        CL_ACCESS_TOKEN: ${{ secrets.CL_ACCESS_TOKEN }}
+
+    # - name: Create PR from stable to master
+    #   if: steps.changelog.outputs.committed == 'true'
+    #   env:
+    #     GH_TOKEN: ${{ secrets.CL_ACCESS_TOKEN }}
+    #   run: |
+    #     if [ -z "$(gh pr list --repo "$GITHUB_REPOSITORY" --head stable --base master --state open --json number --jq '.[].number')" ]; then
+    #       gh pr create --repo "$GITHUB_REPOSITORY" --base master --head stable --title "Update changelog" --body "Sync from release to master."
+    #     fi
 
     - name: Build Packaging
       run: dotnet build Content.Packaging --configuration Release --no-restore /m


### PR DESCRIPTION
Workflow changes that make publish to generate changelog based on diff of current branch commits and last commit that updated changelog file.

Auto-creating PR is commented out due to lack of permissions for service account as of now.