### PR TITLE
Zombified bloodstreams no longer have a max of 1u

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -74,7 +74,6 @@ public sealed partial class ZombieSystem
 
     private static readonly ProtoId<TagPrototype> InvalidForGlobalSpawnSpellTag = "InvalidForGlobalSpawnSpell";
     private static readonly ProtoId<TagPrototype> CannotSuicideTag = "CannotSuicide";
-    private static readonly ProtoId<TagPrototype> CannotRegainBlood = "CannotRegainBlood";
     private static readonly ProtoId<NpcFactionPrototype> ZombieFaction = "Zombie";
     private static readonly string MindRoleZombie = "MindRoleZombie";
     private static readonly List<ProtoId<AntagPrototype>> BannableZombiePrototypes = ["Zombie"];

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -260,6 +260,7 @@ public sealed partial class ZombieSystem
         _bloodstream.ChangeBloodReagents(target, zombiecomp.NewBloodReagents);
         //Stop their blood from automatically regenerating
         _bloodstream.ChangeBloodRefreshAmount(target, 0f);
+        _bloodstream.ChangeBloodIncreaseEnabled(target, false);
 
         //This is specifically here to combat insuls, because frying zombies on grilles is funny as shit.
         _inventory.TryUnequip(target, "gloves", true, true);
@@ -343,7 +344,5 @@ public sealed partial class ZombieSystem
         // Also prevents them from becoming a Survivor. They're undead.
         _tag.AddTag(target, InvalidForGlobalSpawnSpellTag);
         _tag.AddTag(target, CannotSuicideTag);
-        // Also, stop them from regaining blood.
-        _tag.AddTag(target, CannotRegainBlood);
     }
 }

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -21,6 +21,7 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Humanoid;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction.Components;
+using Content.Shared.Metabolism;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Pulling.Components;
@@ -71,6 +72,7 @@ public sealed partial class ZombieSystem
     [Dependency] private NPCSystem _npc = default!;
     [Dependency] private TagSystem _tag = default!;
     [Dependency] private ISharedPlayerManager _player = default!;
+    [Dependency] private BodySystem _body = default!;
 
     private static readonly ProtoId<TagPrototype> InvalidForGlobalSpawnSpellTag = "InvalidForGlobalSpawnSpell";
     private static readonly ProtoId<TagPrototype> CannotSuicideTag = "CannotSuicide";
@@ -143,6 +145,13 @@ public sealed partial class ZombieSystem
         RemComp<LegsParalyzedComponent>(target);
         RemComp<ComplexInteractionComponent>(target);
         RemComp<SentienceTargetComponent>(target);
+
+        // remove the metabolizer from all the body's organs. they're an undead.
+        var metabolizerOrgans = _body.EnumerateOrgans<MetabolizerComponent>(target);
+        foreach(var organ in metabolizerOrgans)
+        {
+            RemComp<MetabolizerComponent>(organ);
+        }
 
         //funny voice
         var accentType = "zombie";

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -74,6 +74,7 @@ public sealed partial class ZombieSystem
 
     private static readonly ProtoId<TagPrototype> InvalidForGlobalSpawnSpellTag = "InvalidForGlobalSpawnSpell";
     private static readonly ProtoId<TagPrototype> CannotSuicideTag = "CannotSuicide";
+    private static readonly ProtoId<TagPrototype> CannotRegainBlood = "CannotRegainBlood";
     private static readonly ProtoId<NpcFactionPrototype> ZombieFaction = "Zombie";
     private static readonly string MindRoleZombie = "MindRoleZombie";
     private static readonly List<ProtoId<AntagPrototype>> BannableZombiePrototypes = ["Zombie"];
@@ -189,7 +190,11 @@ public sealed partial class ZombieSystem
         }
 
         if (TryComp<BloodstreamComponent>(target, out var stream) && stream.BloodReferenceSolution is { } reagents)
+        {
             zombiecomp.BeforeZombifiedBloodReagents = reagents.Clone();
+            // Store the blood refresh amount for cloning later.
+            zombiecomp.BeforeZombifiedBloodRefresh = stream.BloodRefreshAmount;
+        }
 
         if (_visualBody.TryGatherMarkingsData(target, null, out var profiles, out _, out var markings))
         {
@@ -253,6 +258,8 @@ public sealed partial class ZombieSystem
         _bloodstream.SetBloodLossThreshold(target, 0f);
         //Give them zombie blood
         _bloodstream.ChangeBloodReagents(target, zombiecomp.NewBloodReagents);
+        //Stop their blood from automatically regenerating
+        _bloodstream.ChangeBloodRefreshAmount(target, 0f);
 
         //This is specifically here to combat insuls, because frying zombies on grilles is funny as shit.
         _inventory.TryUnequip(target, "gloves", true, true);
@@ -336,5 +343,7 @@ public sealed partial class ZombieSystem
         // Also prevents them from becoming a Survivor. They're undead.
         _tag.AddTag(target, InvalidForGlobalSpawnSpellTag);
         _tag.AddTag(target, CannotSuicideTag);
+        // Also, stop them from regaining blood.
+        _tag.AddTag(target, CannotRegainBlood);
     }
 }

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -306,9 +306,9 @@ namespace Content.Server.Zombies
 
             // Restore the blood refresh amount to what it was before zombification. They can't regain blood otherwise.
             _bloodstream.ChangeBloodRefreshAmount(target, zombiecomp.BeforeZombifiedBloodRefresh);
+            _bloodstream.ChangeBloodIncreaseEnabled(target, true);
 
             // Remove the tags that we added during Zombification
-            _tag.RemoveTag(target, CannotRegainBlood);
             _tag.RemoveTag(target, CannotSuicideTag);
             _tag.RemoveTag(target, InvalidForGlobalSpawnSpellTag);
             return true;

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -28,6 +28,8 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Content.Server.Ghost.Roles.Components;
+using Content.Shared.Medical;
+using Content.Shared.Construction.Steps;
 
 namespace Content.Server.Zombies
 {
@@ -302,6 +304,13 @@ namespace Content.Server.Zombies
 
             _bloodstream.ChangeBloodReagents(target, zombiecomp.BeforeZombifiedBloodReagents);
 
+            // Restore the blood refresh amount to what it was before zombification. They can't regain blood otherwise.
+            _bloodstream.ChangeBloodRefreshAmount(target, zombiecomp.BeforeZombifiedBloodRefresh);
+
+            // Remove the tags that we added during Zombification
+            _tag.RemoveTag(target, CannotRegainBlood);
+            _tag.RemoveTag(target, CannotSuicideTag);
+            _tag.RemoveTag(target, InvalidForGlobalSpawnSpellTag);
             return true;
         }
 

--- a/Content.Shared/Body/Components/BloodstreamComponent.cs
+++ b/Content.Shared/Body/Components/BloodstreamComponent.cs
@@ -108,6 +108,12 @@ public sealed partial class BloodstreamComponent : Component
     public FixedPoint2 BleedPuddleThreshold = 1.0f;
 
     /// <summary>
+    /// Should we allow entities to regain their blood? This affects blood increase from reagents and topicals.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool BloodIncreaseEnabled = true;
+
+    /// <summary>
     /// A modifier set prototype ID corresponding to how damage should be modified
     /// before taking it into account for bloodloss.
     /// </summary>

--- a/Content.Shared/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/BloodstreamSystem.cs
@@ -20,7 +20,6 @@ using Content.Shared.Popups;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Rejuvenate;
 using Content.Shared.StatusEffectNew;
-using Content.Shared.Tag;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
@@ -42,7 +41,6 @@ public sealed partial class BloodstreamSystem : EntitySystem
     [Dependency] private MobStateSystem _mobStateSystem = default!;
     [Dependency] private DamageableSystem _damageableSystem = default!;
     [Dependency] private MetabolizerSystem _metabolizer = default!;
-    [Dependency] private TagSystem _tagSystem = default!;
 
     public override void Update(float frameTime)
     {
@@ -596,7 +594,12 @@ public sealed partial class BloodstreamSystem : EntitySystem
             currentVolume += bloodSolution.RemoveReagent(reagent.Reagent, quantity: bloodSolution.Volume, ignoreReagentData: true);
         }
 
-        ent.Comp.BloodReferenceSolution = reagents.Clone();
+        // Scale the solution to the volume of the blood.
+        var newReagentsSolution = reagents.Clone();
+        newReagentsSolution.ScaleTo(ent.Comp.BloodReferenceSolution.MaxVolume);
+
+        // Set the scaled solution as the new blood reference.
+        ent.Comp.BloodReferenceSolution = newReagentsSolution;
         DirtyField(ent, ent.Comp, nameof(BloodstreamComponent.BloodReferenceSolution));
 
         if (currentVolume == FixedPoint2.Zero)

--- a/Content.Shared/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/BloodstreamSystem.cs
@@ -412,10 +412,6 @@ public sealed partial class BloodstreamSystem : EntitySystem
     public bool TryModifyBloodLevel(Entity<BloodstreamComponent?> ent, FixedPoint2 amount)
     {
         var reference = 1f;
-        if(_tagSystem.HasTag(ent, CannotRegainBlood) && amount > 0)
-        {
-            return false;
-        }
 
         if (amount < 0)
         {
@@ -439,6 +435,9 @@ public sealed partial class BloodstreamSystem : EntitySystem
         if (!Resolve(ent, ref ent.Comp, logMissing: false)
             || !_solutionContainer.ResolveSolution(ent.Owner, ent.Comp.BloodSolutionName, ref ent.Comp.BloodSolution, out var bloodSolution)
             || amount == 0)
+            return false;
+
+        if (!ent.Comp.BloodIncreaseEnabled && amount > 0)
             return false;
 
         // TODO: Either make this percentage based regeneration and pre-pass the percentage.
@@ -625,6 +624,17 @@ public sealed partial class BloodstreamSystem : EntitySystem
         }
         ent.Comp.BloodRefreshAmount = amount;
         DirtyField(ent, ent.Comp, nameof(BloodstreamComponent.BloodRefreshAmount));
+    }
+
+    /// <summary>
+    /// Change whether or not blood can be increased in a bloodstream.
+    /// </summary>
+    public void ChangeBloodIncreaseEnabled(Entity<BloodstreamComponent?> ent, bool status = true)
+    {
+        if (!Resolve(ent, ref ent.Comp, logMissing: false))
+            return;
+        ent.Comp.BloodIncreaseEnabled = status;
+        DirtyField(ent, ent.Comp, nameof(BloodstreamComponent.BloodIncreaseEnabled));
     }
 
     /// <summary>

--- a/Content.Shared/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/BloodstreamSystem.cs
@@ -20,6 +20,7 @@ using Content.Shared.Popups;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Rejuvenate;
 using Content.Shared.StatusEffectNew;
+using Content.Shared.Tag;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
@@ -41,6 +42,9 @@ public sealed partial class BloodstreamSystem : EntitySystem
     [Dependency] private MobStateSystem _mobStateSystem = default!;
     [Dependency] private DamageableSystem _damageableSystem = default!;
     [Dependency] private MetabolizerSystem _metabolizer = default!;
+    [Dependency] private TagSystem _tagSystem = default!;
+
+    private static readonly ProtoId<TagPrototype> CannotRegainBlood = "CannotRegainBlood";
 
     public override void Update(float frameTime)
     {
@@ -408,6 +412,10 @@ public sealed partial class BloodstreamSystem : EntitySystem
     public bool TryModifyBloodLevel(Entity<BloodstreamComponent?> ent, FixedPoint2 amount)
     {
         var reference = 1f;
+        if(_tagSystem.HasTag(ent, CannotRegainBlood) && amount > 0)
+        {
+            return false;
+        }
 
         if (amount < 0)
         {
@@ -600,6 +608,23 @@ public sealed partial class BloodstreamSystem : EntitySystem
         var solution = ent.Comp.BloodReferenceSolution.Clone();
         solution.ScaleSolution(currentVolume / solution.Volume);
         _solutionContainer.AddSolution(ent.Comp.BloodSolution.Value, solution);
+    }
+
+    /// <summary>
+    /// Change how much blood is recovered in a bloodstream.
+    /// </summary>
+    public void ChangeBloodRefreshAmount(Entity<BloodstreamComponent?> ent, FixedPoint2 amount)
+    {
+        if(!Resolve(ent, ref ent.Comp, logMissing: false))
+        {
+            return;
+        }
+        if(amount < 0f)
+        {
+            amount = 0f;
+        }
+        ent.Comp.BloodRefreshAmount = amount;
+        DirtyField(ent, ent.Comp, nameof(BloodstreamComponent.BloodRefreshAmount));
     }
 
     /// <summary>

--- a/Content.Shared/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/BloodstreamSystem.cs
@@ -44,8 +44,6 @@ public sealed partial class BloodstreamSystem : EntitySystem
     [Dependency] private MetabolizerSystem _metabolizer = default!;
     [Dependency] private TagSystem _tagSystem = default!;
 
-    private static readonly ProtoId<TagPrototype> CannotRegainBlood = "CannotRegainBlood";
-
     public override void Update(float frameTime)
     {
         base.Update(frameTime);

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -156,5 +156,5 @@ public sealed partial class ZombieComponent : Component
     /// The blood reagents to give the zombie. In case you want zombies that bleed milk, or something.
     /// </summary>
     [DataField]
-    public Solution NewBloodReagents = new([new("ZombieBlood", 1)]);
+    public Solution NewBloodReagents = new([new("ZombieBlood", 600)]);
 }

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -163,5 +163,5 @@ public sealed partial class ZombieComponent : Component
     /// The blood reagents to give the zombie. In case you want zombies that bleed milk, or something.
     /// </summary>
     [DataField]
-    public Solution NewBloodReagents = new([new("ZombieBlood", 600)]);
+    public Solution NewBloodReagents = new([new("ZombieBlood", 1)]);
 }

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -2,6 +2,7 @@ using Content.Shared.Body;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Roles;
@@ -145,6 +146,12 @@ public sealed partial class ZombieComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier BiteSound = new SoundPathSpecifier("/Audio/Effects/bite.ogg");
+
+    /// <summary>
+    /// The blood refresh of the humanoid to restore in case of cloning.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 BeforeZombifiedBloodRefresh = new();
 
     /// <summary>
     /// The blood reagents of the humanoid to restore in case of cloning

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -224,9 +224,6 @@
   id: CannonBall # Ammo: WeaponLauncherPirateCannon, ShuttleGunPirateCannon
 
 - type: Tag
-  id: CannotRegainBlood # Used by BloodlossSystem to block regaining blood, used by Zombies.
-
-- type: Tag
   id: CannotSuicide # Used by SuicideSystem. Tagged entities ghost when attempting to suicide.
 
 - type: Tag

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -224,6 +224,9 @@
   id: CannonBall # Ammo: WeaponLauncherPirateCannon, ShuttleGunPirateCannon
 
 - type: Tag
+  id: CannotRegainBlood # Used by BloodlossSystem to block regaining blood, used by Zombies.
+
+- type: Tag
   id: CannotSuicide # Used by SuicideSystem. Tagged entities ghost when attempting to suicide.
 
 - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This changes the maximum amount of ZombieBlood that an entity can hold. Currently, the bloodstream caps out at 1u of ZombieBlood.

## Why / Balance
On Zombie rounds, attempting to make the cure is much harder when a Zombie only has 1u of blood to remove. This matches the amount of blood in a solution to have parity with regular playable species.

## Technical details
I changed a 1 to a 600. 

Bloodstream's ChangeBloodReagents method clones the original 1u of ZombieBlood to the entity's BloodReferenceSolution, causing the MaxVolume to be kept at 1u. Default value with the BloodReferenceSolution is 600.

## Test Plan
1. Add ZombifyOnDeath component
2. Kill the entity with ZombifyOnDeath
3. Inspect the Bloodstream's reagents and BloodstreamComponent's Solution's MaxVolume

## Media
Before: 
<img width="1189" height="516" alt="image" src="https://github.com/user-attachments/assets/a474eb72-518a-482e-bcae-946cbc262ec8" />
After:
<img width="1014" height="425" alt="image" src="https://github.com/user-attachments/assets/55a21cbe-70c1-4b67-b0fa-de9d187bb2b8" />

<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Zombified entities no longer have 1u of blood.
