### PR TITLE
Fixes localization warning in MaterialDisplay

### DIFF
--- a/Content.Client/Materials/UI/MaterialDisplay.xaml.cs
+++ b/Content.Client/Materials/UI/MaterialDisplay.xaml.cs
@@ -87,7 +87,7 @@ public sealed partial class MaterialDisplay : PanelContainer
             {
                 Name = $"{sheetsToEject}",
                 Access = AccessLevel.Public,
-                Text = Loc.GetString($"{sheetsToEject}"),
+                Text = sheetsToEject.ToString(),
                 MinWidth = 45,
                 StyleClasses = { styleClass }
             };


### PR DESCRIPTION
## About the PR
bugfix

## Technical details
one-liner
it no longer tries to get the integer from the loc manager and sets the integer itself as text

## Test plan
start the game
open your console
open any lathe ui

## Media
the warning that appears when you open a material silo or any lathe filled with mats
<img width="372" height="63" alt="image" src="https://github.com/user-attachments/assets/8c42a2a3-51ac-4109-944f-4ecd1c8090ce" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
no changes that affect players
