### PR TITLE
Fix vim guide string

### DIFF
--- a/Resources/Locale/en-US/mech/mech.ftl
+++ b/Resources/Locale/en-US/mech/mech.ftl
@@ -14,3 +14,4 @@ mech-energy-missing = Energy: MISSING
 mech-slot-display = Open Slots: {$amount}
 
 mech-construction-guide-string = All mech parts must be attached to the harness.
+mech-construction-guide-string-vim = Two borg legs and an EVA helmet must be attached to the harness.

--- a/Resources/Prototypes/Recipes/Construction/Graphs/mechs/vim_construction.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/mechs/vim_construction.yml
@@ -7,8 +7,7 @@
     - to: vim
       steps:
       - assemblyId: Vim
-        guideString: mech-construction-guide-string
-
+        guideString: mech-construction-guide-string-vim
       - tag: VoiceTrigger
         name: construction-graph-tag-voice-trigger
         icon:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Adds a specific loc string for VIM construction, because "VIM legs" just aren't a thing - the mech requires an oddball set of parts.

Placeholder barring better, more detailed mech construction [guide generation].

## Why / Balance

"All mech parts must be attached to the harness." isn't great for the reasons above.

## Technical details

yammel 'n' fittle

## Test plan

Spawn a vim harness.
Using only the instructions provided, build a vim!

## Media

<img width="310" height="201" alt="image" src="https://github.com/user-attachments/assets/21204e7b-4d47-4fd1-92e5-221b9a55022f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
_...could_