### PR TITLE
Upgrades to attribution UI

### DIFF
--- a/Content.Client/Credits/CreditsWindow.xaml
+++ b/Content.Client/Credits/CreditsWindow.xaml
@@ -1,4 +1,5 @@
 ﻿<DefaultWindow xmlns="https://spacestation14.io"
+               xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                Title="{Loc 'credits-window-title'}"
                SetSize="650 650">
     <TabContainer Name="MasterTabContainer">
@@ -26,11 +27,29 @@
                 <!-- Licenses get added here by code -->
             </BoxContainer>
         </ScrollContainer>
-        <ScrollContainer Name="AttributionsTab"
-                         HScrollEnabled="False">
-            <BoxContainer Name="AttributionsContainer"
-                          Orientation="Vertical"
-                          Margin="2 2 0 0" />
-        </ScrollContainer>
+        <BoxContainer Name="AttributionsTab"
+                      Orientation="Vertical">
+            <BoxContainer Orientation="Horizontal"
+                          Align="Center"
+                          SetHeight="32"
+                          Margin="2">
+                <RichTextLabel Text="{Loc 'credits-window-page-label'}"/>
+                <controls:IntegerLineEdit Name="PageJumpLineEdit"
+                                      SelectAllOnFocus="True"
+                                      SetWidth="40"/>
+                <BoxContainer Name="ButtonsContainer"
+                              Orientation="Horizontal"
+                              Margin="8 0"/>
+                    <!-- Page buttons are generated here so that their invokes can be reset -->
+            </BoxContainer>
+            <ScrollContainer HScrollEnabled="False"
+                             VerticalExpand="True">
+                <BoxContainer Name="AttributionsContainer"
+                              Orientation="Vertical"
+                              Margin="2">
+                    <!-- .rsi and .rga Attributions go here get added here by code -->
+                </BoxContainer>
+            </ScrollContainer>
+        </BoxContainer>
     </TabContainer>
 </DefaultWindow>

--- a/Content.Client/Credits/CreditsWindow.xaml
+++ b/Content.Client/Credits/CreditsWindow.xaml
@@ -36,7 +36,8 @@
                 <RichTextLabel Text="{Loc 'credits-window-page-label'}"/>
                 <controls:IntegerLineEdit Name="PageJumpLineEdit"
                                       SelectAllOnFocus="True"
-                                      SetWidth="40"/>
+                                      SetWidth="40"
+                                      MinValue="1"/>
                 <BoxContainer Name="ButtonsContainer"
                               Orientation="Horizontal"
                               Margin="8 0"/>

--- a/Content.Client/Credits/CreditsWindow.xaml.cs
+++ b/Content.Client/Credits/CreditsWindow.xaml.cs
@@ -97,6 +97,14 @@ public sealed partial class CreditsWindow : DefaultWindow
 
             _attributions.AddRange(rsi);
             _attributions.AddRange(rga);
+
+            // A page can't be entered that we can't go to
+            PageJumpLineEdit.OnTextChanged +=
+                _ =>
+                {
+                    if (PageJumpLineEdit.Value() > _attributions.Count / AttributionsSourcesPerPage)
+                        PageJumpLineEdit.Text = (_attributions.Count / AttributionsSourcesPerPage + 1).ToString();
+                };
         }
 
         // Pick the attributions for this page

--- a/Content.Client/Credits/CreditsWindow.xaml.cs
+++ b/Content.Client/Credits/CreditsWindow.xaml.cs
@@ -99,12 +99,7 @@ public sealed partial class CreditsWindow : DefaultWindow
             _attributions.AddRange(rga);
 
             // A page can't be entered that we can't go to
-            PageJumpLineEdit.OnTextChanged +=
-                _ =>
-                {
-                    if (PageJumpLineEdit.Value() > _attributions.Count / AttributionsSourcesPerPage)
-                        PageJumpLineEdit.Text = (_attributions.Count / AttributionsSourcesPerPage + 1).ToString();
-                };
+            PageJumpLineEdit.MaxValue = _attributions.Count / AttributionsSourcesPerPage + 1;
         }
 
         // Pick the attributions for this page

--- a/Content.Client/Credits/CreditsWindow.xaml.cs
+++ b/Content.Client/Credits/CreditsWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Numerics;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Content.Client.Stylesheets;
 using Content.Shared.CCVar;
@@ -60,6 +61,9 @@ public sealed partial class CreditsWindow : DefaultWindow
 
         MasterTabContainer.OnTabChanged += OnTabChanged;
 
+        PageJumpLineEdit.OnTextEntered +=
+            _ => PopulateAttributions(AttributionsContainer, ButtonsContainer, (PageJumpLineEdit.Value() - 1) * AttributionsSourcesPerPage);
+
         PopulateContributors(Ss14ContributorsContainer);
     }
 
@@ -75,13 +79,17 @@ public sealed partial class CreditsWindow : DefaultWindow
         else if (tab == LicensesTab.GetPositionInParent())
             PopulateLicenses(LicensesContainer);
         else if (tab == AttributionsTab.GetPositionInParent())
-            PopulateAttributions(AttributionsContainer, 0);
+            PopulateAttributions(AttributionsContainer, ButtonsContainer, 0);
     }
 
-    private async void PopulateAttributions(BoxContainer attributionsContainer, int count)
+    private async void PopulateAttributions(BoxContainer attributionsContainer, BoxContainer buttonsContainer, int count)
     {
         attributionsContainer.RemoveAllChildren();
+        buttonsContainer.RemoveAllChildren();
 
+        PageJumpLineEdit.Text = (count / AttributionsSourcesPerPage + 1).ToString();
+
+        // Assemble attributions
         if (_attributions.Count == 0)
         {
             var rsi = await CollectRSiAttributions();
@@ -91,6 +99,7 @@ public sealed partial class CreditsWindow : DefaultWindow
             _attributions.AddRange(rga);
         }
 
+        // Pick the attributions for this page
         foreach (var message in _attributions.Skip(count).Take(AttributionsSourcesPerPage))
         {
             var rich = new RichTextLabel();
@@ -98,22 +107,26 @@ public sealed partial class CreditsWindow : DefaultWindow
             attributionsContainer.AddChild(rich);
         }
 
-        var container = new BoxContainer { Orientation = LayoutOrientation.Horizontal };
+        // Create and add the buttons
+        var previousButton = new Button
+        {
+            Text = Loc.GetString("credits-window-previous-page-button"),
+            Disabled = count - AttributionsSourcesPerPage < 0,
+            StyleClasses = { StyleClass.ButtonOpenRight },
+        };
+        previousButton.OnPressed +=
+            _ => PopulateAttributions(attributionsContainer, buttonsContainer, count - AttributionsSourcesPerPage);
+        buttonsContainer.AddChild(previousButton);
 
-        var previousPageButton = new Button { Text = Loc.GetString("credits-window-previous-page-button") };
-        previousPageButton.OnPressed +=
-            _ => PopulateAttributions(attributionsContainer, count - AttributionsSourcesPerPage);
-
-        var nextPageButton = new Button { Text = Loc.GetString("credits-window-next-page-button") };
-        nextPageButton.OnPressed +=
-            _ => PopulateAttributions(attributionsContainer, count + AttributionsSourcesPerPage);
-
-        if (count - AttributionsSourcesPerPage >= 0)
-            container.AddChild(previousPageButton);
-        if (count + AttributionsSourcesPerPage < _attributions.Count)
-            container.AddChild(nextPageButton);
-
-        attributionsContainer.AddChild(container);
+        var nextButton = new Button
+        {
+            Text = Loc.GetString("credits-window-next-page-button"),
+            Disabled = count + AttributionsSourcesPerPage >= _attributions.Count,
+            StyleClasses = { StyleClass.ButtonOpenLeft },
+        };
+        nextButton.OnPressed +=
+            _ => PopulateAttributions(attributionsContainer, buttonsContainer, count + AttributionsSourcesPerPage);
+        buttonsContainer.AddChild(nextButton);
     }
 
     private Task<List<FormattedMessage>> CollectRSiAttributions()
@@ -216,7 +229,7 @@ public sealed partial class CreditsWindow : DefaultWindow
                         var files = _serialization.Read<string[]>(filesNode, notNullableOverride: true);
                         var copyright = copyrightNode.ToString();
                         var license = licenseNode.ToString();
-                        var source = sourceNode.ToString();
+                        var source = _serialization.Read<string[]>(sourceNode, notNullableOverride: true);
 
                         m.AddMarkupPermissive(_loc.GetString("credits-window-attributions-directory",
                             ("directory", stream.Directory.ToString())));
@@ -230,7 +243,8 @@ public sealed partial class CreditsWindow : DefaultWindow
                         m.AddMarkupPermissive(
                             _loc.GetString("credits-window-attributions-license", ("license", license)));
                         m.AddText("\n");
-                        m.AddMarkupPermissive(_loc.GetString("credits-window-attributions-source", ("source", source)));
+                        m.AddMarkupPermissive(_loc.GetString("credits-window-attributions-source",
+                            ("source", string.Join(", ", source))));
                         m.AddText("\n");
 
                         attrs.Add(m);

--- a/Content.Client/UserInterface/Controls/IntegerLineEdit.cs
+++ b/Content.Client/UserInterface/Controls/IntegerLineEdit.cs
@@ -4,19 +4,49 @@ using Robust.Client.UserInterface.Controls;
 namespace Content.Client.UserInterface.Controls;
 
 /// <summary>
-/// A line edit which only accepts whole numbers as input.
+/// A line edit which accepts only integers as text input, and can clamp input to a lower or upper bound.
 /// </summary>
 public sealed class IntegerLineEdit : LineEdit
 {
-    private static readonly Regex RegNumbers = new("^[0-9]*$");
+    private static readonly Regex RegNumbers = new("^-*?[0-9]*$");
+
+    /// <summary>
+    /// A value entered that's larger than this will be rewritten to this.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public int? MaxValue { get; set; }
+
+    /// <summary>
+    /// A value entered that's smaller than this will be rewritten to this.
+    /// </summary>
+    /// <remarks>This becomes annoying when set above 9.</remarks>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public int? MinValue { get; set; }
+
+    /// <returns>The integer value of the text.</returns>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public int Value()
+    {
+        return int.TryParse(Text, out var i) ? i : 0;
+    }
 
     public IntegerLineEdit()
     {
         IsValid += s => RegNumbers.IsMatch(s);
+
+        OnTextChanged += ClampMax;
+        OnTextChanged += ClampMin;
     }
 
-    public int Value()
+    private void ClampMax(LineEditEventArgs _)
     {
-        return int.TryParse(Text, out var i) ? i : -1;
+        if (MaxValue is {} max && Value() > max)
+            Text = max.ToString();
+    }
+
+    private void ClampMin(LineEditEventArgs _)
+    {
+        if (MinValue is {} min && Value() < min)
+            Text = min.ToString();
     }
 }

--- a/Content.Client/UserInterface/Controls/IntegerLineEdit.cs
+++ b/Content.Client/UserInterface/Controls/IntegerLineEdit.cs
@@ -6,6 +6,7 @@ namespace Content.Client.UserInterface.Controls;
 /// <summary>
 /// A line edit which accepts only integers as text input, and can clamp input to a lower or upper bound.
 /// </summary>
+/// <remarks>If <see cref="MaxValue"/> and <see cref="MinValue"/> are in conflict, MinValue takes priority.</remarks>
 public sealed class IntegerLineEdit : LineEdit
 {
     private static readonly Regex RegNumbers = new("^-*?[0-9]*$");
@@ -40,13 +41,19 @@ public sealed class IntegerLineEdit : LineEdit
 
     private void ClampMax(LineEditEventArgs _)
     {
-        if (MaxValue is {} max && Value() > max)
+        if (!AcceptableNonNumber() && MaxValue is {} max && Value() > max)
             Text = max.ToString();
     }
 
     private void ClampMin(LineEditEventArgs _)
     {
-        if (MinValue is {} min && Value() < min)
+        if (!AcceptableNonNumber() && MinValue is {} min && Value() < min)
             Text = min.ToString();
+    }
+
+    /// <returns>True if the text is blank or only a negative sign.</returns>
+    private bool AcceptableNonNumber()
+    {
+        return Text is "" or "-";
     }
 }

--- a/Content.Client/UserInterface/Controls/IntegerLineEdit.cs
+++ b/Content.Client/UserInterface/Controls/IntegerLineEdit.cs
@@ -1,0 +1,22 @@
+using System.Text.RegularExpressions;
+using Robust.Client.UserInterface.Controls;
+
+namespace Content.Client.UserInterface.Controls;
+
+/// <summary>
+/// A line edit which only accepts whole numbers as input.
+/// </summary>
+public sealed class IntegerLineEdit : LineEdit
+{
+    private static readonly Regex RegNumbers = new("^[0-9]*$");
+
+    public IntegerLineEdit()
+    {
+        IsValid += s => RegNumbers.IsMatch(s);
+    }
+
+    public int Value()
+    {
+        return int.TryParse(Text, out var i) ? i : -1;
+    }
+}

--- a/Content.Client/UserInterface/Controls/IntegerLineEdit.cs
+++ b/Content.Client/UserInterface/Controls/IntegerLineEdit.cs
@@ -19,7 +19,7 @@ public sealed class IntegerLineEdit : LineEdit
     /// <summary>
     /// A value entered that's smaller than this will be rewritten to this.
     /// </summary>
-    /// <remarks>This becomes annoying when set above 9.</remarks>
+    /// <remarks>This becomes annoying when set above 1.</remarks>
     [ViewVariables(VVAccess.ReadWrite)]
     public int? MinValue { get; set; }
 

--- a/Resources/Locale/en-US/credits/credits-window.ftl
+++ b/Resources/Locale/en-US/credits/credits-window.ftl
@@ -13,6 +13,7 @@ credits-window-immortals-title = In Memoriam
 credits-window-special-thanks-section-title = Special Thanks
 credits-window-previous-page-button = Previous Page
 credits-window-next-page-button = Next Page
+credits-window-page-label = Page:
 
 credits-window-attributions-directory = [color=white]Directory:[/color] {$directory}
 credits-window-attributions-files = [color=white]Files:[/color] {$files}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
A few changes to `CreditsWindow` and the attributions page. The buttons have been moved to the top and a `LineEdit` added to jump to a certain page.

The text for when a list is supplied to `source` in an RGA has been improved.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I was making a sound which combined two separate sounds and wanted to source them both. I checked it in attributions and didn't like how it looked, so I made it look better.

But then the button situation bothered me and I had to make it more usable.

## Technical details
<!-- Summary of code changes for easier review. -->
I created a new generic control called `IntegerLineEdit` which uses Regex to prevent entering anything that's not a number. It seemed generically useful enough to spin out on its own. It's used to jump to a specific page in case you have a favorite attribution.

Some bending of xaml to make things look right. The page buttons were relatively unchanged, except they're now disabled instead of not added to the tree.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Launch game, `golobby`. Open credits to press the pretty buttons and type in the fun box.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="608" height="233" alt="image" src="https://github.com/user-attachments/assets/7a1acb1d-2208-474e-9640-000062c06d8d" />

(shoutouts to debugRotation.rsi)

Before:
<img width="616" height="356" alt="attribute-before" src="https://github.com/user-attachments/assets/44e1f212-b434-4c2e-a60f-843ddd86e2e9" />

After:
<img width="554" height="296" alt="attribute-after" src="https://github.com/user-attachments/assets/a0e3b0fa-b6b1-42eb-8a46-1b44b386811f" />


## Requirements
<!-- Confirm t
<img width="554" height="296" alt="attribute-after" src="https://github.com/user-attachments/assets/b7b99485-ef0d-4930-a0bf-bc4e0618f1c2" />
he following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->