### PR TITLE
Zombie event tweaks for new ambu changes

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/ZombieRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/ZombieRuleComponent.cs
@@ -2,6 +2,7 @@ using Content.Shared.Roles;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Content.Server.RoundEnd;
 
 namespace Content.Server.GameTicking.Rules.Components;
 
@@ -25,4 +26,16 @@ public sealed partial class ZombieRuleComponent : Component
     /// </summary>
     [DataField]
     public float ZombieShuttleCallPercentage = 0.7f;
+
+    /// <summary>
+    /// What will happen if zombies get more than 80%
+    /// </summary>
+    [DataField]
+    public RoundEndBehavior ZombieRoundEndBehavior = RoundEndBehavior.ShuttleCall;
+
+    /// <summary>
+    /// Shuttle timer for when shuttle is called
+    /// </summary>
+    [DataField]
+    public TimeSpan ZombieEvacShuttleTime = TimeSpan.FromMinutes(5);
 }

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -121,6 +121,8 @@ public sealed partial class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponen
             _popup.PopupEntity(Loc.GetString("zombie-alone"), healthy[0], healthy[0]);
 
         if (GetInfectedFraction(false) > zombieRuleComponent.ZombieShuttleCallPercentage && !_roundEnd.IsRoundEndRequested())
+            _roundEnd.DoRoundEndBehavior(zombieRuleComponent.ZombieRoundEndBehavior,
+                zombieRuleComponent.ZombieEvacShuttleTime);
         {
             foreach (var station in _station.GetStations())
             {

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -121,14 +121,14 @@ public sealed partial class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponen
             _popup.PopupEntity(Loc.GetString("zombie-alone"), healthy[0], healthy[0]);
 
         if (GetInfectedFraction(false) > zombieRuleComponent.ZombieShuttleCallPercentage && !_roundEnd.IsRoundEndRequested())
-            _roundEnd.DoRoundEndBehavior(zombieRuleComponent.ZombieRoundEndBehavior,
-                zombieRuleComponent.ZombieEvacShuttleTime);
         {
             foreach (var station in _station.GetStations())
             {
                 _chat.DispatchStationAnnouncement(station, Loc.GetString("zombie-shuttle-call"), colorOverride: Color.Crimson);
             }
-            _roundEnd.RequestRoundEnd(checkCooldown: false);
+
+            _roundEnd.DoRoundEndBehavior(zombieRuleComponent.ZombieRoundEndBehavior,
+            zombieRuleComponent.ZombieEvacShuttleTime);
         }
 
         // we include dead for this count because we don't want to end the round

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -486,7 +486,7 @@
   - type: StationEvent
     earliestStart: 45
     minimumPlayers: 40
-    weight: 1 # Zombies was happening basically every single survival round, so now it's super rare
+    weight: 1
     duration: 1
     occursDuringRoundEnd: false
   - type: ZombieRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -484,7 +484,7 @@
   parent: BaseGameRule
   components:
   - type: StationEvent
-    earliestStart: 90
+    earliestStart: 45
     minimumPlayers: 40
     weight: 1 # Zombies was happening basically every single survival round, so now it's super rare
     duration: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I made the zombie minimum round timer lower, as LRP is not reaching 90 minute rounds, and MRP isn't even hitting the minimum player requirement so it wont hurt their RP. I also made it so when the evac percentage is reached, the evac is 5 minutes rather than 10 minutes.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With the new changes regarding ambu, it would be good to have zombies be a bit more common, and if chemists aren't able to scrounge up cures for people in time, the round should not be stalled to 10 minutes.
## Technical details
<!-- Summary of code changes for easier review. -->
2 new comps, similar to the nukie/rev game events
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
force zombie outbreak, infect yourself
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
🆑 
- tweak: Zombies can now appear 45 minutes into the round
- add: When zombies reach their infected goal, the shuttle timer is shortened to 5 minutes.