### PR TITLE
Fix bow and arrow shooting yourself

### DIFF
--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -205,7 +205,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
     }
 
     [SubscribeLocalEvent]
-    private void OnBeingShot(Entity<ProjectileComponent> entity, ref MapInitEvent args)
+    private void OnBeingShot(Entity<ProjectileComponent> entity, ref ProjectileShotEvent args)
     {
         entity.Comp.WhenToStopIgnoringShooter = _timing.CurTime + entity.Comp.DelayToAcknowledgeShooter;
         Dirty(entity);
@@ -268,6 +268,9 @@ public record struct ProjectileReflectAttemptEvent(EntityUid ProjUid, Projectile
 {
     SlotFlags IInventoryRelayEvent.TargetSlots => SlotFlags.WITHOUT_POCKET;
 }
+
+[ByRefEvent]
+public record struct ProjectileShotEvent;
 
 /// <summary>
 /// Raised when a projectile hits an entity

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -269,6 +269,9 @@ public record struct ProjectileReflectAttemptEvent(EntityUid ProjUid, Projectile
     SlotFlags IInventoryRelayEvent.TargetSlots => SlotFlags.WITHOUT_POCKET;
 }
 
+/// <summary>
+/// Raised when a projectile is shot
+/// </summary>
 [ByRefEvent]
 public record struct ProjectileShotEvent;
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -459,6 +459,9 @@ public abstract partial class SharedGunSystem : EntitySystem
             Projectiles.SetShooter(uid, projectile, shooter.Value);
 
         TransformSystem.SetWorldRotation(uid, direction.ToWorldAngle() + projectile.Angle);
+
+        var ev = new ProjectileShotEvent();
+        RaiseLocalEvent(uid, ref ev);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
My tiding was going well, until I took an arrow to the knee

fixes #45537

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bows are typically aimed outwards not inwards

## Technical details
<!-- Summary of code changes for easier review. -->
Arrows were colliding with yourself because the time to ignore was being updated on mapinit, not when they were shot.

PR adds a `ProjectileShotEvent` to `SharedGunSystem` that `SharedProjectileSystem` subscribes to instead of to `OnMapInit` to update the time.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Shoot bow and arrow and fat xenoborg rocket launcher and make sure you don't hit yourself. Maybe other various guns and stuff idk

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed bow and arrow shooting yourself
