### PR TITLE
Bugfix: Magboots only show an alert when worn

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -145,6 +145,9 @@ public abstract partial class ClothingSystem : EntitySystem
         if (!Resolve(item, ref item.Comp, false))
             return false;
 
+        if (item.Comp.InSlotFlag == null)
+            return false;
+
         if ((item.Comp.Slots & item.Comp.InSlotFlag) != SlotFlags.NONE)
             return true;
 

--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -145,6 +145,8 @@ public abstract partial class ClothingSystem : EntitySystem
         if (!Resolve(item, ref item.Comp, false))
             return false;
 
+        // If the entity is in a user's hand, or not on their body at all,
+        // the flag is null, and the bitwise and below returns null!
         if (item.Comp.InSlotFlag == null)
             return false;
 

--- a/Content.Shared/Clothing/MagbootsComponent.cs
+++ b/Content.Shared/Clothing/MagbootsComponent.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Alert;
-using Content.Shared.Inventory;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 

--- a/Content.Shared/Clothing/MagbootsSystem.cs
+++ b/Content.Shared/Clothing/MagbootsSystem.cs
@@ -1,54 +1,32 @@
-using Content.Shared.Actions;
 using Content.Shared.Alert;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Gravity;
 using Content.Shared.Inventory;
-using Content.Shared.Item;
 using Content.Shared.Item.ItemToggle;
 using Content.Shared.Item.ItemToggle.Components;
 using Robust.Shared.Containers;
 
 namespace Content.Shared.Clothing;
 
+/// <summary>
+/// A system for enabling and disabling the effects of magboots.
+/// The boots "force" gravity for the wearing entity when enabled and on a grid.
+/// </summary>
 public sealed partial class SharedMagbootsSystem : EntitySystem
 {
     [Dependency] private AlertsSystem _alerts = default!;
+    [Dependency] private ClothingSystem _clothing = default!;
     [Dependency] private ItemToggleSystem _toggle = default!;
     [Dependency] private SharedContainerSystem _container = default!;
     [Dependency] private SharedGravitySystem _gravity = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<MagbootsComponent, ItemToggledEvent>(OnToggled);
-        SubscribeLocalEvent<MagbootsComponent, ClothingGotEquippedEvent>(OnGotEquipped);
-        SubscribeLocalEvent<MagbootsComponent, ClothingGotUnequippedEvent>(OnGotUnequipped);
-        SubscribeLocalEvent<MagbootsComponent, IsWeightlessEvent>(OnIsWeightless);
-        SubscribeLocalEvent<MagbootsComponent, InventoryRelayedEvent<IsWeightlessEvent>>(OnIsWeightless);
-    }
-
-    private void OnToggled(Entity<MagbootsComponent> ent, ref ItemToggledEvent args)
-    {
-        if (_container.TryGetContainingContainer((ent.Owner, null, null), out var container))
-            UpdateMagbootEffects(container.Owner, ent, args.Activated);
-    }
-
-    private void OnGotUnequipped(Entity<MagbootsComponent> ent, ref ClothingGotUnequippedEvent args)
-    {
-        UpdateMagbootEffects(args.Wearer, ent, false);
-    }
-
-    private void OnGotEquipped(Entity<MagbootsComponent> ent, ref ClothingGotEquippedEvent args)
-    {
-        UpdateMagbootEffects(args.Wearer, ent, _toggle.IsActivated(ent.Owner));
-    }
+    [Dependency] private EntityQuery<MovedByPressureComponent> _movedByPressureQuery = default!;
 
     public void UpdateMagbootEffects(EntityUid user, Entity<MagbootsComponent> ent, bool state)
     {
         // TODO: public api for this and add access
-        if (TryComp<MovedByPressureComponent>(user, out var moved))
+        if (_movedByPressureQuery.TryComp(user, out var moved))
             moved.Enabled = !state;
 
         _gravity.RefreshWeightless(user);
@@ -59,6 +37,34 @@ public sealed partial class SharedMagbootsSystem : EntitySystem
             _alerts.ClearAlert(user, ent.Comp.MagbootsAlert);
     }
 
+    #region Event Handlers
+    [SubscribeLocalEvent]
+    private void OnToggled(Entity<MagbootsComponent> ent, ref ItemToggledEvent args)
+    {
+        if (_clothing.IsEquipped(ent.Owner)
+            && _container.TryGetContainingContainer((ent.Owner, null, null), out var container))
+            UpdateMagbootEffects(container.Owner, ent, args.Activated);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnGotUnequipped(Entity<MagbootsComponent> ent, ref ClothingGotUnequippedEvent args)
+    {
+        UpdateMagbootEffects(args.Wearer, ent, false);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnGotEquipped(Entity<MagbootsComponent> ent, ref ClothingGotEquippedEvent args)
+    {
+        UpdateMagbootEffects(args.Wearer, ent, _toggle.IsActivated(ent.Owner));
+    }
+
+    [SubscribeLocalEvent]
+    private void OnIsWeightless(Entity<MagbootsComponent> ent, ref InventoryRelayedEvent<IsWeightlessEvent> args)
+    {
+        OnIsWeightless(ent, ref args.Args);
+    }
+
+    [SubscribeLocalEvent]
     private void OnIsWeightless(Entity<MagbootsComponent> ent, ref IsWeightlessEvent args)
     {
         if (args.Handled || !_toggle.IsActivated(ent.Owner))
@@ -71,9 +77,5 @@ public sealed partial class SharedMagbootsSystem : EntitySystem
         args.IsWeightless = false;
         args.Handled = true;
     }
-
-    private void OnIsWeightless(Entity<MagbootsComponent> ent, ref InventoryRelayedEvent<IsWeightlessEvent> args)
-    {
-        OnIsWeightless(ent, ref args.Args);
-    }
+    #endregion Event Handlers
 }

--- a/Content.Shared/Clothing/MagbootsSystem.cs
+++ b/Content.Shared/Clothing/MagbootsSystem.cs
@@ -23,6 +23,7 @@ public sealed partial class SharedMagbootsSystem : EntitySystem
 
     [Dependency] private EntityQuery<MovedByPressureComponent> _movedByPressureQuery = default!;
 
+    #region Public API
     public void UpdateMagbootEffects(EntityUid user, Entity<MagbootsComponent> ent, bool state)
     {
         // TODO: public api for this and add access
@@ -36,6 +37,7 @@ public sealed partial class SharedMagbootsSystem : EntitySystem
         else
             _alerts.ClearAlert(user, ent.Comp.MagbootsAlert);
     }
+    #endregion Public API
 
     #region Event Handlers
     [SubscribeLocalEvent]
@@ -59,12 +61,6 @@ public sealed partial class SharedMagbootsSystem : EntitySystem
     }
 
     [SubscribeLocalEvent]
-    private void OnIsWeightless(Entity<MagbootsComponent> ent, ref InventoryRelayedEvent<IsWeightlessEvent> args)
-    {
-        OnIsWeightless(ent, ref args.Args);
-    }
-
-    [SubscribeLocalEvent]
     private void OnIsWeightless(Entity<MagbootsComponent> ent, ref IsWeightlessEvent args)
     {
         if (args.Handled || !_toggle.IsActivated(ent.Owner))
@@ -76,6 +72,12 @@ public sealed partial class SharedMagbootsSystem : EntitySystem
 
         args.IsWeightless = false;
         args.Handled = true;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnIsWeightless(Entity<MagbootsComponent> ent, ref InventoryRelayedEvent<IsWeightlessEvent> args)
+    {
+        OnIsWeightless(ent, ref args.Args);
     }
     #endregion Event Handlers
 }

--- a/Content.Shared/Clothing/MagbootsSystem.cs
+++ b/Content.Shared/Clothing/MagbootsSystem.cs
@@ -21,31 +21,16 @@ public sealed partial class SharedMagbootsSystem : EntitySystem
     [Dependency] private SharedContainerSystem _container = default!;
     [Dependency] private SharedGravitySystem _gravity = default!;
 
-    [Dependency] private EntityQuery<MovedByPressureComponent> _movedByPressureQuery = default!;
+    [Dependency] private EntityQuery<MovedByPressureComponent> _movedByPressureQuery;
 
-    #region Public API
-    public void UpdateMagbootEffects(EntityUid user, Entity<MagbootsComponent> ent, bool state)
-    {
-        // TODO: public api for this and add access
-        if (_movedByPressureQuery.TryComp(user, out var moved))
-            moved.Enabled = !state;
-
-        _gravity.RefreshWeightless(user);
-
-        if (state)
-            _alerts.ShowAlert(user, ent.Comp.MagbootsAlert);
-        else
-            _alerts.ClearAlert(user, ent.Comp.MagbootsAlert);
-    }
-    #endregion Public API
-
-    #region Event Handlers
     [SubscribeLocalEvent]
     private void OnToggled(Entity<MagbootsComponent> ent, ref ItemToggledEvent args)
     {
         if (_clothing.IsEquipped(ent.Owner)
             && _container.TryGetContainingContainer((ent.Owner, null, null), out var container))
+        {
             UpdateMagbootEffects(container.Owner, ent, args.Activated);
+        }
     }
 
     [SubscribeLocalEvent]
@@ -58,6 +43,20 @@ public sealed partial class SharedMagbootsSystem : EntitySystem
     private void OnGotEquipped(Entity<MagbootsComponent> ent, ref ClothingGotEquippedEvent args)
     {
         UpdateMagbootEffects(args.Wearer, ent, _toggle.IsActivated(ent.Owner));
+    }
+
+    public void UpdateMagbootEffects(EntityUid user, Entity<MagbootsComponent> ent, bool state)
+    {
+        // TODO: public api for this and add access
+        if (_movedByPressureQuery.TryComp(user, out var moved))
+            moved.Enabled = !state;
+
+        _gravity.RefreshWeightless(user);
+
+        if (state)
+            _alerts.ShowAlert(user, ent.Comp.MagbootsAlert);
+        else
+            _alerts.ClearAlert(user, ent.Comp.MagbootsAlert);
     }
 
     [SubscribeLocalEvent]
@@ -79,5 +78,4 @@ public sealed partial class SharedMagbootsSystem : EntitySystem
     {
         OnIsWeightless(ent, ref args.Args);
     }
-    #endregion Event Handlers
 }

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -128,12 +128,10 @@
     sprite: Clothing/Shoes/Boots/magboots-ert.rsi
 
 - type: entity
-  parent: BaseAction
+  parent: BaseToggleAction
   id: ActionToggleMagboots
   name: Toggle Magboots
   description: Toggles the magboots on and off.
   components:
   - type: Action
     itemIconStyle: BigItem
-  - type: InstantAction
-    event: !type:ToggleActionEvent


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Fixes two bugs:
1. Magboots' toggle only updates its status when worn.
2. ClothingSystem.IsEquipped checks if the current slots are null (e.g. if the item is in your hand)

Also swaps Magboots over to a BaseToggleAction (as it toggles!)

## Why / Balance

Holy bugfix.

## Technical details

1. MagbootsSystem cleanup: public API moved up top, event handlers separated into a region, EntityQuery used for TryComp.
2. MagbootsSystem.Toggled checks that the boots are equipped via ClothingSystem.IsEquipped.
3. ClothingSystem.IsEquipped now checks if the current flags are not null before checking for slot inequality - this will currently pass as equipped, even when the relevant item is in your hand!

## Test plan

Spawn magboots.
Pick up magboots.
Enable magboots.  No alert.
Put on magboots.  Get an alert added.
Turn off magboots.  Alert goes away.
Turn on magboots.  Alert returns.
Unequip magboots into your hand.  Alert goes away.

## Media

The test plan roughly followed.

https://github.com/user-attachments/assets/cc7fb3ce-fbe4-45e3-a230-6f281d482d03

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: eoin, whatston3
- fix: Magboots can no longer leave an alert in your HUD when unequipped, or add an alert when toggled in your hand.
