### PR TITLE
Bugfix: construction ghosts respect offsets

### DIFF
--- a/Content.Client/Construction/ConstructionPlacementHijack.cs
+++ b/Content.Client/Construction/ConstructionPlacementHijack.cs
@@ -64,7 +64,7 @@ public sealed partial class ConstructionPlacementHijack : PlacementHijack
         if (!_protoMan.HasIndex(targetProtoId))
             return;
 
-        // Spawn our entity, get its SpriteComponent
+        // Set up our placement sprite from a test entity (deleted afterwards)
         var targetUid = _entMan.Spawn(targetProtoId);
         try
         {

--- a/Content.Client/Construction/ConstructionPlacementHijack.cs
+++ b/Content.Client/Construction/ConstructionPlacementHijack.cs
@@ -11,8 +11,11 @@ public sealed partial class ConstructionPlacementHijack : PlacementHijack
 {
     [Dependency] private IEntityManager _entMan = default!;
     [Dependency] private IPrototypeManager _protoMan = default!;
+
+    private EntityQuery<ConstructionGhostComponent> _constructionGhostQuery;
+    private EntityQuery<SpriteComponent> _spriteQuery;
+
     private readonly ConstructionSystem _constructionSystem;
-    private readonly SpriteSystem _spriteSystem;
 
     private readonly ConstructionPrototype? _prototype;
 
@@ -25,7 +28,8 @@ public sealed partial class ConstructionPlacementHijack : PlacementHijack
         IoCManager.InjectDependencies(this);
 
         _constructionSystem = _entMan.System<ConstructionSystem>();
-        _spriteSystem = _entMan.System<SpriteSystem>();
+        _constructionGhostQuery = _entMan.GetEntityQuery<ConstructionGhostComponent>();
+        _spriteQuery = _entMan.GetEntityQuery<SpriteComponent>();
         _prototype = prototype;
         CanRotate = prototype?.CanRotate ?? true;
     }
@@ -44,7 +48,7 @@ public sealed partial class ConstructionPlacementHijack : PlacementHijack
     /// <inheritdoc />
     public override bool HijackDeletion(EntityUid entity)
     {
-        if (_entMan.HasComponent<ConstructionGhostComponent>(entity))
+        if (_constructionGhostQuery.HasComp(entity))
             _constructionSystem.ClearGhost(entity.GetHashCode());
         return true;
     }
@@ -57,9 +61,20 @@ public sealed partial class ConstructionPlacementHijack : PlacementHijack
         if (_prototype is null || !_constructionSystem.TryGetRecipePrototype(_prototype.ID, out var targetProtoId))
             return;
 
-        if (!_protoMan.TryIndex(targetProtoId, out var proto))
+        if (!_protoMan.HasIndex(targetProtoId))
             return;
 
-        manager.CurrentTextures = _spriteSystem.GetPrototypeTextures(proto).ToList();
+        // Spawn our entity, get its SpriteComponent
+        var targetUid = _entMan.Spawn(targetProtoId);
+        try
+        {
+            var sprite = _spriteQuery.Comp(targetUid);
+
+            manager.PreparePlacementSprite((targetUid, sprite));
+        }
+        finally
+        {
+            _entMan.DeleteEntity(targetUid);
+        }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

ConstructionPlacementHijack now uses PlacementManager.PreparePlacementSprite vs. updating the textures used.

## Why / Balance

Resolves #45644.

## Technical details

PlacementManager.PreparePlacementSprite, which uses CopyComp internally, should copy fields like the sprite offset for a given sprite, vs. updating the textures directly.

This may be inefficient, but it seems functional.

## Test plan

Build some lights, the light should draw over the walls when it's positioned as you would expect lights to be placed.

## Media

Very simple test case where lights are placed and constructed from the construction menu.
https://github.com/user-attachments/assets/f7ca0178-2e67-4ef9-97b1-3ebcd5dd4210

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- fix: Construction ghosts for offset objects like lights should now be positioned correctly.
