### PR TITLE
Buff armblade damage.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/armblade.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/armblade.yml
@@ -19,8 +19,9 @@
     attackRate: 1
     damage:
       types:
-        Slash: 11
-        Piercing: 11
+        Slash: 10
+        Piercing: 10
+        Caustic: 5
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/armblade.rsi


### PR DESCRIPTION

Made with the blessing of @ScarKy0 

## About the PR
Buffs the armblade from 11 Piercing, 11 Slashing to 5 Caustic, 10 Piercing, 10 Slashing

## Why / Balance
These thresholds make ling much more viable in ambushing, but keeps loud combat out of the question. 

Unarmoured: 5 hits -> 4 hits
Secoff: 8 hits -> 6 hits
Captain: 7 hits
Secoffs with more optimal armour: 9-11 hits now, depending on what you have
Bloodred: 9 hits

And let's not forget that secoffs can kill anyone except nukies in 3 hits.

## Technical details
Yaml!!

## Test plan
1. Open dev
2. Make yourself ling
3. Spawn urist
4. Give it armour
5. Attack it

## Media
Bloodbath at the devmap
<img width="1426" height="872" alt="image" src="https://github.com/user-attachments/assets/22b34961-9d81-4034-98cd-9be03564e6f5" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
