### PR TITLE
Multi-stage metabolizers: limits are global, reverse order for multi-stage organs

### DIFF
--- a/Content.Shared/Metabolism/MetabolizerSystem.cs
+++ b/Content.Shared/Metabolism/MetabolizerSystem.cs
@@ -126,8 +126,12 @@ public sealed partial class MetabolizerSystem : EntitySystem
         return true;
     }
 
-    private void TryMetabolizeStage(Entity<MetabolizerComponent, OrganComponent?, SolutionManagerComponent?> ent, ProtoId<MetabolismStagePrototype> stage)
+    private void TryMetabolizeStage(Entity<MetabolizerComponent, OrganComponent?, SolutionManagerComponent?> ent, ProtoId<MetabolismStagePrototype> stage, ref int reagentsProcessed)
     {
+        // Have we already processed all the reagents this organ can handle?
+        if (reagentsProcessed >= ent.Comp1.MaxReagentsProcessable)
+            return;
+
         if (!ent.Comp1.Solutions.TryGetValue(stage, out var solutionData))
             return;
 
@@ -153,10 +157,9 @@ public sealed partial class MetabolizerSystem : EntitySystem
 
         var isDead = _mobStateSystem.IsDead(solutionOwner.Value);
 
-        int reagents = 0;
         foreach (var (reagent, quantity) in list)
         {
-            if (!ProtoMan.TryIndex<ReagentPrototype>(reagent.Prototype, out var proto))
+            if (!ProtoMan.TryIndex(reagent.Prototype, out var proto))
                 continue;
 
             // Skip blood reagents
@@ -186,12 +189,12 @@ public sealed partial class MetabolizerSystem : EntitySystem
             var mostToRemove = FixedPoint2.Clamp(rate, 0, quantity);
 
             // we're done here entirely if this is true
-            if (reagents >= ent.Comp1.MaxReagentsProcessable)
+            if (reagentsProcessed >= ent.Comp1.MaxReagentsProcessable)
                 return;
 
-            var scale = (float) mostToRemove;
+            var scale = (float)mostToRemove;
             if (!solutionData.MetabolizeAll)
-                scale /= (float) rate;
+                scale /= (float)rate;
 
             // if it's possible for them to be dead, and they are,
             // then we shouldn't process any effects, but should probably
@@ -241,7 +244,7 @@ public sealed partial class MetabolizerSystem : EntitySystem
                 solution.RemoveReagent(reagent, mostToRemove);
 
                 // We have processed a reagant, so count it towards the cap
-                reagents += 1;
+                reagentsProcessed += 1;
 
                 if (transferSolution is not null && entry.Metabolites is not null)
                 {
@@ -265,9 +268,10 @@ public sealed partial class MetabolizerSystem : EntitySystem
         _organQuery.Resolve(ent, ref ent.Comp2, logMissing: false);
         _solutionQuery.Resolve(ent, ref ent.Comp3, logMissing: false);
 
+        var reagents = 0;
         foreach (var stage in ent.Comp1.Stages)
         {
-            TryMetabolizeStage(ent, stage);
+            TryMetabolizeStage(ent, stage, ref reagents);
         }
     }
 

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -277,7 +277,7 @@
   components:
   - type: Metabolizer
     maxReagents: 6
-    stages: [ Digestion, Bloodstream, Metabolites ]
+    stages: [ Metabolites, Bloodstream, Digestion ]
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -261,7 +261,7 @@
   - type: Metabolizer
     maxReagents: 6
     metabolizerTypes: [ Slime ]
-    stages: [ Digestion, Bloodstream, Metabolites ]
+    stages: [ Metabolites, Bloodstream, Digestion ]
 
 - type: entity
   parent: [ OrganBaseEyes, OrganSlimePersonInternal, OrganSlimePersonExternal ]

--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -90,7 +90,7 @@
     solutionOnBody: false
     updateInterval: 0.25
     metabolizerTypes: [ Dragon ]
-    stages: [ Digestion, Bloodstream ]
+    stages: [ Bloodstream, Digestion ]
   - type: ToolRefinable
     refineResult:
     - id: MaterialBananium1

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -113,7 +113,7 @@
     solutionOnBody: false
     updateInterval: 0.25
     metabolizerTypes: [ Dragon ]
-    stages: [ Digestion, Bloodstream ]
+    stages: [ Bloodstream, Digestion ]
   - type: ToolRefinable
     refineResult:
     - id: FoodMeatDragon


### PR DESCRIPTION
## About the PR

Applies Metabolizer limits globally (vs. per-stage) for multi-stage organs (diona stomachs, slime cores) - these will now only act over six reagents total, not six per stage.

## Why / Balance

Prompted by https://discord.com/channels/310555209753690112/1541854243001073664 (thank you to Bald Man, whose github handle I forget)

Seems like an oversight from #42172.  This makes multi-stage organs _insanely_ powerful in comparison.

If this count should be increased, wonderful, let's talk about it!  I would argue, though, that it _really_ shouldn't be specified per-stage!

Reversing order: part of #45182 (doesn't affect ordering over multiple entities, e.g. stomach vs. lungs vs. heart, only multi-stage entities)

## Technical details

New `reagentsProcessed` parameter in `MetabolismSystem.TryMetabolizeStage` that's used to track the number of reagents processed by this organ so far - this accumulates over stages, and when it reaches a limit, processing stops for all stages.

## Test plan

1. Add the following YAML snippet into the game's files.

<details>
<summary>Test entities</summary>

```yaml
- type: injectorMode
  abstract: true
  id: TestHyposprayMode
  injectSound: /Audio/Items/hypospray.ogg
  injectPopupTarget: injector-component-feel-prick-message
  injectOnUse: true
  delayPerVolume: 0
  transferAmounts:
  - 240

- type: injectorMode
  abstract: true
  parent: TestHyposprayMode
  id: TestInstantHyposprayMode
  mobTime: 0

- type: injectorMode
  parent: [ TestInstantHyposprayMode, BaseInjectMode ]
  id: TestHyposprayInjectMode

- type: injectorMode
  parent: [ TestInstantHyposprayMode, BaseDynamicMode ]
  id: TestHyposprayDynamicMode

- type: entity
  parent: Hypospray
  id: TestHypospray
  name: Whatstone's patent medicine injector
  description: Cures what ails you.
  components:
  - type: Injector
    activeModeProtoId: TestHyposprayDynamicMode
    allowedModes:
    - TestHyposprayDynamicMode
    - TestHyposprayInjectMode
    currentTransferAmount: 240
  - type: Solution
    solution:
      maxVol: 240
      reagents:
      # 6 bloodstream
      - ReagentId: Kelotane
        Quantity: 20
      - ReagentId: Arithrazine
        Quantity: 20
      - ReagentId: Tricordrazine
        Quantity: 20
      - ReagentId: DexalinPlus
        Quantity: 20
      - ReagentId: Cryoxadone
        Quantity: 20
      - ReagentId: Opporozidone
        Quantity: 20

- type: entity
  parent: DrinkCanBaseFull
  id: TestDrinkSodaWaterCan
  name: Whatstone's patent turbo gulp soda
  description: Delicious.
  components:
  - type: Edible
    transferAmount: 240
  - type: Solution
    solution:
      maxVol: 240
      reagents:
      # 6 digestion
      - ReagentId: Cola
        Quantity: 40
      - ReagentId: RoyRogers
        Quantity: 40
      - ReagentId: DrGibb
        Quantity: 40
      - ReagentId: GrapeSoda
        Quantity: 40
      - ReagentId: LemonLime
        Quantity: 40
      - ReagentId: LemonLimeCranberry
        Quantity: 40
  - type: Sprite
    sprite: Objects/Consumable/Drinks/sodawater.rsi
  - type: Item
    sprite: Objects/Consumable/Drinks/sodawater.rsi
```

</details>

2. Spawn Urist McWobbles and a beaker.
3. Fill the beaker with SodiumPolyacrylate, drink it to get yourself thirsty.  You should have a visible thirst status for the purposes of the test.
4. Spawn Whatstone's patent medicine injector and Whatstone's patent turbo gulp soda.
5. Drink the soda and inject yourself with medicine at the same time.
6. Check your solution - your thirst should not decrease until your medicine is processed, as your slime core is processing six reagents total.

## Media

The test procedure - a slime injects medicine and drinks a soda.  The 6 medicines digest at once, but the soda is not processed until those reagents are processed, respecting the new metabolism order.

https://github.com/user-attachments/assets/7507b92e-1429-4e3e-ab10-3dcc27b24fe5

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


## Changelog
:cl:
- tweak: Diona and slimes now process 6 reagents total, of any reagent group.