### PR TITLE
TimerTriggerStatusControl: respect Examinable, less needless precision

### DIFF
--- a/Content.Client/Trigger/UI/TimerTriggerStatusControl.cs
+++ b/Content.Client/Trigger/UI/TimerTriggerStatusControl.cs
@@ -31,7 +31,9 @@ public sealed partial class TimerTriggerStatusControl : PollingItemStatusControl
 
     protected override void Update(in Data data)
     {
-        var markup = Loc.GetString("timer-trigger-status-delay", ("delay", data.Delay.TotalSeconds));
+        var markup = _parent.Comp.Examinable
+            ? Loc.GetString("timer-trigger-status-delay", ("delay", data.Delay.TotalSeconds.ToString("F2")))
+            : Loc.GetString("timer-trigger-status-delay-unknown");
         _label.SetMarkup(markup);
     }
 

--- a/Resources/Locale/en-US/items/item-status.ftl
+++ b/Resources/Locale/en-US/items/item-status.ftl
@@ -33,3 +33,4 @@ anomaly-status-charges = [color=orange]{$charges} charges[/color]
 
 # Timer Trigger Status
 timer-trigger-status-delay = Set Delay: [color=white]{$delay}s[/color]
+timer-trigger-status-delay-unknown = Set Delay: [color=gray]???[/color]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Tweaks the TimerTriggerStatusControl to hide when timers shouldn't be examinable, and prints out fewer decimal places in the time.

## Why / Balance

<img width="110" height="63" alt="image" src="https://github.com/user-attachments/assets/ec3c28ae-61f5-425f-a484-2452063c825b" />

brother

## Technical details
<!-- Summary of code changes for easier review. -->

New fluent string for mystery timers + format string ops.

If you want less precision (maybe no decimal places at all!) just ask, it's easily changed.

## Test plan

1. Spawn pipe bomb, pick it up.  Look at your HUD.  Ooh, the mystery.
2. Spawn cleanade, pick it up.  Look at your HUD.  Ooh, three seconds.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

UI as it exists on the head of the branch.
Two whole decimal places!  Mysterious question marks!

<img width="456" height="437" alt="image" src="https://github.com/user-attachments/assets/8c885ae6-6fdb-4737-8fdf-3adea53a69f2" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Pipe bombs and other unexaminable timers do not show their fuse time when picked up.