### PR TITLE
Stun Prod as a maints electrolyser

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -79,3 +79,9 @@
   - type: Tag
     tags:
     - Stunbaton
+  - type: ReactionMixer
+    sound: !type:SoundPathSpecifier
+      path: /Audio/Effects/sizzle.ogg
+    timetoMix: 5.0
+    reactionTypes:
+    - Electrolysis

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -80,8 +80,5 @@
     tags:
     - Stunbaton
   - type: ReactionMixer
-    sound: !type:SoundPathSpecifier
-      path: /Audio/Effects/sizzle.ogg
-    timetoMix: 5.0
     reactionTypes:
     - Electrolysis


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the Electrolyser Tag to the stunprod, to work as a maints electrolyser.

## Why / Balance
I am fully aware this is completely inadequate. It has no do after, no noise, no event call to charge component to reduce the charge after use, and no no visual indicator or requirement for the prod to be turned on.

I don't have the knowledge to do that, and my hope is someone will get so annoyed at the inadequacy of this PR, that they end up doing it instead and I get to see what I should have done.

That being said:
Why? Because an electrolyser alternative for maint chemists would be awesome. I tried making instead a beaker with a slottable battery, but again I don't actually know what I'm doing lol.

Stun Prod needs 3 hits to stun, so if you make it take 5% battery its now useless as a weapon, so its good to be generous on how many uses you give it.

## Technical details
Just added the reactiomixer tag.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
- add: the stun prod can now be used as an electrolyser.