### PR TITLE
Shield Adjustments based on feedback.

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -11,25 +11,19 @@ public sealed partial class BlockingSystem
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
 
-    private void InitializeUser()
-    {
-        SubscribeLocalEvent<BlockingUserComponent, DamageModifyEvent>(OnUserDamageModified);
-        SubscribeLocalEvent<BlockingUserComponent, EntParentChangedMessage>(OnParentChanged);
-        SubscribeLocalEvent<BlockingUserComponent, ContainerGettingInsertedAttemptEvent>(OnInsertAttempt);
-        SubscribeLocalEvent<BlockingUserComponent, AnchorStateChangedEvent>(OnAnchorChanged);
-        SubscribeLocalEvent<BlockingUserComponent, EntityTerminatingEvent>(OnEntityTerminating);
-    }
-
+    [SubscribeLocalEvent]
     private void OnParentChanged(Entity<BlockingUserComponent> entity, ref EntParentChangedMessage args)
     {
         UserStopBlocking(entity);
     }
 
+    [SubscribeLocalEvent]
     private void OnInsertAttempt(Entity<BlockingUserComponent> entity, ref ContainerGettingInsertedAttemptEvent args)
     {
         UserStopBlocking(entity);
     }
 
+    [SubscribeLocalEvent]
     private void OnAnchorChanged(Entity<BlockingUserComponent> entity, ref AnchorStateChangedEvent args)
     {
         if (args.Anchored)
@@ -38,6 +32,7 @@ public sealed partial class BlockingSystem
         UserStopBlocking(entity);
     }
 
+    [SubscribeLocalEvent]
     private void OnUserDamageModified(Entity<BlockingUserComponent> entity, ref DamageModifyEvent args)
     {
         if (entity.Comp.BlockingItem is not { } item || !_blockQuery.TryComp(item, out var blocking))
@@ -64,6 +59,7 @@ public sealed partial class BlockingSystem
             _audio.PlayPvs(blocking.BlockSound, entity);
     }
 
+    [SubscribeLocalEvent]
     private void OnEntityTerminating(Entity<BlockingUserComponent> entity, ref EntityTerminatingEvent args)
     {
         if (!_blockQuery.TryComp(entity.Comp.BlockingItem, out var blockComponent))

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -18,6 +18,7 @@ using Content.Shared.Toggleable;
 using Content.Shared.Verbs;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Timing;
 using Robust.Shared.Toolshed.Syntax;
 using Robust.Shared.Utility;
 
@@ -25,6 +26,7 @@ namespace Content.Shared.Blocking;
 
 public sealed partial class BlockingSystem : EntitySystem
 {
+    [Dependency] private IGameTiming _timing = default!;
     [Dependency] private ActionContainerSystem _actionContainer = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private ExamineSystemShared _examine = default!;
@@ -42,25 +44,7 @@ public sealed partial class BlockingSystem : EntitySystem
     [Dependency] private EntityQuery<HandsComponent> _handQuery;
     [Dependency] private EntityQuery<MobStateComponent> _mobQuery;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-        InitializeUser();
-
-        SubscribeLocalEvent<BlockingComponent, ItemToggledEvent>(OnItemToggled);
-        SubscribeLocalEvent<BlockingComponent, GotEquippedHandEvent>(OnEquip);
-        SubscribeLocalEvent<BlockingComponent, GotUnequippedHandEvent>(OnUnequip);
-        SubscribeLocalEvent<BlockingComponent, DroppedEvent>(OnDrop);
-
-        SubscribeLocalEvent<BlockingComponent, GetItemActionsEvent>(OnGetActions);
-        SubscribeLocalEvent<BlockingComponent, ToggleActionEvent>(OnToggleAction);
-
-        SubscribeLocalEvent<BlockingComponent, ComponentShutdown>(OnShutdown);
-
-        SubscribeLocalEvent<BlockingComponent, GetVerbsEvent<ExamineVerb>>(OnVerbExamine);
-        SubscribeLocalEvent<BlockingComponent, MapInitEvent>(OnMapInit);
-    }
-
+    [SubscribeLocalEvent]
     private void OnMapInit(Entity<BlockingComponent> entity, ref MapInitEvent args)
     {
         if (!CanBlock(entity.AsNullable()))
@@ -70,6 +54,7 @@ public sealed partial class BlockingSystem : EntitySystem
         DirtyField(entity, entity.Comp, nameof(BlockingComponent.BlockingToggleActionEntity));
     }
 
+    [SubscribeLocalEvent]
     private void OnItemToggled(Entity<BlockingComponent> entity, ref ItemToggledEvent args)
     {
         if (!_handsSystem.IsHeld(entity.Owner, out var holder))
@@ -81,6 +66,7 @@ public sealed partial class BlockingSystem : EntitySystem
             StopBlocking(entity, holder.Value);
     }
 
+    [SubscribeLocalEvent]
     private void OnEquip(Entity<BlockingComponent> entity, ref GotEquippedHandEvent args)
     {
         if (!CanBlock(entity.AsNullable()))
@@ -89,21 +75,25 @@ public sealed partial class BlockingSystem : EntitySystem
         StartBlocking(entity, args.User);
     }
 
+    [SubscribeLocalEvent]
     private void OnUnequip(Entity<BlockingComponent> entity, ref GotUnequippedHandEvent args)
     {
         StopBlocking(entity, args.User);
     }
 
+    [SubscribeLocalEvent]
     private void OnDrop(Entity<BlockingComponent> entity, ref DroppedEvent args)
     {
         StopBlocking(entity, args.User);
     }
 
+    [SubscribeLocalEvent]
     private void OnGetActions(Entity<BlockingComponent> entity, ref GetItemActionsEvent args)
     {
         args.AddAction(ref entity.Comp.BlockingToggleActionEntity, entity.Comp.BlockingToggleAction);
     }
 
+    [SubscribeLocalEvent]
     private void OnToggleAction(Entity<BlockingComponent> entity, ref ToggleActionEvent args)
     {
         if (args.Handled || !CanBlock(entity.AsNullable()))
@@ -134,6 +124,7 @@ public sealed partial class BlockingSystem : EntitySystem
         args.Handled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnShutdown(Entity<BlockingComponent> entity, ref ComponentShutdown args)
     {
         //In theory the user should not be null when this fires off
@@ -297,7 +288,7 @@ public sealed partial class BlockingSystem : EntitySystem
         DirtyField(entity, entity.Comp, nameof(BlockingComponent.User));
 
         //To make sure that this bodytype doesn't get set as anything but the original
-        if (EnsureComp<BlockingUserComponent>(user, out var userComp))
+        if (_timing.ApplyingState || EnsureComp<BlockingUserComponent>(user, out var userComp))
             return;
 
         userComp.BlockingItem = entity;
@@ -347,6 +338,7 @@ public sealed partial class BlockingSystem : EntitySystem
         return entity.Comp.IsRaised ? entity.Comp.ActiveBlockModifier ?? entity.Comp.PassiveBlockModifier : entity.Comp.PassiveBlockModifier;
     }
 
+    [SubscribeLocalEvent]
     private void OnVerbExamine(Entity<BlockingComponent> entity, ref GetVerbsEvent<ExamineVerb> args)
     {
         if (!args.CanInteract || !args.CanAccess)

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -84,7 +84,7 @@
     - type: Blocking
       passiveBlockModifier:
         flatReductions:
-          Blunt: 9
+          Blunt: 12
           Slash: 9
           Piercing: 3
           Heat: 3
@@ -105,7 +105,7 @@
           Blunt: 3
           Slash: 6
           Piercing: 3
-          Heat: 12
+          Heat: 15
 
 - type: entity
   name: ballistic shield
@@ -122,7 +122,7 @@
         flatReductions:
           Blunt: 6
           Slash: 3
-          Piercing: 12
+          Piercing: 15
           Heat: 3
 
 #Craftable shields

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -17,10 +17,10 @@
     - type: Blocking
       passiveBlockModifier:
         flatReductions:
-          Blunt: 10
-          Slash: 10
-          Piercing: 10
-          Heat: 10
+          Blunt: 6
+          Slash: 6
+          Piercing: 6
+          Heat: 6
     - type: Damageable
     - type: Injurable
       damageContainer: Shield
@@ -84,10 +84,10 @@
     - type: Blocking
       passiveBlockModifier:
         flatReductions:
-          Blunt: 15
-          Slash: 15
-          Piercing: 5
-          Heat: 5
+          Blunt: 9
+          Slash: 9
+          Piercing: 3
+          Heat: 3
 
 - type: entity
   name: laser shield
@@ -102,10 +102,10 @@
     - type: Blocking
       passiveBlockModifier:
         flatReductions:
-          Blunt: 5
-          Slash: 10
-          Piercing: 5
-          Heat: 20
+          Blunt: 3
+          Slash: 6
+          Piercing: 3
+          Heat: 12
 
 - type: entity
   name: ballistic shield
@@ -120,10 +120,10 @@
     - type: Blocking
       passiveBlockModifier:
         flatReductions:
-          Blunt: 10
-          Slash: 5
-          Piercing: 20
-          Heat: 5
+          Blunt: 6
+          Slash: 3
+          Piercing: 12
+          Heat: 3
 
 #Craftable shields
 
@@ -140,10 +140,10 @@
     - type: Blocking
       passiveBlockModifier:
         flatReductions:
-          Blunt: 5
-          Slash: 5
-          Piercing: 5
-          Heat: 5
+          Blunt: 6
+          Slash: 6
+          Piercing: 3
+          Heat: 3
     - type: Construction
       graph: WoodenBuckler
       node: woodenBuckler
@@ -151,7 +151,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 75 #Weaker shield
+          damage: 50 #Weaker shield
         behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
@@ -249,7 +249,7 @@
     - type: Blocking
       passiveBlockModifier:
         flatReductions:
-          Blunt: 5
+          Blunt: 6
           Piercing: 1 # Scar told me to.
     - type: Construction
       graph: WebObjects
@@ -304,10 +304,10 @@
         coefficients:
           Heat: 0.5
         flatReductions:
-          Blunt: 5
-          Slash: 10
-          Piercing: 5
-          Heat: 25
+          Blunt: 3
+          Slash: 6
+          Piercing: 3
+          Heat: 24
       blockSound: !type:SoundPathSpecifier
         path: /Audio/Effects/glass_step.ogg
     - type: Destructible
@@ -390,10 +390,10 @@
         coefficients:
           Heat: 0.5
         flatReductions:
-          Blunt: 5
-          Piercing: 10
-          Slash: 5
-          Heat: 25
+          Blunt: 3
+          Piercing: 9
+          Slash: 3
+          Heat: 24
     - type: Appearance
     - type: Damageable
     - type: Injurable

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -10,9 +10,6 @@
       state: riot-icon
     - type: Item
       sprite: Objects/Weapons/Melee/shields.rsi
-      size: Ginormous
-      shape:
-      - 0,0,4,5
       heldPrefix: riot
     - type: Blocking
       passiveBlockModifier:
@@ -54,11 +51,42 @@
             max: 2
 
 - type: entity
-  name: base repairable shield
-  parent: BaseShield
-  id: BaseRepairableShield
-  description: A repairable shield!
   abstract: true
+  parent: BaseShield
+  id: BaseGinormousShield
+  components:
+  - type: Item
+    size: Ginormous
+    shape:
+    - 0,0,3,5
+  - type: HeldSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
+
+- type: entity
+  abstract: true
+  parent: BaseShield
+  id: BaseLargeShield
+  components:
+  - type: Item
+    size: Large
+    shape:
+    - 0,0,2,3
+
+- type: entity
+  abstract: true
+  parent: BaseLargeShield
+  id: BaseRoundShield
+  components:
+  - type: Item
+    shape:
+    - 0,0,2,2
+
+- type: entity
+  abstract: true
+  id: BaseRepairableShield
+  name: base repairable shield
+  description: A repairable shield!
   components:
   - type: Repairable # Negative values represent healing
     damage:
@@ -75,7 +103,7 @@
 
 - type: entity
   name: riot shield
-  parent: [ BaseRepairableShield, BaseShieldDestructible, BaseSecurityContraband ]
+  parent: [ BaseRepairableShield, BaseGinormousShield, BaseShieldDestructible, BaseSecurityContraband ]
   id: RiotShield
   description: A large tower shield. Good for controlling crowds.
   components:
@@ -91,7 +119,7 @@
 
 - type: entity
   name: laser shield
-  parent: [ BaseRepairableShield, BaseShieldDestructible, BaseSecurityContraband ]
+  parent: [ BaseRepairableShield, BaseGinormousShield, BaseShieldDestructible, BaseSecurityContraband ]
   id: RiotLaserShield
   description: A shield built for withstanding lasers, but not much else.
   components:
@@ -109,7 +137,7 @@
 
 - type: entity
   name: ballistic shield
-  parent: [ BaseRepairableShield, BaseShieldDestructible, BaseSecurityContraband ]
+  parent: [ BaseRepairableShield, BaseGinormousShield, BaseShieldDestructible, BaseSecurityContraband ]
   id: RiotBulletShield
   description: A shield built for protecting against ballistics, but not much else.
   components:
@@ -129,7 +157,7 @@
 
 - type: entity
   name: wooden buckler
-  parent: BaseShield
+  parent: BaseRoundShield
   id: WoodenBuckler
   description: A small round wooden makeshift shield.
   components:
@@ -137,6 +165,8 @@
       state: buckler-icon
     - type: Item
       heldPrefix: buckler
+      shape:
+      - 0,0,2,2
     - type: Blocking
       passiveBlockModifier:
         flatReductions:
@@ -168,7 +198,7 @@
 
 - type: entity
   name: cardboard shield
-  parent: BaseShield
+  parent: BaseLargeShield
   id: CardShield
   description: A shield made of cardboard. Won't protect you from much.
   components:
@@ -206,7 +236,7 @@
 
 - type: entity
   name: makeshift shield
-  parent: BaseRepairableShield
+  parent: [ BaseRepairableShield, BaseGinormousShield ]
   id: MakeshiftShield
   description: A rundown looking shield, not good for much.
   components:
@@ -236,7 +266,7 @@
 
 - type: entity
   name: web shield
-  parent: BaseShield
+  parent: BaseLargeShield
   id: WebShield
   description: A stringy shield. It's weak, and doesn't seem to do well against heat.
   components:
@@ -249,7 +279,8 @@
     - type: Blocking
       passiveBlockModifier:
         flatReductions:
-          Blunt: 6
+          Blunt: 9
+          Heat: 6
           Piercing: 1 # Scar told me to.
     - type: Construction
       graph: WebObjects
@@ -275,7 +306,7 @@
 
 - type: entity
   name: clockwork shield
-  parent: [ BaseRepairableShield, BaseShieldDestructible ]
+  parent: [ BaseRepairableShield, BaseRoundShield, BaseShieldDestructible ]
   id: ClockworkShield
   description: Ratvar oyrffrf lbh jvgu uvf cebgrpgvba.
   components:
@@ -287,7 +318,7 @@
 
 - type: entity
   name: mirror shield
-  parent: [ BaseShield, BaseMagicalContraband ]
+  parent: [ BaseLargeShield, BaseMagicalContraband ]
   id: MirrorShield
   description: Eerily glows red... you hear the geometer whispering
   components:
@@ -329,7 +360,7 @@
 
 - type: entity
   name: energy shield
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseShield, BaseSyndicateContraband]
   id: EnergyShield
   description: Exotic energy shield, when folded, can even fit in your pocket.
   components:
@@ -344,8 +375,6 @@
         path: /Audio/Weapons/ebladehum.ogg
     - type: ItemToggleSize
       activatedSize: Huge
-      activatedShape:
-      - 0,0,3,3
     - type: ComponentToggler
       components:
       - type: DisarmMalus
@@ -395,9 +424,6 @@
           Slash: 3
           Heat: 24
     - type: Appearance
-    - type: Damageable
-    - type: Injurable
-      damageContainer: Shield
     - type: ExaminableDamage
       messages: EnergyShieldMessages
     - type: Destructible
@@ -435,7 +461,7 @@
 
 - type: entity
   name: telescopic shield
-  parent: [ BaseRepairableShield, BaseShieldDestructible ]
+  parent: [ BaseRepairableShield, BaseShield, BaseShieldDestructible ]
   id: TelescopicShield
   description: An advanced riot shield made of lightweight materials that collapses for easy storage.
   components:
@@ -456,9 +482,12 @@
       - type: DisarmMalus
         malus: 0.6
     - type: ItemToggleSize
-      activatedSize: Huge
+      activatedSize: Ginormous
       activatedShape:
-      - 0,0,3,3
+      - 0,0,3,5
+    - type: HeldSpeedModifier
+      walkModifier: 0.9
+      sprintModifier: 0.9
     - type: Sprite
       sprite: Objects/Weapons/Melee/teleriot_shield.rsi
       layers:
@@ -467,9 +496,7 @@
           visible: false
           map: [ "shield" ]
     - type: Item
-      size: Small
-      shape:
-      - 0,0,1,1
+      size: Normal
       sprite: Objects/Weapons/Melee/teleriot_shield.rsi
       heldPrefix: teleriot
     - type: UseDelay

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -172,7 +172,7 @@
         flatReductions:
           Blunt: 6
           Slash: 6
-          Piercing: 3
+          Piercing: 6
           Heat: 3
     - type: Construction
       graph: WoodenBuckler

--- a/Resources/Prototypes/Recipes/Construction/Graphs/weapons/makeshift_shield.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/weapons/makeshift_shield.yml
@@ -10,7 +10,7 @@
               amount: 5
               doAfter: 2
             - material: Steel
-              amount: 5
+              amount: 10
               doAfter: 2
 
     - node: makeshiftShield


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adjusted the strength of shields based on feedback and playtesting. The increased health values made them a bit too effective, and rather than make them made of paper again I decided to do something funny.
Also fixed the enumeration modified during state handling issue and cleaned up BlockingSystem again.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Any shield + Armor vest made you a beast in melee even if you only had boxing gloves. It was a little silly.
I reduced the amount of damage shields block, which makes it so that against the majorty of damage sources they block around 35%-50% of damage which is still a significant amount, but makes non-specialized shields far less impactful compared to their specialized counterparts which pretty consistently block 50% of damage from the sources they're built to block.

This basically only affects the generic shields which block a broad range of damage, specialized shields are basically the same at blocking the damage types they want to block, but are also worse at blocking damage types they're not specialized in blocking in return. 

This change makes it so a makeshift shield in the example above now only increases the hits required to kill by about 40% down from 100%. Telescopic shield which has more health increases TTK by 60% also down from 100%.

In addition, I made it so shields have distinct size categories, with the larger shields incuring a 10% slowdown and the smaller shields generally having worse stats overall but no slowdown. The exception being the energy shield which is effectively the same, but also now weak in melee. This should make shields more of a defensive tool that comes with some additional risk to use.

## Technical details
<!-- Summary of code changes for easier review. -->
C# cleanup and YAML microbalance.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Ensure system works, ensure inspecting then picking up shield doesn't crash.
Also be sure the numbers feel good:tm:

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Shields now can block less damage overall.
- tweak: Shields have been split into size categories with larger shields giving a slowdown in exchange for better resistances, and smaller shields being weaker but incurring no slowdown. 

