### PR TITLE
.editorconfig: prefer case block braces on same level as `case`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -126,7 +126,7 @@ resharper_csharp_keep_existing_embedded_arrangement = false
 #csharp_indent_block_contents = true
 csharp_indent_braces = false
 #csharp_indent_case_contents = true
-#csharp_indent_case_contents_when_block = true
+csharp_indent_case_contents_when_block = false
 #csharp_indent_labels = one_less_than_current
 csharp_indent_switch_labels = true
 xmldoc_indent_text = zeroindent
@@ -341,6 +341,7 @@ dotnet_naming_symbols.type_parameters_symbols.applicable_kinds = type_parameter
 
 # ReSharper properties
 resharper_braces_for_ifelse = required_for_multiline
+resharper_csharp_case_block_braces = next_line
 resharper_csharp_wrap_arguments_style = chop_if_long
 resharper_csharp_wrap_parameters_style = chop_if_long
 resharper_keep_existing_attribute_arrangement = true


### PR DESCRIPTION
## About the PR

Adds .editorconfig settings for case brace indentation - as the title says, they should be on the same level as case:
```cs
switch (expression)
{
    case 0:
    {
        foo();
        break;
    }
}
```

Currently, at least in VS Code, the above snippet should be formatted as:
```cs
switch (expression)
{
    case 0:
        {
            foo();
            break;
        }
}
```

Seems a bit much.

## Why / Balance

In VS Code (and likely Visual Studio proper) at present, case statements are expected to indent their braces on the next line.  With this suggestion, this should require them to be on the same indentation as the `case` keyword itself.

## Technical details

.editorconfig ops.

Resharper value taken from https://www.jetbrains.com/help/resharper/EditorConfig_CSHARP_BracesPageSchema.html#Braces_layout
Note that the current expected format (at least in VS/VS Code) is the same as next_line_shifted_2.

(Unscoped) VS/VS Code value taken from
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options#csharp_indent_case_contents_when_block

As best as I can tell, this option doesn't exist for Rider.  Would appreciate a test from someone with Rider, I'm a bit blind on that front, and don't want to cause odd editorconfig issues.

## Test plan
Open your IDE.  Open NPCUtilitySystem.
Gaze lovingly at the lack of yellow squiggles in GetScore.

## Media

<img width="1071" height="464" alt="image" src="https://github.com/user-attachments/assets/2df759ca-8de8-483f-b582-38a2f2016186" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


## Changelog
nope