### PR TITLE
Fix client/server desync when changing emitter bolt types using signals

### DIFF
--- a/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
@@ -272,6 +272,7 @@ namespace Content.Server.Singularity.EntitySystems
             else if (component.SetTypePorts.TryGetValue(args.Port, out var boltType))
             {
                 component.BoltType = boltType;
+                Dirty(uid, component);
             }
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
An upstream port of the one-line fix at https://github.com/new-frontiers-14/frontier-station-14/pull/4810.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
On signal recieved emitter would change bolt type on server but not on client, because the change wasn't networked.
## Technical details
<!-- Summary of code changes for easier review. -->
`EmitterComponent` is properly dirtied on Server `OnSignalRecieved`.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Spawn an A.P.E, change bolt type via signal and checked that both client and server `EmitterComponent` reflect the change.
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.
## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Arimah
- fix: Server and Client no longer desynchronised when using signals to change an emitter bolt type.

