### PR TITLE
Add GravityAffected to SeatBase

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -77,6 +77,7 @@
     bodyType: KinematicController
   - type: Vehicle
     requiresHands: false # you use your feet!
+  - type: GravityAffected
   - type: MovementSpeedModifier
     baseAcceleration: 2
     baseFriction: 2

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -14,6 +14,7 @@
   - type: InteractionOutline
   - type: Physics
     bodyType: Dynamic
+  - type: GravityAffected
   - type: Fixtures
     fixtures:
       fix1:
@@ -77,7 +78,6 @@
     bodyType: KinematicController
   - type: Vehicle
     requiresHands: false # you use your feet!
-  - type: GravityAffected
   - type: MovementSpeedModifier
     baseAcceleration: 2
     baseFriction: 2


### PR DESCRIPTION
## About the PR
Makes office chair vehicles affected by gravity

Resolves #45487
Resolves #45488

## Why / Balance
Office chairs could be freely driven through space

## Technical details
Added GravityAffected to OfficeChairVehicleBase

## Test plan
- Verified office chairs can no longer be freely driven in space

## Media
Not needed

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

## Changelog
:cl:
- fix: Fixed office chairs being able to freely move through space.