### PR TITLE
Readds steel door (no sprite)

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
@@ -145,7 +145,7 @@
     node: steelDoor
   - type: Damageable
     damageModifierSet: SteelMod
-  - type: DestructibleExpand
+  - type: Destructible
     thresholds:
     - trigger: *DamageDoorWeak
       behaviors:

--- a/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
@@ -133,6 +133,26 @@
         spawn:
           IngotSilver1: *BaseDoorSpawn
 
+- type: entity
+  parent: [ BaseMaterialDoorNavMap, StructureHealthDoorWeak]
+  id: SteelDoor
+  name: steel door
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/MaterialDoors/silver-door.rsi # TODO Add steel door sprite
+  - type: Construction
+    graph: DoorGraph
+    node: steelDoor
+  - type: Damageable
+    damageModifierSet: SteelMod
+  - type: DestructibleExpand commentComment on line R148Resolved
+    thresholds:
+    - trigger: *DamageDoorWeak
+      behaviors:
+      - *SoundMetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1: *BaseDoorSpawn
 ### Other doors ###
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
@@ -145,7 +145,7 @@
     node: steelDoor
   - type: Damageable
     damageModifierSet: SteelMod
-  - type: DestructibleExpand commentComment on line R148Resolved
+  - type: DestructibleExpand
     thresholds:
     - trigger: *DamageDoorWeak
       behaviors:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/doors.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/doors.yml
@@ -6,6 +6,13 @@
       actions:
         - !type:DestroyEntity {}
       edges:
+        - to: steelDoor
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: Steel
+              amount: 10
+              doAfter: 8
         - to: woodDoor
           completed:
             - !type:SnapToGrid { }
@@ -47,6 +54,17 @@
           steps:
             - material: Cardboard
               amount: 10
+              doAfter: 8
+    - node: steelDoor
+      entity: SteelDoor
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 10
+          steps:
+            - tool: Anchoring
               doAfter: 8
     - node: woodDoor
       entity: WoodDoor

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -568,6 +568,11 @@
 
 - type: construction
   parent: SilverDoor
+  id: SteelDoor
+  targetNode: steelDoor
+
+- type: construction
+  parent: SilverDoor
   id: PaperDoor
   targetNode: paperDoor
 

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -868,8 +868,6 @@ PinionAirlock: Airlock
 PinionAirlockGlass: AirlockGlass
 PinionAirlockAssembly: AirlockAssembly
 BananiumDoor: GoldDoor
-EncrustedIronstoneDoor: SilverDoor
-IronstoneDoor: SilverDoor
 WallSnowCobblebrick: WallBrick
 WallSandCobblebrick: WallBrick
 WallChromiteCobblebrick: WallBrick
@@ -990,7 +988,6 @@ IronsandStep: null
 TurnstileGenpopEnter: EnergyGateGenpopEnter
 TurnstileGenpopLeave: EnergyGateGenpopLeave
 Turnstile: EnergyGate
-MetalDoor: SilverDoor
 MiningWindow: ReinforcedWindow
 MiningWindowDiagonal: ReinforcedWindowDiagonal
 FloorTileItemLightAstroGrass: null
@@ -1130,3 +1127,7 @@ DrinkNeurotoxinGlass: null
 #2026-08-19
 JanitorServiceLight: null
 
+#2026-08-20
+MetalDoor: SteelDoor
+EncrustedIronstoneDoor: SteelDoor
+IronstoneDoor: SteelDoor


### PR DESCRIPTION
## About the PR
Original PR #45414
Readds metal door, now known as steel door, back into the game
No sprite for now, just to fix migration issues
Originally removed in #44857

## Why / Balance
Steel door was only removed because it looked too similar to silver door, so im readding it back for mapping
why no sprite? i want to at least have the proto set for migration to happen, sprite can be added later, for now it uses silver door sprite.

I would like to merge this quickly so we could work on maps again

## Technical details
ada helped me make it work with the new structure reballance

## Test plan
go in the game, check the construction menu, spawn steel door

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
i dont think there's a need for this
