### PR TITLE
Make flashlight charge level meter update upon power cell removal

### DIFF
--- a/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
@@ -253,8 +253,8 @@ namespace Content.Server.Light.EntitySystems
         {
             var level = GetLevel(ent);
 
-            if (level == ent.Comp.Level)
-                return;
+            //if (level == ent.Comp.Level)
+            //    return;
 
             ent.Comp.Level = level;
             Dirty(ent);

--- a/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
@@ -181,7 +181,6 @@ namespace Content.Server.Light.EntitySystems
 
             _lights.SetEnabled(ent, false, pointLightComponent);
             SetActivated(ent, false, ent, makeNoise);
-            ent.Comp.Level = null;
             _activeLights.Remove(ent);
             return true;
         }

--- a/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
@@ -253,8 +253,8 @@ namespace Content.Server.Light.EntitySystems
         {
             var level = GetLevel(ent);
 
-            //if (level == ent.Comp.Level)
-            //    return;
+            if (level == ent.Comp.Level)
+                return;
 
             ent.Comp.Level = level;
             Dirty(ent);


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Made the flashlight charge level display update when you take out the power cell.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

It was annoying me that a flashlight or seclight still displayed a charge even after the power cell was pulled out.

## Technical details
<!-- Summary of code changes for easier review. -->

Removed Level nullification in `TurnOff` in `HandHeldLightSystem.cs`

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Spawn a flashlight.  Pick it up, then turn it on and off.  Now eject the power cell, and see if the charge display remains green.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:
https://github.com/user-attachments/assets/427f790c-163a-44ff-a526-f4f99e7f614b

After:

https://github.com/user-attachments/assets/7f4c180a-c710-4bc8-a31c-2efc4416490c




## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
