### PR TITLE
Reverts light energy of default lights

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -220,7 +220,7 @@
   components:
   - type: LightBulb
     color: "#FFE4CE" # 5000K color temp
-    lightEnergy: 1.6
+    lightEnergy: 0.8
     lightRadius: 10
     lightSoftness: 1
     PowerUse: 25


### PR DESCRIPTION
## About the PR
Changed the flurecent light (default) light energy back to original state before the resprite ( 1.6 -> 0.8  x2 less )

## Why / Balance
Originally changed in #44857 
Not much information was given why that change was made, but there are now some issues
- The maps are now a bit too bright.
- Lights were mapped with old light intensity which means that a bunch of areas are just too bright rn as too many lights got placed close together
- The light fixture wasn't adjusted so it deviates from mapping view and initialized map view
- Assuming that this change was made for scarcer placing of light as they are supposed to be on top of the walls now, it didn't change the range of the light, so all it did was increase the intensity of the light closer to the source.
- If mappers wanted to have bright lights then they would have used LED lights

I would like an explanation or a discussion about the original change, otherwise i think it looks better

## Technical details
yml number

## Test plan
look at the maps, they are less bright now

## Media
Before
<img width="928" height="679" alt="image" src="https://github.com/user-attachments/assets/8236db22-5624-4496-97e9-d1cc1eaa6fd8" />

After
<img width="975" height="746" alt="image" src="https://github.com/user-attachments/assets/abc7b5a2-32c9-47b9-bdfd-5f2ebafdc9ed" />

Before
<img width="1097" height="869" alt="image" src="https://github.com/user-attachments/assets/49c1de03-1ab7-40df-8a7e-effb66921a2e" />

After
<img width="1060" height="899" alt="image" src="https://github.com/user-attachments/assets/c9e617e4-1d40-4ad2-996b-3cd1e9d55f11" />

Before
<img width="1053" height="853" alt="image" src="https://github.com/user-attachments/assets/b32fff1f-6a7d-4013-aff9-8127ca1e5afc" />

After
<img width="1014" height="904" alt="image" src="https://github.com/user-attachments/assets/d592f59a-373f-4dff-97af-6a5d36830bc7" />

Before
<img width="1162" height="853" alt="image" src="https://github.com/user-attachments/assets/f7b491ee-e0c7-44ba-af53-564309409b67" />

After
<img width="1061" height="862" alt="image" src="https://github.com/user-attachments/assets/478cd92a-f5aa-4dde-8a6b-5b70a14d4b7f" />

Before
<img width="1258" height="929" alt="image" src="https://github.com/user-attachments/assets/f052c7c9-c898-4a5d-b49f-05e7f99af4f7" />

After
<img width="1184" height="901" alt="image" src="https://github.com/user-attachments/assets/959434b5-b76a-4c70-af66-0e8e9e2e987a" />

Before
<img width="1099" height="900" alt="image" src="https://github.com/user-attachments/assets/e76d5311-8b81-4114-a486-e368c3c74d32" />

After
<img width="1141" height="943" alt="image" src="https://github.com/user-attachments/assets/ce34d228-c212-4607-90e4-113c7f82cd3b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- tweak: The default fluorescent lights have been reduced in brightness back to previous levels.