### PR TITLE
Bump LevelOfParallelism

### DIFF
--- a/Content.IntegrationTests/AssemblyInfo.cs
+++ b/Content.IntegrationTests/AssemblyInfo.cs
@@ -5,4 +5,4 @@
 // https://github.com/dotnet/runtime/issues/107197
 // So we can't really parallelize integration tests harder either until the runtime fixes that,
 // *or* we fix serv3 to not spam expression trees.
-[assembly: LevelOfParallelism(2)]
+[assembly: LevelOfParallelism(4)]


### PR DESCRIPTION
Issue, PoolManager has no way to actually throttle tests so if you remove this your RAM will go to the moon faster than DOGE.

I'm too lazy to add a constant with throttles so we get this just to see if it's even faster on github.