### PR TITLE
Fix mono steel tile changes and cleanup

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/dirt.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/dirt.yml
@@ -15,6 +15,7 @@
     color: '#FFFFFF7F'
     cleanable: true
     tileBlacklist: # Everything here just looks bad if it gets regular dirt on it
+    - FloorSteelMono
     - FloorWood
     - FloorWoodLarge
     - FloorWhiteMono

--- a/Resources/Prototypes/Entities/Objects/Tiles/tiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Tiles/tiles.yml
@@ -204,20 +204,6 @@
     node: steeltile
 
 - type: entity
-  name: steel mono tile
-  parent: FloorTileItemSteel
-  id: FloorTileItemSteelMono
-  components:
-  - type: Sprite
-    state: steel-mono
-  - type: FloorTile
-    outputs:
-    - Plating
-    - FloorSteelMono
-  - type: Stack
-    stackType: FloorTileSteelMono
-
-- type: entity
   parent: FloorTileItemSteel
   id: FloorTileItemSteelVerticalSlatsBordered
   name: steel vertical bordered slat tile
@@ -272,6 +258,20 @@
       - FloorSteelMini
   - type: Stack
     stackType: FloorTileSteelMini
+
+- type: entity
+  name: steel mono tile
+  parent: FloorTileItemSteel
+  id: FloorTileItemSteelMono
+  components:
+  - type: Sprite
+    state: steel-mono
+  - type: FloorTile
+    outputs:
+    - Plating
+    - FloorSteelMono
+  - type: Stack
+    stackType: FloorTileSteelMono
 
 - type: entity
   name: steel pavement

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
@@ -19,7 +19,7 @@
     drawdepth: WallMountedItems
     sprite: Structures/Wallmounts/screen.rsi
     state: screen # Note: outer_frame will be added on top of text layers.
-    # noRot: true # TODO From acessibility standpoint, screens with text shouln't be rotattable (Check it with acessibility team) # Mapping Lead already have concerns about this
+    # noRot: true # TODO From an accessibility standpoint, screens with text shouldn't be rotatable; Mapping Lead already have concerns about this.
   - type: Appearance
   - type: Damageable
     damageModifierSet: GlassMod

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/screen.yml
@@ -19,6 +19,7 @@
     drawdepth: WallMountedItems
     sprite: Structures/Wallmounts/screen.rsi
     state: screen # Note: outer_frame will be added on top of text layers.
+    # noRot: true # TODO From acessibility standpoint, screens with text shouln't be rotattable (Check it with acessibility team) # Mapping Lead already have concerns about this
   - type: Appearance
   - type: Damageable
     damageModifierSet: GlassMod

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
@@ -72,6 +72,7 @@
     sprite: Structures/Wallmounts/signalscreen.rsi
     offset: 0, -0.5
     state: signalscreen
+    # noRot: true # TODO From acessibility standpoint, screens with text shouln't be rotattable (Check it with acessibility team)
   - type: Construction
     graph: Timer
     node: screen

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
@@ -72,7 +72,7 @@
     sprite: Structures/Wallmounts/signalscreen.rsi
     offset: 0, -0.5
     state: signalscreen
-    # noRot: true # TODO From acessibility standpoint, screens with text shouln't be rotattable (Check it with acessibility team)
+    # noRot: true # TODO From an accessibility standpoint, screens with text shouldn't be rotatable; Mapping Lead already have concerns about this.
   - type: Construction
     graph: Timer
     node: screen

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -98,7 +98,7 @@
     graph: Grille
     node: grille
 
-### DIAGONAL
+### Diagonal
 - type: entity
   parent: Grille
   id: GrilleDiagonal
@@ -138,7 +138,7 @@
     graph: GrilleDiagonal
     node: grilleDiagonal
 
-### BROKEN
+### Broken state
 - type: entity
   parent: [ BaseStructure, StructureHealthFurnitureWeak ]
   id: GrilleBroken

--- a/Resources/Prototypes/Recipes/Lathes/Packs/tiles.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/tiles.yml
@@ -20,6 +20,7 @@
   - FloorTileItemSteelMini
   - FloorTileItemSteelVerticalSlatsBordered
   - FloorTileItemSteelHorizontalSlatsBordered
+  - FloorTileItemSteelMono
   - FloorTileItemSteelPavement
   - FloorTileItemSteelPavementVertical
   - FloorTileItemSteelCheckerDark

--- a/Resources/Prototypes/Recipes/Lathes/tiles.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tiles.yml
@@ -172,6 +172,11 @@
 
 - type: latheRecipe
   parent: BaseSteelTileRecipe
+  id: FloorTileItemSteelMono
+  result: FloorTileItemSteelMono
+
+- type: latheRecipe
+  parent: BaseSteelTileRecipe
   id: FloorTileItemSteelPavement
   result: FloorTileItemSteelPavement
 

--- a/Resources/Prototypes/Tiles/basic.yml
+++ b/Resources/Prototypes/Tiles/basic.yml
@@ -7,15 +7,6 @@
   itemDrop: FloorTileItemSteel
 
 - type: tile
-  id: FloorSteelMono
-  parent: BaseStationTile
-  name: tiles-steel-floor-mono
-  sprite: /Textures/Tiles/Basic/Gray/gray-mono.png
-  footstepSounds:
-    collection: FootstepTile
-  itemDrop: FloorTileItemSteelMono
-
-- type: tile
   id: FloorSteelMini
   parent: BaseStationTile
   name: tiles-steel-floor-mini
@@ -28,6 +19,15 @@
   name: tiles-steel-floor-pavement
   sprite: /Textures/Tiles/Basic/Gray/gray-pavement.png
   itemDrop: FloorTileItemSteelPavement
+
+- type: tile
+  id: FloorSteelMono
+  parent: BaseStationTile
+  name: tiles-steel-floor-mono
+  sprite: /Textures/Tiles/Basic/Gray/gray-mono.png
+  footstepSounds:
+    collection: FootstepTile
+  itemDrop: FloorTileItemSteelMono
 
 - type: tile
   id: FloorSteelPavementVertical


### PR DESCRIPTION
## About the PR
Original PR #45495
reverts some changes to mono steel tile that was acidentlly removed in #44857 , there's also #45409 that readded the tile but not everything connected to it
moved readded mono tile lines in to original spots

i added comments about norot for timer and screen becuase i dont want to make a seperate PR just for it

## Why / Balance
fix 
and cleanup was from my original PR, 

## Technical details
<!-- Summary of code changes for easier review. -->

## Test plan
try placing monosteeltile on to dirt, you cant
try crafting steel mono tile, you can

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
small fix that no one should notice
