### PR TITLE
Fix SharedEntityStorageSystem.Remove working with nested entities.

### DIFF
--- a/Content.Server/Administration/Commands/RemoveEntityStorageCommand.cs
+++ b/Content.Server/Administration/Commands/RemoveEntityStorageCommand.cs
@@ -36,9 +36,9 @@ namespace Content.Server.Administration.Commands
 
             var parent = transform.ParentUid;
 
-            if (_entManager.TryGetComponent<EntityStorageComponent>(parent, out var storage))
+            if (_entManager.HasComponent<EntityStorageComponent>(parent))
             {
-                entstorage.Remove(entityUid.Value, parent, storage);
+                entstorage.Remove(entityUid.Value);
             }
             else
             {

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Systems;
 using Content.Server.Mech.Components;
+using Content.Server.Mech.Equipment.Components;
 using Content.Shared.Atmos;
 using Content.Shared.Damage.Systems;
 using Content.Shared.DoAfter;
@@ -12,6 +13,7 @@ using Content.Shared.Mech.Components;
 using Content.Shared.Mech.EntitySystems;
 using Content.Shared.Power.Components;
 using Content.Shared.Power.EntitySystems;
+using Content.Shared.Storage.Components;
 using Content.Shared.Tools;
 using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
@@ -150,6 +152,13 @@ public sealed partial class MechSystem : SharedMechSystem
     private void RelaySoundboardUiMessage(EntityUid uid, MechComponent component, ref MechSoundboardPlayMessage args)
     {
         ReceiveEquipmentUiMesssages(component, args);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnEntityStorageDump(Entity<MechGrabberComponent> entity, ref EntityStorageIntoContainerAttemptEvent args)
+    {
+        // There's no reason we should dump into /any/ of the mech's containers.
+        args.Cancelled = true;
     }
 
     private void ReceiveEquipmentUiMesssages<T>(MechComponent component, T args) where T : MechEquipmentUiMessage

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -331,22 +331,26 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
             var parent = parentContainer.Owner;
             var xform = Transform(parent);
 
-            if (TryComp<EntityStorageComponent>(parent, out var entStorageComp))
+            if (!_container.IsEntityInContainer(parent) && TryComp<EntityStorageComponent>(parent, out var entStorageComp))
             {
-                if (!_container.IsEntityInContainer(parent))
+                if (entStorageComp.EnteringOffset == Vector2.Zero)
                 {
-                    if (!TransformSystem.TryGetMapOrGridCoordinates(parent, out var coordinates, xform))
+                    if (!_container.Remove(toRemove, parentContainer))
                         return false;
-
-                    var rot = xform.LocalRotation;
-
-                    if (!_container.Remove(toRemove,
-                            parentContainer,
-                            destination: coordinates.Value.Offset(rot.RotateVec(entStorageComp.EnteringOffset))))
-                        return false;
-
                     break;
                 }
+
+                if (!TransformSystem.TryGetMapOrGridCoordinates(parent, out var coordinates, xform))
+                    return false;
+
+                var rot = xform.LocalRotation;
+
+                if (!_container.Remove(toRemove,
+                        parentContainer,
+                        destination: coordinates.Value.Offset(rot.RotateVec(entStorageComp.EnteringOffset))))
+                    return false;
+
+                break;
             }
 
             if (!_container.Remove(toRemove, parentContainer))

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -331,9 +331,9 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
             var parent = parentContainer.Owner;
             var xform = Transform(parent);
 
-            if (!_container.IsEntityInContainer(parent) && TryComp<EntityStorageComponent>(parent, out var entStorageComp))
+            if (!_container.IsEntityInContainer(parent))
             {
-                if (entStorageComp.EnteringOffset == Vector2.Zero)
+                if (!TryComp<EntityStorageComponent>(parent, out var entStorageComp) || entStorageComp.EnteringOffset == Vector2.Zero)
                 {
                     if (!_container.Remove(toRemove, parentContainer))
                         return false;

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -215,11 +215,10 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
-        var uidXform = Transform(uid);
         var containedArr = component.Contents.ContainedEntities.ToArray();
         foreach (var contained in containedArr)
         {
-            Remove(contained, uid, component, uidXform);
+            Remove(contained);
         }
     }
 
@@ -317,39 +316,51 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
         return true;
     }
 
-    public bool Remove(EntityUid toRemove, EntityUid container, EntityStorageComponent? component = null, TransformComponent? xform = null)
+    /// <summary>
+    /// Removes an entity from it's parent container, taking <see cref="EntityStorageComponent"/> into account.
+    /// Ensures that the entity appears in the next eligible parent container, or offset onto its grid/map.
+    /// </summary>
+    /// <param name="toRemove">The entity to remove.</param>
+    /// <returns>True if the entity was successfully removed without errors.</returns>
+    public bool Remove(EntityUid toRemove)
     {
-        if (!Resolve(container, ref xform, false))
-            return false;
+        var parentContainers = _container.GetContainingContainers(toRemove);
 
-        if (!Resolve(container, ref component))
-            return false;
-
-        // Get our new parent: either the grid the entity is on, or the
-        var newParent = xform.GridUid ?? xform.MapUid;
-        if (!TryComp(newParent, out TransformComponent? parentXform))
-            return false;
-
-        // Reparent the removed entity to our grid, or the map!
-        var (pos, rot) = TransformSystem.GetWorldPositionRotation(xform);
-        pos += rot.RotateVec(component.EnteringOffset);
-        pos = Vector2.Transform(pos, TransformSystem.GetInvWorldMatrix(parentXform));
-        if (!_container.Remove(toRemove, component.Contents, destination: new(newParent.Value, pos)))
-            return false;
-
-        if (_container.IsEntityInContainer(container)
-            && _container.TryGetOuterContainer(container, Transform(container), out var outerContainer))
+        foreach (var parentContainer in parentContainers)
         {
-            var attemptEvent = new EntityStorageIntoContainerAttemptEvent(outerContainer);
-            RaiseLocalEvent(outerContainer.Owner, ref attemptEvent);
-            if (!attemptEvent.Cancelled)
+            var parent = parentContainer.Owner;
+            var xform = Transform(parent);
+
+            if (TryComp<EntityStorageComponent>(parent, out var entStorageComp))
             {
-                _container.Insert(toRemove, outerContainer);
-                return true;
+                if (!_container.IsEntityInContainer(parent))
+                {
+                    if (!TransformSystem.TryGetMapOrGridCoordinates(parent, out var coordinates, xform))
+                        return false;
+
+                    var rot = xform.LocalRotation;
+
+                    if (!_container.Remove(toRemove,
+                            parentContainer,
+                            destination: coordinates.Value.Offset(rot.RotateVec(entStorageComp.EnteringOffset))))
+                        return false;
+
+                    break;
+                }
             }
+
+            if (!_container.Remove(toRemove, parentContainer))
+                return false;
+
+            var attemptEvent = new EntityStorageIntoContainerAttemptEvent(parentContainer);
+            RaiseLocalEvent(xform.ParentUid, ref attemptEvent);
+            if (!attemptEvent.Cancelled)
+                break;
         }
 
-        RemComp<InsideEntityStorageComponent>(toRemove);
+        if (!_container.IsEntityInContainer(toRemove))
+            RemComp<InsideEntityStorageComponent>(toRemove);
+
         return true;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR makes entity storages correctly respect parentage in instances where an entity is inside of multiple containers.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

We don't really do nested entity storages but if we wanted to, this would be necessary!

## Technical details
<!-- Summary of code changes for easier review. -->

The `SharedEntityStorageSystem.Remove` has been heavily rewritten. Now it only takes the entity being removed as an argument. It iterates through the entity's parent containers:

- If the parent isn't inside another container (i.e. on a grid/map), it places the entity in the world, with the entity storage's offset if it exists.
- Otherwise, remove the entity from its container, then check if it's eligible to be in its new parent container. If not, remove it from that parent and keep removing and checking until it either gets an eligible parent container or ends up on the grid/map.

Previously it only checked the outermost container; this was a hack to make it work with Ripleys holding crates (bypassing checking the clamp), but now it properly checks the clamp first, and then the Ripley, before dumping the contents of the crate out. 

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Test 1: Locker parentage

1. Give the base closet `LockerBase` the `Item` component in yaml (allows closets to be put in closets).
2. Make a square with straight railings on a single tile (to prevent closets pushing each other).
3. Place a closet, and enter as a Urist
4. `aghost` and place a new closet on the tile, and close it around the first closet.
5. Place another closet on the tile, close it.
6. `aghost` again to return being the Urist.
7. Check the Urist's parent, confirm it is the first locker.
8. Open the first locker using rightclick, confirm that Urist's parent is now the second locker.
9. Open the second locker using rightclick, confirm that Urist's parent is now the third locker.

Test 2: Ripley

1. Spawn in a Ripley, clamp, crate and second Urist (make note of its uid)
2. Put the second Urist in a crate, install the clamp on the Ripley, enter the Ripley and pick up the crate
3. `controlmob` into the second Urist inside the crate.
4. Open the crate, and notice that you appear on the grid as expected. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

(ignore the ghost picking up the locker)

Showcasing proper parentage:
https://github.com/user-attachments/assets/bf75a69d-9624-4d7b-849e-5ba53ff660ea

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

The `SharedEntityStorageSystem.Remove` now only takes the entity being removed as an argument.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

Not playerfacing, unless we wanna cover the very common scenario for when you pick up Ian in a pet carrier and then go into a crate that a ripley picks up and then you open up the pet carrier releasing Ian, who now properly ends up in the crate instead of outside the ripley.