### PR TITLE
Airlocks now can't be closed when they are collided with counters

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -628,7 +628,8 @@ public abstract partial class SharedDoorSystem : EntitySystem
                 continue;
 
             // Ignore low-passable entities.
-            if ((otherPhysics.Comp.CollisionMask & (int)CollisionGroup.LowImpassable) == 0)
+            if ((otherPhysics.Comp.CollisionMask & (int)CollisionGroup.LowImpassable) == 0 &&
+                otherPhysics.Comp.CollisionLayer != (int) CollisionGroup.CounterLayer)
                 continue;
 
             //For when doors need to close over conveyor belts

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -628,6 +628,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
                 continue;
 
             // Ignore low-passable entities.
+            // Counters also collide with small entities, they are low-passable, but shouldn't be ignored because they are pretty static.
             if ((otherPhysics.Comp.CollisionMask & (int)CollisionGroup.LowImpassable) == 0 &&
                 otherPhysics.Comp.CollisionLayer != (int) CollisionGroup.CounterLayer)
                 continue;

--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -58,6 +58,7 @@ public enum CollisionGroup
     // Tables that SmallMobs can go under
     TableMask = Impassable | MidImpassable,
     TableLayer = MidImpassable,
+    CounterLayer = Impassable | MidImpassable | LowImpassable,
 
     // Tabletop machines, windoors, firelocks
     TabletopMachineMask = Impassable | HighImpassable,

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
@@ -54,5 +54,4 @@
         mask:
         - TableMask
         layer:
-        - TableLayer
-        - LowImpassable
+        - CounterLayer


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
#45612 added LowImpassable to the counters, that means that airlocks now always ignore counters, allowing players to block mice and rats just by placing counter at the same tile as airlocks and by closing it.

## Technical details
N/A

## Test plan
1. Dev
2. Spawn/build counter at the same tile as airlock
3. Attemps to close it

## Media
<img width="800" height="450" alt="counter" src="https://github.com/user-attachments/assets/56bd8f35-a038-4eb9-bc3c-4cccf772c863" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A (probably)

## Changelog
N/A
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
