### PR TITLE
Energy sword toss and embed

### DIFF
--- a/Content.Shared/Projectiles/EmbeddableProjectileComponent.cs
+++ b/Content.Shared/Projectiles/EmbeddableProjectileComponent.cs
@@ -52,4 +52,8 @@ public sealed partial class EmbeddableProjectileComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public EntityUid? EmbeddedIntoUid;
+
+    [DataField, AutoNetworkedField]
+    public bool EmbedWhileActive;
+
 }

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
+using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Throwing;
 using Content.Shared.Whitelist;
 using Robust.Shared.Audio.Systems;
@@ -102,6 +103,15 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         RaiseLocalEvent(embeddable, ref ev);
     }
 
+    public void EmbedWhileActive(Entity<ItemToggleComponent> embeddable, ref ItemToggleComponent args)
+    {
+        if (EntityManager.HasComponent<ItemToggleComponent>(uid:false))
+        {
+            EmbedWhileActive(embeddable, ref args);
+            return;
+        }
+
+    }
     private void EmbedAttach(EntityUid uid, EntityUid target, EntityUid? user, EmbeddableProjectileComponent component)
     {
         TryComp<PhysicsComponent>(uid, out var physics);

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -91,6 +91,14 @@
       visible: false
       shader: unshaded
       map: [ "blade" ]
+  - type: EmbeddableProjectile
+  - type: LandAtCursor
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 15
+        Heat: 15
+        Structural: 12
   - type: Item
     sprite: Objects/Weapons/Melee/e_sword-inhands.rsi
   - type: StaticPrice


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Energy sword can now be thrown! throw it into your targets to do some beginner damage and heat over time until it is pulled out

>throw esword >embeds into target >does intial damage  >does heat over time untill removed, the person who threw the esword can also recall

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

the stun baton can be tossed as a skill check to stun quicker and this is often brought up in discussions on how it gives a leg up on the sword, so i thought what if you could toss the energy sword like the stun baton? this is how i feel it can make an interesting tossing without just copying what the stun baton does

I also think that melees getting more functionality is nice and can lead to more dynamic combat

## Technical details
<!-- Summary of code changes for easier review. -->
ymal implementations with some C# involved 
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
spawn urist
spawn another urist
take control of one urist
spawn energy sword
pick up energy sword as urist and throw it at your target while it is turned on 
it embed and does damage over time
you have an action to recall it
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
none to date
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: gave the energy sword a toss that allows the embedding of people to do damage over time