### PR TITLE
Aghosts can adjust covered pipes

### DIFF
--- a/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Atmos.Components;
 using Content.Shared.Database;
 using Content.Shared.Examine;
+using Content.Shared.Ghost.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
@@ -56,7 +57,8 @@ public abstract partial class SharedAtmosPipeLayersSystem : EntitySystem
 
         var user = args.User;
 
-        if (TryComp<SubFloorHideComponent>(ent, out var subFloorHide) && subFloorHide.IsUnderCover)
+        if (TryComp<SubFloorHideComponent>(ent, out var subFloorHide) && subFloorHide.IsUnderCover
+            && (!TryComp<GhostComponent>(user, out var ghost) || !ghost.CanGhostInteract))
         {
             var v = new Verb
             {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Allows ghosts (admins, mappers, etc.) with `CanGhostInteract` (i.e., aghosts) enabled to change the pipe layer of atmos pipes even when the pipe is hidden under floor covering. Previously, the interaction was blocked for all entities, including ghosts, preventing quick layer adjustments during mapping without removing the floor first.

## Why / Balance
This change is primarily a quality-of-life improvement for maintainers, mappers, and admins. When working on maps or debugging atmos setups, it is often inconvenient to have to remove floor tiles just to cycle a pipe's layer. Ghosts already have the ability to interact with certain entities for administrative purposes; this extends that capability to pipe layer adjustments. It does not affect normal gameplay, as regular players cannot become aghosts.

## Technical details
Added a `GhostComponent` check to the pipe layer adjustment logic. Ghosts with `CanGhostInteract` enabled are now exempt from the floor covering restriction, allowing them to adjust pipe layers without removing the floor. All other behaviour remains unchanged.

## Test plan
1. Place a pipe (pipe/scrubber/vent) on the floor.
2. As a normal player, try to change its layer with a screwdriver → blocked.
3. As a ghost with `CanGhostInteract` (aghost) → layer change works.
4. As a ghost without `CanGhostInteract` (turn off on comps) → blocked as before.

## Media
![Content Client demonstrating ghost interaction](https://github.com/user-attachments/assets/0044ef7c-54fb-4c1d-8aa6-04a2f9bf72be)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

## Changelog
:cl:
ADMIN:
- tweak: Aghosts can now adjust pipe layers even when pipes are under floor cover.