### PR TITLE
fix: publish changelog related steps temporarily commented out, updat…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,31 +39,31 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
 
-    - name: Update changelog
-      run: |
-        dotnet tool install --global SpaceWizards.ChangelogTool --version 1.0.7
-        ss14-changelog update -d Resources/Changelog
-      env:
-        REPO: ${{ github.repository }}
-        BRANCH: stable
-        CHANGELOG_REPO_PATH: Resources/Changelog
-        EXTRA_CATEGORIES: Admin,Maps,Rules
-        GITHUB_TOKEN: ${{ secrets.CL_ACCESS_TOKEN }}
+    # - name: Update changelog
+    #   run: |
+    #     dotnet tool install --global SpaceWizards.ChangelogTool --version 1.0.7
+    #     ss14-changelog update -d Resources/Changelog
+    #   env:
+    #     REPO: ${{ github.repository }}
+    #     BRANCH: stable
+    #     CHANGELOG_REPO_PATH: Resources/Changelog
+    #     EXTRA_CATEGORIES: Admin,Maps,Rules
+    #     GITHUB_TOKEN: ${{ secrets.CL_ACCESS_TOKEN }}
 
-    - name: Commit and push changelog changes
-      id: changelog
-      run: |
-        git config user.name "Space-Wizards-Bot"
-        git config user.email "support@spacestation14.com"
-        if [ -n "$(git status --porcelain Resources/Changelog)" ]; then
-          git add Resources/Changelog
-          git commit -m "Update changelog"
-          git remote set-url origin "https://x-access-token:${CL_ACCESS_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
-          echo "committed=true" >> "$GITHUB_OUTPUT"
-        fi
-      env:
-        CL_ACCESS_TOKEN: ${{ secrets.CL_ACCESS_TOKEN }}
+    # - name: Commit and push changelog changes
+    #   id: changelog
+    #   run: |
+    #     git config user.name "Space-Wizards-Bot"
+    #     git config user.email "support@spacestation14.com"
+    #     if [ -n "$(git status --porcelain Resources/Changelog)" ]; then
+    #       git add Resources/Changelog
+    #       git commit -m "Update changelog"
+    #       git remote set-url origin "https://x-access-token:${CL_ACCESS_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+    #       git push origin "HEAD:${GITHUB_REF_NAME}"
+    #       echo "committed=true" >> "$GITHUB_OUTPUT"
+    #     fi
+    #   env:
+    #     CL_ACCESS_TOKEN: ${{ secrets.CL_ACCESS_TOKEN }}
 
     # - name: Create PR from stable to master
     #   if: steps.changelog.outputs.committed == 'true'

--- a/Resources/Changelog/Admin.yml
+++ b/Resources/Changelog/Admin.yml
@@ -1,4 +1,4 @@
-﻿AdminOnly: true
+AdminOnly: true
 Entries:
 - author: DrSmugleaf
   changes:
@@ -10,8 +10,7 @@ Entries:
   changes:
   - message: Added a new panic bunker UI in the F7 admin panel.
     type: Add
-  - message: Added being able to toggle the panic bunker automatically depending on
-      if admins are online or not.
+  - message: Added being able to toggle the panic bunker automatically depending on if admins are online or not.
     type: Add
   id: 2
   time: '2023-10-12T22:46:00.0000000+00:00'
@@ -29,8 +28,7 @@ Entries:
   time: '2023-10-14T09:00:00.0000000+00:00'
 - author: DrSmugleaf
   changes:
-  - message: Made the panic bunker UI also set the minimum account age/playtime requirements
-      when the two inputs lose focus, not just when pressing enter.
+  - message: Made the panic bunker UI also set the minimum account age/playtime requirements when the two inputs lose focus, not just when pressing enter.
     type: Tweak
   - message: Added message tooltip to the erase verb.
     type: Tweak
@@ -58,8 +56,7 @@ Entries:
   changes:
   - message: Fixed whitelist commands not giving feedback with 0 arguments.
     type: Fix
-  - message: Fixed not trimming starting and trailing whitespaces within names in
-      whitelist commands.
+  - message: Fixed not trimming starting and trailing whitespaces within names in whitelist commands.
     type: Fix
   - message: Added a \[player\] completion type hint to whitelist add and remove commands.
     type: Tweak
@@ -67,15 +64,13 @@ Entries:
   time: '2023-10-21T09:53:00.0000000+00:00'
 - author: DrSmugleaf
   changes:
-  - message: Fixed the Erase verb not removing all chat messages from the player in
-      some cases.
+  - message: Fixed the Erase verb not removing all chat messages from the player in some cases.
     type: Fix
   id: 9
   time: '2023-10-30T01:28:00.0000000+00:00'
 - author: Vasilis
   changes:
-  - message: AME and PA make a sound effect when they are being overloaded. Similar
-      to being sent a fax.
+  - message: AME and PA make a sound effect when they are being overloaded. Similar to being sent a fax.
     type: Add
   id: 10
   time: '2023-11-07T15:03:00.0000000+00:00'
@@ -87,15 +82,13 @@ Entries:
   time: '2023-11-22T16:39:00.0000000+00:00'
 - author: nikthechampiongr
   changes:
-  - message: The Super Bonk smite is now available. Targets will bonk their head on
-      every single table.
+  - message: The Super Bonk smite is now available. Targets will bonk their head on every single table.
     type: Add
   id: 12
   time: '2023-12-12T11:54:00.0000000+00:00'
 - author: DrSmugleaf
   changes:
-  - message: Fixed not being able to right click in AHelps and the players and objects
-      tabs.
+  - message: Fixed not being able to right click in AHelps and the players and objects tabs.
     type: Fix
   id: 13
   time: '2023-12-21T06:34:00.0000000+00:00'
@@ -114,17 +107,14 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/26091
 - author: PJB3005
   changes:
-  - message: Admin messages are now shown as "seen" even if the player dismisses them
-      only temporarily. Also, it is impossible for players to play without dismissing
-      the message (temporary or permanent).
+  - message: Admin messages are now shown as "seen" even if the player dismisses them only temporarily. Also, it is impossible for players to play without dismissing the message (temporary or permanent).
     type: Tweak
   id: 16
   time: '2024-03-21T15:15:46.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/26223
 - author: nikthechampiongr
   changes:
-  - message: The stealthmin command has been added. Admins with the Stealth permission
-      can now hide themselves from adminwho except for other admins with that permission.
+  - message: The stealthmin command has been added. Admins with the Stealth permission can now hide themselves from adminwho except for other admins with that permission.
     type: Add
   id: 17
   time: '2024-03-24T15:39:54.0000000+00:00'
@@ -138,16 +128,14 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/26500
 - author: Simyon
   changes:
-  - message: The aghost command now accepts a optional username argument to aghost
-      other people.
+  - message: The aghost command now accepts a optional username argument to aghost other people.
     type: Tweak
   id: 19
   time: '2024-03-31T02:05:44.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/26546
 - author: PJB3005
   changes:
-  - message: The new "grant_connect_bypass" command grants a player the ability to
-      connect, bypassing whitelist, player cap and panic bunker.
+  - message: The new "grant_connect_bypass" command grants a player the ability to connect, bypassing whitelist, player cap and panic bunker.
     type: Add
   id: 20
   time: '2024-04-09T15:25:21.0000000+00:00'
@@ -161,9 +149,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/27142
 - author: nikthechampiongr
   changes:
-  - message: Banpanel default values for ban severities, whether a server ban should
-      be applied with hwid/ip,  whether to use last available details, and whether
-      to erase the player on ban can now be configured through a Cvar.
+  - message: Banpanel default values for ban severities, whether a server ban should be applied with hwid/ip,  whether to use last available details, and whether to erase the player on ban can now be configured through a Cvar.
     type: Tweak
   id: 22
   time: '2024-04-20T16:18:26.0000000+00:00'
@@ -177,19 +163,14 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/27319
 - author: Errant
   changes:
-  - message: When spawning vox for admemes, they should be given/spawned in a nitrogen-filled
-      space if possible. If they must be placed in normal air, an alternate vox prototype
-      now comes with breathing gear and N2 tank already equipped, but the internals
-      must be turned on via right click and even if you do this instantly they will
-      still probably take ~4 poison damage from the air, so heal them afterwards.
+  - message: When spawning vox for admemes, they should be given/spawned in a nitrogen-filled space if possible. If they must be placed in normal air, an alternate vox prototype now comes with breathing gear and N2 tank already equipped, but the internals must be turned on via right click and even if you do this instantly they will still probably take ~4 poison damage from the air, so heal them afterwards.
     type: Add
   id: 24
   time: '2024-04-27T10:33:35.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/26705
 - author: Tainakov
   changes:
-  - message: +Adminchat flag is added. Now to gain access to the admin chat you will
-      need this flag.
+  - message: +Adminchat flag is added. Now to gain access to the admin chat you will need this flag.
     type: Add
   id: 25
   time: '2024-04-27T11:17:47.0000000+00:00'
@@ -203,34 +184,27 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/24945
 - author: pissdemon
   changes:
-  - message: Players frozen by admins can no longer use the "ghost" or "suicide" console
-      commands.
+  - message: Players frozen by admins can no longer use the "ghost" or "suicide" console commands.
     type: Tweak
-  - message: Added a "Freeze And Mute" admin verb. In addition to acting like Freeze,
-      it will mute the targeted player, which prevents them from speaking or emoting
-      until unfrozen. It can also be used on already frozen but not yet muted players.
+  - message: Added a "Freeze And Mute" admin verb. In addition to acting like Freeze, it will mute the targeted player, which prevents them from speaking or emoting until unfrozen. It can also be used on already frozen but not yet muted players.
     type: Add
   id: 27
   time: '2024-05-12T14:35:30.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/27813
 - author: nikthechampiongr
   changes:
-  - message: Admins are now able to remove station records through the records console
-      interface on their aghost. This will remove the record from the manifest and
-      criminal records as well.
+  - message: Admins are now able to remove station records through the records console interface on their aghost. This will remove the record from the manifest and criminal records as well.
     type: Add
   id: 28
   time: '2024-05-12T15:07:54.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/27883
 - author: Arimah and TsjipTsjip
   changes:
-  - message: Universal access configurator which can modify all access levels with
-      the correct ID card.
+  - message: Universal access configurator which can modify all access levels with the correct ID card.
     type: Add
   - message: Universal ID card which has all access levels.
     type: Add
-  - message: Admin PDA's spawn with a universal ID card, admin ghosts get a universal
-      access configurator in their bluespace satchel.
+  - message: Admin PDA's spawn with a universal ID card, admin ghosts get a universal access configurator in their bluespace satchel.
     type: Tweak
   id: 29
   time: '2024-05-19T23:04:16.0000000+00:00'
@@ -259,8 +233,7 @@ Entries:
   changes:
   - message: Added a search bar to the admin menu player tab.
     type: Add
-  - message: Changed the player tab entry tooltip to be the player name, character
-      name, identity, and job. Moved the time tooltip to the header.
+  - message: Changed the player tab entry tooltip to be the player name, character name, identity, and job. Moved the time tooltip to the header.
     type: Tweak
   id: 32
   time: '2024-05-31T06:28:08.0000000+00:00'
@@ -292,8 +265,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/28609
 - author: nikthechampiongr
   changes:
-  - message: Freeze, freeze & mute, and unfreeze verbs now work on any entity. Not
-      just connected players.
+  - message: Freeze, freeze & mute, and unfreeze verbs now work on any entity. Not just connected players.
     type: Tweak
   id: 36
   time: '2024-06-08T10:40:33.0000000+00:00'
@@ -307,8 +279,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/28876
 - author: nikthechampiongr
   changes:
-  - message: The ahelp panel properly deselects a player when they are no longer on
-      the player list.
+  - message: The ahelp panel properly deselects a player when they are no longer on the player list.
     type: Fix
   id: 38
   time: '2024-06-15T11:25:42.0000000+00:00'
@@ -322,10 +293,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/29259
 - author: nikthechampiongr
   changes:
-  - message: It is now possible to issue BlacklistedRanges bans(This requires you
-      to edit the database manually at the moment.) Bans marked as BlacklistedRange
-      will lead to players joining for the first time who match an ip range to be
-      denied. Players that have joined the server before will be unaffected.
+  - message: It is now possible to issue BlacklistedRanges bans(This requires you to edit the database manually at the moment.) Bans marked as BlacklistedRange will lead to players joining for the first time who match an ip range to be denied. Players that have joined the server before will be unaffected.
     type: Add
   id: 40
   time: '2024-06-21T12:06:07.0000000+00:00'
@@ -346,8 +314,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/29405
 - author: Repo
   changes:
-  - message: Changed admin object tab from auto to manual refresh on tab change or
-      button press so that entries don't shift around when selecting an object.
+  - message: Changed admin object tab from auto to manual refresh on tab change or button press so that entries don't shift around when selecting an object.
     type: Tweak
   id: 43
   time: '2024-06-28T03:32:57.0000000+00:00'
@@ -361,8 +328,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/29582
 - author: Chief-Engineer
   changes:
-  - message: Baby jail no longer prevents accounts with no prior connections from
-      connecting
+  - message: Baby jail no longer prevents accounts with no prior connections from connecting
     type: Fix
   id: 45
   time: '2024-07-11T05:14:01.0000000+00:00'
@@ -401,17 +367,14 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/30580
 - author: Mervill
   changes:
-  - message: added a debug command to set either your hunger or thirst value to a
-      given threshold
+  - message: added a debug command to set either your hunger or thirst value to a given threshold
     type: Add
   id: 50
   time: '2024-08-05T07:36:26.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/30563
 - author: nikthechampiongr
   changes:
-  - message: The player panel has now been added and can be invoked with the playerpanel
-      command. It will display general information on the selected player, as well
-      as allow for general actions to be performed on them.
+  - message: The player panel has now been added and can be invoked with the playerpanel command. It will display general information on the selected player, as well as allow for general actions to be performed on them.
     type: Add
   id: 51
   time: '2024-08-09T05:33:26.0000000+00:00'
@@ -425,8 +388,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/30581
 - author: Simyon
   changes:
-  - message: You can now view and edit the laws of silicons. Cyborg/Law bound entity
-      -> Admin -> Manage laws
+  - message: You can now view and edit the laws of silicons. Cyborg/Law bound entity -> Admin -> Manage laws
     type: Add
   id: 53
   time: '2024-08-09T06:16:22.0000000+00:00'
@@ -447,11 +409,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/30597
 - author: Errant
   changes:
-  - message: The setgamepreset command now only sets the gamemode for a limited number
-      of rounds, specified by a second parameter. Afterwards it switches back to the
-      server default. Omitting the number parameter sets it for 1 round only. To change
-      the game mode for a longer period, either specify a high number or change the
-      game.fallbackpreset cvar so it will reset to what you want
+  - message: The setgamepreset command now only sets the gamemode for a limited number of rounds, specified by a second parameter. Afterwards it switches back to the server default. Omitting the number parameter sets it for 1 round only. To change the game mode for a longer period, either specify a high number or change the game.fallbackpreset cvar so it will reset to what you want
     type: Tweak
   id: 56
   time: '2024-08-09T07:04:19.0000000+00:00'
@@ -493,8 +451,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/31045
 - author: PursuitInAshes
   changes:
-  - message: The resave command is no longer usable with the mapping permission, instead
-      it requires host permissions.
+  - message: The resave command is no longer usable with the mapping permission, instead it requires host permissions.
     type: Tweak
   id: 62
   time: '2024-08-25T01:55:31.0000000+00:00'
@@ -521,8 +478,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/30433
 - author: nikthechampiongr
   changes:
-  - message: The addobjective command will now offer completions for username and
-      objectives.
+  - message: The addobjective command will now offer completions for username and objectives.
     type: Tweak
   id: 65
   time: '2024-09-08T07:28:43.0000000+00:00'
@@ -538,16 +494,14 @@ Entries:
   changes:
   - message: Rename verb now acts the same as the rename command.
     type: Fix
-  - message: Renamed entities will now have their new name appear immediately on entity
-      examination and on crew monitor console.
+  - message: Renamed entities will now have their new name appear immediately on entity examination and on crew monitor console.
     type: Fix
   id: 67
   time: '2024-09-15T01:55:03.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/31654
 - author: ElectroJr
   changes:
-  - message: The `menuvis all` once again makes all entities show up in the right-click
-      context menu.
+  - message: The `menuvis all` once again makes all entities show up in the right-click context menu.
     type: Fix
   id: 68
   time: '2024-09-23T07:28:42.0000000+00:00'
@@ -561,24 +515,21 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/32531
 - author: IProduceWidgets
   changes:
-  - message: invokeverb should work with smite names now. Find the names in the smite
-      tab on mouse hover.
+  - message: invokeverb should work with smite names now. Find the names in the smite tab on mouse hover.
     type: Fix
   id: 70
   time: '2024-10-16T22:24:31.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/32844
 - author: BramvanZijp
   changes:
-  - message: CC, ERT, Admin, and Deathsquad PDA's now have all departmental programs
-      pre-installed.
+  - message: CC, ERT, Admin, and Deathsquad PDA's now have all departmental programs pre-installed.
     type: Tweak
   id: 71
   time: '2024-10-31T14:53:38.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/32601
 - author: metalgearsloth
   changes:
-  - message: Added on-call functionality for discord relay to get notified on unanswered
-      ahelps.
+  - message: Added on-call functionality for discord relay to get notified on unanswered ahelps.
     type: Add
   id: 72
   time: '2024-11-02T09:29:16.0000000+00:00'
@@ -599,8 +550,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/30659
 - author: Aquif
   changes:
-  - message: tag:with toolshed command. It takes in a list of entities via pipe and
-      returns the entities from the list with the given tag.
+  - message: tag:with toolshed command. It takes in a list of entities via pipe and returns the entities from the list with the given tag.
     type: Add
   id: 75
   time: '2024-11-13T23:27:31.0000000+00:00'
@@ -614,8 +564,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/33262
 - author: ScarKy0, GoldenCan
   changes:
-  - message: Players that take over emagged/ion stormed borgs now correctly get assigned
-      the antag role.
+  - message: Players that take over emagged/ion stormed borgs now correctly get assigned the antag role.
     type: Fix
   id: 77
   time: '2024-11-20T07:55:12.0000000+00:00'
@@ -629,30 +578,23 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/31836
 - author: slarticodefast
   changes:
-  - message: Health scanning a slime as an aghost will no longer insert the scanner
-      into their inventory.
+  - message: Health scanning a slime as an aghost will no longer insert the scanner into their inventory.
     type: Fix
   id: 79
   time: '2024-12-18T00:12:35.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/33884
 - author: slarticodefast
   changes:
-  - message: The panic bunker now only automatically disables when an admin with the
-      'Admin' permission is online instead of any permission.
+  - message: The panic bunker now only automatically disables when an admin with the 'Admin' permission is online instead of any permission.
     type: Tweak
   id: 80
   time: '2024-12-18T13:15:05.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/33879
 - author: ElectroJr
   changes:
-  - message: Some toolshed command permissions have changed. The "emplace" and "iterate"
-      command no longer require QUER` permissions, they now match the "do" command
-      and only require DEBUG. Several previously unrestricted commands now require
-      the DEBUG flag.
+  - message: Some toolshed command permissions have changed. The "emplace" and "iterate" command no longer require QUER` permissions, they now match the "do" command and only require DEBUG. Several previously unrestricted commands now require the DEBUG flag.
     type: Tweak
-  - message: Toolshed command parsing has changed. In particular, command substitution
-      (using the output of a command in place of another command's argument) now requires
-      that the command be wrapped in curly braces
+  - message: Toolshed command parsing has changed. In particular, command substitution (using the output of a command in place of another command's argument) now requires that the command be wrapped in curly braces
     type: Tweak
   id: 81
   time: '2024-12-21T07:02:05.0000000+00:00'
@@ -680,28 +622,23 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/34122
 - author: Errant
   changes:
-  - message: The Admin Menu and Admin Overlay now shows the specific role types of
-      players and antagonists, respectively. The old admin overlay can still be used
-      with cvar ui.admin_overlay_classic true
+  - message: The Admin Menu and Admin Overlay now shows the specific role types of players and antagonists, respectively. The old admin overlay can still be used with cvar ui.admin_overlay_classic true
     type: Tweak
   id: 85
   time: '2025-01-11T21:17:26.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/33420
 - author: Myra
   changes:
-  - message: Added IPIntel's API to the connection code. If enabled, this will automate
-      VPN/Proxy detection.
+  - message: Added IPIntel's API to the connection code. If enabled, this will automate VPN/Proxy detection.
     type: Add
   id: 86
   time: '2025-01-12T19:41:26.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/33339
 - author: PJB3005
   changes:
-  - message: Deadmin status is now synchronized to database, making it persistent
-      across server restarts and between multiple game servers.
+  - message: Deadmin status is now synchronized to database, making it persistent across server restarts and between multiple game servers.
     type: Tweak
-  - message: Admins can now be suspended via the permissions panel. This effectively
-      removes their admin status without completely deleting their record.
+  - message: Admins can now be suspended via the permissions panel. This effectively removes their admin status without completely deleting their record.
     type: Add
   id: 87
   time: '2025-01-14T23:46:45.0000000+00:00'
@@ -715,8 +652,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/33483
 - author: Myra
   changes:
-  - message: Admins are by default now hidden from the reported player count on the
-      launcher.
+  - message: Admins are by default now hidden from the reported player count on the launcher.
     type: Add
   id: 89
   time: '2025-01-15T21:10:54.0000000+00:00'
@@ -730,9 +666,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/33782
 - author: PJB3005
   changes:
-  - message: Introduced an option to automatically disconnect players from their current
-      server if they join another one within the same server community. Admins are
-      always exempt.
+  - message: Introduced an option to automatically disconnect players from their current server if they join another one within the same server community. Admins are always exempt.
     type: Add
   id: 91
   time: '2025-01-21T23:23:47.0000000+00:00'
@@ -746,8 +680,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/34824
 - author: Palladinium
   changes:
-  - message: Added atmospherics device information (air alarms, vents, scrubbers)
-      to admin logs
+  - message: Added atmospherics device information (air alarms, vents, scrubbers) to admin logs
     type: Add
   id: 93
   time: '2025-02-06T05:10:21.0000000+00:00'
@@ -775,25 +708,21 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/35258
 - author: SlamBamActionman
   changes:
-  - message: Users with +VVEDIT perms can now use `changecvar playtest.[modifier]
-      [float]` to modify damage/healing scaling live.
+  - message: Users with +VVEDIT perms can now use `changecvar playtest.[modifier] [float]` to modify damage/healing scaling live.
     type: Add
   id: 97
   time: '2025-02-18T07:28:42.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/35255
 - author: ScarKy0
   changes:
-  - message: Aghost's intrinsic comms console now uses a new color, announces globally
-      and has significantly lowered delays. Announce command and admin menu option
-      remain unchanged.
+  - message: Aghost's intrinsic comms console now uses a new color, announces globally and has significantly lowered delays. Announce command and admin menu option remain unchanged.
     type: Tweak
   id: 98
   time: '2025-02-18T09:04:37.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/35248
 - author: Simyon
   changes:
-  - message: Admins with the Server and Mapping AdminFlag can now change the CVars
-      "events.enabled" and "shuttle.auto_call_time" for parity in the "mapping" command.
+  - message: Admins with the Server and Mapping AdminFlag can now change the CVars "events.enabled" and "shuttle.auto_call_time" for parity in the "mapping" command.
     type: Tweak
   id: 99
   time: '2025-02-18T10:26:09.0000000+00:00'
@@ -821,53 +750,44 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/35477
 - author: ScarKy0
   changes:
-  - message: Admin IDs can now freely change their name, job and icon, like the agent
-      ID. Not chameleon though.
+  - message: Admin IDs can now freely change their name, job and icon, like the agent ID. Not chameleon though.
     type: Add
   id: 103
   time: '2025-02-25T14:25:48.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/35345
 - author: Errant
   changes:
-  - message: Some admin settings are now configurable from the Options menu's new
-      Admin tab.
+  - message: Some admin settings are now configurable from the Options menu's new Admin tab.
     type: Add
   id: 104
   time: '2025-02-26T22:32:43.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/35543
 - author: Schrodinger71
   changes:
-  - message: For the admin overlay, new configs have been added to display the starting
-      position and total time.
+  - message: For the admin overlay, new configs have been added to display the starting position and total time.
     type: Add
   id: 105
   time: '2025-02-28T20:51:30.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/35520
 - author: Beck Thompson, Errant
   changes:
-  - message: Brand new players with NULL playtime data are no longer missing the clock
-      icon in the Bwoink menu. Disconnected new players also no longer lose their
-      clock icon.
+  - message: Brand new players with NULL playtime data are no longer missing the clock icon in the Bwoink menu. Disconnected new players also no longer lose their clock icon.
     type: Fix
-  - message: Connected players who have entered the round are now sorted above connected
-      players who are still in the lobby. Players still in the lobby have a half-full
-      symbol.
+  - message: Connected players who have entered the round are now sorted above connected players who are still in the lobby. Players still in the lobby have a half-full symbol.
     type: Tweak
   id: 106
   time: '2025-03-05T16:25:43.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/35648
 - author: slarticodefast
   changes:
-  - message: Added the 'forceghost < player >' command which forces someone to become
-      an observer.
+  - message: Added the 'forceghost < player >' command which forces someone to become an observer.
     type: Add
   id: 107
   time: '2025-03-08T02:39:04.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/35518
 - author: Errant
   changes:
-  - message: It is no longer impossible to resize the player list in the ahelp window,
-      when at small window sizes.
+  - message: It is no longer impossible to resize the player list in the ahelp window, when at small window sizes.
     type: Fix
   id: 108
   time: '2025-03-10T09:40:36.0000000+00:00'
@@ -881,10 +801,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/35783
 - author: Errant
   changes:
-  - message: All Solo Antagonist, Team Antagonist, Altered Silicon and (non-harmless)
-      Free Agent ghostroles are now marked as Antagonist on all interfaces where this
-      distinction exists. (Classic admin overlay, admin playerlist, round end player
-      list)
+  - message: All Solo Antagonist, Team Antagonist, Altered Silicon and (non-harmless) Free Agent ghostroles are now marked as Antagonist on all interfaces where this distinction exists. (Classic admin overlay, admin playerlist, round end player list)
     type: Fix
   id: 110
   time: '2025-03-16T22:11:31.0000000+00:00'
@@ -902,8 +819,7 @@ Entries:
     type: Add
   - message: Extreme impact logs always send an admin alert.
     type: Add
-  - message: High impact logs send an admin alert if the player causing it is a new
-      player.
+  - message: High impact logs send an admin alert if the player causing it is a new player.
     type: Add
   - message: Several logs have had their impact levels adjusted.
     type: Tweak
@@ -912,25 +828,18 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/35961
 - author: SlamBamActionman
   changes:
-  - message: 'Any adminlog chat alert that includes an antag now has "\[ANTAG: entityName\]"
-      appended to the end.'
+  - message: 'Any adminlog chat alert that includes an antag now has "\[ANTAG: entityName\]" appended to the end.'
     type: Tweak
   id: 113
   time: '2025-03-21T23:21:32.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/35994
 - author: Errant
   changes:
-  - message: The Antag column on the player list has been removed, and it's functionality
-      folded into the Character and Role Type columns.
+  - message: The Antag column on the player list has been removed, and it's functionality folded into the Character and Role Type columns.
     type: Remove
-  - message: The Role Type column now sorts entries in a revised order. All antagonist
-      types are grouped at the end.
+  - message: The Role Type column now sorts entries in a revised order. All antagonist types are grouped at the end.
     type: Tweak
-  - message: On the player list, the names of antagonist players are now prefixed
-      with an antag symbol, and (optionally) shown in the color of their current role
-      type. The default setting is to show the "standard antag dagger" symbol for
-      any type of antag, same as the ahelp relay. Optionally a distinct icon can be
-      shown for each role type for easier identification.
+  - message: On the player list, the names of antagonist players are now prefixed with an antag symbol, and (optionally) shown in the color of their current role type. The default setting is to show the "standard antag dagger" symbol for any type of antag, same as the ahelp relay. Optionally a distinct icon can be shown for each role type for easier identification.
     type: Tweak
   - message: More playerlist/overlay settings can now be changed in Admin Options.
     type: Tweak
@@ -939,32 +848,23 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/35538
 - author: ScarKy0
   changes:
-  - message: The "Spawn here" verb now reliably transfers mind of the target to their
-      new body.
+  - message: The "Spawn here" verb now reliably transfers mind of the target to their new body.
     type: Fix
   id: 115
   time: '2025-03-25T18:40:54.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/36080
 - author: Errant
   changes:
-  - message: Admin overlays of mobs/players in very close proximity no longer overlap
-      each other. They now form stacks of up to 3. If more than 3 overlay entries
-      are stacked, any additional entries will be drawn over the 3rd element of the
-      stack. These names are ordered by vertical position, but when the coordinates
-      match exactly (such as someone carrying a mothroach/pAI, or ghosts orbiting),
-      the top member of the stack is NOT guaranteed to be the most visible/interesting
-      element in the stack.
+  - message: Admin overlays of mobs/players in very close proximity no longer overlap each other. They now form stacks of up to 3. If more than 3 overlay entries are stacked, any additional entries will be drawn over the 3rd element of the stack. These names are ordered by vertical position, but when the coordinates match exactly (such as someone carrying a mothroach/pAI, or ghosts orbiting), the top member of the stack is NOT guaranteed to be the most visible/interesting element in the stack.
     type: Add
-  - message: Ghosts near the mouse cursor no longer show up on the admin overlay,
-      including any ghosts in stacks near the mouse cursor.
+  - message: Ghosts near the mouse cursor no longer show up on the admin overlay, including any ghosts in stacks near the mouse cursor.
     type: Add
   id: 116
   time: '2025-03-25T20:15:22.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/35622
 - author: slarticodefast
   changes:
-  - message: Added an antag control verb to create a paradox clone ghost role of a
-      selected player.
+  - message: Added an antag control verb to create a paradox clone ghost role of a selected player.
     type: Add
   id: 117
   time: '2025-03-27T17:04:25.0000000+00:00'
@@ -1001,8 +901,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/36396
 - author: Errant
   changes:
-  - message: The Copy button on the PlayerPanel now copies only the target username,
-      not the entire line.
+  - message: The Copy button on the PlayerPanel now copies only the target username, not the entire line.
     type: Fix
   id: 122
   time: '2025-04-11T21:04:37.0000000+00:00'
@@ -1032,8 +931,7 @@ Entries:
   changes:
   - message: '"chatwindow" command has been added to open an additional chat window'
     type: Add
-  - message: '"achatwindow" command has been added to open an additional chat window,
-      preconfigured for monitoring admin channels'
+  - message: '"achatwindow" command has been added to open an additional chat window, preconfigured for monitoring admin channels'
     type: Add
   id: 126
   time: '2025-04-14T15:37:59.0000000+00:00'
@@ -1047,78 +945,60 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/36607
 - author: Errant
   changes:
-  - message: Mind Roles now have subtypes, which can more specifically indicate what
-      role they are. For example, depending on clientside settings a Traitor can either
-      show as "SOLO ANTAGONIST" or "TRAITOR" on both the admin overlay and playerlist.
-      See Admin Options for the available settings. (Note, many minor roles don't
-      ((currently)) have a subtype configured, and will default to showing their role
-      type instead)
+  - message: Mind Roles now have subtypes, which can more specifically indicate what role they are. For example, depending on clientside settings a Traitor can either show as "SOLO ANTAGONIST" or "TRAITOR" on both the admin overlay and playerlist. See Admin Options for the available settings. (Note, many minor roles don't ((currently)) have a subtype configured, and will default to showing their role type instead)
     type: Tweak
   id: 128
   time: '2025-04-16T17:04:48.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/35359
 - author: Errant
   changes:
-  - message: Antag tags on admin notices now show exactly what kind of antag that
-      mob is.
+  - message: Antag tags on admin notices now show exactly what kind of antag that mob is.
     type: Tweak
   id: 129
   time: '2025-04-16T22:59:36.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/36640
 - author: IProduceWidgets
   changes:
-  - message: stationevent toolshed commands should now work again to provide event
-      statistics.
+  - message: stationevent toolshed commands should now work again to provide event statistics.
     type: Fix
   id: 130
   time: '2025-04-18T07:44:29.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/32200
 - author: Errant
   changes:
-  - message: The setgamepreset command no longer changes the preset permanently. When
-      used with only one parameter (for the preset to be used), it will make that
-      change for the next round that starts. The optional second parameter can specify
-      the number of upcoming rounds that will use the specified preset. If you want
-      to change the game preset permanently, set an arbitrarily high number as the
-      second parameter, or preferably just modify the game.defaultpreset cvar
+  - message: The setgamepreset command no longer changes the preset permanently. When used with only one parameter (for the preset to be used), it will make that change for the next round that starts. The optional second parameter can specify the number of upcoming rounds that will use the specified preset. If you want to change the game preset permanently, set an arbitrarily high number as the second parameter, or preferably just modify the game.defaultpreset cvar
     type: Tweak
   id: 131
   time: '2025-04-18T12:24:39.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/30812
 - author: Tayrtahn
   changes:
-  - message: Added MarkerOne, MarkerTwo, and MarkerThree components for testing and
-      tracking purposes.
+  - message: Added MarkerOne, MarkerTwo, and MarkerThree components for testing and tracking purposes.
     type: Add
   id: 132
   time: '2025-04-20T19:08:41.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/36776
 - author: sowelipililimute
   changes:
-  - message: The Funding Allocation Computer now has a CVar to enable configuring
-      the primary cut (off by default)
+  - message: The Funding Allocation Computer now has a CVar to enable configuring the primary cut (off by default)
     type: Add
-  - message: The Funding Allocation Computer now has a CVar to enable configuring
-      the lockbox cut (on by default)
+  - message: The Funding Allocation Computer now has a CVar to enable configuring the lockbox cut (on by default)
     type: Add
-  - message: The Funding Allocation Computer now has a CVar to enable hiding the primary
-      account from the funding splits (on by default)
+  - message: The Funding Allocation Computer now has a CVar to enable hiding the primary account from the funding splits (on by default)
     type: Add
   id: 133
   time: '2025-04-22T12:34:53.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/36790
 - author: qrwas
   changes:
-  - message: 'Added new Cvar: game.contraband_examine_only_in_hud to display contraband
-      only in security glasses **disabled by default**'
+  - message: 'Added new Cvar: game.contraband_examine_only_in_hud to display contraband only in security glasses **disabled by default**'
     type: Add
   id: 134
   time: '2025-04-26T21:06:35.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/36412
 - author: K-Dynamic
   changes:
-  - message: CC officials now wear a centcomm carapace for body armour, which have
-      identical stats to the command carapace.
+  - message: CC officials now wear a centcomm carapace for body armour, which have identical stats to the command carapace.
     type: Add
   id: 135
   time: '2025-04-30T00:40:27.0000000+00:00'
@@ -1141,56 +1021,49 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/37102
 - author: ScarKy0
   changes:
-  - message: Added a new "Strip All" debug verb. Used for stripping all inventory
-      items and dropping hand items.
+  - message: Added a new "Strip All" debug verb. Used for stripping all inventory items and dropping hand items.
     type: Add
   id: 138
   time: '2025-05-15T20:56:58.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37426
 - author: VerinSenpai
   changes:
-  - message: Round controls in the admin window now require confirmation. This can
-      be bypassed by using the console.
+  - message: Round controls in the admin window now require confirmation. This can be bypassed by using the console.
     type: Tweak
   id: 139
   time: '2025-05-26T02:37:21.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37836
 - author: perryprog
   changes:
-  - message: The server shutdown button in the admin window now requires confirmation.
-      This can be bypassed by using the console.
+  - message: The server shutdown button in the admin window now requires confirmation. This can be bypassed by using the console.
     type: Tweak
   id: 140
   time: '2025-05-27T23:44:15.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37849
 - author: Samuka
   changes:
-  - message: the command solution:adjreagent now actually works and no longer needs
-      a "FixedPoint2" for the amount
+  - message: the command solution:adjreagent now actually works and no longer needs a "FixedPoint2" for the amount
     type: Fix
   id: 141
   time: '2025-06-08T03:47:37.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38134
 - author: ScarKy0
   changes:
-  - message: 'addaction/rmaction commands. NOTE: Addaction will not work correctly
-      if the action requires the entity to have a component (such as Dragon''s Devour).'
+  - message: "addaction/rmaction commands. NOTE: Addaction will not work correctly if the action requires the entity to have a component (such as Dragon's Devour)."
     type: Add
   id: 142
   time: '2025-06-16T10:25:44.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38317
 - author: Errant, crazybrain
   changes:
-  - message: The admin player and object tabs now show entries in the correct visual
-      style.
+  - message: The admin player and object tabs now show entries in the correct visual style.
     type: Fix
   id: 143
   time: '2025-06-21T01:13:25.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38261
 - author: SlamBamActionman
   changes:
-  - message: customvote and cancelvote command permission has been moved from Moderator
-      to Round.
+  - message: customvote and cancelvote command permission has been moved from Moderator to Round.
     type: Tweak
   id: 144
   time: '2025-06-21T16:34:11.0000000+00:00'
@@ -1211,24 +1084,21 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/38206
 - author: perryprog
   changes:
-  - message: The /showaccessreaders command is now usable by those with +MAPPING or
-      +DEBUG, instead of being +HOST only.
+  - message: The /showaccessreaders command is now usable by those with +MAPPING or +DEBUG, instead of being +HOST only.
     type: Tweak
   id: 147
   time: '2025-06-26T10:43:40.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38593
 - author: VerinSenpai
   changes:
-  - message: The addbodypart command no longer incorrectly errors out when you try
-      to pass the required number of arguments.
+  - message: The addbodypart command no longer incorrectly errors out when you try to pass the required number of arguments.
     type: Fix
   id: 148
   time: '2025-06-28T11:11:08.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38612
 - author: BramvanZijp
   changes:
-  - message: The Super Door Remote can now effect doors that the user's ID card has
-      access to, even if the remote itself somehow cannot access them.
+  - message: The Super Door Remote can now effect doors that the user's ID card has access to, even if the remote itself somehow cannot access them.
     type: Tweak
   id: 149
   time: '2025-06-29T16:21:15.0000000+00:00'
@@ -1249,8 +1119,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/35514
 - author: perryprog
   changes:
-  - message: Admin ghosts can now interact with things beneath subfloors, such as
-      disposal routers.
+  - message: Admin ghosts can now interact with things beneath subfloors, such as disposal routers.
     type: Tweak
   id: 152
   time: '2025-07-10T11:14:37.0000000+00:00'
@@ -1271,32 +1140,28 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/38155
 - author: slarticodefast
   changes:
-  - message: The aghost's satchel of holding is now explosion resistant. Same for
-      the aghost themselves, so held explosives no longer chain react.
+  - message: The aghost's satchel of holding is now explosion resistant. Same for the aghost themselves, so held explosives no longer chain react.
     type: Tweak
   id: 155
   time: '2025-07-16T22:35:14.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38384
 - author: perryprog
   changes:
-  - message: Rejuvenate will now remove drowsiness, forced sleep, and the seeing rainbows
-      status effect.
+  - message: Rejuvenate will now remove drowsiness, forced sleep, and the seeing rainbows status effect.
     type: Add
   id: 156
   time: '2025-07-24T15:13:29.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/39025
 - author: slarticodefast, beck-thompson
   changes:
-  - message: Added the "Open Camera" admin verb and the "camera" console command which
-      allow you to observe entities in separate window using a remote camera.
+  - message: Added the "Open Camera" admin verb and the "camera" console command which allow you to observe entities in separate window using a remote camera.
     type: Add
   id: 157
   time: '2025-07-25T16:53:01.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/36969
 - author: perryprog
   changes:
-  - message: savegrid and savemap will no longer fail to save unpaused grids with
-      vending machines on them.
+  - message: savegrid and savemap will no longer fail to save unpaused grids with vending machines on them.
     type: Fix
   id: 158
   time: '2025-07-31T18:34:29.0000000+00:00'
@@ -1317,8 +1182,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/39424
 - author: slarticodefast
   changes:
-  - message: Paused maps from cryostorage and polymorphing are now named to make them
-      easier to find when debugging.
+  - message: Paused maps from cryostorage and polymorphing are now named to make them easier to find when debugging.
     type: Tweak
   id: 161
   time: '2025-08-07T14:55:26.0000000+00:00'
@@ -1332,8 +1196,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/35531
 - author: EmoGarbage404, soutbridge-fur
   changes:
-  - message: A new experimental gamemode "Dynamic" has been added to the voting options
-      and admin seletion.
+  - message: A new experimental gamemode "Dynamic" has been added to the voting options and admin seletion.
     type: Add
   id: 163
   time: '2025-08-15T14:06:51.0000000+00:00'
@@ -1347,13 +1210,11 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/39756
 - author: Southbridge
   changes:
-  - message: Added dropdown to every log entry in the admin log viewer with additional
-      information.
+  - message: Added dropdown to every log entry in the admin log viewer with additional information.
     type: Add
   - message: Added color-highlighting in the log search to find results.
     type: Add
-  - message: Modified player list searches and the log search to utilize regex instead
-      of regular string searches.
+  - message: Modified player list searches and the log search to utilize regex instead of regular string searches.
     type: Tweak
   id: 165
   time: '2025-08-21T20:12:16.0000000+00:00'
@@ -1362,16 +1223,14 @@ Entries:
   changes:
   - message: The 'Delete' button in the objects tab is now a confirm button.
     type: Tweak
-  - message: Fixed the 'Teleport' button in the objects tab not working for stations
-      and maps.
+  - message: Fixed the 'Teleport' button in the objects tab not working for stations and maps.
     type: Fix
   id: 166
   time: '2025-08-22T22:37:52.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/39832
 - author: Samuka
   changes:
-  - message: setgamepreset now takes another argument that determines what title and
-      description of the game mode will be shown in the lobby screen.
+  - message: setgamepreset now takes another argument that determines what title and description of the game mode will be shown in the lobby screen.
     type: Tweak
   - message: Removed SecretGreenshift from game presets.
     type: Remove
@@ -1389,29 +1248,21 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/39046
 - author: slarticodefast
   changes:
-  - message: The listplayers command now requires PII permissions due to showing IP
-      addresses.
+  - &o0
+    message: The listplayers command now requires PII permissions due to showing IP addresses.
     type: Tweak
   id: 169
   time: '2025-09-13T15:53:48.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/40324
 - author: slarticodefast
   changes:
-  - message: The listplayers command now requires PII permissions due to showing IP
-      addresses.
-    type: Tweak
+  - *o0
   id: 170
   time: '2025-09-16T07:59:11.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/40395
 - author: Errant, beck-thompson, FairlySadPanda
   changes:
-  - message: 'Antag bans can now be placed on players through the Roleban GUI. Antag
-      bans can lock all roundstart antag options individually, and block all antag
-      ghostroles (though some of the  more "generic" antag ghostroles are grouped
-      together and cannot be banned individually). Zombie conversion forcibly ghosts
-      a rolebanned player. Some antag types are not yet supported: Being converted
-      into a Revolutionary, players who are only banned from antagonist borgs specifically,
-      getting ion stormed or emagged, and the effects of the wizard gun spell.'
+  - message: 'Antag bans can now be placed on players through the Roleban GUI. Antag bans can lock all roundstart antag options individually, and block all antag ghostroles (though some of the  more "generic" antag ghostroles are grouped together and cannot be banned individually). Zombie conversion forcibly ghosts a rolebanned player. Some antag types are not yet supported: Being converted into a Revolutionary, players who are only banned from antagonist borgs specifically, getting ion stormed or emagged, and the effects of the wizard gun spell.'
     type: Add
   id: 171
   time: '2025-09-17T21:59:07.0000000+00:00'
@@ -1441,8 +1292,7 @@ Entries:
   changes:
   - message: The Homing Rod smite. Does what it says on the tin.
     type: Add
-  - message: The Slowming Rod smite. Slowly chases the target, and destroys everything
-      on the way.
+  - message: The Slowming Rod smite. Slowly chases the target, and destroys everything on the way.
     type: Add
   id: 175
   time: '2025-09-25T21:43:53.0000000+00:00'
@@ -1470,8 +1320,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/40614
 - author: Errant
   changes:
-  - message: The old buttons to Teleport and kick (Player Actions Panel) have been
-      removed from the first tab of the admin menu.
+  - message: The old buttons to Teleport and kick (Player Actions Panel) have been removed from the first tab of the admin menu.
     type: Remove
   id: 179
   time: '2025-10-17T15:38:26.0000000+00:00'
@@ -1485,8 +1334,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/41060
 - author: beck
   changes:
-  - message: TPTO command links are now added for admin logs that involve players
-      or coordinates!
+  - message: TPTO command links are now added for admin logs that involve players or coordinates!
     type: Add
   id: 181
   time: '2025-10-27T02:51:40.0000000+00:00'
@@ -1507,25 +1355,21 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/41261
 - author: slarticodefast
   changes:
-  - message: Added the "quickinspect" command to quickly inspect the selected component
-      for an entity via a keybind.
+  - message: Added the "quickinspect" command to quickly inspect the selected component for an entity via a keybind.
     type: Add
   id: 184
   time: '2025-11-12T23:22:27.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/41348
 - author: ScarKy0
   changes:
-  - message: Admin ghosts can no longer be selected for "Warp To Most Followed". Remove
-      the NotGhostnadoWarpable tag from your aghost entity if you wish to still be
-      able to be selected.
+  - message: Admin ghosts can no longer be selected for "Warp To Most Followed". Remove the NotGhostnadoWarpable tag from your aghost entity if you wish to still be able to be selected.
     type: Fix
   id: 185
   time: '2025-11-15T23:31:28.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/41448
 - author: Errant
   changes:
-  - message: Looc and Deadchat logs now show mob information, similar to the logs
-      of the IC chat channels.
+  - message: Looc and Deadchat logs now show mob information, similar to the logs of the IC chat channels.
     type: Tweak
   - message: Mobs who have been "Freeze and Muted" can no longer send on LOOC or Deadchat.
     type: Fix
@@ -1536,8 +1380,7 @@ Entries:
   changes:
   - message: The killsign can now be customized to use any sprite via it's component.
     type: Add
-  - message: Hidden Kill Sign smite. Visible to everyone but the person you apply
-      it to.
+  - message: Hidden Kill Sign smite. Visible to everyone but the person you apply it to.
     type: Add
   id: 187
   time: '2025-12-14T02:16:52.0000000+00:00'
@@ -1551,18 +1394,14 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/41839
 - author: Hitlinemoss
   changes:
-  - message: Added a debug wizard's grimoire, for debugging purposes. Contains 99999
-      WizCoin and has ownerOnly set to false. You can use this for admeme purposes
-      but probably shouldn't unless you want to risk everyone on the station having
-      every spell.
+  - message: Added a debug wizard's grimoire, for debugging purposes. Contains 99999 WizCoin and has ownerOnly set to false. You can use this for admeme purposes but probably shouldn't unless you want to risk everyone on the station having every spell.
     type: Add
   id: 189
   time: '2025-12-18T19:33:08.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/41900
 - author: ScarKy0
   changes:
-  - message: Station AI Radial actions are now logged. Search for "Station AI Radial"
-      in the logs menu under Actions.
+  - message: Station AI Radial actions are now logged. Search for "Station AI Radial" in the logs menu under Actions.
     type: Add
   id: 190
   time: '2025-12-20T18:23:43.0000000+00:00'
@@ -1576,16 +1415,14 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/40525
 - author: ScarKy0
   changes:
-  - message: Msg toolshed command. Used for sending messages to the target entities,
-      via popups, chat, tippy or as a subtle message.
+  - message: Msg toolshed command. Used for sending messages to the target entities, via popups, chat, tippy or as a subtle message.
     type: Add
   id: 192
   time: '2026-01-05T21:13:40.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/41936
 - author: mikeysaurus
   changes:
-  - message: Admins can now vvwrite FTLCooldownOverride to override the FTL Cooldown's
-      timer.
+  - message: Admins can now vvwrite FTLCooldownOverride to override the FTL Cooldown's timer.
     type: Add
   id: 193
   time: '2026-01-09T06:58:22.0000000+00:00'
@@ -1599,16 +1436,14 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/42370
 - author: Velken
   changes:
-  - message: new Admin version of the Anomaly Scanner, that shows the hidden particle
-      types.
+  - message: new Admin version of the Anomaly Scanner, that shows the hidden particle types.
     type: Add
   id: 195
   time: '2026-01-16T22:24:15.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/42443
 - author: Samuka
   changes:
-  - message: shuttle called and recalled logs now show who recalled or called the
-      shuttle
+  - message: shuttle called and recalled logs now show who recalled or called the shuttle
     type: Fix
   id: 196
   time: '2026-01-24T19:15:40.0000000+00:00'
@@ -1622,16 +1457,14 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/42691
 - author: Velken
   changes:
-  - message: Log for buying from a store will be High instead of Low if user is not
-      of an expected faction for that store, or Extreme if they also have mindshield.
+  - message: Log for buying from a store will be High instead of Low if user is not of an expected faction for that store, or Extreme if they also have mindshield.
     type: Tweak
   id: 198
   time: '2026-01-29T18:55:18.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/42687
 - author: Samuka
   changes:
-  - message: Central Command fax always tells admins where the fax came from instead
-      of saying "unknown" until it was refreshed
+  - message: Central Command fax always tells admins where the fax came from instead of saying "unknown" until it was refreshed
     type: Fix
   id: 199
   time: '2026-02-01T18:12:16.0000000+00:00'
@@ -1652,8 +1485,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/42769
 - author: Hitlinemoss
   changes:
-  - message: Names for the diona, reptilian, and vox Urists have been tweaked to be
-      more consistent with other Urists.
+  - message: Names for the diona, reptilian, and vox Urists have been tweaked to be more consistent with other Urists.
     type: Tweak
   - message: The skeleton Urist is now named "Urist McBones".
     type: Tweak
@@ -1662,8 +1494,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/42791
 - author: slarticodefast
   changes:
-  - message: Using the "fuckrules" command will now create an admin log and alert
-      the admins via chat.
+  - message: Using the "fuckrules" command will now create an admin log and alert the admins via chat.
     type: Add
   id: 203
   time: '2026-02-21T20:22:27.0000000+00:00'
@@ -1693,16 +1524,14 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/41427
 - author: SlamBamActionman
   changes:
-  - message: adduplink command now works properly, gives an uplink implant if there's
-      no PDA, and returns the uplink code in the command terminal.
+  - message: adduplink command now works properly, gives an uplink implant if there's no PDA, and returns the uplink code in the command terminal.
     type: Fix
   id: 207
   time: '2026-04-04T20:14:15.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38712
 - author: mikeysaurus
   changes:
-  - message: The debug SetOutfit command now also fills target's storage containers
-      based on the gear preset.
+  - message: The debug SetOutfit command now also fills target's storage containers based on the gear preset.
     type: Tweak
   id: 208
   time: '2026-04-09T05:05:01.0000000+00:00'
@@ -1718,16 +1547,14 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/43098
 - author: IProduceWidgets
   changes:
-  - message: The `delaystart` command now accepts negative values, allowing to speed
-      up the start of the round.
+  - message: The `delaystart` command now accepts negative values, allowing to speed up the start of the round.
     type: Tweak
   id: 210
   time: '2026-05-09T19:27:05.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38270
 - author: Beck
   changes:
-  - message: You can now see the contraband and chameleon status of items in the examine
-      menu
+  - message: You can now see the contraband and chameleon status of items in the examine menu
     type: Add
   id: 211
   time: '2026-05-10T11:01:26.0000000+00:00'
@@ -1748,8 +1575,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/44223
 - author: Zekins3366
   changes:
-  - message: Construction menu now updates immediately after reloading construction
-      prototypes.
+  - message: Construction menu now updates immediately after reloading construction prototypes.
     type: Fix
   id: 214
   time: '2026-06-05T15:24:37.0000000+00:00'
@@ -1890,5 +1716,39 @@ Entries:
   id: 232
   time: '2026-07-18T06:40:21.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/44238
+- author: sowelipililimute
+  changes:
+  - message: '`body:insert` has been added, allowing entities to be inserted as organs into a body.'
+    type: Add
+  - message: '`body:organs` has been added, allowing all organs within a body to be enumerated.'
+    type: Add
+  - message: '`organ:parent` has been added, allowing you to get the parent organ from a child organ (torso from arm, arm from hand.)'
+    type: Add
+  - message: '`organ:children` has been added, allowing you to get all child organs from a parent organ. (hand from arm, internal organs & limbs from torso)'
+    type: Add
+  - message: '`organ:detach` has been added, allowing you to split off an organ from a body into its own body. For debug purposes only; this has no associated game-ready functionality.'
+    type: Add
+  - message: '`organ:attach` has been added, allowing you to attach an organ to a parent organ.'
+    type: Add
+  - message: '`organ:is` has been added, allowing you to test if an entity is an organ of a specific type.'
+    type: Add
+  - message: '`organ:of_type` has been added, allowing you to filter for entities that are organs of a specific type.'
+    type: Add
+  id: 233
+  time: '2026-07-26T09:36:27.0000000+00:00'
+- author: Centronias
+  changes:
+  - message: Satiation reduction command "unsatiate"
+    type: Add
+  - message: Hunger reduction command "hungry"
+    type: Remove
+  - message: Thirst reduction command "thirst"
+    type: Remove
+  - message: Satiation setting command "setsatiation"
+    type: Add
+  - message: Hunger / thirst setting command "setnutrit"
+    type: Remove
+  id: 234
+  time: '2026-08-08T22:59:23.0000000+00:00'
 Name: Admin
 Order: 3

--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -1,2510 +1,17 @@
-﻿Entries:
-- author: Compilatron144
-  changes:
-  - message: Plasma got a Christmas makeover.
-    type: Add
-  id: 9229
-  time: '2025-11-27T10:42:38.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41573
-- author: slarticodefast
-  changes:
-  - message: Fixed helmet lights.
-    type: Fix
-  id: 9230
-  time: '2025-11-27T16:13:30.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41599
-- author: slarticodefast
-  changes:
-  - message: Fixed sounds playing and popups showing when opening the verb menu on
-      borgs or other entities with lockable UIs.
-    type: Fix
-  id: 9231
-  time: '2025-11-28T21:53:59.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41609
-- author: NoreUhh
-  changes:
-  - message: Caninase/Felinase now require Psicodine instead of Cognizine in their
-      recipes and now provide their respective accents at a lower chem threshold.
-    type: Tweak
-  id: 9232
-  time: '2025-11-29T07:32:40.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41527
-- author: jckspjf
-  changes:
-  - message: Added shot glasses to the bartender guidebook entry.
-    type: Add
-  id: 9233
-  time: '2025-11-29T16:43:48.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41618
-- author: Minemoder
-  changes:
-  - message: Monkies, Kobolds, and Scurrets will now show their ID on HUDs.
-    type: Fix
-  id: 9234
-  time: '2025-11-29T20:48:23.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41624
-- author: aada
-  changes:
-  - message: Hardsuits and other toggleable clothing now show in the strip menu.
-    type: Fix
-  id: 9235
-  time: '2025-11-30T05:20:03.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41631
-- author: slarticodefast
-  changes:
-  - message: Borgs are now predicted. Interacting with them or using borg modules
-      or the borg UI should feel much more responsive.
-    type: Fix
-  id: 9236
-  time: '2025-11-30T10:37:36.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41600
-- author: Princess-Cheeseballs
-  changes:
-  - message: Contacting another entity while on fire will transfer less firestacks.
-    type: Fix
-  id: 9237
-  time: '2025-11-30T14:10:57.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41636
-- author: slarticodefast
-  changes:
-  - message: Fixed the RCD placement ghost getting stuck for engi borgs.
-    type: Fix
-  id: 9238
-  time: '2025-12-01T01:35:25.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41648
-- author: Beck, Toast
-  changes:
-  - message: Clowns can now get flowers that spray water at 4 hours of playtime
-    type: Add
-  id: 9239
-  time: '2025-12-01T01:48:51.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41469
-- author: Ian321
-  changes:
-  - message: The blood spewed from a biomass reclaimed now contains DNA.
-    type: Add
-  - message: Gingerbread man now bleed sugar and butter.
-    type: Tweak
-  id: 9240
-  time: '2025-12-01T05:47:46.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41489
-- author: Spessmann
-  changes:
-  - message: Added a new station, Snowball, a round and icy lowpop station.
-    type: Add
-  - message: Removed Amber station.
-    type: Remove
-  id: 9242
-  time: '2025-12-02T07:25:10.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/40300
-- author: Samuka
-  changes:
-  - message: Game no longer sends the xenoborg shuttle call announcement over and
-      over
-    type: Fix
-  id: 9243
-  time: '2025-12-02T14:41:06.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41437
-- author: imatsoup
-  changes:
-  - message: When a Rat King is spawned, the default orders for their army is now
-      set to Follow instead of Loose.
-    type: Tweak
-  id: 9244
-  time: '2025-12-03T03:37:32.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41680
-- author: Hitlinemoss
-  changes:
-  - message: Medipens now have slightly clearer descriptions.
-    type: Tweak
-  id: 9245
-  time: '2025-12-03T17:52:02.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41682
-- author: jckspjf
-  changes:
-  - message: Changed the wording on Pun Pun's jacket to make more sense in English.
-    type: Tweak
-  id: 9246
-  time: '2025-12-04T01:19:37.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41695
-- author: Hitlinemoss
-  changes:
-  - message: Light crates' descriptions now accurately reflect the number of lights
-      they contain.
-    type: Fix
-  id: 9247
-  time: '2025-12-04T08:07:46.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41697
-- author: Minerva
-  changes:
-  - message: Spesos now fit in envelopes.
-    type: Tweak
-  id: 9248
-  time: '2025-12-04T17:07:51.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41700
-- author: SlamBamActionman
-  changes:
-  - message: Ephedrine, Desoxyephedrine and Hyperzine have had their stats reworked,
-      with Desoxyephedrine now giving a higher max stamina and Hyperzine lasting much
-      longer, among other changes.
-    type: Tweak
-  id: 9249
-  time: '2025-12-04T18:05:29.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41693
-- author: SlamBamActionman
-  changes:
-  - message: Changed Exo Botany's layout to have more trays and better functionality.
-    type: Tweak
-  - message: Fixed various decals and minor bugs with Exo.
-    type: Fix
-  id: 9250
-  time: '2025-12-04T19:44:47.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41598
-- author: ScarKy0
-  changes:
-  - message: Added Warfarin and Hemorrhinol, reagents that interact with blood clotting
-      and bleeding speed. Read about them in the guidebook!
-    type: Add
-  id: 9251
-  time: '2025-12-05T00:54:05.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41685
-- author: MissKay1994
-  changes:
-  - message: The explorer mask is now correctly worn by vox
-    type: Fix
-  id: 9252
-  time: '2025-12-05T10:46:28.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41405
-- author: alexalexmax
-  changes:
-  - message: Recharging spray painters no longer lose the ability to paint airlocks
-      after running out of charges once
-    type: Fix
-  id: 9253
-  time: '2025-12-05T11:00:10.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41725
-- author: Hitlinemoss
-  changes:
-  - message: Several figurines have received new voice lines.
-    type: Add
-  id: 9254
-  time: '2025-12-05T12:36:47.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41723
-- author: PJB3005
-  changes:
-  - message: Fixed shuttle FTL screen for people with UI scale above 100%
-    type: Fix
-  id: 9255
-  time: '2025-12-05T15:05:53.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/40933
-- author: SlamBamActionman
-  changes:
-  - message: Added Impedrezene, Fresium, Heartbreaker, Benzene, Tear Gas, Bleach,
-      Mannitol, Lipolicide, Wine, Beer, Coffee and Space Glue to random plant reagent
-      mutations.
-    type: Add
-  - message: Removed Nocturine, Lexorin and Hyperzine from random plant reagent mutations.
-    type: Remove
-  - message: Lowered Chemical Synthesis Kit uplink cost from 4 TC to 3 TC.
-    type: Tweak
-  - message: Lowered Nocturine Bottle's uplink cost from 6 TC to 4 TC.
-    type: Tweak
-  - message: Lowered the hypopen refill delay from 1.25s to 0.75s.
-    type: Tweak
-  id: 9256
-  time: '2025-12-05T17:14:05.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41716
-- author: Princess-Cheeseballs
-  changes:
-  - message: Vestine can now be used to mutate plants into producing syndicate chems.
-    type: Add
-  id: 9257
-  time: '2025-12-05T17:33:52.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41731
-- author: Samuka
-  changes:
-  - message: Mothership core won't explode when destroyed (until bug is fixed)
-    type: Tweak
-  id: 9258
-  time: '2025-12-06T18:26:05.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41743
-- author: august-sun
-  changes:
-  - message: Added the sticky grappling hand, a clown version of the grappling gun.
-    type: Add
-  id: 9259
-  time: '2025-12-06T20:52:51.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37551
-- author: Beck
-  changes:
-  - message: The voice mask can no longer be purchased in the uplink.
-    type: Remove
-  - message: You can now purchase a voice mask implanter for 2 TC in the uplink!
-    type: Add
-  - message: The thief communicator kit now comes with a voice implanter rather than
-      voice mask!
-    type: Tweak
-  id: 9260
-  time: '2025-12-07T02:48:06.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41551
-- author: SlamBamActionman
-  changes:
-  - message: Removed the Zookeeper and Boxer jobs.
-    type: Remove
-  id: 9261
-  time: '2025-12-07T03:19:52.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41741
-- author: Hitlinemoss
-  changes:
-  - message: The hyperzine injector/microinjector now accurately list their new, longer
-      durations.
-    type: Fix
-  id: 9262
-  time: '2025-12-07T11:56:11.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41755
-- author: Velken
-  changes:
-  - message: Snap Pops can now crafted into a more dangerous version by adding extra
-      gunpowder.
-    type: Add
-  id: 9263
-  time: '2025-12-07T13:38:08.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/38654
-- author: Princess-Cheeseballs
-  changes:
-  - message: Security IDs once again work at the HoP computer
-    type: Fix
-  id: 9264
-  time: '2025-12-07T16:27:03.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41739
-- author: metalgearsloth
-  changes:
-  - message: Increased bullet speeds from 25m/s to 40m/s by default.
-    type: Tweak
-  id: 9265
-  time: '2025-12-07T16:47:15.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/34971
-- author: Samuka
-  changes:
-  - message: Xenoborg lights are now brighter
-    type: Tweak
-  id: 9266
-  time: '2025-12-07T18:04:51.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41580
-- author: Hitlinemoss
-  changes:
-  - message: Station-specific jobs no longer list which maps they're available on
-      in their descriptions. The actual list of maps they are available on remains
-      the same.
-    type: Tweak
-  id: 9267
-  time: '2025-12-07T20:39:49.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41748
-- author: Princess-Cheeseballs
-  changes:
-  - message: Bible has been restored to its normal healing rate.
-    type: Fix
-  id: 9268
-  time: '2025-12-08T01:23:03.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41777
-- author: UpAndLeaves
-  changes:
-  - message: New players no longer have a chance of being Dionae, Vox, Slime People,
-      or Vulpkanin when joining for the first time. They can still manually select
-      these species.
-    type: Tweak
-  id: 9269
-  time: '2025-12-08T01:49:42.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41678
-- author: kleinerstation13
-  changes:
-  - message: The Hushpup, a 10 TC silenced shotgun, is now available via the uplink
-      for traitors and nukies.
-    type: Add
-  id: 9270
-  time: '2025-12-08T20:20:04.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41512
-- author: TiniestShark
-  changes:
-  - message: Gas canisters can now have paper labels attached to them.
-    type: Add
-  id: 9271
-  time: '2025-12-09T09:45:29.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41737
-- author: ArtisticRoomba
-  changes:
-  - message: The syndicate jaws of life can now pry open bolted doors.
-    type: Tweak
-  - message: The authentication disruptor can now disrupt bolted doors.
-    type: Fix
-  id: 9272
-  time: '2025-12-09T13:03:25.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41138
-- author: alexalexmax
-  changes:
-  - message: Fixed monkeys(and other mobs) being immune to eye damage when welding
-    type: Fix
-  id: 9273
-  time: '2025-12-09T13:17:19.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41788
-- author: K-Dynamic
-  changes:
-  - message: Chefs now start with chef shoes instead of black shoes.
-    type: Tweak
-  id: 9274
-  time: '2025-12-10T02:40:39.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41814
-- author: slarticodefast
-  changes:
-  - message: Fixed rigged power cells immediately exploding when inserted into a device
-      even if it's toggled off.
-    type: Fix
-  id: 9275
-  time: '2025-12-10T10:40:31.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41813
-- author: jckspjf
-  changes:
-  - message: Escape objectives now properly specify escape via the shuttle rather
-      than escape pods.
-    type: Tweak
-  id: 9276
-  time: '2025-12-10T10:55:57.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41809
-- author: kontakt
-  changes:
-  - message: Paramedic Void Suit now uses the correct speed reduction when worn again.
-    type: Fix
-  id: 9277
-  time: '2025-12-10T19:04:39.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41820
-- author: cloudyias
-  changes:
-  - message: Diona are now less harmed by rooting in blood
-    type: Add
-  id: 9278
-  time: '2025-12-12T02:13:46.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41642
-- author: Princess-Cheeseballs
-  changes:
-  - message: You can no longer detonate or disable borgs with the robotics console.
-    type: Remove
-  id: 9279
-  time: '2025-12-12T10:36:52.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41834
-- author: alexalexmax
-  changes:
-  - message: The scram implanter now teleports you within a 100 tile radius, as originally
-      intended, and will not teleport you into open space.
-    type: Fix
-  id: 9280
-  time: '2025-12-12T11:27:11.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41808
-- author: kontakt
-  changes:
-  - message: Potassium Iodide is now sometimes available in radiation lockers.
-    type: Add
-  id: 9281
-  time: '2025-12-12T17:58:08.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41576
-- author: K-Dynamic
-  changes:
-  - message: Soda Dispenser, Booze Dispenser, and ChemDispenser have had their prices
-      reduced.
-    type: Tweak
-  id: 9282
-  time: '2025-12-13T02:46:10.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41756
-- author: Absotively
-  changes:
-  - message: Hand labelers can now remove labels via the verb menu whether or not
-      they have a label set.
-    type: Tweak
-  id: 9283
-  time: '2025-12-13T19:13:25.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/40330
-- author: NoreUhh
-  changes:
-  - message: Vulpkanin hair no longer clips through hoods and hardsuits.
-    type: Fix
-  id: 9284
-  time: '2025-12-14T00:55:00.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41827
-- author: ScarKy0
-  changes:
-  - message: Cyborgs no longer lose access when they run out of power.
-    type: Tweak
-  id: 9285
-  time: '2025-12-14T00:55:00.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41844
-- author: aada
-  changes:
-  - message: Five cargo bounties have had their worth reduced so you can't make a
-      profit buying crates for them.
-    type: Fix
-  id: 9286
-  time: '2025-12-14T01:39:45.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41846
-- author: Mehnix
-  changes:
-  - message: Bananas, Mimanas, Corn, Gatfruit, Capfruit, Bungo, and Cherries can now
-      be butchered to get their waste product in addition to being eaten.
-    type: Add
-  id: 9287
-  time: '2025-12-14T02:30:09.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/36786
-- author: Borsh
-  changes:
-  - message: Added random gate
-    type: Add
-  id: 9288
-  time: '2025-12-14T19:27:31.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41627
-- author: Hitlinemoss
-  changes:
-  - message: All shotgun shells (and associated ammo boxes / magazines) now have proper
-      descriptions.
-    type: Fix
-  - message: Machine pistol magazines are now considered Security contraband.
-    type: Fix
-  - message: Practice machine pistol magazines are no longer loaded with real bullets.
-    type: Fix
-  id: 9289
-  time: '2025-12-14T20:27:56.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41841
-- author: Hitlinemoss
-  changes:
-  - message: Skeletons are now vulnerable to Holy damage from sources such as the
-      space bible or holy water.
-    type: Add
-  id: 9290
-  time: '2025-12-14T20:41:52.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41757
-- author: Red_Spy
-  changes:
-  - message: The chamber is now empty by default for weapons with a removable magazine.
-    type: Tweak
-  id: 9291
-  time: '2025-12-14T20:55:47.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41791
-- author: aada
-  changes:
-  - message: Maintenance closets have more toys in them.
-    type: Tweak
-  - message: The toy box crate now has random contents.
-    type: Tweak
-  - message: The roller skate bounty now only requires 1 pair of roller skates but
-      gives less money
-    type: Tweak
-  - message: The syndicate balloon, syndicate tricky bomb, foam rifle, and golden
-      bike horn all had their value reduced
-    type: Tweak
-  id: 9292
-  time: '2025-12-14T20:56:03.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41840
-- author: jckspjf
-  changes:
-  - message: Added Pun Pun's jumpsuit into Bardrobes.
-    type: Add
-  id: 9293
-  time: '2025-12-15T01:33:51.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41705
-- author: ScarKy0
-  changes:
-  - message: Removed roundstart tools module from the Medical, Service and Janitor
-      cyborgs. The module can still be printed at the exosuit fab.
-    type: Remove
-  id: 9294
-  time: '2025-12-15T01:50:21.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41823
-- author: Meara1179
-  changes:
-  - message: Added crowbar to the Medical Borg's Rescue module.
-    type: Add
-  id: 9296
-  time: '2025-12-15T03:59:08.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41861
-- author: Samuka
-  changes:
-  - message: Repairing borgs now takes multiple mini doafters instead of one big one
-    type: Tweak
-  id: 9297
-  time: '2025-12-15T12:27:53.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41638
-- author: JesterX666
-  changes:
-  - message: Explosions with heat now ignite inflammable gas mixes in the atmosphere
-    type: Fix
-  id: 9298
-  time: '2025-12-15T23:39:27.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41262
-- author: SlamBamActionman
-  changes:
-  - message: Exo has been updated to the holiday version.
-    type: Tweak
-  id: 9299
-  time: '2025-12-16T01:07:13.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41715
-- author: Princess-Cheeseballs
-  changes:
-  - message: New cryo chem, arcryox.
-    type: Add
-  - message: Cryo chems now use EvenHeal making cryoxadone more like omnizine.
-    type: Tweak
-  id: 9300
-  time: '2025-12-16T01:20:44.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41696
-- author: Samuka
-  changes:
-  - message: Added the door control module for the engi xenoborg
-    type: Add
-  - message: The xenoborg door remote can now eletrify doors
-    type: Tweak
-  - message: Engi xenoborg can now see if doors are eletrified
-    type: Tweak
-  id: 9301
-  time: '2025-12-16T01:37:24.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41546
-- author: imatsoup
-  changes:
-  - message: Vupkanin now have audio for when they Weh, Hew, and Honk under the effects
-      of the chems that make you do those things.
-    type: Fix
-  id: 9302
-  time: '2025-12-16T01:50:55.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41610
-- author: Hitlinemoss
-  changes:
-  - message: Station AI is now rolled before most non-Command/non-Security roles.
-    type: Tweak
-  id: 9303
-  time: '2025-12-16T02:12:36.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41663
-- author: captainkawaii666
-  changes:
-  - message: A foolbox with various pranking items for clowns
-    type: Add
-  - message: Crayon boxes are now slightly smaller
-    type: Tweak
-  id: 9304
-  time: '2025-12-16T03:32:22.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41473
-- author: Pangogie
-  changes:
-  - message: Killer tomatoes now have a 3x3 grid size.
-    type: Tweak
-  id: 9305
-  time: '2025-12-16T07:23:11.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/35866
-- author: alexalexmax
-  changes:
-  - message: Getting stunned or killed while buckled/crawling will drop any held items.
-    type: Tweak
-  id: 9306
-  time: '2025-12-16T18:45:19.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41566
-- author: slarticodefast
-  changes:
-  - message: Fixed the station AI's battery alert not updating.
-    type: Fix
-  id: 9307
-  time: '2025-12-16T19:00:27.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41879
-- author: kontakt
-  changes:
-  - message: Flammable items no longer have bonus mass.
-    type: Fix
-  id: 9308
-  time: '2025-12-17T08:37:35.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41803
-- author: nkokic
-  changes:
-  - message: Bloodstream and Chemstream have been merged. Injected chemicals can now
-      react with your blood.
-    type: Tweak
-  id: 9309
-  time: '2025-12-17T19:33:53.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/35071
-- author: Centronias
-  changes:
-  - message: Borgs with rechargable ballistic weapons (e.g. Syndicate Assault Borgs)
-      no longer lose their entire magazine upon being EMP'd. The EMP still disables
-      the ammo recharge for its effective duration.
-    type: Tweak
-  id: 9310
-  time: '2025-12-17T23:04:41.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/38537
-- author: NoreUhh
-  changes:
-  - message: Fixed Vulpkanin stomachs being smaller than other species.
-    type: Fix
-  id: 9311
-  time: '2025-12-18T00:53:37.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41893
-- author: Samuka
-  changes:
-  - message: Renamed some xenoborg modules
-    type: Tweak
-  id: 9312
-  time: '2025-12-18T02:29:30.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41625
-- author: PJB3005
-  changes:
-  - message: Fix loadout names not being exported/imported
-    type: Fix
-  id: 9313
-  time: '2025-12-18T09:25:51.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41891
-- author: Hitlinemoss
-  changes:
-  - message: The wizard's grimoire now has a proper description.
-    type: Tweak
-  id: 9314
-  time: '2025-12-18T19:33:08.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41900
-- author: SlamBamActionman
-  changes:
-  - message: Hyperzine now provides a 1.5x max stamina modifier for its duration.
-    type: Tweak
-  id: 9315
-  time: '2025-12-18T19:53:29.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41902
-- author: Unkn0wnGh0st333
-  changes:
-  - message: Syndicate Wall Lockers and Secure Crates have been added! Mappers Rejoice!
-    type: Add
-  - message: Armory lockers have changed name to Blood-Red Lockers and locked variants
-      are now actually locked behind syndicate access.
-    type: Tweak
-  id: 9316
-  time: '2025-12-18T20:55:15.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/33251
-- author: Empoleon4444
-  changes:
-  - message: Changed Ghost Role Raffles to be shorter overall
-    type: Tweak
-  id: 9317
-  time: '2025-12-18T21:08:51.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/33157
-- author: Hitlinemoss
-  changes:
-  - message: Small cardboard boxes have been added (2x2 instead of 3x3), and can be
-      made in the crafting menu for 1 cardboard each.
-    type: Add
-  - message: Cardboard boxes now require 2 cardboard to make (from 1).
-    type: Tweak
-  - message: The names and descriptions of stamp boxes and circuit totes have been
-      adjusted.
-    type: Tweak
-  id: 9319
-  time: '2025-12-19T07:04:09.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41335
-- author: SirWarock
-  changes:
-  - message: Shields are now examinable for their damage - You'll see how much dawg
-      it got left in it on a glance!
-    type: Add
-  - message: Shields are now repairable with a welder - Some shields are excluded,
-      notably the Energy Shield.
-    type: Add
-  id: 9320
-  time: '2025-12-20T01:50:14.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41326
-- author: chromiumboy
-  changes:
-  - message: Station AI cores constructed with a positronic brain that is actively
-      seeking a mind will open a ghost role to become its AI.
-    type: Tweak
-  id: 9321
-  time: '2025-12-20T14:34:40.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/40607
-- author: korczoczek
-  changes:
-  - message: Added opened sprite variants to olive oil, mayo and flour, cornmeal,
-      rice, sugar bags
-    type: Tweak
-  id: 9322
-  time: '2025-12-20T18:37:22.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41923
-- author: SirWarock
-  changes:
-  - message: Hyposprays and Hypopens now start in their dynamic mode. It functions
-      exactly as the previous Inject/Draw mode.
-    type: Tweak
-  - message: The Gorlex Hypospray is now syndicate contraband.
-    type: Tweak
-  - message: Injectors now inject twice as quick into targets that are lying down
-      for any reason, most notably being buckled on a medical bed or being critical.
-      Before, only critical patients had this luxury.
-    type: Tweak
-  - message: Clumsy now affects syringes when you're self-injecting.
-    type: Tweak
-  id: 9323
-  time: '2025-12-21T00:10:55.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41833
-- author: SirWarock
-  changes:
-  - message: Medical Cyborg Hyposprays now finally have a fillsprite!
-    type: Add
-  - message: Fixed Gorlex Hyposprays not showing their fill sprites!
-    type: Fix
-  - message: Bluespace syringes are now slightly faster when injecting large amounts,
-      usually twice as fast as normal syringes.
-    type: Tweak
-  id: 9324
-  time: '2025-12-21T20:33:07.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41932
-- author: MilonPL
-  changes:
-  - message: Fixed beaker solutions duplicating whenever it's thrown.
-    type: Fix
-  id: 9326
-  time: '2025-12-22T08:12:37.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/33231
-- author: JohnJJohn
-  changes:
-  - message: Cable items, such as wire coils can now be destroyed.
-    type: Tweak
-  id: 9327
-  time: '2025-12-22T17:11:34.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41279
-- author: whatston3, Crude Oil
-  changes:
-  - message: FTL Arrival visualization displays properly again when arriving at a
-      dock
-    type: Fix
-  id: 9328
-  time: '2025-12-22T21:15:36.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41951
-- author: ArtisticRoomba
-  changes:
-  - message: Devices that collect atmospheric data or reference the grid's atmosphere
-      will now properly reference the new atmosphere if the grid's atmosphere is ever
-      rebuilt or changed significantly.
-    type: Fix
-  id: 9329
-  time: '2025-12-23T08:12:52.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41585
-- author: imatsoup
-  changes:
-  - message: The donk co. microwave is now considered Syndicate contraband.
-    type: Tweak
-  - message: The donk co. microwave circuitboard is now considered Syndicate contraband.
-    type: Tweak
-  id: 9330
-  time: '2025-12-23T10:01:37.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41960
-- author: SirWarock
-  changes:
-  - message: Added Jet Injectors, an hypodermic alternative to Syringes!
-    type: Add
-  - message: Jet Injectors now spawn in Medical Doctor Lockers, as well as being stocked
-      in the NanoMed Plus!
-    type: Add
-  - message: Added Advanced Jet Injectors, with a bigger storage and faster injection
-      times than the base one!
-    type: Add
-  id: 9331
-  time: '2025-12-25T19:57:41.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/40076
-- author: TheFlyingSentry
-  changes:
-  - message: Fixed Xeno air alarms not showing state changes.
-    type: Fix
-  id: 9332
-  time: '2025-12-25T23:34:06.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41590
-- author: alexalexmax
-  changes:
-  - message: Voice masks and voice mask implants can have their effects toggled from
-      within the voice mask menu.
-    type: Add
-  - message: Voice masks and voice mask implanters now hide any accents you have,
-      including innate accents and conditional ones.
-    type: Tweak
-  id: 9333
-  time: '2025-12-26T03:00:24.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41965
-- author: Nox38
-  changes:
-  - message: Overhauled ERT starting equipment.
-    type: Tweak
-  - message: Added several new loadouts for ERT!
-    type: Add
-  id: 9334
-  time: '2025-12-26T21:47:30.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/38481
-- author: SonarZeBat
-  changes:
-  - message: Xenoborgs gamemode minimum players changed from 40 to 30.
-    type: Tweak
-  id: 9335
-  time: '2025-12-27T14:14:07.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42111
-- author: EchoOfNothing
-  changes:
-  - message: IFF controls are now merged into a single control.
-    type: Tweak
-  - message: Syndicate IFF console now has IFF turned off by default.
-    type: Tweak
-  id: 9336
-  time: '2025-12-27T14:32:07.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42104
-- author: B_Kirill
-  changes:
-  - message: Broken vending machines now properly block and close their UI.
-    type: Fix
-  id: 9337
-  time: '2025-12-28T01:10:36.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42110
-- author: SnappingOpossum
-  changes:
-  - message: Happy Honk Big Bite may now contain crayon boxes.
-    type: Add
-  id: 9338
-  time: '2025-12-28T06:36:49.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42077
-- author: Ilya246
-  changes:
-  - message: Large grid shuttle collisions should now be somewhat less laggy.
-    type: Fix
-  id: 9339
-  time: '2025-12-28T07:30:08.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/40984
-- author: PAFFhassoocks
-  changes:
-  - message: Ninjas no longer spawn with a survival box, and instead have the items
-      directly in their bags, excluding the emergency tank.
-    type: Tweak
-  id: 9340
-  time: '2025-12-29T10:42:30.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42102
-- author: GeneralGaws
-  changes:
-  - message: The Decoy Syndicate Bomb in the Traitor uplink now has a purchase timer,
-      same as the regular Syndicate Bomb.
-    type: Tweak
-  id: 9341
-  time: '2025-12-29T10:59:18.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42114
-- author: 0-Anon
-  changes:
-  - message: Rat creatures will now restore bloodlevel when exposed to ammonia gas.
-    type: Tweak
-  id: 9342
-  time: '2025-12-29T22:49:25.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42167
-- author: OnyxTheBrave
-  changes:
-  - message: The Chemmaster 4000 can now switch between making pills from the internal
-      buffer or from an inserted beaker.
-    type: Tweak
-  id: 9343
-  time: '2025-12-30T21:52:19.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/40121
-- author: jessicamaybe
-  changes:
-  - message: Moved borg module remove button to the left side
-    type: Tweak
-  id: 9344
-  time: '2025-12-30T23:26:26.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42119
-- author: TheFotY
-  changes:
-  - message: Paper can now be extinguished (e.g. fire extinguisher)
-    type: Fix
-  id: 9345
-  time: '2025-12-31T00:23:19.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42142
-- author: YoungThugSS14
-  changes:
-  - message: Ninjas now spawn with a custom satchel.
-    type: Add
-  id: 9346
-  time: '2025-12-31T01:37:36.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42112
-- author: kontakt
-  changes:
-  - message: Fixed broken FTL links for implanters and medibot.
-    type: Fix
-  id: 9347
-  time: '2025-12-31T01:52:22.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42181
-- author: Princess-Cheeseballs
-  changes:
-  - message: You can now spill the contents out of hyposprays and jet injectors
-    type: Tweak
-  id: 9348
-  time: '2026-01-01T05:42:54.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42158
-- author: Samuka
-  changes:
-  - message: xenoborg thrusters can't be toggled off
-    type: Tweak
-  - message: xenoborg thrusters can't unwrenched
-    type: Tweak
-  - message: xenoborg thrusters can't be rotated while anchored
-    type: Tweak
-  id: 9349
-  time: '2026-01-01T21:36:57.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42201
-- author: Ian321
-  changes:
-  - message: The clustersoap now visually changes when eaten.
-    type: Fix
-  - message: Soaplets now leave red residue behind.
-    type: Fix
-  - message: Soaplets now contain less soap.
-    type: Tweak
-  id: 9350
-  time: '2026-01-03T01:33:43.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/34165
-- author: K-Dynamic
-  changes:
-  - message: Intercoms have new appearance.
-    type: Tweak
-  id: 9351
-  time: '2026-01-03T07:01:04.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41962
-- author: SeaWyrm
-  changes:
-  - message: Red sand astro-tiles are now researchable as part of the astro-tile research
-      option
-    type: Add
-  - message: Iron-red concrete tiles can now be created at Cutters
-    type: Add
-  id: 9352
-  time: '2026-01-03T07:15:10.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/39793
-- author: TheShuEd
-  changes:
-  - message: Melee weapon attack animations now looks way cooler!
-    type: Tweak
-  id: 9353
-  time: '2026-01-03T21:43:01.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41425
-- author: TheFlyingSentry
-  changes:
-  - message: Other Dragon rifts now remain intact when one is destroyed.
-    type: Tweak
-  id: 9354
-  time: '2026-01-05T00:42:26.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42234
-- author: ThatGuyUSA
-  changes:
-  - message: There are more IDs and icons that can be used for a variety of roles.
-    type: Add
-  id: 9355
-  time: '2026-01-06T10:41:32.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42200
-- author: 0-Anon
-  changes:
-  - message: Guaranteed a bottle of Crazy Glue and Crazy Lube in the toy box.
-    type: Tweak
-  id: 9356
-  time: '2026-01-07T01:32:38.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42146
-- author: ScarKy0
-  changes:
-  - message: The Chameleon Projector now requires a battery to operate. It spawns
-      with a medium powercell, giving it a starting battery life of 3 minutes.
-    type: Add
-  - message: Lowered the price of the Chameleon Projector to 3TC.
-    type: Tweak
-  id: 9357
-  time: '2026-01-07T06:05:08.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42271
-- author: Samuka
-  changes:
-  - message: The xenoborg camera monitor now shows the names of each xenoborg.
-    type: Tweak
-  id: 9358
-  time: '2026-01-07T16:38:00.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42205
-- author: SomegnihT
-  changes:
-  - message: Vox now properly say they turn into fried chicken upon getting enough
-      heat damage
-    type: Fix
-  id: 9359
-  time: '2026-01-07T19:37:53.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42280
-- author: aada
-  changes:
-  - message: Toy swords now deal a very small amount of stamina damage for proper
-      sword fights.
-    type: Tweak
-  id: 9360
-  time: '2026-01-07T22:03:27.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42184
-- author: kontakt
-  changes:
-  - message: The Ninja's spider clan charge must now be planted on a wall or window.
-    type: Tweak
-  id: 9361
-  time: '2026-01-07T22:19:41.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41208
-- author: Princess-Cheeseballs
-  changes:
-  - message: Audio will now play properly when toggling internals.
-    type: Fix
-  id: 9362
-  time: '2026-01-08T11:03:07.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42304
-- author: aada
-  changes:
-  - message: The handheld health analyzer no longer requires a battery.
-    type: Tweak
-  id: 9363
-  time: '2026-01-08T19:38:23.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42292
-- author: perryprog
-  changes:
-  - message: The go go hat can now only retrieve and store items when worn.
-    type: Fix
-  id: 9364
-  time: '2026-01-08T19:38:23.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/39189
-- author: LevitatingTree
-  changes:
-  - message: Saying ":?" now lets you shrug like "idk" used to.
-    type: Add
-  id: 9365
-  time: '2026-01-08T19:52:57.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41236
-- author: B_Kirill, ScarKy0
-  changes:
-  - message: Added a bonfire with stake that sets the attached entities on fire.
-    type: Add
-  - message: A bonfire and a bonfire with stake can now be constructed.
-    type: Add
-  id: 9366
-  time: '2026-01-09T04:14:07.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42211
-- author: mikeysaurus
-  changes:
-  - message: All non-arrivals shuttles are defaulted to have a 60 second cooldown
-      before they can FTL again.
-    type: Tweak
-  id: 9367
-  time: '2026-01-09T06:58:22.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42209
-- author: perryprog
-  changes:
-  - message: Added a button to the smart fridge UI to remove empty entries.
-    type: Add
-  id: 9368
-  time: '2026-01-09T15:02:32.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/39195
-- author: B_Kirill
-  changes:
-  - message: Projectiles like bullets, rockets and fireballs no longer slow down during
-      flight.
-    type: Fix
-  id: 9369
-  time: '2026-01-09T18:45:19.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42320
-- author: Hitlinemoss
-  changes:
-  - message: Cabbage placed on taco shells no longer turns into a carrot.
-    type: Fix
-  id: 9370
-  time: '2026-01-09T23:24:27.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42326
-- author: Solid_Syn, BeckT
-  changes:
-  - message: Clowns now have the ability to toggle the wig on their mask!
-    type: Tweak
-  id: 9371
-  time: '2026-01-10T17:01:32.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42208
-- author: BarryNorfolk
-  changes:
-  - message: Network configurators now properly show colours between objects again.
-    type: Fix
-  id: 9372
-  time: '2026-01-10T20:09:37.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42335
-- author: ScarKy0
-  changes:
-  - message: Examining the state of dead entities is now predicted.
-    type: Fix
-  id: 9373
-  time: '2026-01-10T23:16:52.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42253
-- author: ScarKy0
-  changes:
-  - message: Janitor Cyborg's modules now feature a wirebrush.
-    type: Tweak
-  - message: The spray in the advanced cleaning module now self refills with space
-      cleaner, but has been halved in volume.
-    type: Tweak
-  id: 9374
-  time: '2026-01-11T04:19:48.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42330
-- author: SlamBamActionman
-  changes:
-  - message: Added an admin log for whenever a player connects/disconnects.
-    type: Add
-  id: 9375
-  time: '2026-01-11T21:46:54.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42363
-- author: Velken
-  changes:
-  - message: Fixed description for "help osay" command
-    type: Fix
-  id: 9376
-  time: '2026-01-12T03:04:57.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42368
-- author: Princess-Cheeseballs
-  changes:
-  - message: Borg hypo was moved to its own module
-    type: Tweak
-  - message: Roundstart chem module has been improved to be more like the advanced
-      chem module
-    type: Tweak
-  id: 9377
-  time: '2026-01-12T21:10:07.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42123
-- author: chaisftw
-  changes:
-  - message: Spray bottles now have fill level sprites.
-    type: Add
-  id: 9378
-  time: '2026-01-12T22:14:53.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42155
-- author: PicklOH
-  changes:
-  - message: Changed the destruction category of Space Law to be more accurate and
-      include Silicons.
-    type: Tweak
-  id: 9379
-  time: '2026-01-12T22:30:25.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42317
-- author: Quantum-cross
-  changes:
-  - message: Now you can be a late join antagonist even if you're arriving via the
-      arrivals shuttle!
-    type: Tweak
-  id: 9380
-  time: '2026-01-12T22:30:25.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/39837
-- author: Princess-Cheeseballs
-  changes:
-  - message: Botany's chemical mutation table now takes rarity into account when selecting
-      chemicals. This means Omnizine is no longer the most common chemical to roll.
-    type: Fix
-  - message: Vestine chemical mutation table has been adjusted to be less powerful.
-      Vestine is now poisonous to plants.
-    type: Tweak
-  - message: Stellibinin now reduces plant toxicity at 50% the effectiveness of Dylovene.
-    type: Add
-  id: 9381
-  time: '2026-01-13T07:42:52.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42302
-- author: ScarKy0
-  changes:
-  - message: Hyperzine Injector cost has been lowered to 2TC from 4TC.
-    type: Tweak
-  - message: Hyperzine Microinjector Kit cost has been lowered to 5TC from 12TC.
-    type: Tweak
-  id: 9382
-  time: '2026-01-13T07:57:46.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42383
-- author: SlamBamActionman
-  changes:
-  - message: Added the Corpsman Medicine Bundle, a duffelbag of basic healing reagents.
-      It is available after 20 minutes for free via the new Syndicate Delivery Console
-      on the Nukie planet.
-    type: Add
-  - message: Added new handheld maps on the Nukie planet that shows the target station.
-    type: Add
-  id: 9383
-  time: '2026-01-13T08:12:43.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42337
-- author: ScarKy0
-  changes:
-  - message: The Smuggler's Satchel now costs 1TC instead of 2TC.
-    type: Tweak
-  id: 9384
-  time: '2026-01-13T10:16:02.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42381
-- author: alexalexmax
-  changes:
-  - message: The ninja headset is now immune to EMPs.
-    type: Tweak
-  id: 9385
-  time: '2026-01-13T13:44:00.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42334
-- author: ScarKy0
-  changes:
-  - message: The throwing knives bundle now comes with 8 knives instead of 4.
-    type: Tweak
-  - message: Throwing knives now take half the time (1.5s) to unembed from a target.
-    type: Tweak
-  id: 9387
-  time: '2026-01-13T17:04:44.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42391
-- author: ScarKy0
-  changes:
-  - message: Scram implant no longer brings the person pulling you along.
-    type: Fix
-  id: 9388
-  time: '2026-01-13T17:18:55.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42393
-- author: ScarKy0
-  changes:
-  - message: Vipers now start with a high capacity magazine.
-    type: Tweak
-  - message: The uplink now has a high capacity magazine instead of the regular one.
-    type: Tweak
-  - message: High capacity magazines now hold 1 less bullet (15 total).
-    type: Tweak
-  id: 9389
-  time: '2026-01-13T18:30:44.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42392
-- author: SirWarock
-  changes:
-  - message: Cyborg Chassis can now be pried open when the cyborg is in critical state!
-    type: Add
-  - message: Cyborg Chassis' maintenance panel now needs to be opened with a screwdriver
-      again.
-    type: Tweak
-  id: 9390
-  time: '2026-01-13T22:21:52.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42319
-- author: SapphicOverload
-  changes:
-  - message: Fixed tritium fires consuming either 18 times more oxygen and making
-      10 times more water vapor than intended or consuming no oxygen at all, depending
-      on whether there is more or less oxygen than tritium respectively.
-    type: Fix
-  id: 9391
-  time: '2026-01-13T22:35:55.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41870
-- author: ArtisticRoomba
-  changes:
-  - message: The frezon production conversion rate has been increased. Tritium combines
-      with oxygen to make frezon at a 1:50 ratio instead of a 1:8 ratio. This means
-      you'll be making more frezon for less tritium inputted in a standard frezon
-      setup.
-    type: Tweak
-  id: 9392
-  time: '2026-01-13T23:41:36.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42400
-- author: ArtisticRoomba
-  changes:
-  - message: The tritiumfire reaction now properly limits the amount of tritium burned
-      by the limiting gas in the mix instead of limiting by which gas is in excess.
-    type: Fix
-  id: 9393
-  time: '2026-01-14T05:21:21.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42407
-- author: skrybl
-  changes:
-  - message: Changed the sprite for the janitorial maid uniform.
-    type: Tweak
-  id: 9394
-  time: '2026-01-14T15:03:04.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/38335
-- author: SlamBamActionman
-  changes:
-  - message: Added a target station map inside the LoneOp's Striker shuttle.
-    type: Add
-  id: 9395
-  time: '2026-01-14T20:04:37.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42376
-- author: Samuka
-  changes:
-  - message: Xenoborgs no longer drop core pinpointers.
-    type: Remove
-  - message: Xenoborgs now drop core pinpointer pieces. With 4 you can craft a repaired
-      core pinpointer!
-    type: Add
-  id: 9396
-  time: '2026-01-14T20:36:12.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42295
-- author: korczoczek
-  changes:
-  - message: Lathes will now return materials when a recipe gets cancelled
-    type: Fix
-  - message: Lathes will no longer void materials if unpowered in the middle of producing
-      a recipe
-    type: Fix
-  id: 9397
-  time: '2026-01-14T21:26:39.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42416
-- author: TheFlyingSentry
-  changes:
-  - message: Containment units no longer contribute to light pollution
-    type: Fix
-  id: 9398
-  time: '2026-01-14T21:40:38.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42289
-- author: ArtisticRoomba
-  changes:
-  - message: The TEG now produces 75% more power. This is to counteract tritium fires
-      no longer producing 10x the amount of heat they used to output, due to a bug.
-    type: Tweak
-  id: 9400
-  time: '2026-01-15T05:40:22.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42421
-- author: kontakt
-  changes:
-  - message: Cancer mice are now significantly more radioactive.
-    type: Tweak
-  id: 9401
-  time: '2026-01-15T16:46:46.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42298
-- author: Samuka
-  changes:
-  - message: The heavy xenoborg can now slowly move in space like the scout and stealth
-      xenoborgs.
-    type: Tweak
-  id: 9402
-  time: '2026-01-15T17:10:59.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42415
-- author: rumaks-xyz
-  changes:
-  - message: Chemical reactions no longer occur inside pills
-    type: Tweak
-  id: 9403
-  time: '2026-01-15T18:08:00.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41457
-- author: Fruitsalad
-  changes:
-  - message: Added a new user interface for cryo pods
-    type: Add
-  id: 9404
-  time: '2026-01-15T18:08:00.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41850
-- author: Orsoniks
-  changes:
-  - message: Health examine colours now reflect the medicines used to heal that type
-      of damage.
-    type: Tweak
-  id: 9405
-  time: '2026-01-15T18:42:32.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/38231
-- author: aada
-  changes:
-  - message: New tiny and cute vials that hold 10 units.
-    type: Add
-  - message: Vials can now be closed to avoid spilling.
-    type: Tweak
-  id: 9406
-  time: '2026-01-15T19:00:27.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/36132
-- author: ScarKy0
-  changes:
-  - message: Added the Paper Centrifuge! A craftable, makeshift centrifudge primarly
-      usable in maintenance chemistry.
-    type: Add
-  id: 9407
-  time: '2026-01-15T20:01:06.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42040
-- author: B_Kirill
-  changes:
-  - message: Added camera map. Cutting MAP wire hides camera from map while keeping
-      it accessible in camera list.
-    type: Add
-  id: 9409
-  time: '2026-01-15T21:37:19.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/39684
-- author: ScarKy0
-  changes:
-  - message: Added Makeshift and Regular Mortar&Pestle! It can be found in the nutrimax
-      and dinnerware vendors or crafted. It works slower and can only process 1 item
-      at a time.
-    type: Add
-  - message: Added Makeshift and Regular Handheld Juicer! It can be found in the nutrimax
-      and dinnerware vendors or crafted. It works slower and can only process 1 item
-      at a time.
-    type: Add
-  id: 9410
-  time: '2026-01-16T00:35:32.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42019
-- author: EmoGarbage404
-  changes:
-  - message: Fixed flatpackers ignoring material costs for certain machine board requirements
-      and being able to print unlatheable items for flatpacks.
-    type: Fix
-  id: 9411
-  time: '2026-01-16T00:52:35.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42445
-- author: sowelipililimute
-  changes:
-  - message: Using a core pinpointer piece on another piece no longer causes you to
-      start an unintended construction recipe.
-    type: Fix
-  id: 9412
-  time: '2026-01-16T02:09:01.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42446
-- author: neomoth
-  changes:
-  - message: Fix zombie resistance, instead of making you more likely to be infected,
-      it now properly makes you less likely to be infected.
-    type: Fix
-  id: 9413
-  time: '2026-01-16T08:40:47.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42451
-- author: Samuka
-  changes:
-  - message: The mothership now starts with more materials so there is less need to
-      salvage for them.
-    type: Tweak
-  - message: Xenoborgs guidebook entry got updated in regards to preparation and tactics.
-    type: Tweak
-  id: 9414
-  time: '2026-01-16T17:19:48.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42448
-- author: Kowlin
-  changes:
-  - message: All intern jobs now lock out after 10 hours, up from 5 hours.
-    type: Tweak
-  - message: Security Officer now requires 4 hours of Security Cadet, up from 2.5
-      hours.
-    type: Tweak
-  - message: Head of Security now requires 3 hours of Warden, up from 1 hour.
-    type: Tweak
-  id: 9415
-  time: '2026-01-17T20:24:42.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42372
-- author: sowelipililimute
-  changes:
-  - message: Vox can eat trash again.
-    type: Fix
-  id: 9416
-  time: '2026-01-18T20:44:50.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42503
-- author: sowelipililimute
-  changes:
-  - message: Gibbing now drops your inventory contents again.
-    type: Fix
-  id: 9417
-  time: '2026-01-18T21:25:27.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42504
-- author: sowelipililimute
-  changes:
-  - message: Vent critters, rat king, etc. now ghost when dead instead of requiring
-      the player to /ghost.
-    type: Fix
-  id: 9418
-  time: '2026-01-18T21:41:57.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42506
-- author: Thinbug0
-  changes:
-  - message: Peek at the future with this new Magic 9 Ball!
-    type: Add
-  id: 9419
-  time: '2026-01-18T23:16:32.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42189
-- author: aada
-  changes:
-  - message: Items given to the medical department round start have been significantly
-      rebalanced. In particular, players no longer spawn with their tools and must
-      get them from a locker or vending machine.
-    type: Tweak
-  id: 9420
-  time: '2026-01-19T05:21:50.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42423
-- author: DDeegan
-  changes:
-  - message: Thieving Beacons set their coordinates automatically when unfolded.
-    type: Tweak
-  id: 9421
-  time: '2026-01-19T09:18:14.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42520
-- author: ArtisticRoomba
-  changes:
-  - message: The flashbang, explosive grenade, electrical disruptor kit, and cluster
-      grenade have been removed from the traitor uplink.
-    type: Remove
-  - message: The grenade penguin has been lowered in price to 4 TC.
-    type: Tweak
-  - message: The syndicate bomb has had its explosive power tweaked. It is now a more
-      concentrated explosion over a smaller area.
-    type: Tweak
-  - message: The EMP Grenade now detonates on impact.
-    type: Tweak
-  id: 9422
-  time: '2026-01-19T22:10:03.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42477
-- author: Princess-Cheeseballs
-  changes:
-  - message: Tazinide and Licoxide now are less effective at shocking and don't last
-      as long.
-    type: Tweak
-  - message: Nocturine now lasts 9 seconds instead of 6 seconds.
-    type: Tweak
-  - message: Hyperzine overdose can no longer be negated completely with Omnizine.
-    type: Tweak
-  - message: Hypodarts now have an increased chemical capacity of 10u up from 7u
-    type: Tweak
-  - message: Combat Medkit and Combat Medipen have had their prices reduced to 3 TC
-    type: Tweak
-  id: 9423
-  time: '2026-01-19T22:33:08.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42484
-- author: Princess-Cheeseballs
-  changes:
-  - message: Web Vests are now 5 TC and Bloodred Hardsuits are now 7 TC.
-    type: Tweak
-  - message: All outer clothes with pockets are now 2x3, all armored outerwear are
-      now 3x4.
-    type: Tweak
-  - message: Chameleon Kit now comes with an Agent ID card for free. Chameleon sunglasses
-      now offer flash protection. Chameleon Vests can now wear oxygen tanks.
-    type: Tweak
-  - message: Several items such as the Carp Hardsuit, Syndicate EVA Suit, Blood-Red
-      Magboots, and Syndicate Jetpack have had their costs reduced.
-    type: Tweak
-  - message: Syndicate Shoulder Holster has been removed.
-    type: Remove
-  id: 9424
-  time: '2026-01-19T22:48:48.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42482
-- author: Princess-Cheeseballs
-  changes:
-  - message: Longarms in the uplink are cheaper but don't come with extra ammo.
-    type: Tweak
-  - message: Syndicate knuckle dusters are now 4 TC
-    type: Tweak
-  - message: Shotgun slugs in the uplink are now 2 TC
-    type: Tweak
-  - message: China Lake's grenades now fly slower in the air
-    type: Tweak
-  - message: Python has been removed from the uplink
-    type: Remove
-  id: 9425
-  time: '2026-01-19T23:06:47.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42468
-- author: ahandleman
-  changes:
-  - message: Fixed seeds being unique after sampling.
-    type: Fix
-  id: 9426
-  time: '2026-01-20T01:41:24.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42527
-- author: sowelipililimute
-  changes:
-  - message: The time-locked loadout towels have been removed.
-    type: Remove
-  id: 9427
-  time: '2026-01-20T05:15:24.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42536
-- author: sowelipililimute
-  changes:
-  - message: The markings editor has been redesigned to have a better UI.
-    type: Tweak
-  - message: The character export format has changed and characters from newer servers
-      may not work when exported to older servers.
-    type: Tweak
-  id: 9428
-  time: '2026-01-20T07:23:51.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42476
-- author: sowelipililimute
-  changes:
-  - message: Inflatables can now be sourced from emergency lockers.
-    type: Add
-  id: 9429
-  time: '2026-01-20T08:03:06.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42539
-- author: B_Kirill
-  changes:
-  - message: Hair styling tools, such as mirrors and scissors, now use their own names
-      as UI window titles.
-    type: Tweak
-  - message: Hair styling tools, such as mirrors and scissors, no longer attempt to
-      open UI on non-humanoids.
-    type: Fix
-  id: 9430
-  time: '2026-01-20T12:15:37.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42544
-- author: insoPL
-  changes:
-  - message: Added icon indicating if the gloves are insulated or not.
-    type: Add
-  id: 9431
-  time: '2026-01-20T16:02:53.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42444
-- author: sowelipililimute
-  changes:
-  - message: Voice emotes are now correct for your character's sex
-    type: Fix
-  id: 9432
-  time: '2026-01-20T19:29:53.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42550
-- author: Velken, Murphyneko
-  changes:
-  - message: Station tiles and floors can now be placed on planets, asteroids and
-      different platings.
-    type: Tweak
-  id: 9433
-  time: '2026-01-20T20:51:15.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42543
-- author: osjarw
-  changes:
-  - message: Now the Medibot has a DoAfter bar, displaying injection progress.
-    type: Add
-  id: 9434
-  time: '2026-01-20T21:07:38.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/32932
-- author: sowelipililimute
-  changes:
-  - message: Species now properly render their sex-specific sprites
-    type: Fix
-  id: 9435
-  time: '2026-01-20T21:24:06.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42554
-- author: ScarKy0
-  changes:
-  - message: Audio for mortars, juicers and the paperfuge can no longer be stacked
-      infinitely.
-    type: Fix
-  id: 9436
-  time: '2026-01-20T21:40:41.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42498
-- author: Velken
-  changes:
-  - message: RCD can no longer spam lights in the same spot.
-    type: Fix
-  - message: RCD can no longer be used to destroy indestructible tiles.
-    type: Fix
-  id: 9437
-  time: '2026-01-20T22:04:09.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42556
-- author: sowelipililimute
-  changes:
-  - message: Clothing now hides your body when it should, and doesn't show your body
-      when it shouldn't.
-    type: Fix
-  id: 9438
-  time: '2026-01-20T22:39:51.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42553
-- author: kipdotnet
-  changes:
-  - message: The "Lizard Power" graffiti decal has been replaced.
-    type: Tweak
-  id: 9439
-  time: '2026-01-20T22:39:51.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42541
-- author: ArtisticRoomba
-  changes:
-  - message: Powernet consumers like lathes, computers, blenders, centrifuges, electrolyzers,
-      grinders, holopads, microwaves, etc. now have simple dynamic power consumption
-      behavior. When not in use, they will consume either little or no power, and
-      while in use, they will consume a sane amount of power.
-    type: Add
-  id: 9440
-  time: '2026-01-21T04:21:38.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41961
-- author: sowelipililimute
-  changes:
-  - message: Cat tails are no longer accessible to humans.
-    type: Fix
-  id: 9441
-  time: '2026-01-22T02:43:47.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42579
-- author: ArtisticRoomba
-  changes:
-  - message: Extra-bright lantern has been removed from the traitor uplink.
-    type: Remove
-  - message: Stealthbox has been buffed significantly, you'll be able to remain in
-      stealth for much longer when moving at speed.
-    type: Tweak
-  - message: Decoy bundle has been moved to the Useless category and reduced to 1
-      TC in the traitor uplink.
-    type: Tweak
-  id: 9442
-  time: '2026-01-22T07:45:20.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42510
-- author: ScarKy0
-  changes:
-  - message: Force-prying crit borgs now also opens their panel.
-    type: Tweak
-  id: 9443
-  time: '2026-01-22T09:59:49.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42460
-- author: VlaDOS1408
-  changes:
-  - message: The cargo request console UI has been redesigned.
-    type: Tweak
-  id: 9444
-  time: '2026-01-22T16:53:48.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/34052
-- author: Absotively
-  changes:
-  - message: APC power toggle and midi channel window "show track names" button now
-      use switch-style buttons
-    type: Tweak
-  id: 9445
-  time: '2026-01-22T17:46:58.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/39161
-- author: SabreML
-  changes:
-  - message: Added a colour picker and colour palette selector to the Spraypainter's
-      decal menu.
-    type: Add
-  - message: Made a few other tweaks to the Spraypainter's UI as well.
-    type: Tweak
-  id: 9446
-  time: '2026-01-22T18:02:54.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41943
-- author: Minerva
-  changes:
-  - message: Defibrillator cabinets can now be constructed and deconstructed.
-    type: Add
-  id: 9447
-  time: '2026-01-22T18:43:26.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42571
-- author: sowelipililimute
-  changes:
-  - message: Arachnids can now eat raw meat again.
-    type: Fix
-  id: 9448
-  time: '2026-01-22T21:14:52.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42529
-- author: sowelipililimute
-  changes:
-  - message: Hands will no longer sometimes display in the wrong order.
-    type: Fix
-  id: 9449
-  time: '2026-01-22T21:47:37.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42534
-- author: Bhijn and Myr
-  changes:
-  - message: Grappling hooks have been reworked. They are now physics-driven, meaning
-      that they use actual physical forces to retract.
-    type: Tweak
-  - message: The majority of known exploits of grappling hooks have been fixed as
-      a result. You can no longer clip into walls via grappling hook, and you can
-      no longer teleport your friends across the station by having them hook onto
-      an object and stay still.
-    type: Fix
-  id: 9450
-  time: '2026-01-22T22:30:46.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42409
-- author: B_Kirill
-  changes:
-  - message: Fixed construction preview ghost sprite offset not matching the original
-      entity.
-    type: Fix
-  id: 9451
-  time: '2026-01-22T22:47:33.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42193
-- author: Beck, Julian
-  changes:
-  - message: Added feedback popups that players get at the end of the round! They
-      will list all "test" PRs or PRs that people want feedback on. Right now they
-      will link to a form thread
-    type: Add
-  id: 9452
-  time: '2026-01-22T22:47:33.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41352
-- author: archee1
-  changes:
-  - message: thief's 'Steal the beer goggles' objective has been replaced with 'Steal
-      the HUDs' collection objective, requiring varied HUD eyewear items.
-    type: Tweak
-  id: 9453
-  time: '2026-01-22T23:04:31.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/38043
-- author: sowelipililimute
-  changes:
-  - message: Drinking or eating things now gradually trickles into the bloodstream,
-      instead of being a fixed delay
-    type: Tweak
-  - message: Reagent effect groups are now stages of metabolism in the guidebook
-    type: Tweak
-  - message: Many reagents that break down into other ones have clearer guidebook
-      descriptions and slightly adjusted behaviour
-    type: Tweak
-  id: 9454
-  time: '2026-01-23T02:05:59.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42172
-- author: Princess-Cheeseballs
-  changes:
-  - message: Added the Syndimov Lawboard to the Traitor Uplink.
-    type: Add
-  - message: You can now get Pythons and Cat Ears in the Syndicate Snack box.
-    type: Add
-  - message: Removed Whitehole Grenade, Necronomicon, Explosive Banana Peel and Super
-      Surplus crates from the uplink.
-    type: Remove
-  - message: Removed Singularity Beacon and Antimov Lawboard from the Traitor Uplink.
-    type: Remove
-  - message: Several less used uplink items have had their costs reduced.
-    type: Tweak
-  - message: Clustersoap and Cluster Bananas now explodes into soaplets when thrown
-      and no longer needs to be primed. The Clustersoap has been reduced to 1 TC as
-      well.
-    type: Tweak
-  - message: Martyr Cyborgs now start glowing red before exploding.
-    type: Tweak
-  - message: Scram Implanter's range has been crunched down to 10-15 tiles from 0-100.
-    type: Tweak
-  - message: Rigged Boxing Gloves have had their overall time to stun increased but
-      are also now available for all Traitors to purchase.
-    type: Tweak
-  - message: Combat bakery kit now comes with a flatpack microwave instead of a machine
-      board. The throwing croissants and baguette have been made equivalent in damage
-      to other Traitor uplink items as well.
-    type: Tweak
-  - message: Holoclowns no longer try to attack their host.
-    type: Fix
-  - message: Singularity grenade shouldn't throw you inside walls anymore
-    type: Fix
-  id: 9455
-  time: '2026-01-24T00:26:43.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42582
-- author: alexalexmax
-  changes:
-  - message: Tasers no longer slow holoparasites down.
-    type: Fix
-  id: 9456
-  time: '2026-01-24T04:18:37.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42315
-- author: Hitlinemoss
-  changes:
-  - message: The "Auto-fill the highlights with the character's information" accessibility
-      option has been renamed to "Automatically set the highlights list based on your
-      character's name and job".
-    type: Tweak
-  - message: More automatic job-text highlights have been added.
-    type: Tweak
-  id: 9457
-  time: '2026-01-24T21:06:28.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42630
-- author: SlamBamActionman
-  changes:
-  - message: Added an toggle for "hold-to-attack" under the accessibility tab.
-    type: Add
-  id: 9458
-  time: '2026-01-25T22:30:52.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42596
-- author: roryflowers
-  changes:
-  - message: Tritium's thermal output is increased to its previous value, to reenable
-      maxcap explosives and make the TEG easier to run.
-    type: Fix
-  id: 9459
-  time: '2026-01-26T00:39:55.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42641
-- author: SlamBamActionman
-  changes:
-  - message: Crowbars are now consistent with other 1x2 items in terms of storage,
-      e.g. in pockets.
-    type: Tweak
-  id: 9460
-  time: '2026-01-26T01:35:49.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42585
-- author: ScholarNZL
-  changes:
-  - message: Fixed a dev environment crash related to construction event validation.
-    type: Fix
-  id: 9461
-  time: '2026-01-26T06:12:02.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41396
-- author: B_Kirill
-  changes:
-  - message: Fixed being able to pick up chameleon projector disguises via context
-      menu.
-    type: Fix
-  id: 9462
-  time: '2026-01-26T14:03:39.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42656
-- author: Ohelig
-  changes:
-  - message: Empty gas canisters now have a populated UI.
-    type: Fix
-  id: 9463
-  time: '2026-01-26T15:02:20.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42616
-- author: notquitehadouken
-  changes:
-  - message: Doors close on clown spider webs now
-    type: Fix
-  id: 9464
-  time: '2026-01-26T15:19:39.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42589
-- author: Marlyn
-  changes:
-  - message: Opporozidone no longer has instarot issues that get worse the longer
-      the server has been running
-    type: Fix
-  id: 9465
-  time: '2026-01-26T15:45:24.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42472
-- author: PJB3005
-  changes:
-  - message: Job lizard plushies can be found in various lockers around the station
-      instead of being loadout items.
-    type: Tweak
-  id: 9466
-  time: '2026-01-26T16:15:54.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42545
-- author: Princess-Cheeseballs
-  changes:
-  - message: Boxing gloves in the uplink are now the rigged variants instead of the
-      normal variants.
-    type: Fix
-  id: 9467
-  time: '2026-01-26T20:25:53.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42662
-- author: ScholarNZL
-  changes:
-  - message: Fixed an exploit where deconstructing a meat spike with the correct timing
-      could delete someone being hooked onto it.
-    type: Fix
-  id: 9468
-  time: '2026-01-27T04:24:58.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42644
-- author: B_Kirill
-  changes:
-  - message: Fireplaces can now ignite gases.
-    type: Tweak
-  - message: Entities buckled to the bonfire with stake no longer suffocate in the
-      walls above the bonfire.
-    type: Fix
-  id: 9469
-  time: '2026-01-27T13:35:54.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42675
-- author: ScholarNZL
-  changes:
-  - message: Removed a duplicate disposal bin entity in Kitchen.
-    type: Tweak
-  id: 9470
-  time: '2026-01-27T21:01:59.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42670
-- author: Princess-Cheeseballs
-  changes:
-  - message: Friendly visitor shuttles will no longer spawn.
-    type: Remove
-  - message: Syndicate Evac pod will no longer spawn.
-    type: Remove
-  id: 9471
-  time: '2026-01-27T23:03:05.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41915
-- author: Velken
-  changes:
-  - message: Fixed some explosions ignoring indestructible tiles.
-    type: Fix
-  id: 9472
-  time: '2026-01-28T00:37:53.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42682
-- author: ShepardToTheStars
-  changes:
-  - message: The health analyzer and the MedTek PDA app now reactivate once you get
-      back in range of your patient.
-    type: Tweak
-  id: 9473
-  time: '2026-01-28T08:42:18.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42608
-- author: Huaqas
-  changes:
-  - message: Removed the Reptilian laugh sound effect due to copyright concerns.
-    type: Remove
-  id: 9474
-  time: '2026-01-28T11:55:00.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42594
-- author: SlamBamActionman
-  changes:
-  - message: Silicons now see an indicator for jobs that are considered "crew" under
-      the normal crewsimov lawset.
-    type: Add
-  id: 9475
-  time: '2026-01-29T07:13:48.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37038
-- author: Princess-Cheeseballs
-  changes:
-  - message: Estoc DMR is now only purchasable by Nukies
-    type: Tweak
-  id: 9476
-  time: '2026-01-29T08:11:10.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42698
-- author: jessicamaybe
-  changes:
-  - message: Mobs that don't need internals no longer have the internals indicator
-    type: Tweak
-  id: 9477
-  time: '2026-01-30T05:30:13.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42705
-- author: Thinbug0
-  changes:
-  - message: Ghosts appearances will now change depending on their cause of death
-    type: Add
-  id: 9478
-  time: '2026-01-30T23:31:08.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37949
-- author: SlamBamActionman
-  changes:
-  - message: Mime PDAs no longer have the NanoTask and Notekeeper applications installed
-      by default.
-    type: Remove
-  id: 9479
-  time: '2026-01-31T22:38:01.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42706
-- author: Samuka
-  changes:
-  - message: Fax machines now add text to the paper telling where the fax is from
-    type: Tweak
-  id: 9480
-  time: '2026-02-01T18:12:16.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41108
-- author: Quantum-cross
-  changes:
-  - message: Anomalies will no longer spawn multiple things on the same tile (asteroid
-      wall, etc)
-    type: Fix
-  id: 9481
-  time: '2026-02-02T12:35:31.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37833
-- author: Samur7
-  changes:
-  - message: Security bio suit now hides tails again.
-    type: Fix
-  id: 9482
-  time: '2026-02-02T16:45:34.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42748
-- author: sowelipililimute
-  changes:
-  - message: DNA scrambling properly
-    type: Fix
-  id: 9483
-  time: '2026-02-02T23:54:12.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42757
-- author: sowelipililimute
-  changes:
-  - message: Dragons now heal when eating people again
-    type: Fix
-  id: 9484
-  time: '2026-02-03T00:32:09.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42758
-- author: sowelipililimute
-  changes:
-  - message: Zombified markings no longer persist between rounds
-    type: Fix
-  id: 9485
-  time: '2026-02-03T03:28:51.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42756
-- author: sowelipililimute
-  changes:
-  - message: Marking colours can now be changed again
-    type: Fix
-  id: 9486
-  time: '2026-02-03T19:00:17.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42771
-- author: Minemoder
-  changes:
-  - message: The Syndi Law Circuit is now a kit containing the lawboard and and a
-      Syndicate ID.
-    type: Tweak
-  - message: The Syndicate ID now uses the Syndicate icon instead of the blank icon.
-    type: Tweak
-  id: 9487
-  time: '2026-02-03T20:12:55.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42764
-- author: veprolet
-  changes:
-  - message: Volumetric devices now respect their pressure limits more.
-    type: Fix
-  id: 9489
-  time: '2026-02-04T10:43:59.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/35211
-- author: 0-Anon
-  changes:
-  - message: Adjusted the Mute Toxin chemical reaction recipe to no longer require
-      uranium.
-    type: Tweak
-  id: 9490
-  time: '2026-02-04T19:24:59.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42787
-- author: ScholarNZL
-  changes:
-  - message: Rat King and Rat Servants now have partial shock resistance, preventing
-      electrified doors from stunning them while still dealing reduced damage.
-    type: Tweak
-  id: 9491
-  time: '2026-02-04T22:13:06.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42569
-- author: ArtisticRoomba
-  changes:
-  - message: Fixed the Gas Filter not transferring enough mols to the filter outlet.
-    type: Fix
-  id: 9492
-  time: '2026-02-05T08:34:11.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42801
-- author: insoPL, ArtisticRoomba
-  changes:
-  - message: Added functionality to the Optical Thermal Scanner. The eyewear will
-      now overlay tiles with a solid color corresponding to its temperature if it's
-      not room temperature, as well as if a tile is pure vacuum.
-    type: Add
-  id: 9493
-  time: '2026-02-06T10:44:18.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42613
-- author: AreYouConfused
-  changes:
-  - message: Vox's tail rings no longer replace the vox's tail and now correctly layer
-      ontop of the tail.
-    type: Fix
-  id: 9494
-  time: '2026-02-06T21:18:22.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42808
-- author: 11BelowStudio
-  changes:
-  - message: Chaplains can now choose a custom name. Hallelujah!
-    type: Add
-  id: 9495
-  time: '2026-02-07T01:46:53.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42819
-- author: InsoPL
-  changes:
-  - message: Optical Thermal Scanners can now be found in the Engi-Vend.
-    type: Add
-  id: 9496
-  time: '2026-02-07T10:10:58.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42824
-- author: DIMMoon1
-  changes:
-  - message: Firelocks now automatically re-close if they have a danger signal and
-      they're powered.
-    type: Fix
-  id: 9497
-  time: '2026-02-07T10:35:56.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37523
-- author: qwerltaz
-  changes:
-  - message: Ammonia and Nitrous Oxide now do more damage according to the concentration
-      of gas in the atmosphere.
-    type: Tweak
-  id: 9498
-  time: '2026-02-07T10:51:57.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/39591
-- author: SuperGDPWYL
-  changes:
-  - message: Emitters now alert the Engineering radio channel if they are destroyed,
-      deconstructed, lose power or are unlocked, when powered.
-    type: Add
-  id: 9499
-  time: '2026-02-07T12:02:24.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/39513
-- author: MidZik
-  changes:
-  - message: Fixed containment fields dying even when one side still had power.
-    type: Fix
-  id: 9500
-  time: '2026-02-07T12:54:14.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41006
-- author: PAFFhassoocks
-  changes:
-  - message: The nukie infiltrator ship now starts with a universal pinpointer.
-    type: Tweak
-  id: 9501
-  time: '2026-02-07T13:17:49.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42101
-- author: SlamBamActionman
-  changes:
-  - message: Stackables items now merge when stopping on/after a conveyor belt.
-    type: Add
-  id: 9502
-  time: '2026-02-07T13:34:08.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42829
-- author: 11BelowStudio
-  changes:
-  - message: Closed the legal loophole which technically allowed engineers to open-carry
-      the syndicate fire axe.
-    type: Fix
-  id: 9503
-  time: '2026-02-07T15:30:24.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42820
-- author: TrixxedHeart
-  changes:
-  - message: Vox can now wag their tails
-    type: Add
-  id: 9504
-  time: '2026-02-08T01:38:54.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/40925
-- author: Liem161
-  changes:
-  - message: Added sprites for holding practice disabler in both hands.
-    type: Add
-  id: 9505
-  time: '2026-02-08T03:41:21.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42838
-- author: salarua
-  changes:
-  - message: Warfarin is now named heparin.
-    type: Fix
-  id: 9506
-  time: '2026-02-08T04:38:09.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42847
-- author: TriviaSolari
-  changes:
-  - message: RCDs can once again be used to construct hull tiles in space without
-      requiring lattices first
-    type: Fix
-  id: 9507
-  time: '2026-02-09T01:12:17.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42740
-- author: TytosB
-  changes:
-  - message: 'added new station: Serpentcrest. along with accompanying evac and cargo
-      shuttles'
-    type: Add
-  id: 9508
-  time: '2026-02-09T07:05:01.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/38991
-- author: mdrkrg
-  changes:
-  - message: APC sprites now shows the correct state on round start.
-    type: Fix
-  id: 9509
-  time: '2026-02-09T13:14:57.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42852
-- author: ScarKy0
-  changes:
-  - message: Vulpkanin now have a yawn sound.
-    type: Add
-  id: 9510
-  time: '2026-02-09T15:32:39.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42768
-- author: TytosB
-  changes:
-  - message: adjusted several rooms and added missing items on map serpentcrest. increased
-      min pop to 50.
-    type: Tweak
-  id: 9511
-  time: '2026-02-09T20:34:02.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42863
-- author: SeaWyrm
-  changes:
-  - message: Horizonal and vertical steel slat floor tiles, as well as their dark
-      and white variants, can now be created with a Cutter lathe.
-    type: Add
-  id: 9512
-  time: '2026-02-10T01:48:01.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/37832
-- author: ArtisticRoomba
-  changes:
-  - message: Fixed filters not transferring heat energy from the inlet to the filter
-      outlet while still transferring physical gas.
-    type: Fix
-  id: 9513
-  time: '2026-02-10T10:26:03.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42876
-- author: 11BelowStudio
-  changes:
-  - message: Regular bots are now repaired gradually (short incremental doafters)
-      instead of via one long doafter, for parity with borgs.
-    type: Tweak
-  id: 9514
-  time: '2026-02-10T17:15:00.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42878
-- author: TiniestShark
-  changes:
-  - message: Added the ability for Vulps to wag their tails.
-    type: Add
-  id: 9515
-  time: '2026-02-10T22:26:00.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42843
-- author: magnnusson
-  changes:
-  - message: Intercoms can now be constructed on walls.
-    type: Fix
-  id: 9516
-  time: '2026-02-11T20:01:44.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42821
-- author: Minemoder
-  changes:
-  - message: The sneeze emote has been readded.
-    type: Add
-  id: 9517
-  time: '2026-02-11T22:01:36.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41479
-- author: bnuuy
-  changes:
-  - message: Cleaning evidence off a person no longer reveals their true identity.
-    type: Fix
-  id: 9518
-  time: '2026-02-11T22:31:43.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42868
-- author: bnuuy
-  changes:
-  - message: The fake mindshield action button now correctly shows your mindshield
-      status when using the chameleon controller.
-    type: Fix
-  id: 9521
-  time: '2026-02-13T05:25:04.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42900
-- author: bnuuy
-  changes:
-  - message: Changing your name with the Identity Mask implant now automatically updates
-      your Agent ID!
-    type: Tweak
-  id: 9522
-  time: '2026-02-13T21:58:20.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42772
-- author: ScarKy0
-  changes:
-  - message: Vulpkanins now have sulfur-based blood and unique organ sprites.
-    type: Add
-  id: 9523
-  time: '2026-02-14T23:49:21.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42722
-- author: ScarKy0
-  changes:
-  - message: Paradox clones now correctly copy the voice and pronouns of the original.
-    type: Fix
-  id: 9524
-  time: '2026-02-15T01:24:33.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42923
-- author: TriviaSolari
-  changes:
-  - message: Station AI is now able to read loose papers and envelopes.
-    type: Tweak
-  id: 9525
-  time: '2026-02-15T10:59:24.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42926
-- author: Le-Arctic-Fox
-  changes:
-  - message: Changed viper magazine to high capacity in the basic operative bundle
-    type: Fix
-  id: 9526
-  time: '2026-02-15T11:16:02.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42927
-- author: ScarKy0
-  changes:
-  - message: Drinking blood as non-animal species makes you sick again.
-    type: Fix
-  - message: Injecting someone else's blood is now slightly poisonous.
-    type: Add
-  id: 9527
-  time: '2026-02-16T17:25:45.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42942
-- author: Synthestra
-  changes:
-  - message: Thieves' "Steal the HUDs" objective can now be completed with the thieving
-      beacon
-    type: Fix
-  id: 9528
-  time: '2026-02-16T20:43:08.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42945
-- author: Steel
-  changes:
-  - message: Jetpacks now turn off when another jetpack is activated.
-    type: Fix
-  id: 9529
-  time: '2026-02-16T22:03:05.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42689
-- author: nekokiwa
-  changes:
-  - message: Barber Scissors no longer misgender the target when blocked by a hat.
-    type: Fix
-  id: 9530
-  time: '2026-02-16T23:03:26.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42948
-- author: Pgriha
-  changes:
-  - message: Added new emote for moths. They can flaps their wings!
-    type: Add
-  id: 9531
-  time: '2026-02-18T00:04:52.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42912
-- author: pcaessayrs
-  changes:
-  - message: Added Emp interaction with bar sign
-    type: Add
-  id: 9532
-  time: '2026-02-18T00:27:56.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42950
-- author: Minemoder, ScarKy0
-  changes:
-  - message: Diona, Vox and Vulpkanins now have unique sneeze sounds.
-    type: Add
-  id: 9533
-  time: '2026-02-18T02:02:44.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42929
-- author: PicklOH
-  changes:
-  - message: Fixed Det coat armor values
-    type: Fix
-  id: 9534
-  time: '2026-02-18T20:06:53.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42969
-- author: robinthegirlthing
-  changes:
-  - message: The basic operative bundle now contains an esword, instead of a viper
-      magazine and agent ID card.
-    type: Tweak
-  id: 9535
-  time: '2026-02-18T21:10:25.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42930
-- author: Samuka
-  changes:
-  - message: Added more xenoborg names!
-    type: Add
-  id: 9537
-  time: '2026-02-21T23:54:26.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42984
-- author: lyxcaster
-  changes:
-  - message: Made glasses actually correct short-sighted vision!
-    type: Tweak
-  id: 9538
-  time: '2026-02-22T00:07:34.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42990
-- author: SlamBamActionman
-  changes:
-  - message: Added unlockable press hat and press vest for the Reporter job.
-    type: Add
-  id: 9539
-  time: '2026-02-22T22:52:38.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/41079
-- author: 11BelowStudio
-  changes:
-  - message: Added an extra APC to the comms room in Packed, to stop it from getting
-      overloaded at round start.
-    type: Fix
-  id: 9540
-  time: '2026-02-22T23:20:39.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42953
-- author: ketufaispikinut
-  changes:
-  - message: Changed the EMP Implanter's uplink icon so it is less easily confused
-      with the Scram Implanter's.
-    type: Tweak
-  id: 9541
-  time: '2026-02-23T01:24:02.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42998
-- author: DaturoDewitt
-  changes:
-  - message: Lizards can laugh again!
-    type: Add
-  id: 9542
-  time: '2026-02-23T23:07:01.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42915
-- author: TiniestShark
-  changes:
-  - message: Removed the majority of unique corgi sprites.
-    type: Remove
-  id: 9543
-  time: '2026-02-25T01:34:33.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/42696
+AdminOnly: false
+Entries:
 - author: ScarKy0
   changes:
   - message: Cyborgs can now pry unpowered doors without the need for a crowbar.
     type: Add
-  - message: Entities that can pry things innately (zombies, spiders, etc) now have
-      an alert telling them so.
+  - message: Entities that can pry things innately (zombies, spiders, etc) now have an alert telling them so.
     type: Add
   id: 9544
   time: '2026-02-25T23:33:16.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/41812
 - author: SlamBamActionman
   changes:
-  - message: Tweaked German, Scottish (previously Dwarfish) and Southern accents to
-      not outright replace words.
+  - message: Tweaked German, Scottish (previously Dwarfish) and Southern accents to not outright replace words.
     type: Tweak
   id: 9545
   time: '2026-02-26T17:45:58.0000000+00:00'
@@ -2525,46 +32,35 @@
   url: https://github.com/space-wizards/space-station-14/pull/42962
 - author: TriviaSolari
   changes:
-  - message: Holosign projectors and dragon rifts no longer place signs at strange
-      angles.
+  - message: Holosign projectors and dragon rifts no longer place signs at strange angles.
     type: Fix
   id: 9548
   time: '2026-02-27T00:08:28.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/42909
 - author: sowelipililimute
   changes:
-  - message: Underlying technical work for future medical improvements have resulted
-      in the following changes to better accomodate future development. Please note
-      that these changes are not representative of the final product and that the
-      medical balance will receive a major overhaul once limb and organ damage are
-      fully implemented.
+  - &o0
+    message: Underlying technical work for future medical improvements have resulted in the following changes to better accomodate future development. Please note that these changes are not representative of the final product and that the medical balance will receive a major overhaul once limb and organ damage are fully implemented.
     type: Tweak
   - message: Species now regenerate -0.05 of brute types individually (from -0.02).
     type: Tweak
-  - message: Several mobs and weapons previously dealing split brute damage now deal
-      singular damage types.
+  - message: Several mobs and weapons previously dealing split brute damage now deal singular damage types.
     type: Tweak
-  - message: Several reagents previously dealing split brute damage now deals singular
-      damage types.
+  - message: Several reagents previously dealing split brute damage now deals singular damage types.
     type: Tweak
-  - message: Several reagents previously healing split brute damage now evenly heals
-      instead.
+  - message: Several reagents previously healing split brute damage now evenly heals instead.
     type: Tweak
-  - message: Spiders now regenerate -0.03 of brute and burn types individually (from
-      -0.02).
+  - message: Spiders now regenerate -0.03 of brute and burn types individually (from -0.02).
     type: Tweak
   - message: Skeletons now evenly heal when using milk.
     type: Tweak
-  - message: Tomato killers now heal evenly when splashed with water, blood, or robust
-      harvest.
+  - message: Tomato killers now heal evenly when splashed with water, blood, or robust harvest.
     type: Tweak
   - message: Tricordrazine now evenly heals both brute, burn and toxin.
     type: Tweak
-  - message: Desoxyephedrine now deals slighlty more blunt damage (to offset tricordazine
-      changes).
+  - message: Desoxyephedrine now deals slighlty more blunt damage (to offset tricordazine changes).
     type: Tweak
-  - message: Crusher mark leech hits now heal 5 of each brute category on hit (was
-      7).
+  - message: Crusher mark leech hits now heal 5 of each brute category on hit (was 7).
     type: Tweak
   id: 9549
   time: '2026-02-27T06:33:44.0000000+00:00'
@@ -2585,8 +81,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43066
 - author: ScarKy0
   changes:
-  - message: Makeshift Juicers now correctly craft in your hands instead of being
-      a construction ghost.
+  - message: Makeshift Juicers now correctly craft in your hands instead of being a construction ghost.
     type: Fix
   id: 9553
   time: '2026-02-28T14:54:14.0000000+00:00'
@@ -2600,8 +95,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43013
 - author: Velken
   changes:
-  - message: Fixed door remotes working on fences, curtains and other entities they
-      shouldn't work on.
+  - message: Fixed door remotes working on fences, curtains and other entities they shouldn't work on.
     type: Fix
   id: 9555
   time: '2026-02-28T20:30:12.0000000+00:00'
@@ -2617,8 +111,7 @@
   changes:
   - message: The rollerskates and clown mask/shoes cargo bounties have been removed.
     type: Remove
-  - message: The pancakes cargo bounty now requires half as many pancakes, but rewards
-      half as many spesos.
+  - message: The pancakes cargo bounty now requires half as many pancakes, but rewards half as many spesos.
     type: Tweak
   id: 9557
   time: '2026-02-28T22:04:55.0000000+00:00'
@@ -2685,28 +178,19 @@
   url: https://github.com/space-wizards/space-station-14/pull/43082
 - author: august-sun
   changes:
-  - message: The Estoc DMR now has less slowdown when wielding and the same accuracy
-      as other rifles.
+  - message: The Estoc DMR now has less slowdown when wielding and the same accuracy as other rifles.
     type: Tweak
   id: 9566
   time: '2026-03-07T02:00:51.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43038
 - author: sowelipililimute
   changes:
-  - message: Underlying technical work for future medical improvements have resulted
-      in the following changes to better accomodate future development. Please note
-      that these changes are not representative of the final product and that the
-      medical balance will receive a major overhaul once limb and organ damage are
-      fully implemented.
+  - *o0
+  - message: Passive regeneration on mobs no longer stops after taking a certain amount of damage.
     type: Tweak
-  - message: Passive regeneration on mobs no longer stops after taking a certain amount
-      of damage.
-    type: Tweak
-  - message: Necrosol has been removed in favour of Acryox always healing, regardless
-      of damage.
+  - message: Necrosol has been removed in favour of Acryox always healing, regardless of damage.
     type: Remove
-  - message: Hyperzine now heals you when critical, rather than relying on being above
-      a certain amount of damage.
+  - message: Hyperzine now heals you when critical, rather than relying on being above a certain amount of damage.
     type: Tweak
   - message: Tricordrazine and Holy Water no longer have an upper damage
     type: Tweak
@@ -2731,8 +215,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/42866
 - author: ScarKy0
   changes:
-  - message: Hostile vent critters now crawl out of a single vent, alerting the station
-      about the location in advance.
+  - message: Hostile vent critters now crawl out of a single vent, alerting the station about the location in advance.
     type: Add
   - message: Friendly critters no longer have an announcement when spawning.
     type: Remove
@@ -2771,8 +254,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43225
 - author: SnappingOpossum
   changes:
-  - message: Certain randomised items and decorations no longer spawn with the wrong
-      rotation.
+  - message: Certain randomised items and decorations no longer spawn with the wrong rotation.
     type: Fix
   id: 9575
   time: '2026-03-14T16:32:36.0000000+00:00'
@@ -2786,8 +268,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43189
 - author: Centronias
   changes:
-  - message: Certain small cargo products are now delivered in parcel wrap rather
-      than in crates.
+  - message: Certain small cargo products are now delivered in parcel wrap rather than in crates.
     type: Tweak
   id: 9577
   time: '2026-03-15T13:59:56.0000000+00:00'
@@ -2808,8 +289,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43170
 - author: slarticodefast
   changes:
-  - message: The reagent grinder interactions and user interface are now predicted
-      and should feel much more responsive.
+  - message: The reagent grinder interactions and user interface are now predicted and should feel much more responsive.
     type: Tweak
   id: 9580
   time: '2026-03-15T19:29:12.0000000+00:00'
@@ -2823,16 +303,14 @@
   url: https://github.com/space-wizards/space-station-14/pull/42394
 - author: murolem
   changes:
-  - message: Retextured technology disk to have the color of their discipline and
-      extra marks for each tier. Also increased sell price for higher-tier disks.
+  - message: Retextured technology disk to have the color of their discipline and extra marks for each tier. Also increased sell price for higher-tier disks.
     type: Tweak
   id: 9582
   time: '2026-03-17T23:05:16.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37719
 - author: Buunie099
   changes:
-  - message: Fixed guidebook showing the wrong value for the maximum temperature of
-      hellfire heaters.
+  - message: Fixed guidebook showing the wrong value for the maximum temperature of hellfire heaters.
     type: Tweak
   id: 9583
   time: '2026-03-18T06:31:14.0000000+00:00'
@@ -2860,8 +338,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43321
 - author: mqole
   changes:
-  - message: Flatpacks now use the collision of the flatpacked entity, so they can
-      be opened on tables and aren't blocked by ghosts.
+  - message: Flatpacks now use the collision of the flatpacked entity, so they can be opened on tables and aren't blocked by ghosts.
     type: Fix
   id: 9587
   time: '2026-03-24T20:25:18.0000000+00:00'
@@ -2877,8 +354,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43293
 - author: ArcaneValiance
   changes:
-  - message: Ambuzol and Ambuzol Plus pills now properly cure and prevent infection
-      respectively.
+  - message: Ambuzol and Ambuzol Plus pills now properly cure and prevent infection respectively.
     type: Fix
   id: 9589
   time: '2026-03-25T13:49:55.0000000+00:00'
@@ -2906,16 +382,14 @@
   url: https://github.com/space-wizards/space-station-14/pull/43371
 - author: Minerva
   changes:
-  - message: Singularity distortion effects now respect the reduced motion accessibility
-      option.
+  - message: Singularity distortion effects now respect the reduced motion accessibility option.
     type: Tweak
   id: 9593
   time: '2026-03-28T16:01:16.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43362
 - author: M4rchy-S
   changes:
-  - message: '"Reduce motion of visual effects" now works for drunk and blood loss
-      status'
+  - message: '"Reduce motion of visual effects" now works for drunk and blood loss status'
     type: Add
   id: 9594
   time: '2026-03-28T22:19:17.0000000+00:00'
@@ -2964,8 +438,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43429
 - author: Booblesnoot42
   changes:
-  - message: 'EXPERIMENTAL: Player-controlled spiders and slimes are now forced to
-      attack if they are passive near enemies for too long.'
+  - message: 'EXPERIMENTAL: Player-controlled spiders and slimes are now forced to attack if they are passive near enemies for too long.'
     type: Tweak
   id: 9601
   time: '2026-04-03T06:18:14.0000000+00:00'
@@ -2974,8 +447,7 @@
   changes:
   - message: Added a new uplink category for objective items.
     type: Add
-  - message: 'Added a new objective for traitors: Hijack the Automated Trade Station.
-      Your uplink will have a hijack beacon for you to use if you have this objective'
+  - message: 'Added a new objective for traitors: Hijack the Automated Trade Station. Your uplink will have a hijack beacon for you to use if you have this objective'
     type: Add
   id: 9602
   time: '2026-04-03T10:35:56.0000000+00:00'
@@ -3003,24 +475,21 @@
   url: https://github.com/space-wizards/space-station-14/pull/43388
 - author: Samuka
   changes:
-  - message: When reloading guns or magazines with stack items, it only reloads one
-      at the time, instead of inserting the whole stack.
+  - message: When reloading guns or magazines with stack items, it only reloads one at the time, instead of inserting the whole stack.
     type: Fix
   id: 9606
   time: '2026-04-03T21:44:59.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/41503
 - author: 0-Anon
   changes:
-  - message: Rebalanced the syndicate reinforcement specializations to be more effective
-      at their roles.
+  - message: Rebalanced the syndicate reinforcement specializations to be more effective at their roles.
     type: Tweak
   id: 9607
   time: '2026-04-04T04:06:27.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43057
 - author: spanky-spanky
   changes:
-  - message: Cell rechargers, weapon rechargers and turbo rechargers can now be picked
-      up to transport them when unanchored.
+  - message: Cell rechargers, weapon rechargers and turbo rechargers can now be picked up to transport them when unanchored.
     type: Tweak
   id: 9608
   time: '2026-04-04T07:15:23.0000000+00:00'
@@ -3034,8 +503,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/42766
 - author: Zekins3366
   changes:
-  - message: Fixed being able to set multiple conflicting head-top visuals on humans
-      at the same time.
+  - message: Fixed being able to set multiple conflicting head-top visuals on humans at the same time.
     type: Fix
   id: 9610
   time: '2026-04-04T16:48:03.0000000+00:00'
@@ -3049,16 +517,14 @@
   url: https://github.com/space-wizards/space-station-14/pull/43445
 - author: themias
   changes:
-  - message: Instead of disappearing, space dragons now burst into giblets if they
-      go too long without summoning a rift.
+  - message: Instead of disappearing, space dragons now burst into giblets if they go too long without summoning a rift.
     type: Tweak
   id: 9612
   time: '2026-04-04T18:35:44.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43296
 - author: VanderslootAssgiraffe
   changes:
-  - message: Added new lobby art depicting a mime mocking nukies trapped behind an
-      invisible wall as the mime defuses the nuke
+  - message: Added new lobby art depicting a mime mocking nukies trapped behind an invisible wall as the mime defuses the nuke
     type: Add
   id: 9613
   time: '2026-04-04T19:38:12.0000000+00:00'
@@ -3072,8 +538,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/42701
 - author: SlamBamActionman
   changes:
-  - message: Uplink PDA codes are now universal. This means any PDA can open an uplink
-      store, as long as they have the correct code.
+  - message: Uplink PDA codes are now universal. This means any PDA can open an uplink store, as long as they have the correct code.
     type: Tweak
   - message: PDA ringtones now feature more notes.
     type: Tweak
@@ -3082,8 +547,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/38712
 - author: Naxel
   changes:
-  - message: Heavily optimized the radiation system to prevent severe server lag when
-      a large number of radiation sources are active.
+  - message: Heavily optimized the radiation system to prevent severe server lag when a large number of radiation sources are active.
     type: Fix
   id: 9616
   time: '2026-04-05T04:53:47.0000000+00:00'
@@ -3136,8 +600,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43431
 - author: psykana
   changes:
-  - message: Nuclear operatives round end summary now shows the Disk's location. If
-      it wasn't atomized, that is.
+  - message: Nuclear operatives round end summary now shows the Disk's location. If it wasn't atomized, that is.
     type: Add
   id: 9623
   time: '2026-04-06T21:41:16.0000000+00:00'
@@ -3146,8 +609,7 @@
   changes:
   - message: Added a new Traitor objective to kill the Station AI!
     type: Add
-  - message: Traitor kill objectives will now show stage names instead of character
-      names if applicable
+  - message: Traitor kill objectives will now show stage names instead of character names if applicable
     type: Fix
   id: 9624
   time: '2026-04-06T22:23:53.0000000+00:00'
@@ -3189,8 +651,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43535
 - author: AndrewFenriz
   changes:
-  - message: 'Added visual overlays to the janibelt for: Soap, Cleaner Grenade, Plungers,
-      Light Replacer, Wire Brush, Wet Floor Signs, and Holosign Projector.'
+  - message: 'Added visual overlays to the janibelt for: Soap, Cleaner Grenade, Plungers, Light Replacer, Wire Brush, Wet Floor Signs, and Holosign Projector.'
     type: Add
   - message: Added missing sprites for trash bags when equipped on the belt.
     type: Add
@@ -3199,8 +660,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43492
 - author: SirWarock
   changes:
-  - message: Fixed the Prediction Issue when trying to forcefeed someone with a pulled-down
-      mask!
+  - message: Fixed the Prediction Issue when trying to forcefeed someone with a pulled-down mask!
     type: Fix
   id: 9631
   time: '2026-04-10T13:24:59.0000000+00:00'
@@ -3223,24 +683,21 @@
   url: https://github.com/space-wizards/space-station-14/pull/43385
 - author: ArtisticRoomba
   changes:
-  - message: Fixed the pneumatic valve overshooting gas equalization between the two
-      connected pipenets.
+  - message: Fixed the pneumatic valve overshooting gas equalization between the two connected pipenets.
     type: Fix
   id: 9634
   time: '2026-04-10T20:41:53.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43542
 - author: Buunie099
   changes:
-  - message: Revenants will passively chill their environments based on how much essence
-      they have
+  - message: Revenants will passively chill their environments based on how much essence they have
     type: Add
   id: 9635
   time: '2026-04-11T10:49:41.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43500
 - author: ProPeperos
   changes:
-  - message: Fixed stacks of concrete and astro mowed/jungle grass splitting in to
-      wrong items
+  - message: Fixed stacks of concrete and astro mowed/jungle grass splitting in to wrong items
     type: Fix
   id: 9636
   time: '2026-04-11T19:05:06.0000000+00:00'
@@ -3268,41 +725,35 @@
   url: https://github.com/space-wizards/space-station-14/pull/43528
 - author: Princess-Cheeseballs
   changes:
-  - message: Target station map at the nuclear operative outpost will now show the
-      target station.
+  - message: Target station map at the nuclear operative outpost will now show the target station.
     type: Fix
   id: 9640
   time: '2026-04-13T13:40:47.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43583
 - author: Glissadia
   changes:
-  - message: The ChemMaster UI now updates automatically when reagents are dragged
-      and dropped into the ChemMaster.
+  - message: The ChemMaster UI now updates automatically when reagents are dragged and dropped into the ChemMaster.
     type: Fix
   id: 9641
   time: '2026-04-13T20:08:01.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43584
 - author: peaceful-joules
   changes:
-  - message: Airlocks that were hacked via access breaker no longer have buggy examine
-      window.
+  - message: Airlocks that were hacked via access breaker no longer have buggy examine window.
     type: Fix
   id: 9642
   time: '2026-04-16T17:25:23.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43564
 - author: perryprog
   changes:
-  - message: Door wire panels are now viewed via Alt + E, or via right clicking on
-      the door. Left clicking with a multitool or wirecutters still works as before.
-      Left clicking with other items now opens the door instead of the wire panel.
+  - message: Door wire panels are now viewed via Alt + E, or via right clicking on the door. Left clicking with a multitool or wirecutters still works as before. Left clicking with other items now opens the door instead of the wire panel.
     type: Tweak
   id: 9643
   time: '2026-04-16T22:37:00.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38733
 - author: 11BelowStudio
   changes:
-  - message: Closed the legal loophole which allowed security officers to use web
-      vests.
+  - message: Closed the legal loophole which allowed security officers to use web vests.
     type: Fix
   - message: Bartenders may only use their own armour vests.
     type: Tweak
@@ -3341,8 +792,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43629
 - author: SlamBamActionman
   changes:
-  - message: Wizard's Knock spell no longer unlocks cryosleep units, magic lamps and
-      the locker trap spell.
+  - message: Wizard's Knock spell no longer unlocks cryosleep units, magic lamps and the locker trap spell.
     type: Fix
   id: 9649
   time: '2026-04-18T16:58:59.0000000+00:00'
@@ -3358,13 +808,11 @@
   changes:
   - message: Gas Canisters can now explode from overpressure.
     type: Add
-  - message: Max Caps have been entirely reworked with different fuse lengths and
-      explosive strengths.
+  - message: Max Caps have been entirely reworked with different fuse lengths and explosive strengths.
     type: Tweak
   - message: Max Cap intensity limits have been removed.
     type: Tweak
-  - message: Tritium fire energy production has been divided by 10, returning to its
-      intended value.
+  - message: Tritium fire energy production has been divided by 10, returning to its intended value.
     type: Tweak
   - message: The TEG now produces 25% more power.
     type: Tweak
@@ -3373,8 +821,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43281
 - author: ArtisticRoomba
   changes:
-  - message: Passive gates now have better equalization behavior and have less of
-      a tendency to over-equalize.
+  - message: Passive gates now have better equalization behavior and have less of a tendency to over-equalize.
     type: Fix
   id: 9652
   time: '2026-04-19T05:51:57.0000000+00:00'
@@ -3392,8 +839,7 @@
     type: Add
   - message: NPCs can now wield guns and close their bolts.
     type: Add
-  - message: NPCs can now reload guns without a cartridge in the chamber, provided
-      there are cartridges in the clip.
+  - message: NPCs can now reload guns without a cartridge in the chamber, provided there are cartridges in the clip.
     type: Add
   id: 9654
   time: '2026-04-21T04:37:45.0000000+00:00'
@@ -3407,8 +853,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43560
 - author: themias
   changes:
-  - message: Stunning with ninja gloves now causes the swirling stars effect on the
-      victim
+  - message: Stunning with ninja gloves now causes the swirling stars effect on the victim
     type: Fix
   id: 9656
   time: '2026-04-22T04:58:52.0000000+00:00'
@@ -3436,8 +881,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43161
 - author: Nox38
   changes:
-  - message: All military boots (jack, combat, merc) now have the 50% injury slowdown
-      resistance effect.
+  - message: All military boots (jack, combat, merc) now have the 50% injury slowdown resistance effect.
     type: Tweak
   id: 9660
   time: '2026-04-24T09:01:35.0000000+00:00'
@@ -3458,8 +902,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/39044
 - author: zHonys
   changes:
-  - message: Falling asleep while crit will no longer cause you to say whatever is
-      typed in your chatbox.
+  - message: Falling asleep while crit will no longer cause you to say whatever is typed in your chatbox.
     type: Fix
   id: 9663
   time: '2026-04-24T10:48:17.0000000+00:00'
@@ -3491,24 +934,19 @@
     type: Add
   - message: Blood volume has been doubled.
     type: Tweak
-  - message: Many chef recipes have been changed so the final result better matches
-      the ingredients put in. This means overall the nutritional value of the chef's
-      meals have increased.
+  - message: Many chef recipes have been changed so the final result better matches the ingredients put in. This means overall the nutritional value of the chef's meals have increased.
     type: Tweak
   - message: Many chef recipes have had their ingredients changed
     type: Tweak
   - message: Most slicable foods now give a lot more slices.
     type: Tweak
-  - message: Reagent container sizes have been standardized, at a base of 30 units
-      per inventory square. Most containers can now hold more than they did before.
+  - message: Reagent container sizes have been standardized, at a base of 30 units per inventory square. Most containers can now hold more than they did before.
     type: Tweak
   - message: Chemical jugs and bar jugs are now Large (2x4) items.
     type: Tweak
   - message: Buckets now hold 360u and are 3x4 items.
     type: Tweak
-  - message: Nukie medical duffel bag now comes with a bicaridine jug, a mixed puncturase
-      & tranexamic acid jug, a mixed dermaline & pyrazine jug, and a mixed saline
-      & dexalin plus jug.
+  - message: Nukie medical duffel bag now comes with a bicaridine jug, a mixed puncturase & tranexamic acid jug, a mixed dermaline & pyrazine jug, and a mixed saline & dexalin plus jug.
     type: Tweak
   id: 9667
   time: '2026-04-25T02:15:12.0000000+00:00'
@@ -3611,8 +1049,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43823
 - author: Princess-Cheeseballs
   changes:
-  - message: Grindable entities as sources of reagents show up in the chemistry guidebook
-      again.
+  - message: Grindable entities as sources of reagents show up in the chemistry guidebook again.
     type: Fix
   id: 9680
   time: '2026-05-01T20:14:44.0000000+00:00'
@@ -3639,16 +1076,14 @@
   url: https://github.com/space-wizards/space-station-14/pull/43809
 - author: Centronias
   changes:
-  - message: PKA mods now apply their effects immediately upon inserting, instead
-      of requiring somebody to wield them to update with the mods' effects.
+  - message: PKA mods now apply their effects immediately upon inserting, instead of requiring somebody to wield them to update with the mods' effects.
     type: Fix
   id: 9683
   time: '2026-05-05T17:33:59.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43856
 - author: rumaks-xyz
   changes:
-  - message: Chemical dispenser and ChemMaster transfer increments have been changed
-      to 1u, 5u, 10u, 15u, 20u, 30u, 40u, 60u, and 120u
+  - message: Chemical dispenser and ChemMaster transfer increments have been changed to 1u, 5u, 10u, 15u, 20u, 30u, 40u, 60u, and 120u
     type: Tweak
   id: 9684
   time: '2026-05-06T09:59:53.0000000+00:00'
@@ -3662,8 +1097,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43877
 - author: mokiros
   changes:
-  - message: You can now examine if an item covers your eyes, mouth, or entire face
-      (like gas masks, sunglasses, etc.)
+  - message: You can now examine if an item covers your eyes, mouth, or entire face (like gas masks, sunglasses, etc.)
     type: Add
   id: 9686
   time: '2026-05-07T21:00:47.0000000+00:00'
@@ -3716,8 +1150,7 @@
   changes:
   - message: A desk bell is now included in the bureaucracy crate.
     type: Add
-  - message: Variants can be crafted by adding 2 lv cable or a bike horn after screwdrivering
-      a desk bell.
+  - message: Variants can be crafted by adding 2 lv cable or a bike horn after screwdrivering a desk bell.
     type: Add
   id: 9693
   time: '2026-05-16T22:29:20.0000000+00:00'
@@ -3752,8 +1185,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43983
 - author: Pok27
   changes:
-  - message: Radial menus no longer prevent sending to chat, or deleting text from
-      the chat input box.
+  - message: Radial menus no longer prevent sending to chat, or deleting text from the chat input box.
     type: Fix
   id: 9698
   time: '2026-05-19T11:59:10.0000000+00:00'
@@ -3762,32 +1194,27 @@
   changes:
   - message: Exo now has a Psychologist's office and job slot.
     type: Add
-  - message: Exo now features 5 Security Officer job slots (was 4) and 3 Cadet job
-      slots (was 4).
+  - message: Exo now features 5 Security Officer job slots (was 4) and 3 Cadet job slots (was 4).
     type: Tweak
   - message: Exo Botany has an additional scrubber to prevent gas leakage.
     type: Tweak
-  - message: Exo Security's mini-armory is now Sec access, and there has been a temporary
-      holding cell added.
+  - message: Exo Security's mini-armory is now Sec access, and there has been a temporary holding cell added.
     type: Tweak
   id: 9699
   time: '2026-05-20T07:22:18.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43533
 - author: mqole
   changes:
-  - message: A toggle in the Accessibility menu will now allow you to turn off the
-      static in the AI camera overlay.
+  - message: A toggle in the Accessibility menu will now allow you to turn off the static in the AI camera overlay.
     type: Add
   id: 9700
   time: '2026-05-20T19:49:00.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/44003
 - author: ScarKy0
   changes:
-  - message: Vulpkanin can now use more saturated colors in the red-orange-yellow
-      range.
+  - message: Vulpkanin can now use more saturated colors in the red-orange-yellow range.
     type: Tweak
-  - message: Vox are no longer hue restricted, but have decreased allowed saturation
-      in the red-pink colors.
+  - message: Vox are no longer hue restricted, but have decreased allowed saturation in the red-pink colors.
     type: Tweak
   id: 9701
   time: '2026-05-20T21:35:56.0000000+00:00'
@@ -3801,8 +1228,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/37708
 - author: themias
   changes:
-  - message: Prisoner IDs with permanent sentences show the correct message upon early
-      release.
+  - message: Prisoner IDs with permanent sentences show the correct message upon early release.
     type: Fix
   id: 9703
   time: '2026-05-22T16:28:14.0000000+00:00'
@@ -3816,16 +1242,14 @@
   url: https://github.com/space-wizards/space-station-14/pull/39571
 - author: perryprog
   changes:
-  - message: The wand of monkey polymorph no longer deletes items in the monkey's
-      inventory on death.
+  - message: The wand of monkey polymorph no longer deletes items in the monkey's inventory on death.
     type: Fix
   id: 9705
   time: '2026-05-22T21:10:41.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/39423
 - author: perryprog
   changes:
-  - message: Fixed an error texture appearing when holding certain items using the
-      H.A.R.M.P.A.C.K.
+  - message: Fixed an error texture appearing when holding certain items using the H.A.R.M.P.A.C.K.
     type: Fix
   id: 9706
   time: '2026-05-22T21:10:41.0000000+00:00'
@@ -3841,8 +1265,7 @@
   changes:
   - message: SSD players should no longer show the stun animation forever.
     type: Fix
-  - message: You should no longer have your vision permanently darkened if you're
-      killed while sleeping.
+  - message: You should no longer have your vision permanently darkened if you're killed while sleeping.
     type: Fix
   id: 9708
   time: '2026-05-23T08:42:11.0000000+00:00'
@@ -3893,24 +1316,21 @@
   url: https://github.com/space-wizards/space-station-14/pull/44083
 - author: ArtisticRoomba
   changes:
-  - message: Fixed Delta-Pressure computing the pressure differential for a structure
-      incorrectly.
+  - message: Fixed Delta-Pressure computing the pressure differential for a structure incorrectly.
     type: Fix
   id: 9715
   time: '2026-05-25T23:33:59.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43517
 - author: RemFexxel
   changes:
-  - message: Edited spelling errors and out-of-place text in the Space Law's crime
-      list.
+  - message: Edited spelling errors and out-of-place text in the Space Law's crime list.
     type: Fix
   id: 9716
   time: '2026-05-25T23:53:02.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/44084
 - author: Hitlinemoss
   changes:
-  - message: Several existing borg lawsets now use more unique terms than "members
-      of the crew" for their 0th law when emagged.
+  - message: Several existing borg lawsets now use more unique terms than "members of the crew" for their 0th law when emagged.
     type: Tweak
   id: 9717
   time: '2026-05-26T20:01:19.0000000+00:00'
@@ -3924,8 +1344,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/44102
 - author: Baa14453
   changes:
-  - message: Added adorable Sheep, Space Sheep, and Rainbow Sheep. Shear them with
-      wire-cutters.
+  - message: Added adorable Sheep, Space Sheep, and Rainbow Sheep. Shear them with wire-cutters.
     type: Add
   - message: Added Sheep plushies.
     type: Add
@@ -3936,30 +1355,25 @@
   url: https://github.com/space-wizards/space-station-14/pull/38505
 - author: chromiumboy
   changes:
-  - message: Creatures will be knocked down for 1.5s if they do not exit disposals
-      via a disposals unit.
+  - message: Creatures will be knocked down for 1.5s if they do not exit disposals via a disposals unit.
     type: Tweak
-  - message: Things trapped in an endless loop in disposals may spontaneously unanchor
-      a pipe and escape.
+  - message: Things trapped in an endless loop in disposals may spontaneously unanchor a pipe and escape.
     type: Tweak
-  - message: Up to 30 things can be inserted into a disposal/mailing unit before it
-      needs to be flushed.
+  - message: Up to 30 things can be inserted into a disposal/mailing unit before it needs to be flushed.
     type: Tweak
   id: 9720
   time: '2026-05-27T04:55:15.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/40540
 - author: HoofedEar
   changes:
-  - message: Reagent grinders, centrifuges, and electrolysis units no longer function
-      without power
+  - message: Reagent grinders, centrifuges, and electrolysis units no longer function without power
     type: Fix
   id: 9721
   time: '2026-05-27T05:18:36.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43879
 - author: ashley-graves
   changes:
-  - message: Fixed the overlay for DamageVisuals being under the sprite in DamageOverlay
-      mode.
+  - message: Fixed the overlay for DamageVisuals being under the sprite in DamageOverlay mode.
     type: Fix
   id: 9722
   time: '2026-05-27T09:04:26.0000000+00:00'
@@ -4059,8 +1473,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/44197
 - author: ScarKy0
   changes:
-  - message: The "Crit Anomalies" objective will now correctly randomize the number
-      of anomalies to crit.
+  - message: The "Crit Anomalies" objective will now correctly randomize the number of anomalies to crit.
     type: Fix
   id: 9736
   time: '2026-06-03T19:22:13.0000000+00:00'
@@ -4076,12 +1489,9 @@
   changes:
   - message: A couple of broken messages related to meatspiking have been fixed.
     type: Fix
-  - message: Cotton buns, web winter coats, and web winter boots are now sliceable
-      again.
+  - message: Cotton buns, web winter coats, and web winter boots are now sliceable again.
     type: Fix
-  - message: A bunch of mobs that erroneously required a meat spike no longer need
-      to do so. The only mobs that should need meatspiking to butcher are humanoid
-      species, monkeys, kobolds, scurrets, and xenos.
+  - message: A bunch of mobs that erroneously required a meat spike no longer need to do so. The only mobs that should need meatspiking to butcher are humanoid species, monkeys, kobolds, scurrets, and xenos.
     type: Fix
   id: 9738
   time: '2026-06-04T21:18:52.0000000+00:00'
@@ -5210,3 +2620,1043 @@
   id: 9890
   time: '2026-07-23T06:39:04.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/43315
+- author: Dogbone10
+  changes:
+  - message: Bluespace bags can now fit Ginormous items, HOWEVER they've had their size slightly reduced.
+    type: Tweak
+  - message: Marked unique backpacks (syndicate filled ones mostly) with the Backpack tag.
+    type: Fix
+  id: 9891
+  time: '2026-07-24T15:20:40.0000000+00:00'
+- author: whatston3
+  changes:
+  - message: Light bulbs and tubes once again break into glass shards when sufficiently damaged.
+    type: Fix
+  id: 9892
+  time: '2026-07-24T23:00:39.0000000+00:00'
+- author: JokeCam
+  changes:
+  - message: Made sure yaml sound params are not getting overriden by default values
+    type: Tweak
+  id: 9893
+  time: '2026-07-25T16:30:57.0000000+00:00'
+- author: Mehnix
+  changes:
+  - message: Artifact nodes with multiple triggers now have a popup when each trigger is activated successfully.
+    type: Tweak
+  id: 9894
+  time: '2026-07-25T21:23:18.0000000+00:00'
+- author: ArtisticRoomba
+  changes:
+  - message: Disposals units, mailing units, and toilets now dynamically consume power depending on if they are working or not. This has dropped the idle power draw of stations drastically.
+    type: Tweak
+  id: 9895
+  time: '2026-07-26T07:46:41.0000000+00:00'
+- author: Princess-Cheeseballs
+  changes:
+  - message: Electric grille heat amounts have been changed to 3000W for low, 6000W for medium, and 12000W for high up from 800W for low, 1600W for medium, and 2400W for high. However its heat is now divided between the items being cooked.
+    type: Tweak
+  - message: Cryo chems now heat up the user when metabolizing, but the temperature needed for them to work is now 273K/0C.
+    type: Tweak
+  id: 9896
+  time: '2026-07-26T08:12:20.0000000+00:00'
+- author: sudobeans
+  changes:
+  - message: Fixed bug where metamorphic glasses of some liquids (e.g. water) appeared to be empty.
+    type: Fix
+  id: 9897
+  time: '2026-07-26T08:45:18.0000000+00:00'
+- author: 0-Anon
+  changes:
+  - message: Adjusted the reagents you get in higher tier batteries to be more appropriate.
+    type: Tweak
+  id: 9898
+  time: '2026-07-26T13:42:50.0000000+00:00'
+- author: Ataman
+  changes:
+  - message: The GUI for instruments has been completely overhauled.
+    type: Tweak
+  - message: MIDI files for instruments are now stored and used as a persistent collection.
+    type: Add
+  - message: MIDI files in your collection can be filtered and played in random order.
+    type: Add
+  id: 9899
+  time: '2026-07-26T17:05:55.0000000+00:00'
+- author: Samuka
+  changes:
+  - message: Cloaking device from xenoborgs no longer lasts forever.
+    type: Fix
+  id: 9900
+  time: '2026-07-26T20:24:42.0000000+00:00'
+- author: Kickguy223
+  changes:
+  - message: Hypereutatic-blade no longer allows full speed 0g movement
+    type: Fix
+  id: 9901
+  time: '2026-07-26T22:16:43.0000000+00:00'
+- author: ZigTag
+  changes:
+  - message: Bluespace beakers are now 2x2
+    type: Tweak
+  id: 9902
+  time: '2026-07-27T04:54:38.0000000+00:00'
+- author: AndrewFenriz
+  changes:
+  - message: Fixed vehicles sometimes continuing to move after unbuckling.
+    type: Fix
+  id: 9903
+  time: '2026-07-27T08:16:37.0000000+00:00'
+- author: Ataman
+  changes:
+  - message: The minimum volume for MIDI Input can now be adjusted inside the instrument UI.
+    type: Add
+  id: 9904
+  time: '2026-07-28T04:44:13.0000000+00:00'
+- author: Keer-Sar
+  changes:
+  - message: Corgis and their variants can now smoke, except puppy Ian.
+    type: Add
+  - message: Removed Smart Corgis
+    type: Remove
+  - message: Clothes wearable by Smart Corgis can now be worn by normal corgis and their variants.
+    type: Tweak
+  id: 9905
+  time: '2026-07-28T06:17:30.0000000+00:00'
+- author: TheShuEd
+  changes:
+  - message: New T3 “TeleSci” technology added. Allows you to create a portal control console, a stationary teleporter, and coordinate chips.
+    type: Add
+  id: 9906
+  time: '2026-07-28T11:55:22.0000000+00:00'
+- author: gorillagaming
+  changes:
+  - message: The G.O.R.I.L.L.A gauntlet now works
+    type: Fix
+  - message: You can now punch and attack anomalies again!
+    type: Fix
+  id: 9907
+  time: '2026-07-28T14:47:11.0000000+00:00'
+- author: Fruitsalad
+  changes:
+  - message: The mop now has an animated UI.
+    type: Add
+  id: 9908
+  time: '2026-07-28T18:56:05.0000000+00:00'
+- author: whatston3
+  changes:
+  - message: Muted characters shouldn't hear their own vocal emotes anymore.
+    type: Fix
+  id: 9909
+  time: '2026-07-28T19:16:48.0000000+00:00'
+- author: Miguel4387
+  changes:
+  - message: Coins can now be flipped and act as 2 sided dice.
+    type: Tweak
+  - message: New coin that can be found in dice bags made specifically for coin flips.
+    type: Add
+  id: 9910
+  time: '2026-07-28T19:19:05.0000000+00:00'
+- author: Fildrance
+  changes:
+  - message: now artifact spawns resources as stacks
+    type: Tweak
+  id: 9911
+  time: '2026-07-28T20:01:22.0000000+00:00'
+- author: august-sun
+  changes:
+  - message: Added tactical bola. Does not lose durability when used, slightly slower removal time. Available in sec lockers, SecTech, and secfab.
+    type: Add
+  - message: Bolas now require an active and empty hand to remove.
+    type: Tweak
+  id: 9912
+  time: '2026-07-29T00:23:02.0000000+00:00'
+- author: BlythT
+  changes:
+  - message: Fix enabling auto chat highlights wiping your current custom chat highlights.
+    type: Fix
+  id: 9913
+  time: '2026-07-29T03:22:56.0000000+00:00'
+- author: PAFFhassoocks
+  changes:
+  - message: All nukie hardsuit headlights are now much brighter.
+    type: Tweak
+  - message: The cybersun juggernaut suit now has a headlight.
+    type: Add
+  id: 9914
+  time: '2026-07-29T05:58:26.0000000+00:00'
+- author: whatston3
+  changes:
+  - message: Holoparasites should no longer be spammed with popups warning them about attacking their host.
+    type: Fix
+  id: 9915
+  time: '2026-07-29T21:03:50.0000000+00:00'
+- author: ketufaispikinut
+  changes:
+  - message: Added a tram driver job.
+    type: Add
+  id: 9916
+  time: '2026-07-29T21:25:20.0000000+00:00'
+- author: Keer-Sar
+  changes:
+  - message: Added the Throngler back to the grand lottery.
+    type: Add
+  id: 9917
+  time: '2026-07-30T00:05:21.0000000+00:00'
+- author: Keer-Sar
+  changes:
+  - message: Re-added tip that mentions The Throngler.
+    type: Add
+  id: 9918
+  time: '2026-07-30T01:13:06.0000000+00:00'
+- author: jckspjf
+  changes:
+  - message: Cluwne can now be selected in Agent IDs.
+    type: Tweak
+  id: 9919
+  time: '2026-07-30T03:02:32.0000000+00:00'
+- author: YoungThugSS14
+  changes:
+  - message: C4 can no longer be stuck to hardsuits, allowing for an invisible bomb.
+    type: Fix
+  id: 9920
+  time: '2026-07-30T05:09:14.0000000+00:00'
+- author: SnappingOpossum
+  changes:
+  - message: You can now alloy brass from copper and zinc at high temperatures and break it back down in any centrifuge.
+    type: Add
+  - message: You can now solidify reagent brass using frost oil.
+    type: Add
+  - message: Brass sheets, clockwork glass sheets, and clockwork glass shards now grind directly into brass instead of copper and zinc.
+    type: Tweak
+  id: 9921
+  time: '2026-07-30T06:10:39.0000000+00:00'
+- author: qrwas
+  changes:
+  - message: Toggling ghost visibility now removes the text bubble output above their heads.
+    type: Fix
+  id: 9922
+  time: '2026-07-30T18:55:58.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: In Dev - Added Cargo area, a Writing corner and more space in Portal room and tweaked other things
+    type: Add
+  id: 9923
+  time: '2026-07-30T18:55:58.0000000+00:00'
+- author: B_Kirill, mirrorcult
+  changes:
+  - message: Wall-mounted entities are now only visible from the side of the wall they are attached to.
+    type: Tweak
+  id: 9924
+  time: '2026-07-30T19:55:34.0000000+00:00'
+- author: ketufaispikinut
+  changes:
+  - message: Resprited the fake mindshield action sprites.
+    type: Tweak
+  id: 9925
+  time: '2026-07-30T22:54:27.0000000+00:00'
+- author: opl
+  changes:
+  - message: Wizard's teleport scroll can no longer teleport its user into a wall.
+    type: Fix
+  id: 9926
+  time: '2026-07-31T18:02:15.0000000+00:00'
+- author: AndrewFenriz
+  changes:
+  - message: 'Operating certain vehicles now requires free hands: one for the janicart and two for all mechs.'
+    type: Tweak
+  id: 9927
+  time: '2026-07-31T18:05:43.0000000+00:00'
+- author: Bandirpvp
+  changes:
+  - message: Novelty lighter mystery boxes now rarely spawn inside maintenance closets, and also may contain the Spiderclan flippo.
+    type: Add
+  - message: Shadycigs contraband inventory now contains an NT Flippo.
+    type: Tweak
+  id: 9928
+  time: '2026-07-31T22:39:50.0000000+00:00'
+- author: w3ryfrate
+  changes:
+  - message: Conveyor belts can now be anchored and unanchored with a wrench. They will now only be able to rotate when not anchored.
+    type: Tweak
+  id: 9929
+  time: '2026-08-01T01:14:46.0000000+00:00'
+- author: Chubbygummibear
+  changes:
+  - message: Directional and rotating lights are once again working as expected.
+    type: Fix
+  id: 9930
+  time: '2026-08-01T03:31:29.0000000+00:00'
+- author: mMikulas
+  changes:
+  - message: Fixed windoors being unable to close when placed adjacent to walls.
+    type: Fix
+  id: 9931
+  time: '2026-08-01T04:04:20.0000000+00:00'
+- author: aada
+  changes:
+  - message: Disposals now are destructible again, and they eject their contents when destroyed.
+    type: Fix
+  id: 9932
+  time: '2026-08-01T04:38:05.0000000+00:00'
+- author: Hitlinemoss
+  changes:
+  - message: Station pets, rat kings, revenants, and space dragons no longer have a numeric identifier appended to their names. When "Add colors to character names" is enabled, their names are now also colorized.
+    type: Tweak
+  id: 9933
+  time: '2026-08-01T05:06:12.0000000+00:00'
+- author: metalgearsloth
+  changes:
+  - message: Fix ghosts changing their transparency when hovering them.
+    type: Fix
+  - message: Fix entity shaders not stacking, such as interactionoutline with the water shader.
+    type: Fix
+  id: 9934
+  time: '2026-08-01T07:05:22.0000000+00:00'
+- author: MissKay1994
+  changes:
+  - message: Goliath tentacles now stun for a much shorter duration
+    type: Tweak
+  id: 9935
+  time: '2026-08-01T10:10:10.0000000+00:00'
+- author: whatston3
+  changes:
+  - message: Vox and reptilians' tail wag now respects wearing a suit.
+    type: Fix
+  id: 9936
+  time: '2026-08-01T13:07:24.0000000+00:00'
+- author: SnappingOpossum
+  changes:
+  - message: Tram drivers no longer start with a mind shield implanted.
+    type: Tweak
+  - message: Tram drivers can no longer start as antags or become sleeper agents.
+    type: Fix
+  - message: Tram drivers now properly start with gloves equipped when they have them selected.
+    type: Fix
+  id: 9937
+  time: '2026-08-01T14:39:24.0000000+00:00'
+- author: AndrewFenriz
+  changes:
+  - message: Vending machine contraband now updates immediately when its manager wire is cut or mended.
+    type: Fix
+  id: 9938
+  time: '2026-08-01T16:01:06.0000000+00:00'
+- author: ActiveMammmoth
+  changes:
+  - message: Added an effect for artifacts that allows artifacts to emit light.
+    type: Add
+  id: 9939
+  time: '2026-08-01T16:32:07.0000000+00:00'
+- author: Ataman
+  changes:
+  - message: Instruments that support percussion can now filter the percussion channel again.
+    type: Fix
+  id: 9940
+  time: '2026-08-01T16:50:07.0000000+00:00'
+- author: w3ryfrate
+  changes:
+  - message: Machine frames no longer crash the game when destroyed by a gun.
+    type: Fix
+  id: 9941
+  time: '2026-08-01T17:05:48.0000000+00:00'
+- author: TheGrimbeeper
+  changes:
+  - message: Microwave handheld artifacts for a new trigger.
+    type: Add
+  id: 9942
+  time: '2026-08-01T23:17:38.0000000+00:00'
+- author: Mehnix
+  changes:
+  - message: Added several new artifact triggers themed around interacting with various objects.
+    type: Add
+  id: 9943
+  time: '2026-08-02T22:34:43.0000000+00:00'
+- author: riccardi48
+  changes:
+  - message: The cargo telepad now shuts down when unpowered.
+    type: Fix
+  id: 9944
+  time: '2026-08-03T08:54:58.0000000+00:00'
+- author: whatston3
+  changes:
+  - message: You can once again hear when you speak.
+    type: Fix
+  id: 9945
+  time: '2026-08-03T15:25:47.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: On Marathon - Fixed some known issues
+    type: Fix
+  id: 9946
+  time: '2026-08-03T18:39:36.0000000+00:00'
+- author: whatston3
+  changes:
+  - message: Ghosts can now extinguish candles with their Boo! action.
+    type: Add
+  id: 9947
+  time: '2026-08-04T05:29:12.0000000+00:00'
+- author: whatston3
+  changes:
+  - message: All grass astro-tiles now need a crowbar to be pried off the floor.
+    type: Tweak
+  id: 9948
+  time: '2026-08-04T21:46:05.0000000+00:00'
+- author: NopeOfAllNopes
+  changes:
+  - message: Impact grenades now explode when hitting a wall, making them usable in zero-G.
+    type: Fix
+  id: 9949
+  time: '2026-08-05T07:29:00.0000000+00:00'
+- author: Centronias
+  changes:
+  - message: Light tubes look like tubes again, rather than like bulbs.
+    type: Fix
+  id: 9950
+  time: '2026-08-07T04:46:15.0000000+00:00'
+- author: metalgearsloth
+  changes:
+  - message: Diagonal walls now occlude properly.
+    type: Add
+  id: 9951
+  time: '2026-08-07T07:29:07.0000000+00:00'
+- author: Cabin-keeper
+  changes:
+  - message: Added Strawberry Ice, a strong stimulant with withdrawal effects derived from desoxyephedrine.
+    type: Add
+  id: 9952
+  time: '2026-08-07T10:17:42.0000000+00:00'
+- author: metalgearsloth
+  changes:
+  - message: Added ambient space light.
+    type: Add
+  id: 9953
+  time: '2026-08-08T01:51:23.0000000+00:00'
+- author: metalgearsloth
+  changes:
+  - message: Jobs are now filled first by minimum amounts required by the map, falling back to same department if roles can't be filled, then by player preference.
+    type: Tweak
+  id: 9954
+  time: '2026-08-08T01:59:09.0000000+00:00'
+- author: metalgearsloth
+  changes:
+  - message: Add option to toggle ambient occlusion resolution and tweak it slightly.
+    type: Tweak
+  id: 9955
+  time: '2026-08-08T06:29:36.0000000+00:00'
+- author: Pok27
+  changes:
+  - message: Plants are now separate from  the tray.
+    type: Tweak
+  id: 9956
+  time: '2026-08-08T22:12:46.0000000+00:00'
+- author: Prole0, SirWarock
+  changes:
+  - message: Others can now see a popup whenever you clean evidence.
+    type: Tweak
+  - message: You can get your prints instantly with a forensic pad when used on yourself.
+    type: Tweak
+  id: 9957
+  time: '2026-08-08T23:03:10.0000000+00:00'
+- author: Nem
+  changes:
+  - message: Mice and mothroaches now have adjectives.
+    type: Add
+  id: 9958
+  time: '2026-08-09T00:36:41.0000000+00:00'
+- author: Pok27
+  changes:
+  - message: Added a black outline to various in-world text to improve readability against the background.
+    type: Add
+  id: 9959
+  time: '2026-08-09T01:18:31.0000000+00:00'
+- author: riccardi48
+  changes:
+  - message: Fixed bug which allows duplicate orders spawning in when breaking telepad.
+    type: Fix
+  id: 9960
+  time: '2026-08-09T05:33:49.0000000+00:00'
+- author: AndrewFenriz
+  changes:
+  - message: Blink and ninja katana can no longer teleport into blocked destinations.
+    type: Fix
+  id: 9961
+  time: '2026-08-09T12:38:40.0000000+00:00'
+- author: UpAndLeaves
+  changes:
+  - message: The contra overlay now recurses through bags.
+    type: Tweak
+  id: 9962
+  time: '2026-08-09T18:33:58.0000000+00:00'
+- author: TiniestShark
+  changes:
+  - message: Added inhand art for all paperwork, folders, and stamps.
+    type: Tweak
+  id: 9963
+  time: '2026-08-10T04:05:00.0000000+00:00'
+- author: TiniestShark
+  changes:
+  - message: Added a salvagable target to the possible scrap pool. It gives a small amount of wood when scrapped.
+    type: Add
+  id: 9964
+  time: '2026-08-10T04:25:39.0000000+00:00'
+- author: ketufaispikinut
+  changes:
+  - message: Snowball station now has a custom parallax.
+    type: Add
+  id: 9965
+  time: '2026-08-10T04:56:18.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: Added custom space light to maps with custom parallax
+    type: Add
+  id: 9966
+  time: '2026-08-10T18:11:59.0000000+00:00'
+- author: whatston3
+  changes:
+  - message: Colored jumpsuits now properly fit monkeys and kobolds.
+    type: Fix
+  id: 9967
+  time: '2026-08-11T01:46:05.0000000+00:00'
+- author: Krunklehorn
+  changes:
+  - message: APC power outage events now only affect the main station grid.
+    type: Fix
+  id: 9968
+  time: '2026-08-11T05:09:31.0000000+00:00'
+- author: rivermyth
+  changes:
+  - message: Fixed agent IDs not spawning with intended Syndicate accesses.
+    type: Fix
+  id: 9969
+  time: '2026-08-11T09:01:55.0000000+00:00'
+- author: Mehnix
+  changes:
+  - message: Added several new artifact triggers themed around attacking or shooting things at the artifact.
+    type: Add
+  id: 9970
+  time: '2026-08-11T10:38:03.0000000+00:00'
+- author: insoPL
+  changes:
+  - message: Docks type are now visible on shuttle nav screen.
+    type: Add
+  id: 9971
+  time: '2026-08-11T15:19:28.0000000+00:00'
+- author: Mehnix
+  changes:
+  - message: You can now use a defibrillator on living and critical mobs, as well inanimate objects, walls, airlocks, etc.
+    type: Tweak
+  - message: Trying to defibrillate something will now create a popup indicating such.
+    type: Tweak
+  id: 9972
+  time: '2026-08-11T15:30:19.0000000+00:00'
+- author: Mehnix
+  changes:
+  - message: Entity Interaction artifact triggers now work properly when there are multiple of them as potential trigger candidates.
+    type: Fix
+  id: 9973
+  time: '2026-08-11T19:53:47.0000000+00:00'
+- author: w3ryfrate
+  changes:
+  - message: The BreakerFlip game rule no longer targets protected grids.
+    type: Fix
+  - message: You can now blacklist components from triggering the BreakerFlip game rule via the YAML file.
+    type: Tweak
+  - message: Admins can now see information about each APC turned on/off by the BreakerFlip game rule.
+    type: Tweak
+  id: 9974
+  time: '2026-08-11T21:46:26.0000000+00:00'
+- author: modder123543
+  changes:
+  - message: Characters now scream when they fall into a chasm.
+    type: Add
+  id: 9975
+  time: '2026-08-11T21:49:57.0000000+00:00'
+- author: marianolarre
+  changes:
+  - message: The recycler has received new sprites!
+    type: Tweak
+  id: 9976
+  time: '2026-08-11T23:28:12.0000000+00:00'
+- author: whatston3
+  changes:
+  - message: Arachnids can now properly digest uncooked meat.
+    type: Fix
+  id: 9977
+  time: '2026-08-12T00:11:25.0000000+00:00'
+- author: Zekins3366
+  changes:
+  - message: Fixed airlock(windoor) displaying incorrect sprites after client reconnection
+    type: Fix
+  id: 9978
+  time: '2026-08-12T02:02:49.0000000+00:00'
+- author: TheGrimbeeper
+  changes:
+  - message: Fixed artifact bug where unlocking time was not correctly increased when triggers were applied, in some cases.
+    type: Fix
+  id: 9979
+  time: '2026-08-12T08:40:55.0000000+00:00'
+- author: AftrLite
+  changes:
+  - message: Sprites for walls and tiles have been revamped! Certain wallmounts and floor objects have been updated to work with the new sprites; more will be updated in the future.
+    type: Tweak
+  - message: Lights and other wallmounts have been offset inwards against the wall to align with the new wall visuals.
+    type: Tweak
+  - message: Turnstiles are now energy gates, with the same functionality.
+    type: Tweak
+  - message: Renamed "xeno" structures to "exodermis" and "xenoborg" structures to "mechadermis".
+    type: Tweak
+  - message: Removed several wall and floor types no longer supported in the new sprite style.
+    type: Remove
+  id: 9980
+  time: '2026-08-12T18:00:35.0000000+00:00'
+- author: SlamBamActionman
+  changes:
+  - message: Changed Exo to work with the new sprites.
+    type: Tweak
+  - message: Updated Exo's AI upload and Vault to be less Nukie-friendly.
+    type: Tweak
+  id: 9981
+  time: '2026-08-12T23:44:47.0000000+00:00'
+- author: Samuka
+  changes:
+  - message: Added the xenoborg crystal!
+    type: Add
+  - message: Added the xenoborg extractor which can produce the xenoborg crystal.
+    type: Add
+  - message: The recipes to make xenoborg chassis and xenoborg modules now uses xenoborg crystals instead of normal materials.
+    type: Tweak
+  id: 9982
+  time: '2026-08-13T01:03:46.0000000+00:00'
+- author: marianolarre
+  changes:
+  - message: Changed texture for Frezon, Amonium, Plasma, Tritium and Water vapor!
+    type: Tweak
+  id: 9983
+  time: '2026-08-13T01:22:50.0000000+00:00'
+- author: ScarKy0
+  changes:
+  - message: You can now ride around in office chairs.
+    type: Add
+  id: 9984
+  time: '2026-08-13T01:57:58.0000000+00:00'
+- author: SeaWyrm
+  changes:
+  - message: Added corner pieces for all directional windows
+    type: Add
+  id: 9985
+  time: '2026-08-13T02:24:49.0000000+00:00'
+- author: Mixelz
+  changes:
+  - message: Plasma Station updated to work with the new sprites.
+    type: Tweak
+  - message: Plasma Station has had various minor tweaks to its maints, spawns and HoP.
+    type: Tweak
+  id: 9986
+  time: '2026-08-13T07:07:45.0000000+00:00'
+- author: metalgearsloth
+  changes:
+  - message: Removed civilian department from rolling for fallback roles.
+    type: Tweak
+  id: 9987
+  time: '2026-08-13T08:58:30.0000000+00:00'
+- author: TiniestShark
+  changes:
+  - message: QM's Turtleneck now features toggleable zip-off cargo pants.
+    type: Add
+  id: 9988
+  time: '2026-08-13T12:35:29.0000000+00:00'
+- author: ketufaispikinut
+  changes:
+  - message: Tweaked Elkridge so that it works with new sprites.
+    type: Tweak
+  id: 9989
+  time: '2026-08-13T12:35:29.0000000+00:00'
+- author: Samuka
+  changes:
+  - message: The xenoborg laser cannon deals slightly less damage but has more shots per full charge
+    type: Tweak
+  - message: Added a new sprite for the xenoborg laser cannon
+    type: Add
+  - message: Added new sprites for the xenoborg lasers
+    type: Add
+  id: 9990
+  time: '2026-08-13T18:13:27.0000000+00:00'
+- author: Hitlinemoss
+  changes:
+  - message: Monkeys & kobolds now have a neck slot whitelisted for medals, pins, scarves, ties, whistles, & harmonicas.
+    type: Add
+  id: 9991
+  time: '2026-08-14T00:21:14.0000000+00:00'
+- author: TiniestShark
+  changes:
+  - message: Changed hardsuit helmet lights and visors to be on their own unshaded layer.
+    type: Tweak
+  - message: Hardhats, pumpkin hats, and fire helmets have re-drawn and separated out lighting effects.
+    type: Tweak
+  id: 9992
+  time: '2026-08-14T05:54:47.0000000+00:00'
+- author: SlamBamActionman
+  changes:
+  - message: Handcuffing now only applies a faster cuff timer when the target is stamina crit, asleep or crit/dead, instead of for every stun.
+    type: Fix
+  id: 9993
+  time: '2026-08-14T11:48:46.0000000+00:00'
+- author: whatston3
+  changes:
+  - message: Characters' feet no longer poke through the north side of secret doors.
+    type: Fix
+  id: 9994
+  time: '2026-08-14T15:21:57.0000000+00:00'
+- author: whatston3
+  changes:
+  - message: APCs now display when they have been overloaded, or when the breaker is manually disabled.
+    type: Add
+  id: 9995
+  time: '2026-08-14T15:33:51.0000000+00:00'
+- author: eoineoineoin
+  changes:
+  - message: Communications Console UI has been reworked
+    type: Tweak
+  id: 9996
+  time: '2026-08-14T18:52:42.0000000+00:00'
+- author: AndrewFenriz
+  changes:
+  - message: Mechs can no longer be entered if they break while someone is entering them.
+    type: Fix
+  - message: Mech pilot removal alerts are no longer shown when the removal attempt fails to start.
+    type: Fix
+  id: 9997
+  time: '2026-08-15T00:44:39.0000000+00:00'
+- author: SlamBamActionman
+  changes:
+  - message: Further tweaks to Exo's air/firelock layout post-respritening.
+    type: Tweak
+  id: 9998
+  time: '2026-08-15T16:24:03.0000000+00:00'
+- author: SlamBamActionman
+  changes:
+  - message: Updated ATS to work with the respritening.
+    type: Fix
+  id: 9999
+  time: '2026-08-15T16:24:58.0000000+00:00'
+- author: ketufaispikinut
+  changes:
+  - message: Fixed a few doors with broken accesses or rotations on Elkridge.
+    type: Tweak
+  id: 10000
+  time: '2026-08-15T16:25:53.0000000+00:00'
+- author: SlamBamActionman
+  changes:
+  - message: Updated salvage dungeon random-gen rooms to work with the respritening.
+    type: Fix
+  id: 10001
+  time: '2026-08-15T16:26:09.0000000+00:00'
+- author: aada
+  changes:
+  - message: Alcohol will now make you clumsy.
+    type: Add
+  id: 10002
+  time: '2026-08-15T19:07:56.0000000+00:00'
+- author: whatston3
+  changes:
+  - message: Text screens can now scroll, supporting up to 32 characters per line.
+    type: Add
+  id: 10003
+  time: '2026-08-15T22:15:43.0000000+00:00'
+- author: MuffinLazer
+  changes:
+  - message: Several uplink descriptions have been updated for clarity.
+    type: Tweak
+  id: 10004
+  time: '2026-08-15T23:21:50.0000000+00:00'
+- author: Astroskier
+  changes:
+  - message: Added Fold Option to Light Riot Helmet
+    type: Add
+  id: 10005
+  time: '2026-08-16T02:27:41.0000000+00:00'
+- author: beck-thompson
+  changes:
+  - message: Motherships tool modules have been combined into one
+    type: Tweak
+  id: 10006
+  time: '2026-08-16T06:59:55.0000000+00:00'
+- author: beck-thompson
+  changes:
+  - message: Xenoborgs are now EMP resistant
+    type: Add
+  id: 10007
+  time: '2026-08-16T07:00:12.0000000+00:00'
+- author: beck-thompson
+  changes:
+  - message: Both Exception and Runtime now meow at regular intervals if an error occurs on the server.
+    type: Add
+  id: 10008
+  time: '2026-08-16T09:22:02.0000000+00:00'
+- author: SlamBamActionman
+  changes:
+  - message: Melee weapons failing to deal damage to an object now displays a pop-up after a few hits.
+    type: Add
+  id: 10009
+  time: '2026-08-16T09:28:29.0000000+00:00'
+- author: aada
+  changes:
+  - message: The health of all structures (walls, machines, furniture, etc.) have been rebalanced. Generally, doors are now weaker than walls and many structures are more vulnerable than they were previously.
+    type: Tweak
+  - message: The resistances of all structures have been changed to match their material composition. Generally metal is now weak to Burn while resisting Brute, and glass the opposite.
+    type: Tweak
+  - message: Uranium windows are now as durable as regular windows. They remain strong against delta pressure and radiation.
+    type: Tweak
+  - message: Secure windoors have been removed for being an oxymoron.
+    type: Remove
+  id: 10010
+  time: '2026-08-16T09:35:20.0000000+00:00'
+- author: AndrewFenriz
+  changes:
+  - message: Uranium projectiles now emit a faint green glow
+    type: Tweak
+  id: 10011
+  time: '2026-08-16T22:35:45.0000000+00:00'
+- author: whatston3
+  changes:
+  - message: Diona are once again thirstier than a typical species.
+    type: Tweak
+  id: 10012
+  time: '2026-08-17T00:57:17.0000000+00:00'
+- author: SirWarock
+  changes:
+  - message: Masks can now be pulled up and down by others!
+    type: Add
+  - message: Fixed Bandanas and other foldable masks inability to be toggled after being folded once.
+    type: Fix
+  id: 10013
+  time: '2026-08-17T00:57:17.0000000+00:00'
+- author: YoungThugSS14
+  changes:
+  - message: You can now drink straight from the sink tap.
+    type: Tweak
+  id: 10014
+  time: '2026-08-17T03:44:45.0000000+00:00'
+- author: metalgearsloth
+  changes:
+  - message: Fix slippery puddles mispredicting when going out of range.
+    type: Fix
+  id: 10015
+  time: '2026-08-17T09:42:40.0000000+00:00'
+- author: UpAndLeaves
+  changes:
+  - message: Passive health regeneration now pauses for five seconds after taking damage.
+    type: Tweak
+  id: 10016
+  time: '2026-08-17T12:54:19.0000000+00:00'
+- author: aada
+  changes:
+  - message: The construction materials of several structures have been updated to match their damage resistances. Most notably secure lockers, secure crates, and firelocks now use plasteel.
+    type: Tweak
+  - message: Some cargo orders containing secure crates have had their price increased by 100-200.
+    type: Tweak
+  id: 10017
+  time: '2026-08-17T20:55:50.0000000+00:00'
+- author: w3ryfrate
+  changes:
+  - message: New sound cue and notification dispatched to the chat when a player receives an administration note.
+    type: Add
+  - message: New button in the escape button that opens the admin remarks panel.
+    type: Add
+  id: 10018
+  time: '2026-08-18T04:52:34.0000000+00:00'
+- author: Princess-Cheeseballs
+  changes:
+  - message: Removed the unused bar drink Neurotoxin from the game
+    type: Remove
+  id: 10019
+  time: '2026-08-18T09:26:19.0000000+00:00'
+- author: SirWarock
+  changes:
+  - message: Light Replacers are now predicted!
+    type: Tweak
+  - message: Light Replacers now have a radial menu that lets you select with what lights to replace with!
+    type: Tweak
+  - message: Said light Replacers also have a radial menu button to let you eject lights!
+    type: Tweak
+  id: 10020
+  time: '2026-08-18T10:36:31.0000000+00:00'
+- author: Wintoli
+  changes:
+  - message: Fixed slicing tools so that they increase rather than decrease butcher speed depending on the tool.
+    type: Fix
+  id: 10021
+  time: '2026-08-18T12:54:43.0000000+00:00'
+- author: Princess-Cheeseballs
+  changes:
+  - message: Minibombs now do less damage outside of their center
+    type: Tweak
+  - message: Max Caps now do more damage to structures
+    type: Tweak
+  id: 10022
+  time: '2026-08-18T13:16:47.0000000+00:00'
+- author: spiritaaa
+  changes:
+  - message: Reworked ambuzol and it's precursors
+    type: Tweak
+  - message: Nukies no longer get ambuzol+ pills, instead get 10 ambuzol pills
+    type: Tweak
+  - message: Ambuzol+ can no longer be synthesized
+    type: Remove
+  - message: Histamine can now be synthesized
+    type: Add
+  id: 10023
+  time: '2026-08-19T03:45:43.0000000+00:00'
+- author: mulchmuncheur
+  changes:
+  - message: Flare has been added back to the survival box
+    type: Add
+  - message: Survival boxes have been made larger.
+    type: Tweak
+  id: 10024
+  time: '2026-08-19T10:26:59.0000000+00:00'
+- author: ThatGuyUSA
+  changes:
+  - message: Engineer Xenoborgs now have their own unique modules.
+    type: Add
+  - message: Added Tile gun module (Made by Samuka) to the Engineer Xenoborg starting modules.
+    type: Add
+  id: 10025
+  time: '2026-08-19T12:01:19.0000000+00:00'
+- author: August Sun, Thug, Samuka, Beck
+  changes:
+  - message: Specific Xenoborg modules are now mutually exclusive with one-another.
+    type: Fix
+  - message: Engi Xenoborg deflector module that creates a strong forcefield that blocks pathways and bullets. By August Sun.
+    type: Add
+  - message: Engi Xenoborg tile gun module that shoots high velocity tiles. By Samuka.
+    type: Add
+  - message: Engi Xenoborg zap module that gives defensive shocks to anyone who comes in contact. By Samuka.
+    type: Add
+  - message: Engi Xenoborg oil gun module that shoots slippery and flammable oil vials. By Samuka.
+    type: Add
+  - message: Engi Xenoborg nanite gun module that heals friends and poisons foes. By Thug.
+    type: Add
+  - message: Heavy Xenoborg fire laser gun module that shoots 3 flaming beams. By August Sun.
+    type: Add
+  - message: Heavy Xenoborg guided missile launcher module that shoots a tracking rocket. By Samuka.
+    type: Add
+  - message: Heavy Xenoborg rocket launcher module that shoots destructive rockets. By Beck.
+    type: Add
+  - message: Heavy Xenoborg radiation module that passively irradiates nearby entities. By August Sun.
+    type: Add
+  - message: Scout Xenoborg jump module that allows you to jump long distances. By August Sun.
+    type: Add
+  - message: Scout Xenoborg bio knife module that allows you to deal poison damage to entities with specific metabolizers. By Beck.
+    type: Add
+  id: 10026
+  time: '2026-08-19T16:13:22.0000000+00:00'
+- author: ScarKy0
+  changes:
+  - message: Changeling Sting can now be made by bartenders.
+    type: Add
+  id: 10027
+  time: '2026-08-19T19:39:20.0000000+00:00'
+- author: Mehnix
+  changes:
+  - message: Reagents that produce lots of emotes will no longer spam your chat box.
+    type: Tweak
+  id: 10028
+  time: '2026-08-19T20:30:06.0000000+00:00'
+- author: ScarKy0
+  changes:
+  - message: All entities no longer share their thirst and hunger.
+    type: Fix
+  id: 10029
+  time: '2026-08-20T01:18:12.0000000+00:00'
+- author: UpAndLeaves
+  changes:
+  - message: Smart-equipping a gun doesn't give you its magazine anymore.
+    type: Fix
+  id: 10030
+  time: '2026-08-20T12:08:06.0000000+00:00'
+- author: AndrewFenriz
+  changes:
+  - message: Fixed office chairs being able to freely move through space.
+    type: Fix
+  id: 10031
+  time: '2026-08-20T12:52:58.0000000+00:00'
+- author: Kickguy223, ScarKy0, Pok24, Slarticodefast, SlamBamActionMan, Ketufaispikinut, Velken, Chillyconmor, Alexalexmax, Princess Cheeseballs, TriviaSolari, Centronias, TiniestShark
+  changes:
+  - message: Added the Changeling, a stealth oriented antagonist who devours crewmembers and assumes their appearance. Read more about it in the guidebook!
+    type: Add
+  id: 10032
+  time: '2026-08-20T13:16:41.0000000+00:00'
+- author: Hitlinemoss
+  changes:
+  - message: Snails & snoths now use adjectives instead of numeric identifiers.
+    type: Add
+  id: 10033
+  time: '2026-08-20T21:54:22.0000000+00:00'
+- author: beck-thompson
+  changes:
+  - message: Xenoborg rockets have been nerfed in damage / explosive power across the board. The launchers reload rate has gone from 12s -> 17s, its maximum spread has gone from 60deg -> 50deg, its cost has gone from 3 crystals -> 4 crystals.
+    type: Fix
+  id: 10034
+  time: '2026-08-21T18:58:12.0000000+00:00'
+- author: jessicamaybe
+  changes:
+  - message: Fixed bow and arrow shooting yourself
+    type: Fix
+  id: 10035
+  time: '2026-08-22T02:42:08.0000000+00:00'
+- author: metalgearsloth
+  changes:
+  - message: Added an options menu button to control max FPS (though you should really use vsync!)
+    type: Add
+  id: 10036
+  time: '2026-08-22T07:36:39.0000000+00:00'
+- author: metalgearsloth
+  changes:
+  - message: Fix stealth shader in some instances.
+    type: Fix
+  id: 10037
+  time: '2026-08-22T07:37:13.0000000+00:00'
+- author: Mixelz
+  changes:
+  - message: Plasma Station has been updated using the align command, and wallmounts moved.
+    type: Fix
+  id: 10038
+  time: '2026-08-22T23:10:27.0000000+00:00'
+- author: Mixelz
+  changes:
+  - message: Saltern Station has been updated using the align command, and wallmounts moved
+    type: Fix
+  id: 10039
+  time: '2026-08-23T03:46:55.0000000+00:00'
+- author: SlamBamActionman
+  changes:
+  - message: Bagel station has been updated using the align command, and wallmounts moved.
+    type: Fix
+  id: 10040
+  time: '2026-08-23T04:10:01.0000000+00:00'
+- author: SlamBamActionman
+  changes:
+  - message: Terminal has been updated using the align command, and wallmounts moved.
+    type: Fix
+  id: 10041
+  time: '2026-08-23T04:10:12.0000000+00:00'
+- author: SlamBamActionman
+  changes:
+  - message: All custom Salvage grids are now compatible with the respritening.
+    type: Fix
+  id: 10042
+  time: '2026-08-23T04:10:23.0000000+00:00'
+- author: SlamBamActionman
+  changes:
+  - message: Tram2 has been updated to work with the respritening, with wallmounts moved.
+    type: Fix
+  id: 10043
+  time: '2026-08-23T04:10:33.0000000+00:00'
+- author: AreYouConfused
+  changes:
+  - message: High temperatures now properly deals damage as expected.
+    type: Fix
+  - message: The guidebook now lists correct values for moths' weaknessess.
+    type: Fix
+  id: 10044
+  time: '2026-08-24T08:19:59.0000000+00:00'

--- a/Resources/Changelog/Maps.yml
+++ b/Resources/Changelog/Maps.yml
@@ -1,40 +1,32 @@
-﻿Entries:
+AdminOnly: false
+Entries:
 - author: ArtisticRoomba
   changes:
-  - message: The mapping changelog has been added! This primarily serves as a way
-      to make players aware of large changes or important fixes to maps, without cluttering
-      the main changelog.
+  - message: The mapping changelog has been added! This primarily serves as a way to make players aware of large changes or important fixes to maps, without cluttering the main changelog.
     type: Add
   id: 1
   time: '2025-02-03T01:29:24.112Z'
 - author: ArtisticRoomba
   changes:
-  - message: A chemical dispenser has been added to the nukie planet, allowing new
-      agents to work in a familiar environment.
+  - message: A chemical dispenser has been added to the nukie planet, allowing new agents to work in a familiar environment.
     type: Add
   id: 2
   time: '2025-01-27T07:10:24.000Z'
 - author: ArtisticRoomba
   changes:
-  - message: On many stations, power has been rebalanced to allow more time for engineering
-      to setup power. This should allow time for activities like TA mentoring and
-      more complex power setups.
+  - message: On many stations, power has been rebalanced to allow more time for engineering to setup power. This should allow time for activities like TA mentoring and more complex power setups.
     type: Tweak
   id: 3
   time: '2025-01-27T07:10:24.000Z'
 - author: Nox, ToxicSonicFan04
   changes:
-  - message: Station armory contents have been tweaked to balance security gear to
-      the amount of security personnel.
+  - message: Station armory contents have been tweaked to balance security gear to the amount of security personnel.
     type: Tweak
   id: 4
   time: '2025-01-27T07:10:24.000Z'
 - author: ArtisticRoomba
   changes:
-  - message: On Meta, Engineering and Atmospherics now share a distinct HV subnet
-      seperate from the station's main power grid. Previously Engineering and Atmos
-      couldn't share power, and one side would be discharged depending on who setup
-      power first.
+  - message: On Meta, Engineering and Atmospherics now share a distinct HV subnet seperate from the station's main power grid. Previously Engineering and Atmos couldn't share power, and one side would be discharged depending on who setup power first.
     type: Fix
   id: 5
   time: '2025-01-26T12:00:00Z'
@@ -46,8 +38,7 @@
   time: '2025-01-12T12:00:00Z'
 - author: Compilatron144
   changes:
-  - message: Plasma station's population limit has been raised to make it into a high
-      population station.
+  - message: Plasma station's population limit has been raised to make it into a high population station.
     type: Tweak
   id: 7
   time: '2025-01-19T12:00:00Z'
@@ -83,8 +74,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/37157
 - author: Southbridge
   changes:
-  - message: On Bagel, removed the very convenient Captain's ID sitting out in deep
-      space.
+  - message: On Bagel, removed the very convenient Captain's ID sitting out in deep space.
     type: Remove
   id: 12
   time: '2025-05-04T07:20:33.0000000+00:00'
@@ -108,21 +98,18 @@
     type: Tweak
   - message: On Amber, overhauled the security department to introduce GenPop.
     type: Tweak
-  - message: On Amber, overhauled and moved the AI satellite to the east side of the
-      map, enlarging it to accommodate AI turrets in the future.
+  - message: On Amber, overhauled and moved the AI satellite to the east side of the map, enlarging it to accommodate AI turrets in the future.
     type: Tweak
   id: 14
   time: '2025-05-08T01:39:09.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37262
 - author: Deerstop
   changes:
-  - message: On Elkridge, the botany area has been improved with additional trays,
-      vents, and scrubbers.
+  - message: On Elkridge, the botany area has been improved with additional trays, vents, and scrubbers.
     type: Tweak
   - message: On Elkridge, firelocks and emergency lights have been added to security.
     type: Fix
-  - message: On Elkridge, the backstage area is now accessible to service and theatre
-      access.
+  - message: On Elkridge, the backstage area is now accessible to service and theatre access.
     type: Tweak
   - message: On Elkridge, the service request console is now backstage
     type: Tweak
@@ -131,8 +118,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/37206
 - author: spanky-spanky
   changes:
-  - message: On Omega, the TEG burn chamber blast door buttons are now engineering
-      access instead of atmospherics.
+  - message: On Omega, the TEG burn chamber blast door buttons are now engineering access instead of atmospherics.
     type: Fix
   - message: On Omega, security now get hardsuits.
     type: Fix
@@ -157,8 +143,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/37565
 - author: Minemoder
   changes:
-  - message: The ATS station anchor room was rebuilt to prevent stealing from the
-      room, and to add shuttle miners to repressurize the ATS.
+  - message: The ATS station anchor room was rebuilt to prevent stealing from the room, and to add shuttle miners to repressurize the ATS.
     type: Tweak
   id: 19
   time: '2025-05-18T08:12:47.0000000+00:00'
@@ -167,8 +152,7 @@
   changes:
   - message: On Convex, added a job board computer to the salvage bay.
     type: Add
-  - message: On Convex, remove the extra pair of mass scanners and expedition consoles
-      from the salvage bay.
+  - message: On Convex, remove the extra pair of mass scanners and expedition consoles from the salvage bay.
     type: Remove
   id: 20
   time: '2025-05-18T17:43:43.0000000+00:00'
@@ -179,8 +163,7 @@
     type: Add
   - message: On Box, swapped the devices in the freezer to their freezer variants.
     type: Tweak
-  - message: On Box, modified the containment area to be a little more intuitive for
-      both singularity and tesla setups.
+  - message: On Box, modified the containment area to be a little more intuitive for both singularity and tesla setups.
     type: Tweak
   - message: On Box, modified TEG piping to make more sense.
     type: Tweak
@@ -189,8 +172,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/37602
 - author: Deerstop
   changes:
-  - message: On Elkridge, the salvage bay has received an overhaul, including the
-      new Job Board Computer
+  - message: On Elkridge, the salvage bay has received an overhaul, including the new Job Board Computer
     type: Tweak
   id: 22
   time: '2025-05-19T18:55:41.0000000+00:00'
@@ -262,16 +244,14 @@
   url: https://github.com/space-wizards/space-station-14/pull/37066
 - author: ArtisticRoomba
   changes:
-  - message: The ATS has been updated to allow atmos techs to easily refill the ATS
-      with air after a spacing.
+  - message: The ATS has been updated to allow atmos techs to easily refill the ATS with air after a spacing.
     type: Tweak
   id: 32
   time: '2025-05-28T07:52:52.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/37891
 - author: Spessmann
   changes:
-  - message: Randomized maintenance rooms now use decal spawners, which prevent them
-      from having the decals oriented wrong
+  - message: Randomized maintenance rooms now use decal spawners, which prevent them from having the decals oriented wrong
     type: Tweak
   id: 33
   time: '2025-05-29T05:03:47.0000000+00:00'
@@ -287,8 +267,7 @@
   changes:
   - message: Elkridge now has turrets within the AI core, vault and armory
     type: Add
-  - message: Elkridge now has criminal records computer next to genpop within security
-      lobby
+  - message: Elkridge now has criminal records computer next to genpop within security lobby
     type: Add
   id: 35
   time: '2025-05-30T12:52:06.0000000+00:00'
@@ -302,16 +281,14 @@
   url: https://github.com/space-wizards/space-station-14/pull/37687
 - author: Mixelz
   changes:
-  - message: On Plasma, added Genpop, Salv Job Board & AI Turrets! Along with several
-      other fixes & rebalanced maints loot.
+  - message: On Plasma, added Genpop, Salv Job Board & AI Turrets! Along with several other fixes & rebalanced maints loot.
     type: Add
   id: 37
   time: '2025-06-03T04:30:22.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38028
 - author: JpegOfAFrog
   changes:
-  - message: On Plasma Station evacuation shuttle, gas holding tanks are now filled
-      when the shuttle arrives.
+  - message: On Plasma Station evacuation shuttle, gas holding tanks are now filled when the shuttle arrives.
     type: Tweak
   id: 38
   time: '2025-06-03T05:58:25.0000000+00:00'
@@ -339,50 +316,42 @@
   url: https://github.com/space-wizards/space-station-14/pull/38068
 - author: spanky-spanky
   changes:
-  - message: Most emergency shuttles have been lightly overhauled to mitigate spacing
-      damage.
+  - message: Most emergency shuttles have been lightly overhauled to mitigate spacing damage.
     type: Tweak
   id: 42
   time: '2025-06-09T22:56:33.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38186
 - author: ArtisticRoomba
   changes:
-  - message: Amber AI core LV powernet has been atomized, so each room gets its own
-      APC. Previously if you toggled the APC while the AI turrets were on it would
-      cause endless seizure-inducing flickering, so this is a tempfix until the proper
-      cause is found.
+  - message: Amber AI core LV powernet has been atomized, so each room gets its own APC. Previously if you toggled the APC while the AI turrets were on it would cause endless seizure-inducing flickering, so this is a tempfix until the proper cause is found.
     type: Tweak
   id: 43
   time: '2025-06-10T09:36:33.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38209
 - author: Vortebo
   changes:
-  - message: On Relic, mapping errors have been fixed and more job-required equipment
-      is available.
+  - message: On Relic, mapping errors have been fixed and more job-required equipment is available.
     type: Fix
   id: 44
   time: '2025-06-11T22:25:38.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38269
 - author: Deerstop
   changes:
-  - message: On Elkridge, several areas have received major overhauls, including the
-      Vault, HoP, EVA, Genpop, and the Armoury.
+  - message: On Elkridge, several areas have received major overhauls, including the Vault, HoP, EVA, Genpop, and the Armoury.
     type: Tweak
   id: 45
   time: '2025-06-13T19:17:57.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38259
 - author: SlamBamActionman
   changes:
-  - message: Exo has received a "day 1 patch", fixing various incorrectly mapped features
-      and some smaller balance tweaks.
+  - message: Exo has received a "day 1 patch", fixing various incorrectly mapped features and some smaller balance tweaks.
     type: Fix
   id: 46
   time: '2025-06-16T16:43:46.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/38348
 - author: SlamBamActionman
   changes:
-  - message: Exo has received minor balance changes and fixes, along with having its
-      Atmos layout slightly modified.
+  - message: Exo has received minor balance changes and fixes, along with having its Atmos layout slightly modified.
     type: Tweak
   id: 47
   time: '2025-06-19T04:06:17.0000000+00:00'
@@ -396,9 +365,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/37494
 - author: SlamBamActionman
   changes:
-  - message: Exo station has had several minor changes and fixes, including a change
-      to the Nuke vault to allow it to be anchored in its center and its windows blocked
-      with blastdoors.
+  - message: Exo station has had several minor changes and fixes, including a change to the Nuke vault to allow it to be anchored in its center and its windows blocked with blastdoors.
     type: Fix
   - message: Exo station's playercap has been increased from 30-70 to 40-80.
     type: Tweak
@@ -481,8 +448,7 @@
     type: Add
   - message: On Plasma, removed a pipe router that to mail routing problems.
     type: Fix
-  - message: On Plasma, removed a leftover waste pipe from underneath the science
-      circuit imprinter.
+  - message: On Plasma, removed a leftover waste pipe from underneath the science circuit imprinter.
     type: Fix
   id: 60
   time: '2025-07-23T00:53:50.0000000+00:00'
@@ -496,9 +462,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/39150
 - author: SlamBamActionman
   changes:
-  - message: Exo station has had a major Security department rework, along with the
-      eastern maintenance section of the station, as well as several other minor changes
-      across the station.
+  - message: Exo station has had a major Security department rework, along with the eastern maintenance section of the station, as well as several other minor changes across the station.
     type: Tweak
   id: 62
   time: '2025-07-31T20:28:39.0000000+00:00'
@@ -530,8 +494,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/38339
 - author: beck-thompson
   changes:
-  - message: Removed a lot of mapped gear on the nukie planet and replaced it with
-      random spawners.
+  - message: Removed a lot of mapped gear on the nukie planet and replaced it with random spawners.
     type: Tweak
   - message: Two new random spawners with loot for the nukie planet
     type: Add
@@ -540,11 +503,9 @@
   url: https://github.com/space-wizards/space-station-14/pull/39090
 - author: beck-thompson
   changes:
-  - message: Replaced the guaranteed explosives on the infiltrator with a random grenade
-      spawner and ammo bundle.
+  - message: Replaced the guaranteed explosives on the infiltrator with a random grenade spawner and ammo bundle.
     type: Tweak
-  - message: Replaced the guaranteed med spawns on the infiltrator with random med
-      kit spawners.
+  - message: Replaced the guaranteed med spawns on the infiltrator with random med kit spawners.
     type: Tweak
   - message: Added a random loot spawner to the infiltrator.
     type: Add
@@ -560,8 +521,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/39801
 - author: F1restar4
   changes:
-  - message: On Exo, added an atmospherics network monitor console to atmos' front
-      room
+  - message: On Exo, added an atmospherics network monitor console to atmos' front room
     type: Add
   id: 69
   time: '2025-08-26T08:32:58.0000000+00:00'
@@ -570,13 +530,9 @@
   changes:
   - message: On Relic, added the prison station.
     type: Add
-  - message: On Relic, Cargo has been removed, along with the trade station. Botany,
-      the Janitor's closet, and the bar have also been removed.
+  - message: On Relic, Cargo has been removed, along with the trade station. Botany, the Janitor's closet, and the bar have also been removed.
     type: Remove
-  - message: On Relic, Atmospherics has been relocated, with accompanying pipe adjustments.
-      The layouts and contents of Engineering, Science, Security, and many individual
-      rooms have been modified. The cargo shuttle is now a prison shuttle. The arrivals
-      shuttle now flies in the correct direction.
+  - message: On Relic, Atmospherics has been relocated, with accompanying pipe adjustments. The layouts and contents of Engineering, Science, Security, and many individual rooms have been modified. The cargo shuttle is now a prison shuttle. The arrivals shuttle now flies in the correct direction.
     type: Tweak
   id: 70
   time: '2025-08-28T17:40:36.0000000+00:00'
@@ -594,19 +550,16 @@
   changes:
   - message: On Marathon, gave the containment area some much needed love.
     type: Add
-  - message: On Marathon, redesigned the TEG burn chamber in preparation for the atmos
-      pressure update.
+  - message: On Marathon, redesigned the TEG burn chamber in preparation for the atmos pressure update.
     type: Tweak
-  - message: On Marathon, touched up a couple areas in Atmos and expanded the burn
-      chamber area.
+  - message: On Marathon, touched up a couple areas in Atmos and expanded the burn chamber area.
     type: Tweak
   id: 72
   time: '2025-08-29T05:40:38.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/39955
 - author: Southbridge
   changes:
-  - message: On Box, redesigned the burn chambers to be ready for the atmos pressure
-      update.
+  - message: On Box, redesigned the burn chambers to be ready for the atmos pressure update.
     type: Tweak
   id: 73
   time: '2025-08-29T05:42:00.0000000+00:00'
@@ -615,8 +568,7 @@
   changes:
   - message: On Bagel, ensured there were late join spawners at arrivals
     type: Add
-  - message: On Bagel, overhauled the TEG so it's a bit more ready for the pressure
-      update
+  - message: On Bagel, overhauled the TEG so it's a bit more ready for the pressure update
     type: Tweak
   id: 74
 - author: ScarKy0
@@ -639,16 +591,14 @@
   url: https://github.com/space-wizards/space-station-14/pull/39969
 - author: Southbridge
   changes:
-  - message: On the Cryptid, Flatline, and Cruiser event shuttles, replaced some static
-      spawns with random ones.
+  - message: On the Cryptid, Flatline, and Cruiser event shuttles, replaced some static spawns with random ones.
     type: Tweak
   id: 77
   time: '2025-09-01T23:13:52.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/40059
 - author: ArtisticRoomba
   changes:
-  - message: On Exo, the main atmospherics burn chamber is now made out of reinforced
-      plasma glass instead of resin.
+  - message: On Exo, the main atmospherics burn chamber is now made out of reinforced plasma glass instead of resin.
     type: Fix
   id: 78
   time: '2025-09-06T06:02:26.0000000+00:00'
@@ -657,8 +607,7 @@
   changes:
   - message: 'Exo: Moved the Common Telecoms from the AI Core to Bridge.'
     type: Tweak
-  - message: 'Exo: Changed the station lighting to reduce the visual impact for colorblind
-      users.'
+  - message: 'Exo: Changed the station lighting to reduce the visual impact for colorblind users.'
     type: Fix
   - message: 'Exo: Minor map fixes in various areas.'
     type: Fix
@@ -688,8 +637,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/40359
 - author: F1restar4
   changes:
-  - message: On Fland, Fixed evac's air storage cell instantly shattering due to delta
-      pressure
+  - message: On Fland, Fixed evac's air storage cell instantly shattering due to delta pressure
     type: Fix
   id: 83
   time: '2025-09-17T04:47:18.0000000+00:00'
@@ -740,19 +688,16 @@
   url: https://github.com/space-wizards/space-station-14/pull/40590
 - author: ToastEnjoyer
   changes:
-  - message: On Marathon, added various improvements to engineering, parts of maints,
-      and some service improvements.
+  - message: On Marathon, added various improvements to engineering, parts of maints, and some service improvements.
     type: Tweak
-  - message: On Marathon, the security front has been fixed so that power is there
-      roundstart.
+  - message: On Marathon, the security front has been fixed so that power is there roundstart.
     type: Fix
   id: 90
   time: '2025-10-07T02:21:21.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/40725
 - author: Vortebo
   changes:
-  - message: On Relic, some small changes to address unintended gameplay issues and
-      further increase historical accuracy.
+  - message: On Relic, some small changes to address unintended gameplay issues and further increase historical accuracy.
     type: Tweak
   id: 91
   time: '2025-10-08T16:59:59.0000000+00:00'
@@ -796,11 +741,9 @@
   changes:
   - message: On Amber, redesigned the kitchen to be slightly larger.
     type: Tweak
-  - message: On Amber, converted the method to get to the AI core from a disposal
-      chute to an actual sky-bridge.
+  - message: On Amber, converted the method to get to the AI core from a disposal chute to an actual sky-bridge.
     type: Tweak
-  - message: On Amber, added an abundance of cameras to allow the AI to actually see
-      the station now.
+  - message: On Amber, added an abundance of cameras to allow the AI to actually see the station now.
     type: Fix
   id: 97
   time: '2025-10-13T21:06:19.0000000+00:00'
@@ -828,8 +771,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/41329
 - author: Blackern5000
   changes:
-  - message: Entirely remade the meatball magnet wreck to better work as a wreck for
-      salvage.
+  - message: Entirely remade the meatball magnet wreck to better work as a wreck for salvage.
     type: Tweak
   id: 101
   time: '2025-11-27T10:28:23.0000000+00:00'
@@ -852,19 +794,16 @@
   url: https://github.com/space-wizards/space-station-14/pull/40300
 - author: Hitlinemoss
   changes:
-  - message: On Snowball, the airlock connecting EVA Storage and the Head of Personnel's
-      office now uses Head of Personnel access rather than Externals access.
+  - message: On Snowball, the airlock connecting EVA Storage and the Head of Personnel's office now uses Head of Personnel access rather than Externals access.
     type: Fix
-  - message: On Snowball, the Head of Personnel's office windoors are now linked to
-      each other, like on other maps.
+  - message: On Snowball, the Head of Personnel's office windoors are now linked to each other, like on other maps.
     type: Fix
   id: 104
   time: '2025-12-02T19:16:19.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/41675
 - author: Spessmann
   changes:
-  - message: On Snowball, the Service access requirement on the dorms airlocks has
-      been removed
+  - message: On Snowball, the Service access requirement on the dorms airlocks has been removed
     type: Fix
   - message: On Snowball, more station beacons have been added to medical.
     type: Add
@@ -873,8 +812,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/41683
 - author: Hitlinemoss
   changes:
-  - message: On Snowball, the Head of Security's hardsuit is no longer absent, and
-      now spawns in their locker.
+  - message: On Snowball, the Head of Security's hardsuit is no longer absent, and now spawns in their locker.
     type: Fix
   id: 106
   time: '2025-12-04T03:44:12.0000000+00:00'
@@ -941,8 +879,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/41806
 - author: Minemoder
   changes:
-  - message: The Arrivals Shuttle had its powernet changed to not rely on generators
-      and become more tamper proof.
+  - message: The Arrivals Shuttle had its powernet changed to not rely on generators and become more tamper proof.
     type: Tweak
   id: 115
   time: '2025-12-18T20:37:25.0000000+00:00'
@@ -965,8 +902,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/42028
 - author: EchoOfNothing
   changes:
-  - message: On Plasma, added a second APC to telecommunications, so the APC is no
-      longer overloaded at the start of the round.
+  - message: On Plasma, added a second APC to telecommunications, so the APC is no longer overloaded at the start of the round.
     type: Fix
   id: 118
   time: '2025-12-29T04:05:53.0000000+00:00'
@@ -1003,8 +939,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/42822
 - author: Vortebo
   changes:
-  - message: On Relic, small changes to e.g. spawns, wiring, pipes, signage have been
-      made to slightly reduce friction in gameplay. Slightly.
+  - message: On Relic, small changes to e.g. spawns, wiring, pipes, signage have been made to slightly reduce friction in gameplay. Slightly.
     type: Tweak
   id: 123
   time: '2026-02-22T22:16:29.0000000+00:00'
@@ -1020,11 +955,9 @@
   url: https://github.com/space-wizards/space-station-14/pull/42911
 - author: Blackern5000
   changes:
-  - message: Entirely remade the Vegan Meatball magnet wreck to better work as a wreck
-      for salvage.
+  - message: Entirely remade the Vegan Meatball magnet wreck to better work as a wreck for salvage.
     type: Tweak
-  - message: The Vegan Meatball magnet wreck should no longer pollute space with dozens
-      of enemies after despawning
+  - message: The Vegan Meatball magnet wreck should no longer pollute space with dozens of enemies after despawning
     type: Fix
   id: 125
   time: '2026-02-22T23:20:39.0000000+00:00'
@@ -1054,8 +987,7 @@
   url: https://github.com/space-wizards/space-station-14/pull/43102
 - author: Sapphic_bee
   changes:
-  - message: On Exo, the AI north and south external cameras are now connected to
-      power.
+  - message: On Exo, the AI north and south external cameras are now connected to power.
     type: Fix
   id: 130
   time: '2026-03-15T00:02:49.0000000+00:00'
@@ -1243,4 +1175,136 @@
   id: 153
   time: '2026-07-22T07:15:37.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/44754
+- author: Minemoder
+  changes:
+  - message: The displaced telescience ruin had its intercom changed from all channels to only common and science.
+    type: Tweak
+  id: 154
+  time: '2026-07-27T00:00:03.0000000+00:00'
+- author: Emisse
+  changes:
+  - message: Several job slots have been tweaked across the board to accommodate a smaller maxpop.
+    type: Tweak
+  - message: Reach has been removed from the default map pool.
+    type: Remove
+  id: 155
+  time: '2026-07-29T14:47:34.0000000+00:00'
+- author: SuperDicq
+  changes:
+  - message: Added Sushi Station!
+    type: Add
+  - message: Some more Sushi Station updates.
+    type: Tweak
+  id: 156
+  time: '2026-08-01T17:20:31.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: On all Cargo shuttles - Tweaked atmos systems and small fixes
+    type: Tweak
+  id: 157
+  time: '2026-08-01T19:47:13.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: On Fland - Reworked the TEG room + small tweaks around atmos.
+    type: Tweak
+  id: 158
+  time: '2026-08-01T19:47:13.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: On Bagel - Replaced some pressure pumps to manual valves in atmos
+    type: Tweak
+  id: 159
+  time: '2026-08-01T20:12:53.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: On Box station - Added AI restoration console in RD office and minor issue fixes
+    type: Add
+  id: 160
+  time: '2026-08-03T18:19:36.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: On Elkridge - Added AI restoration console to RD office and other issue fixes
+    type: Add
+  id: 161
+  time: '2026-08-03T18:36:28.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: On Bagel - Moved exosuit fabricator and material silo in science and other minor tweaks and fixes.
+    type: Tweak
+  - message: On Bagel - Added missing AI restoration console to RD office.
+    type: Add
+  id: 162
+  time: '2026-08-03T18:42:03.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: On Plasma - Added missing AI Restoration computer and other issue fixes
+    type: Add
+  - message: On Plasma - Arrivals and Evac airlocks no longer bolt when open
+    type: Tweak
+  - message: On Plasma - You can now clean all the dirt decals
+    type: Fix
+  id: 163
+  time: '2026-08-03T21:20:28.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: On Packed - You will no longer spawn in cryogenics pod at round start and other tweaks and fixes
+    type: Fix
+  id: 164
+  time: '2026-08-05T19:30:13.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: On Elkridge - You will no longer spawn in cryogenics pod at round start
+    type: Fix
+  id: 165
+  time: '2026-08-05T20:08:46.0000000+00:00'
+- author: Spessmann
+  changes:
+  - message: On Snowball added wheelchairs to med
+    type: Add
+  - message: On Snowball removed escape pods
+    type: Remove
+  id: 166
+  time: '2026-08-09T04:34:51.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: Updated Box to comply with the Respritening.
+    type: Tweak
+  id: 167
+  time: '2026-08-22T23:10:16.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: Updated Snowball to comply with the Respritening.
+    type: Tweak
+  id: 168
+  time: '2026-08-22T23:10:33.0000000+00:00'
+- author: SuperDicq
+  changes:
+  - message: Updated Sushi Station to comply with the Respritening.
+    type: Tweak
+  id: 169
+  time: '2026-08-22T23:10:41.0000000+00:00'
+- author: ScarKy0
+  changes:
+  - message: Updated event shuttles to comply with the Respritening.
+    type: Tweak
+  id: 170
+  time: '2026-08-22T23:11:05.0000000+00:00'
+- author: ketufaispikinut
+  changes:
+  - message: Added energy gates to Elkridge's arrivals.
+    type: Add
+  id: 171
+  time: '2026-08-22T23:11:14.0000000+00:00'
+- author: ScarKy0
+  changes:
+  - message: Updated Marathon to comply with the Respritening.
+    type: Tweak
+  id: 172
+  time: '2026-08-22T23:13:04.0000000+00:00'
+- author: ProPeperos
+  changes:
+  - message: Updated Packed to comply with the Respritening.
+    type: Tweak
+  id: 173
+  time: '2026-08-22T23:13:15.0000000+00:00'
 Order: 2

--- a/Resources/Changelog/Rules.yml
+++ b/Resources/Changelog/Rules.yml
@@ -1,4 +1,5 @@
-﻿Entries:
+AdminOnly: false
+Entries:
 - author: Errant
   changes:
   - message: Tab created.


### PR DESCRIPTION
Needs a pair of eyes on changelog.
Changelog publish steps are not working due to branch protection, so needs some additional work, so commenting them out for now.