### PR TITLE
Sheep Plushie Inhand Fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/Plushies/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Plushies/plushies.yml
@@ -1189,7 +1189,7 @@
     sprite: Objects/Fun/Plushies/sheep.rsi
     state: sheeptoy
   - type: Item
-    sprite: Objects/Fun/Plushies/carp.rsi
+    sprite: Objects/Fun/Plushies/sheep.rsi
     heldPrefix: sheeptoy
     storedRotation: -90
   - type: EmitSoundOnUse
@@ -1229,6 +1229,9 @@
   - type: Sprite
     sprite: Objects/Fun/Plushies/sheep.rsi
     state: spacesheeptoy
+  - type: Item
+    sprite: Objects/Fun/Plushies/sheep.rsi
+    heldPrefix: spacesheeptoy
   - type: FoodSequenceElement
     entries:
       CottonBurger: SheepSpacePlushie


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Sheep plushies had inhand sprites but they weren't showing up ingame. This fixes that.

## Why / Balance
Inhands good.

## Technical details
Small yaml fix, sheep plushie was pulling from the carp folder mistakenly, spacesheep didn't have the item inclusion.

## Test plan
Spawn sheep plushie
Hold inhand
It shows up.

## Media
<img width="208" height="253" alt="Screenshot 2026-08-23 130735" src="https://github.com/user-attachments/assets/b7a76064-fd33-49e2-bf51-e57156a7d991" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

## Changelog
N/A
