### PR TITLE
Fix bug where utility knife loses tool qualities

### DIFF
--- a/Content.Shared/Tools/Components/ToolComponent.cs
+++ b/Content.Shared/Tools/Components/ToolComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class ToolComponent : Component
     public HashSet<ProtoId<ToolQualityPrototype>> Qualities = [];
 
     /// <summary>
-    ///     For tool interactions that have a delay before action this will modify the rate, time to wait is divided by this value
+    /// For tool interactions that have a delay before action this will modify the rate, time to wait is divided by this value
     /// </summary>
     [DataField, AutoNetworkedField]
     public float SpeedModifier = 1f;

--- a/Content.Shared/Tools/Components/ToolComponent.cs
+++ b/Content.Shared/Tools/Components/ToolComponent.cs
@@ -5,20 +5,20 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Tools.Components;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(SharedToolSystem))]
 public sealed partial class ToolComponent : Component
 {
-    [DataField]
-    public HashSet<ProtoId<ToolQualityPrototype>> Qualities  = [];
+    [DataField, AutoNetworkedField]
+    public HashSet<ProtoId<ToolQualityPrototype>> Qualities = [];
 
     /// <summary>
     ///     For tool interactions that have a delay before action this will modify the rate, time to wait is divided by this value
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float SpeedModifier = 1f;
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public SoundSpecifier? UseSound;
 }
 

--- a/Content.Shared/Tools/Systems/SharedToolSystem.MultipleTool.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.MultipleTool.cs
@@ -68,6 +68,7 @@ public abstract partial class SharedToolSystem
         var current = multiple.Entries[multiple.CurrentEntry];
         tool.UseSound = current.UseSound;
         tool.Qualities = current.Behavior;
+        Dirty(uid, tool);
 
         // TODO: Replace this with a better solution later
         if (TryComp<PryingComponent>(uid, out var pryComp))

--- a/Content.Shared/Tools/Systems/SharedToolSystem.MultipleTool.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.MultipleTool.cs
@@ -74,6 +74,7 @@ public abstract partial class SharedToolSystem
         if (TryComp<PryingComponent>(uid, out var pryComp))
         {
             pryComp.Enabled = current.Behavior.Contains("Prying");
+            Dirty(uid, pryComp);
         }
 
         if (playSound && current.ChangeSound != null)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

If you spawn a "utility knife", extend it, then right-click on a jumpsuit, the verb UI indicates that you are not able to cut the jumpsuit with the knife:

<img width="1300" height="641" alt="SlicingBefore" src="https://github.com/user-attachments/assets/0981989e-b0df-4476-a7e1-d9cdfd9e6905" />

But if you _left-click_ on the jumpsuit, you'll slice it anyway (but the sound that's supposed to play won't)

Fix that.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->

ComponentTogglerSystem was adding a ToolComponent with fields configured in the utility knife yaml. However, no fields in the ToolComponent were networked, so when the added ToolComponent was sent from the server, the existing component's fields were replaced with null in ClientGameStateManager.HandleEntityState()

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Spawn a jumpsuit, spawn a utility knife. Activate-in-hand the utility knife. Right-click jumpsuit. "Slice" menu option should not be disabled.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
