### PR TITLE
Variantize autofill

### DIFF
--- a/Content.Server/Administration/Commands/VariantizeCommand.cs
+++ b/Content.Server/Administration/Commands/VariantizeCommand.cs
@@ -48,7 +48,7 @@ public sealed partial class VariantizeCommand : LocalizedEntityCommands
         return args.Length switch
         {
             1 => CompletionResult.FromHintOptions(CompletionHelper.Components<MapGridComponent>(args[0], EntityManager),
-                Loc.GetString($"{Command}-hint-map")),
+                Loc.GetString($"cmd-{Command}-hint-grid")),
             _ => CompletionResult.Empty,
         };
     }

--- a/Content.Server/Administration/Commands/VariantizeCommand.cs
+++ b/Content.Server/Administration/Commands/VariantizeCommand.cs
@@ -7,17 +7,11 @@ using Robust.Shared.Map.Components;
 namespace Content.Server.Administration.Commands;
 
 [AdminCommand(AdminFlags.Mapping)]
-public sealed partial class VariantizeCommand : IConsoleCommand
+public sealed partial class VariantizeCommand : LocalizedEntityCommands
 {
-    [Dependency] private IEntityManager _entManager = default!;
+    public override string Command => "variantize";
 
-    public string Command => "variantize";
-
-    public string Description => Loc.GetString("variantize-command-description");
-
-    public string Help => Loc.GetString("variantize-command-help-text");
-
-    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         if (args.Length != 1)
         {
@@ -25,21 +19,21 @@ public sealed partial class VariantizeCommand : IConsoleCommand
             return;
         }
 
-        if (!NetEntity.TryParse(args[0], out var euidNet) || !_entManager.TryGetEntity(euidNet, out var euid))
+        if (!NetEntity.TryParse(args[0], out var euidNet) || !EntityManager.TryGetEntity(euidNet, out var euid))
         {
             shell.WriteError($"Failed to parse euid '{args[0]}'.");
             return;
         }
 
-        if (!_entManager.TryGetComponent(euid, out MapGridComponent? gridComp))
+        if (!EntityManager.TryGetComponent(euid, out MapGridComponent? gridComp))
         {
             shell.WriteError($"Euid '{euid}' does not exist or is not a grid.");
             return;
         }
 
-        var mapsSystem = _entManager.System<SharedMapSystem>();
-        var tileSystem = _entManager.System<TileSystem>();
-        var turfSystem = _entManager.System<TurfSystem>();
+        var mapsSystem = EntityManager.System<SharedMapSystem>();
+        var tileSystem = EntityManager.System<TileSystem>();
+        var turfSystem = EntityManager.System<TurfSystem>();
 
         foreach (var tile in mapsSystem.GetAllTiles(euid.Value, gridComp))
         {
@@ -47,5 +41,15 @@ public sealed partial class VariantizeCommand : IConsoleCommand
             var newTile = new Tile(tile.Tile.TypeId, tile.Tile.Flags, tileSystem.PickVariant(def), tile.Tile.RotationMirroring);
             mapsSystem.SetTile(euid.Value, gridComp, tile.GridIndices, newTile);
         }
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        return args.Length switch
+        {
+            1 => CompletionResult.FromHintOptions(CompletionHelper.Components<MapGridComponent>(args[0], EntityManager),
+                Loc.GetString($"{Command}-hint-map")),
+            _ => CompletionResult.Empty,
+        };
     }
 }

--- a/Resources/Locale/en-US/administration/commands/variantize-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/variantize-command.ftl
@@ -1,2 +1,3 @@
-﻿variantize-command-description = Randomizes all tile variants on a given grid.
-variantize-command-help-text = variantize <grid id>
+﻿cmd-variantize-desc = Randomizes all tile variants on a given grid.
+cmd-variantize-help = variantize <grid id>
+cmd-hint-map = Grid id

--- a/Resources/Locale/en-US/administration/commands/variantize-command.ftl
+++ b/Resources/Locale/en-US/administration/commands/variantize-command.ftl
@@ -1,3 +1,3 @@
 ﻿cmd-variantize-desc = Randomizes all tile variants on a given grid.
 cmd-variantize-help = variantize <grid id>
-cmd-hint-map = Grid id
+cmd-variantize-hint-grid = Grid


### PR DESCRIPTION
## About the PR
The variantize command can now fill in grid Ids

## Why / Balance
mapping QOL

## Technical details
Variantizecommand is now a LocalizedEntityCommands and includes autocomplete logic

## Test plan
variantize

## Media
<img width="662" height="439" alt="image" src="https://github.com/user-attachments/assets/5c6122b0-9999-4849-8030-b3edd7f04011" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The variantize command has new localization strings. Check variantize-command.ftl

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
