### PR TITLE
Rate limit emitters, only raise PowerStateChanged on a change in state.

### DIFF
--- a/Content.Server/Power/EntitySystems/PowerStateSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerStateSystem.cs
@@ -7,6 +7,8 @@ namespace Content.Server.Power.EntitySystems;
 /// <inheritdoc/>>
 public sealed partial class PowerStateSystem : SharedPowerStateSystem
 {
+    [Dependency] EntityQuery<PowerConsumerComponent> _powerConsumerQuery = default!;
+
     /// <summary> Init IsWorking and power values on startup. </summary>
     [SubscribeLocalEvent]
     private void OnComponentStartup(Entity<PowerStateComponent> ent, ref ComponentStartup args)
@@ -22,7 +24,7 @@ public sealed partial class PowerStateSystem : SharedPowerStateSystem
     {
         base.SetPowerLoad(ent, isWorking);
 
-        if (TryComp<PowerConsumerComponent>(ent, out var powerConsumer))
+        if (_powerConsumerQuery.TryComp(ent, out var powerConsumer))
             powerConsumer.DrawRate = isWorking ? ent.Comp.WorkingPowerDraw : ent.Comp.IdlePowerDraw;
     }
 }

--- a/Content.Server/Radio/Components/NotifyOnNonFunctioningComponent.cs
+++ b/Content.Server/Radio/Components/NotifyOnNonFunctioningComponent.cs
@@ -1,6 +1,7 @@
 using Content.Server.Radio.EntitySystems;
 using Content.Shared.Radio;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Radio.Components;
 
@@ -10,7 +11,7 @@ namespace Content.Server.Radio.Components;
 /// Can be used for singularity containment field emitters
 /// or other crucial parts of infrastructure.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, AutoGenerateComponentPause]
 [Access(typeof(NotifyOnNonFunctioningSystem))]
 public sealed partial class NotifyOnNonFunctioningComponent : Component
 {
@@ -57,6 +58,18 @@ public sealed partial class NotifyOnNonFunctioningComponent : Component
     /// </summary>
     [DataField]
     public LocId? LocUnanchored;
+
+    /// <summary>
+    /// The next time that this device can send a radio message.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
+    public TimeSpan NextMessage;
+
+    /// <summary>
+    /// The minimum amount of time between sending consecutive messages.
+    /// </summary>
+    [DataField]
+    public TimeSpan NextMessageDelay = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// Marker, if power is required to send radio message.

--- a/Content.Server/Radio/EntitySystems/NotifyOnNonFunctioningSystem.cs
+++ b/Content.Server/Radio/EntitySystems/NotifyOnNonFunctioningSystem.cs
@@ -82,13 +82,12 @@ public sealed partial class NotifyOnNonFunctioningSystem : EntitySystem
             AlertRadioIfWasWorking(ent, ent.Comp.LocUnpowered, true);
     }
 
-    private bool AlertRadioIfWasWorking(Entity<NotifyOnNonFunctioningComponent> ent, string locString, bool ignorePower = false)
+    private void AlertRadioIfWasWorking(Entity<NotifyOnNonFunctioningComponent> ent, string locString, bool ignorePower = false)
     {
         if (!_powerState.GetWorkingState(ent.Owner))
-            return false;
+            return;
 
         AlertRadio(ent, locString, ignorePower);
-        return true;
     }
 
     private void AlertRadio(Entity<NotifyOnNonFunctioningComponent> ent, string locString, bool ignorePower = false)

--- a/Content.Server/Radio/EntitySystems/NotifyOnNonFunctioningSystem.cs
+++ b/Content.Server/Radio/EntitySystems/NotifyOnNonFunctioningSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Construction;
 using Content.Shared.Destructible;
 using Content.Shared.Lock;
 using Content.Shared.Power.EntitySystems;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Server.Radio.EntitySystems;
@@ -16,9 +17,13 @@ namespace Content.Server.Radio.EntitySystems;
 /// </summary>
 public sealed partial class NotifyOnNonFunctioningSystem : EntitySystem
 {
-    [Dependency] private RadioSystem _radio = default!;
+    [Dependency] private IGameTiming _timing = default!;
     [Dependency] private NavMapSystem _navMap = default!;
     [Dependency] private PowerStateSystem _powerState = default!;
+    [Dependency] private RadioSystem _radio = default!;
+
+    [Dependency] private EntityQuery<ApcPowerReceiverComponent> _powerReceiverQuery = default!;
+    [Dependency] private EntityQuery<PowerConsumerComponent> _powerConsumerQuery = default!;
 
     /// <summary> Notify on entity destruction. </summary>
     [SubscribeLocalEvent]
@@ -70,35 +75,40 @@ public sealed partial class NotifyOnNonFunctioningSystem : EntitySystem
     [SubscribeLocalEvent]
     private void ReceivedChanged(Entity<NotifyOnNonFunctioningComponent> ent, ref PowerConsumerReceivedChanged args)
     {
-        if (!ent.Comp.LocUnpowered.HasValue ||!_powerState.GetWorkingState(ent.Owner))
+        if (!ent.Comp.LocUnpowered.HasValue || !_powerState.GetWorkingState(ent.Owner))
             return;
 
         if (args.ReceivedPower < args.DrawRate)
             AlertRadioIfWasWorking(ent, ent.Comp.LocUnpowered, true);
     }
 
-    private void AlertRadioIfWasWorking(Entity<NotifyOnNonFunctioningComponent> ent, string locString, bool ignorePower = false)
+    private bool AlertRadioIfWasWorking(Entity<NotifyOnNonFunctioningComponent> ent, string locString, bool ignorePower = false)
     {
-
         if (!_powerState.GetWorkingState(ent.Owner))
-            return;
+            return false;
 
         AlertRadio(ent, locString, ignorePower);
+        return true;
     }
 
     private void AlertRadio(Entity<NotifyOnNonFunctioningComponent> ent, string locString, bool ignorePower = false)
     {
+        // Are we rate-limited?
+        if (ent.Comp.NextMessage > _timing.CurTime)
+            return;
+
         if (ent.Comp.RequirePowered && !ignorePower)
         {
-            if (TryComp<ApcPowerReceiverComponent>(ent, out var apc) && !apc.Powered)
+            if (_powerReceiverQuery.TryComp(ent, out var apc) && !apc.Powered)
                 return;
 
-            if (TryComp<PowerConsumerComponent>(ent, out var consumer) && consumer.DrawRate > consumer.ReceivedPower)
+            if (_powerConsumerQuery.TryComp(ent, out var consumer) && consumer.DrawRate > consumer.ReceivedPower)
                 return;
         }
 
         var locationInfo = FormattedMessage.RemoveMarkupOrThrow(_navMap.GetNearestBeaconString(ent.Owner));
         var message = Loc.GetString(locString, ("location", locationInfo));
         _radio.SendRadioMessage(ent.Owner, message, ent.Comp.RadioChannel, ent.Owner);
+        ent.Comp.NextMessage = _timing.CurTime + ent.Comp.NextMessageDelay;
     }
 }

--- a/Content.Shared/Power/EntitySystems/PowerStateSystem.cs
+++ b/Content.Shared/Power/EntitySystems/PowerStateSystem.cs
@@ -11,7 +11,7 @@ public abstract partial class SharedPowerStateSystem : EntitySystem
 {
     [Dependency] private SharedPowerReceiverSystem _powerReceiverSystem = default!;
 
-    [Dependency] protected EntityQuery<PowerStateComponent> _powerStateQuery = default!;
+    [Dependency] protected EntityQuery<PowerStateComponent> PowerStateQuery = default!;
 
     /// <summary>
     /// Sets the working state of the entity, adjusting its power draw accordingly.
@@ -21,10 +21,13 @@ public abstract partial class SharedPowerStateSystem : EntitySystem
     [PublicAPI]
     public virtual void SetWorkingState(Entity<PowerStateComponent?> ent, bool isWorking)
     {
-        if (!_powerStateQuery.Resolve(ent, ref ent.Comp))
+        if (!PowerStateQuery.Resolve(ent, ref ent.Comp))
             return;
 
         SetPowerLoad((ent, ent.Comp), isWorking);
+
+        if (ent.Comp.IsWorking == isWorking)
+            return;
 
         ent.Comp.IsWorking = isWorking;
 
@@ -44,7 +47,7 @@ public abstract partial class SharedPowerStateSystem : EntitySystem
         // Sometimes systems calling this API handle generic objects that can or can't consume power,
         // so to reduce boilerplate we don't log an error. Any entity that *should* have an ApcPowerRecieverComponent
         // will log an error in tests if someone tries to add an entity that doesn't have one.
-        if (!_powerStateQuery.Resolve(ent, ref ent.Comp, false))
+        if (!PowerStateQuery.Resolve(ent, ref ent.Comp, false))
             return;
 
         SetWorkingState(ent, isWorking);
@@ -57,7 +60,7 @@ public abstract partial class SharedPowerStateSystem : EntitySystem
     [PublicAPI]
     public bool GetWorkingState(Entity<PowerStateComponent?> ent)
     {
-        if (!_powerStateQuery.Resolve(ent, ref ent.Comp))
+        if (!PowerStateQuery.Resolve(ent, ref ent.Comp))
             return false;
 
         return ent.Comp.IsWorking;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Addressing #45502 through two approaches:

1. Explicitly rate limits emitters (currently to 10s / message, though this is chosen arbitrarily)
2. Only generates PowerStateChanged messages on an actual change in the power state (checking previous value vs. new value)

Also does a tiny bit of housekeeping in the affected systems, hope you don't mind.

## Why / Balance

Resolves #45502.

## Technical details

New timer fields in NotifyOnNonFunctioningComponent - the fields currently track _all_ message types, so a destruction is suppressed the same as a change in power.  This can change, but "don't spam the radio" seems like a fair goal.  If this _is_ being changed, I would suggest that the timer for lower importance messages be increased!

## Test plan

Open the dev map, go to the engineering spot, build an emitter setup like in the media shown below.
Turn the power off, you should get notifications.
Quickly turn the power back on and off again.  You should _not_ get new notifications if you were quick.
Wait 10 seconds.
Destroy one of the emitters.  You should get a notification.
Turn another one of the emitters off.  You should get a notification.
Deconstruct one of the emitters.  You should _not_ get a notification (the loc string is not set!)

## Media

A rough following of the test plan.  The end is a bit meandering, I was confused on getting no notification after deconstructing the machine.

https://github.com/user-attachments/assets/fba846b0-a4e5-4a90-98d3-6cfd8138e7c0

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

The breaking changes could _possibly_ be omitted, it has been out for a very short time.
## Breaking changes

`PowerStateSystem._powerStateQuery` renamed to `PowerStateSystem.PowerStateQuery`

## Changelog
not on stable