### PR TITLE
Added tile replacement as a variation pass entity effect

### DIFF
--- a/Content.Shared/EntityEffects/Effects/VariationPass/EntitySpawnVariationPassEntityEffect.cs
+++ b/Content.Shared/EntityEffects/Effects/VariationPass/EntitySpawnVariationPassEntityEffect.cs
@@ -1,10 +1,12 @@
 ﻿using System.Linq;
 using Content.Shared.EntityTable;
 using Content.Shared.EntityTable.EntitySelectors;
+using Content.Shared.Maps;
 using Content.Shared.Physics;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Shared.EntityEffects.Effects.VariationPass;
@@ -19,10 +21,19 @@ public sealed partial class EntitySpawnVariationPassEntityEffectSystem : EntityE
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private EntityTableSystem _tables = default!;
+    [Dependency] private ITileDefinitionManager _tileDefManager = default!;
 
     protected override void Effect(Entity<MapGridComponent> entity, ref EntityEffectEvent<EntitySpawnVariationPass> args)
     {
         var tiles = _map.GetAllTiles(entity, entity).ToList();
+
+        if (args.Effect.EligibleTiles != null)
+        {
+            var variationPass = args.Effect;
+            tiles = tiles.Where(tile => variationPass.EligibleTiles.Contains(_tileDefManager[tile.Tile.TypeId].ID))
+                .ToList();
+        }
+
         var totalTiles = tiles.Count();
 
         var dirtyMod = _random.NextGaussian(args.Effect.TilesPerEntityAverage, args.Effect.TilesPerEntityStdDev);
@@ -91,6 +102,12 @@ public sealed partial class EntitySpawnVariationPassEntityEffectSystem : EntityE
 /// <inheritdoc cref="EntityEffect"/>
 public sealed partial class EntitySpawnVariationPass : EntityEffectBase<EntitySpawnVariationPass>
 {
+    /// <summary>
+    /// The tiles that the entities map spawn on. If null, all tiles are eligible.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<ContentTileDefinition>>? EligibleTiles;
+
     /// <summary>
     /// Number of tiles before we spawn one entity on average.
     /// </summary>

--- a/Content.Shared/EntityEffects/Effects/VariationPass/TileReplacementVariationPassEntityEffect.cs
+++ b/Content.Shared/EntityEffects/Effects/VariationPass/TileReplacementVariationPassEntityEffect.cs
@@ -1,0 +1,74 @@
+﻿using System.Linq;
+using Content.Shared.Maps;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Shared.EntityEffects.Effects.VariationPass;
+
+/// <summary>
+/// Used for replacing tiles on a grid.
+/// </summary>
+/// <inheritdoc cref="EntityEffectSystem{T,TEffect}"/>
+public sealed partial class TileReplacementVariationPassEntityEffectSystem : EntityEffectSystem<MapGridComponent, TileReplacementVariationPass>
+{
+    [Dependency] private SharedMapSystem _map = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private ITileDefinitionManager _tileDefManager = default!;
+
+    protected override void Effect(Entity<MapGridComponent> entity, ref EntityEffectEvent<TileReplacementVariationPass> args)
+    {
+        var tiles = _map.GetAllTiles(entity, entity).ToList();
+
+        if (args.Effect.ReplaceableTiles != null)
+        {
+            var variationPass = args.Effect;
+            tiles = tiles.Where(tile => variationPass.ReplaceableTiles.Contains(_tileDefManager[tile.Tile.TypeId].ID))
+                .ToList();
+        }
+
+        var totalTiles = tiles.Count();
+
+        var mod = _random.NextGaussian(args.Effect.TilesPerAverage, args.Effect.TilesPerStdDev);
+        var replacementTileCount = Math.Max((int) (totalTiles * (1 / mod)), 0);
+
+        for (var i = 0; i < replacementTileCount; i++)
+        {
+            if (tiles.Count == 0)
+                break;
+
+            var selectedTile = _random.PickAndTake(tiles);
+            var tileToSet = _random.Pick(args.Effect.ReplacementTiles);
+            _map.SetTile(entity, selectedTile.GridIndices, new Tile(ProtoMan.Index(tileToSet).TileId));
+        }
+    }
+}
+
+/// <inheritdoc cref="EntityEffect"/>
+public sealed partial class TileReplacementVariationPass : EntityEffectBase<TileReplacementVariationPass>
+{
+    /// <summary>
+    /// Number of tiles before we replace an entity on average.
+    /// </summary>
+    [DataField]
+    public float TilesPerAverage = 50f;
+
+    /// <summary>
+    /// Standard deviation for the randomness selection.
+    /// </summary>
+    [DataField]
+    public float TilesPerStdDev = 7f;
+
+    /// <summary>
+    /// The floor tiles that will be replaced. If null, will replace all.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<ContentTileDefinition>>? ReplaceableTiles;
+
+    /// <summary>
+    /// The tiles that will be replaced into. Randomly picked from the list.
+    /// </summary>
+    [DataField(required: true)]
+    public List<ProtoId<ContentTileDefinition>> ReplacementTiles = default!;
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Adds a new variation pass entity effect that replaces tiles on a grid. 

Also adds support for `EntitySpawnVariationPass` to only place on certain grid tiles. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Necessary for BreakSalv. Could also be used for other interesting things maybe? OwO

## Technical details
<!-- Summary of code changes for easier review. -->

Get tiles. Filter tiles. Select tiles randomly. Replace with random tile. 

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Go into dev_map.yml
2. Add the following to the map entity:
```
- type: EntityEffectOnMapInit
  effects:
  - !type:TileReplacementVariationPass
    tilesPerAverage: 2
    tilesPerStdDev: 0
    replaceableTiles:
    - Plating
    replacementTiles:
    - FloorAstroGrass
    - FloorJungleAstroGrass
  - !type:EntitySpawnVariationPass
    eligibleTiles:
    - FloorAstroGrass
    - FloorJungleAstroGrass
    tilesPerEntityAverage: 20
    tilesPerEntityStdDev: 3
    table: !type:GroupSelector
      children:
      - id: FloraTreeLarge
      - id: FloraTree
  - !type:EntitySpawnVariationPass
    eligibleTiles:
    - FloorAstroGrass
    - FloorJungleAstroGrass
    tilesPerEntityAverage: 4
    tilesPerEntityStdDev: 1
    table: !type:AllSelector
      children:
      - id: DecalSpawnerGrassDE
```
3. Boot up the dev environment and enjoy the greenery!

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="1344" height="1051" alt="image" src="https://github.com/user-attachments/assets/465dffb9-9858-4f96-b497-fb8543d8230c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
Not playerfacing.