### PR TITLE
Bugfix: SharedEntitySystem.Remove parents you to the grid or the map.

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -6,9 +6,7 @@ using Content.Shared.Explosion;
 using Content.Shared.Foldable;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
-using Content.Shared.Item;
 using Content.Shared.Lock;
-using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
@@ -37,6 +35,7 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
     [Dependency] private SharedContainerSystem _container = default!;
     [Dependency] private SharedInteractionSystem _interaction = default!;
     [Dependency] private SharedJointSystem _joints = default!;
+    [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
     [Dependency] protected SharedPopupSystem Popup = default!;
     [Dependency] protected SharedTransformSystem TransformSystem = default!;
@@ -327,13 +326,16 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
         if (!Resolve(container, ref component))
             return false;
 
-        var toRemoveTransform = Transform(toRemove);
-        if (toRemoveTransform.MapUid is not { } toRemoveMap)
+        // Get our new parent: either the grid the entity is on, or the
+        var newParent = xform.GridUid ?? xform.MapUid ?? EntityUid.Invalid;
+        if (!TryComp(newParent, out TransformComponent? parentXform))
             return false;
 
+        // Reparent the removed entity to our grid, or the map!
         var (pos, rot) = TransformSystem.GetWorldPositionRotation(xform);
         pos += rot.RotateVec(component.EnteringOffset);
-        if (!_container.Remove(toRemove, component.Contents, destination: new(toRemoveMap, pos)))
+        pos = Vector2.Transform(pos, TransformSystem.GetInvWorldMatrix(parentXform));
+        if (!_container.Remove(toRemove, component.Contents, destination: new(newParent, pos)))
             return false;
 
         if (_container.IsEntityInContainer(container)

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -326,7 +326,7 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
             return false;
 
         // Get our new parent: either the grid the entity is on, or the
-        var newParent = xform.GridUid ?? xform.MapUid ?? EntityUid.Invalid;
+        var newParent = xform.GridUid ?? xform.MapUid;
         if (!TryComp(newParent, out TransformComponent? parentXform))
             return false;
 
@@ -334,7 +334,7 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
         var (pos, rot) = TransformSystem.GetWorldPositionRotation(xform);
         pos += rot.RotateVec(component.EnteringOffset);
         pos = Vector2.Transform(pos, TransformSystem.GetInvWorldMatrix(parentXform));
-        if (!_container.Remove(toRemove, component.Contents, destination: new(newParent, pos)))
+        if (!_container.Remove(toRemove, component.Contents, destination: new(newParent.Value, pos)))
             return false;
 
         if (_container.IsEntityInContainer(container)

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -35,7 +35,6 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
     [Dependency] private SharedContainerSystem _container = default!;
     [Dependency] private SharedInteractionSystem _interaction = default!;
     [Dependency] private SharedJointSystem _joints = default!;
-    [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
     [Dependency] protected SharedPopupSystem Popup = default!;
     [Dependency] protected SharedTransformSystem TransformSystem = default!;


### PR DESCRIPTION
## About the PR

Fixes a regression introduced in https://github.com/space-wizards/space-station-14/pull/42420.

Currently, when exiting a container, entities are always reparented to the map (destination passed in L336 in PR above) , where previously SetWorldPosition would parent the mob either to the grid or the map.  This restores that behaviour, though doing the transformation ourselves.

## Why / Balance

Bugfix.

Resolves https://discord.com/channels/310555209753690112/1540073360556425298.
Resolves https://discord.com/channels/310555209753690112/1528453268949307542/1539668297228746822.

## Technical details

Checks for the entity's grid or map, depending on which it can get, does a transform back to that, then passes _that_ in as destination.

## Test plan

Hop in a box on a grid.
Jump out of the box.
Not parented to the map, you should still be able to run around.
Get back into the box.
Move into space.
Get out of the box.
Now you're in space, and you can't move around.

## Media

The test plan running on the head of this PR:

https://github.com/user-attachments/assets/480501db-b470-4f2c-85e8-e5bb964c806c

The current behaviour on master:

https://github.com/user-attachments/assets/a0cd0430-ee6b-4dcb-8c1c-53dda735a153

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
Nope.