### PR TITLE
Zombies now have fake hands (less metagameable in the strip menu)

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -314,8 +314,9 @@ public sealed partial class ZombieSystem
 
         if (TryComp<HandsComponent>(target, out var handsComp))
         {
-            _hands.RemoveHands(target);
-            RemComp(target, handsComp);
+            _hands.FakeHands(target);
+            //_hands.RemoveHands(target);
+            //RemComp(target, handsComp);
         }
 
         // Sloth: What the fuck?

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -312,11 +312,9 @@ public sealed partial class ZombieSystem
             MakeGhostRole(target);
         }
 
-        if (TryComp<HandsComponent>(target, out var handsComp))
+        if (HasComp<HandsComponent>(target)) // replaces hands with non-functional placeholders (still looks like hands on the strip menu)
         {
             _hands.FakeHands(target);
-            //_hands.RemoveHands(target);
-            //RemComp(target, handsComp);
         }
 
         // Sloth: What the fuck?

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -187,6 +187,55 @@ public abstract partial class SharedHandsSystem
             RemoveHand(ent, handId);
         }
     }
+    
+    /// <summary>
+    /// Turn the specified hand into a fake hand
+    /// </summary>
+    public virtual void FakeThisHand(Entity<HandsComponent?> ent, string handName)
+    {
+        if (!Resolve(ent, ref ent.Comp, false))
+            return;
+
+        OnPlayerRemoveHand?.Invoke((ent, ent.Comp), handName);
+
+        TryDrop(ent, handName, null, false);
+
+        if (ContainerSystem.TryGetContainer(ent, handName, out var container))
+            ContainerSystem.ShutdownContainer(container);
+        
+        var oldHand =  ent.Comp.Hands[handName];
+        var newHand = new Hand(oldHand.Location, oldHand.EmptyLabel, oldHand.EmptyRepresentative, new EntityWhitelist
+        {
+            Components = ["VirtualItem"]
+        });
+
+        if (!ent.Comp.Hands.Remove(handName))
+            return;
+
+        ent.Comp.SortedHands.Remove(handName);
+        if (ent.Comp.ActiveHandId == handName)
+            TrySetActiveHand(ent, ent.Comp.SortedHands.FirstOrDefault());
+
+        RaiseLocalEvent(ent, new HandCountChangedEvent(ent));
+        Dirty(ent);
+        
+        ent.Comp.Hands.Add(handName, newHand);
+        
+        RaiseLocalEvent(ent, new HandCountChangedEvent(ent));
+        Dirty(ent);
+    }
+
+    public void FakeHands(Entity<HandsComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp, false))
+            return;
+
+        var handIds = new List<string>(ent.Comp.Hands.Keys);
+        foreach (var handId in handIds)
+        {
+            FakeThisHand(ent, handId);
+        }
+    }
 
     private void HandleSetHand(RequestSetHandEvent msg, EntitySessionEventArgs eventArgs)
     {

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -189,7 +189,7 @@ public abstract partial class SharedHandsSystem
     }
     
     /// <summary>
-    /// Turn the specified hand into a fake hand
+    /// Turn the specified hand into a "fake" hand (copy of old hand, but can't pick up anything)
     /// </summary>
     public virtual void FakeThisHand(Entity<HandsComponent?> ent, string handName)
     {
@@ -204,10 +204,8 @@ public abstract partial class SharedHandsSystem
             ContainerSystem.ShutdownContainer(container);
         
         var oldHand =  ent.Comp.Hands[handName];
-        var newHand = new Hand(oldHand.Location, oldHand.EmptyLabel, oldHand.EmptyRepresentative, new EntityWhitelist
-        {
-            Components = ["VirtualItem"]
-        });
+        // Copy over the old hand, but with an empty entity whitelist (can't hold anything)
+        var newHand = new Hand(oldHand.Location, oldHand.EmptyLabel, oldHand.EmptyRepresentative, EntityWhitelist.StaticInstantiate());
 
         if (!ent.Comp.Hands.Remove(handName))
             return;
@@ -225,6 +223,9 @@ public abstract partial class SharedHandsSystem
         Dirty(ent);
     }
 
+    /// <summary>
+    /// Replaces all of the entity's hands with "fake" hands
+    /// </summary>
     public void FakeHands(Entity<HandsComponent?> ent)
     {
         if (!Resolve(ent, ref ent.Comp, false))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Resolves #43723

## About the PR
<!-- What did you change? -->
* Zombies will no longer _lose_ their hands upon turning; instead, their hands are replaced with 'fake' copies of their hands.
* These 'fake' hands look identical to their old hands; however, they can't hold anything.
* The intent is to make zombies still appear to have the hands they're expected to have within the strip menu.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
* Prevents zombies from being _as_ metagameable via the strip menu
  * They can still be metagamed if you were to try giving them something to hold - but it's less obvious than the previous complete lack of hands in the strip menu.
* Zombies are still unable to hold anything in their hands, and they can still do their regular zombie activities.

## Technical details
<!-- Summary of code changes for easier review. -->
* Added methods to `SharedHandsSystem.cs` to allow for hands to be replaced with "fake" hands - copying over all attributes from the old hand, but with a completely blank entity whitelist (preventing anything from being put into that hand).
  * Drops anything held in the old hand (and removes the old hand) first before adding in the "fake" replacement hand
* The `ZombifyEntity` method of `ZombieSystem.Transform.cs` now uses those methods to replace all hands with "fake" hands instead of simply getting rid of all the hands.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
* Zombified an entity
* Attempted picking stuff up as the entity (unable to do so)
* Attempted doing regular zombie stuff as the entity (possible to do so)
* Opened up that entity's strip menu (it has hands)
* Attempted putting stuff in the zombie's hands (unable to do so)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/56c98d0d-1483-4c66-bce6-30fed6cf0696


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
* Zombie transformation will now use the new `FakeHands` method from `SharedHandsSystem.cs` instead of the `RemoveHands` method.
  * They will still have hands; but with a blank entity whitelist (preventing them from being used).
    * May need to edit `SharedHandsSystem.FakeThisHand` (alternative version of `SharedHandsSystem.RemoveHand`) to copy over any non-standard fields of the `Hands.Components.Hand` struct in order to make the new 'fake' hand share any non-standard fields of the old Hand struct.
  * Zombies will **not** have their `HandsComponent` removed.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Zombies are now given non-functional hands to replace any hands their non-undead self had.