### PR TITLE
Apply drunk-related effects instantly instead of after delay

### DIFF
--- a/Content.Client/Drunk/DrunkOverlay.cs
+++ b/Content.Client/Drunk/DrunkOverlay.cs
@@ -29,7 +29,7 @@ public sealed partial class DrunkOverlay : Overlay
     // Needed so it doesn't always look the same for 0 motion.
     public float Phase = 0f;
 
-    private const float VisualThreshold = 10.0f;
+    private const float VisualThreshold = 40.0f;
     private const float PowerDivisor = 250.0f;
     /// <remarks>
     /// This is a magic number based on my person preference of how quickly the bloodloss effect should kick in.
@@ -114,13 +114,13 @@ public sealed partial class DrunkOverlay : Overlay
     private float BoozePowerToVisual(float boozePower)
     {
         // Clamp booze power when it's low, to prevent really jittery effects
-        if (boozePower < 50f)
+        if (boozePower < 1f)
         {
             return 0;
         }
         else
         {
-            return Math.Clamp((boozePower - VisualThreshold) / PowerDivisor, 0.0f, 1.0f);
+            return Math.Clamp((boozePower + VisualThreshold) / PowerDivisor, 0.0f, 1.0f);
         }
     }
 }

--- a/Content.Shared/Speech/Components/SlurredAccentComponent.cs
+++ b/Content.Shared/Speech/Components/SlurredAccentComponent.cs
@@ -14,11 +14,11 @@ public sealed partial class SlurredAccentComponent : BaseAccentComponent
     /// Divisor applied to total seconds used to get the odds of slurred speech occuring.
     /// </summary>
     [DataField]
-    public float SlurredModifier = 1100f;
+    public float SlurredModifier = 180f;
 
     /// <summary>
     /// Minimum amount of time on the slurred accent for it to start taking effect.
     /// </summary>
     [DataField]
-    public float SlurredThreshold = 80f;
+    public float SlurredThreshold;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The woozy effect from being drunk and blood loss, and slurred speech, will start immediately instead of after about 1-2 minutes. The power and length are the same, it's just no longer delayed. 

Change slurred speech ceiling so it's reached around the same time max booze power is reached. Seems it was super high and we only reached like 15% of it at maximum drunk effect and this maximum slurred speech was really weak. Now it's actually properly slurred when very drunk.

Keep the `boozePower < 1f` check in `BoozePowerToVisual` to prevent initial big jitter.

The cap values are the same, so super drunk substances like frezon give the same huge drunk effects because they hit the same cap quickly.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Ehh it's annoying when trying to add other effects that should seamlessly work with the woozy effect and it forces you to replicate this threshold logic in every new effect that is applied together with drunk. Also annoying from a gameplay perspective for the effect to just wait a minute before starting, I found no point to it.

It's only a game, and we don't need to simulate ethanol having a delay to its effect. Food, pills, and liquids already work instantly after consumption in the game for simplicity.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- tweak: Being drunk now starts immediately after ingesting ethanol, and the effect is more pronounced when totally wasted.