### PR TITLE
Add a confirmation message to the regenerative stasis action

### DIFF
--- a/Content.Shared/Actions/Components/ConfirmableActionComponent.cs
+++ b/Content.Shared/Actions/Components/ConfirmableActionComponent.cs
@@ -54,13 +54,13 @@ public sealed partial class ConfirmableActionComponent : Component
     /// If true, this action must be confirmed when untoggled.
     /// True by default.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool ConfirmWhenUntoggled = true;
 
     /// <summary>
     /// If true, this action must be confirmed when toggled.
     /// True by default.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool ConfirmWhenToggled = true;
 }

--- a/Content.Shared/Actions/Components/ConfirmableActionComponent.cs
+++ b/Content.Shared/Actions/Components/ConfirmableActionComponent.cs
@@ -49,4 +49,18 @@ public sealed partial class ConfirmableActionComponent : Component
     /// </summary>
     [DataField]
     public TimeSpan PrimeTime = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// If true, this action must be confirmed when untoggled.
+    /// True by default.
+    /// </summary>
+    [DataField]
+    public bool ConfirmWhenUntoggled = true;
+
+    /// <summary>
+    /// If true, this action must be confirmed when toggled.
+    /// True by default.
+    /// </summary>
+    [DataField]
+    public bool ConfirmWhenToggled = true;
 }

--- a/Content.Shared/Actions/ConfirmableActionSystem.cs
+++ b/Content.Shared/Actions/ConfirmableActionSystem.cs
@@ -13,13 +13,9 @@ public sealed partial class ConfirmableActionSystem : EntitySystem
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
+    [Dependency] private EntityQuery<ActionComponent> _actionQuery = default!;
 
-        SubscribeLocalEvent<ConfirmableActionComponent, ActionAttemptEvent>(OnAttempt);
-    }
-
+    /// <inheritdoc/>
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -37,13 +33,23 @@ public sealed partial class ConfirmableActionSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnAttempt(Entity<ConfirmableActionComponent> ent, ref ActionAttemptEvent args)
     {
         if (args.Cancelled)
             return;
 
+        // Check if we should be confirming based on the action's toggle status.
+        if (_actionQuery.TryComp(ent, out var action))
+        {
+            if (action.Toggled && !ent.Comp.ConfirmWhenToggled)
+                return;
+            if (!action.Toggled && !ent.Comp.ConfirmWhenUntoggled)
+                return;
+        }
+
         // if not primed, prime it and cancel the action
-        if (ent.Comp.NextConfirm is not {} confirm)
+        if (ent.Comp.NextConfirm is not { } confirm)
         {
             Prime(ent, args.User);
             args.Cancelled = true;

--- a/Resources/Locale/en-US/actions/actions/suicide.ftl
+++ b/Resources/Locale/en-US/actions/actions/suicide.ftl
@@ -1,2 +1,1 @@
 suicide-action-popup = THIS ACTION WILL KILL YOU! Use it again to confirm.
-suicide-regen-action-popup = This action will kill you until you regenerate. Use it again to confirm.

--- a/Resources/Locale/en-US/actions/actions/suicide.ftl
+++ b/Resources/Locale/en-US/actions/actions/suicide.ftl
@@ -1,1 +1,2 @@
 suicide-action-popup = THIS ACTION WILL KILL YOU! Use it again to confirm.
+suicide-regen-action-popup = This action will kill you until you regenerate. Use it again to confirm.

--- a/Resources/Locale/en-US/changeling/stasis.ftl
+++ b/Resources/Locale/en-US/changeling/stasis.ftl
@@ -4,3 +4,5 @@ changeling-stasis-active-desc = Exit the stasis, healing all damage to your body
 changeling-stasis-enter = We enter stasis, gathering energy to rise once more.
 changeling-stasis-exit = We rise from the dead, healing all injuries.
 changeling-stasis-exit-others = {CAPITALIZE(THE($user))} rises from the dead, their wounds healed.
+
+suicide-regen-action-popup = This action will kill you until you regenerate. Use it again to confirm.

--- a/Resources/Prototypes/Actions/changeling.yml
+++ b/Resources/Prototypes/Actions/changeling.yml
@@ -96,6 +96,8 @@
     useDelay: 2
     checkCanInteract: false # You can heal even if you are killed
     checkConsciousness: false
+  - type: ConfirmableAction
+    popup: suicide-regen-action-popup
   - type: RegenerativeStasisAction
     bonusCooldownPerDamage: 0.675 # Bonus 135s (total 180s) at 200 damage
     minStasisCooldown: 45

--- a/Resources/Prototypes/Actions/changeling.yml
+++ b/Resources/Prototypes/Actions/changeling.yml
@@ -98,6 +98,7 @@
     checkConsciousness: false
   - type: ConfirmableAction
     popup: suicide-regen-action-popup
+    confirmWhenToggled: false
   - type: RegenerativeStasisAction
     bonusCooldownPerDamage: 0.675 # Bonus 135s (total 180s) at 200 damage
     minStasisCooldown: 45


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

What it says on the tin.

Resolves #45505.

## Why / Balance

Yeah, just seems like a good idea.

## Technical details

Adds the ConfirmableAction component to ActionChangelingStasis.  Not using BaseSuicideAction because I gave it a subtler message.  You aren't round removed, so there's no need for allcaps.

## Test plan

Be me.
Spawn.
Become ling.
Regenerative stasis.
Big scary red text.
Ignore it and spam the button anyway.
Die.

## Media

https://github.com/user-attachments/assets/d72cab11-30e6-4aca-9676-f00c286cb8c5

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
not in stable yet... meh