### PR TITLE
[MALD PR] fix the AI door menu

### DIFF
--- a/Content.Client/UserInterface/Controls/SimpleRadialMenu.xaml.cs
+++ b/Content.Client/UserInterface/Controls/SimpleRadialMenu.xaml.cs
@@ -86,7 +86,7 @@ public sealed partial class SimpleRadialMenu : RadialMenu
         switch (models)
         {
             case RadialMenuOptionBase[] asArray:
-                asArray.Sort(CompareByTooltip);
+                Array.Sort(asArray, CompareByTooltip);
                 return asArray;
             case List<RadialMenuOptionBase> asList:
                 asList.Sort(CompareByTooltip);
@@ -154,7 +154,7 @@ public sealed partial class SimpleRadialMenu : RadialMenu
             _ => null
         };
 
-        if(imageControl != null)
+        if (imageControl != null)
             button.AddChild(imageControl);
 
         if (model is RadialMenuActionOptionBase actionOption)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Split apart from #45445 upon request - fixes the AI door menu.

plus one sneaky whitespace cleanup

## Why / Balance

Bugfix!

## Technical details

Not honestly sure what Array.Sort is doing internally that the Sort<T> isn't.

## Test plan

Be AI, alt-click on a door.

## Media

Following the test plan.  Note how the lock option jumps between the left and right slot!

https://github.com/user-attachments/assets/20cdbc1c-7ebd-4307-a7cc-bd00b84e1b6f

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
not in stable, meh

<details>

<summary>Fossil evidence:</summary>

For the archaeologists, the joke here is that this was called hotfix, but I was told "technically this isn't a hotfix", so I renamed the title to "mald PR"

</details>