### PR TITLE
Disable Strippable admin alert for mannequins and animals

### DIFF
--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Interaction.Components;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.VirtualItem;
+using Content.Shared.Mind.Components;
 using Content.Shared.Popups;
 using Content.Shared.Strip.Components;
 using Content.Shared.Verbs;
@@ -359,7 +360,11 @@ public abstract partial class SharedStrippableSystem : EntitySystem
         RaiseLocalEvent(item, new DroppedEvent(user), true); // Gas tank internals etc.
 
         _handsSystem.PickupOrDrop(user, item, animateUser: stealth, animate: !stealth);
-        _adminLogger.Add(LogType.Stripping, LogImpact.High, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s {slot} slot");
+        // Entities that have never been mind-controlled (mannequins, unpossessed animals) don't need to alert admins.
+        var impact = TryComp<MindContainerComponent>(target, out var mindContainer) && mindContainer.LastMind != null
+            ? LogImpact.High
+            : LogImpact.Low;
+        _adminLogger.Add(LogType.Stripping, impact, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s {slot} slot");
     }
 
     /// <summary>
@@ -574,7 +579,11 @@ public abstract partial class SharedStrippableSystem : EntitySystem
 
         _handsSystem.TryDrop(target, item, checkActionBlocker: false);
         _handsSystem.PickupOrDrop(user, item, animateUser: stealth, animate: !stealth, handsComp: user.Comp);
-        _adminLogger.Add(LogType.Stripping, LogImpact.High, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands");
+        // Entities that have never been mind-controlled (mannequins, unpossessed animals) don't need to alert admins.
+        var impact = TryComp<MindContainerComponent>(target, out var mindContainer) && mindContainer.LastMind != null
+            ? LogImpact.High
+            : LogImpact.Low;
+        _adminLogger.Add(LogType.Stripping, impact, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands");
 
         // Hand update will trigger strippable update.
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Suppresses the "new player stripping someone" admin alert when the target has never been mind-controlled by a player (mannequins, animals, etc).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The admin alert for low-playtime players stripping entities exists to catch griefers targeting real crewmembers, but it also fires for mannequins and animals that no player has ever piloted, spamming admins with useless pings. Stripping an SSD (disconnected) player's body still alerts, since their `MindContainerComponent.LastMind` stays set.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
- Strip a mannequin/animal as a fresh account: no admin alert.
- Strip a live player as a fresh account: admin alert still fires.
- Strip an SSD (disconnected) player's body as a fresh account, alert still fires.
