### PR TITLE
Nerf xenoborg rocket module

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -252,7 +252,7 @@
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
   - type: BallisticAmmoSelfRefiller
-    autoRefillRate: 12s
+    autoRefillRate: 17s
   - type: MagazineVisuals
     magState: mag
     steps: 7

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -241,7 +241,7 @@
     shotsPerBurst: 6
     minAngle: 10
     angleIncrease: 10
-    maxAngle: 60
+    maxAngle: 50
     projectileSpeed: 12.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rocket1.ogg

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Explosives/explosives.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Explosives/explosives.yml
@@ -259,9 +259,9 @@
     - timer
   - type: Explosive
     explosionType: XenoborgAntiStructureExplosion
-    totalIntensity: 25
-    intensitySlope: 3
-    maxIntensity: 3
+    totalIntensity: 20.0
+    intensitySlope: 3.0
+    maxIntensity: 3.0
     maxTileBreak: 0
   - type: SineWaveAnimation
     xWave:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Explosives/explosives.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Explosives/explosives.yml
@@ -260,8 +260,8 @@
   - type: Explosive
     explosionType: XenoborgAntiStructureExplosion
     totalIntensity: 15.0
-    intensitySlope: 1.5
-    maxIntensity: 2.0
+    intensitySlope: 1.6
+    maxIntensity: 1.8
     maxTileBreak: 0
   - type: SineWaveAnimation
     xWave:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Explosives/explosives.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Explosives/explosives.yml
@@ -259,9 +259,9 @@
     - timer
   - type: Explosive
     explosionType: XenoborgAntiStructureExplosion
-    totalIntensity: 20.0
-    intensitySlope: 3.0
-    maxIntensity: 3.0
+    totalIntensity: 15.0
+    intensitySlope: 1.5
+    maxIntensity: 2.0
     maxTileBreak: 0
   - type: SineWaveAnimation
     xWave:

--- a/Resources/Prototypes/Recipes/Lathes/xenoborgs.yml
+++ b/Resources/Prototypes/Recipes/Lathes/xenoborgs.yml
@@ -120,7 +120,7 @@
   id: XenoborgModuleRocketRecipe
   result: XenoborgModuleRocket
   materials:
-    XenoborgCrystal: 300
+    XenoborgCrystal: 400
 
 - type: latheRecipe
   parent: BaseXenoborgModulesRecipe

--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -142,7 +142,7 @@
     types:
       Heat: 4
       Blunt: 2
-      Piercing: 2
+      Piercing: 3
       Structural: 50
   lightColor: Blue
   fireColor: Blue

--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -140,10 +140,10 @@
   id: XenoborgAntiStructureExplosion
   damagePerIntensity:
     types:
-      Heat: 3
-      Blunt: 3
-      Piercing: 3
-      Structural: 200
+      Heat: 4
+      Blunt: 2
+      Piercing: 2
+      Structural: 50
   lightColor: Blue
   fireColor: Blue
   texturePath: /Textures/Effects/fire_greyscale.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Nerfed the rocket modules damage!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It was too strong! This should hopefully make it a lot more for what I was aiming for, you shouldn't be able to eat your way through the entire station. This is more meant to blow up one set of doors that are blocking you or one wall

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Xenoborg rockets have been nerfed in damage / explosive power across the board. The launchers reload rate has gone from 12s -> 17s, its maximum spread has gone from 60deg -> 50deg, its cost has gone from 3 crystals -> 4 crystals.
