### PR TITLE
Added Chat Filters

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -48,6 +48,7 @@
                 <ui:OptionColorSlider Name="HighlightsColorSlider"
                     Title="{Loc 'ui-options-highlights-color'}"
                     Example="{Loc 'ui-options-highlights-color-example'}"/>
+                <ui:OptionDropDown Name="WordFilterSymbolDropDown" Title="{Loc 'ui-options-word-filters-symbol'}" />
                 <Label Text="{Loc 'ui-options-accessibility-header-content'}"
                        StyleClasses="LabelKeyText"/>
                 <CheckBox Name="CensorNudityCheckBox" Text="{Loc 'ui-options-censor-nudity'}" />

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -32,7 +32,14 @@ public sealed partial class AccessibilityTab : Control
         Control.AddOptionPercentSlider(CCVars.SpeechBubbleBackgroundOpacity, SpeechBubbleBackgroundOpacitySlider);
         Control.AddOptionCheckBox(CCVars.ChatAutoFillHighlights, AutoFillHighlightsCheckBox);
         Control.AddOptionColorSlider(CCVars.ChatHighlightsColor, HighlightsColorSlider);
-
+        var symbolOptions = new List<OptionDropDownCVar<string>.ValueOption>
+            {
+                new("*", "* (Asterisk)"),
+                new("#", "# (Hash)"),
+                new("?", "? (Question)"),
+                new("-", "- (Dash)"),
+            };
+        Control.AddOptionDropDown(CCVars.ChatWordFiltersSymbol, WordFilterSymbolDropDown, symbolOptions);
         Control.AddOptionCheckBox(CCVars.AccessibilityClientCensorNudity, CensorNudityCheckBox);
 
         Control.Initialize();

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.WordFilters.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.WordFilters.cs
@@ -1,0 +1,88 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using Content.Shared.CCVar;
+
+namespace Content.Client.UserInterface.Systems.Chat;
+
+public sealed partial class ChatUIController
+{
+    /// <summary>
+    ///     The list of words to be masked in the chatbox.
+    /// </summary>
+    private readonly List<Regex> _filters = new();
+
+    /// <summary>
+    ///     The string holding the special symbol used to mask words.
+    /// </summary>
+    private string? _filterSymbol;
+
+    public event Action<string>? WordFiltersUpdated;
+
+    private void InitializeFilters()
+    {
+        _config.OnValueChanged(CCVars.ChatWordFiltersSymbol, (value) => { _filterSymbol = value; }, true);
+
+        // Load filters if any were saved.
+        var filters = _config.GetCVar(CCVars.ChatWordFilters);
+
+        if (!string.IsNullOrEmpty(filters))
+        {
+            UpdateWordFilters(filters, true);
+        }
+    }
+
+
+    public void UpdateWordFilters(string newFilters, bool firstLoad = false)
+    {
+        // Do nothing if the provided filters are the same as the old ones and it is not the first time.
+        if (!firstLoad && _config.GetCVar(CCVars.ChatWordFilters).Equals(newFilters, StringComparison.CurrentCultureIgnoreCase))
+            return;
+
+        _config.SetCVar(CCVars.ChatWordFilters, newFilters);
+        _config.SaveToFile();
+
+        ReloadWordFilters();
+        WordFiltersUpdated?.Invoke(newFilters);
+    }
+
+    public void ReloadWordFilters()
+    {
+        _filters.Clear();
+
+        var filters = _config.GetCVar(CCVars.ChatWordFilters);
+
+        // We first subdivide the filters based on newlines to prevent replacing
+        // a valid "\n" tag and adding it to the final regex.
+        var splittedFilters = filters.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        Array.Sort(splittedFilters, (x, y) => y.Length.CompareTo(x.Length));
+
+        for (var i = 0; i < splittedFilters.Length; i++)
+        {
+            // Replace every "\" character with a "\\" to prevent "\n", "\0", etc...
+            var keyword = splittedFilters[i].Replace(@"\", @"\\");
+
+            // Escape the keyword to prevent special characters like "(" and ")" to be considered valid regex.
+            keyword = Regex.Escape(keyword);
+
+            // 1. Since the "["s in WrappedMessage are already sanitized, add 2 extra "\"s
+            // to make sure it matches the literal "\" before the square bracket.
+            keyword = keyword.Replace(@"\[", @"\\\[");
+
+            // If present, replace the double quotes at the edges with tags
+            // that make sure the words to match are separated by spaces or punctuation.
+            // NOTE: The reason why we don't use \b tags is that \b doesn't match reverse slash characters "\" so
+            // a pre-sanitized (see 1.) string like "\[test]" wouldn't get picked up by the \b.
+            if (keyword.Any(c => c == '"'))
+            {
+                // Matches the last double quote character.
+                keyword = StartDoubleQuote.Replace(keyword, "(?!\\w)");
+                // When matching for the first double quote character we also consider the possibility
+                // of the double quote being preceded by a @ character.
+                keyword = EndDoubleQuote.Replace(keyword, "(?<!\\w)");
+            }
+
+            _filters.Add(new Regex("(?i)(" + keyword + ")(?-i)(?![^[]*])"));
+        }
+    }
+}

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -241,6 +241,7 @@ public sealed partial class ChatUIController : UIController
         _config.OnValueChanged(CCVars.ChatWindowOpacity, OnChatWindowOpacityChanged);
 
         InitializeHighlights();
+        InitializeFilters();
     }
 
     public void OnScreenLoad()
@@ -832,6 +833,12 @@ public sealed partial class ChatUIController : UIController
         foreach (var highlight in _highlights)
         {
             msg.WrappedMessage = SharedChatSystem.InjectTagAroundString(msg, highlight, "color", _highlightsColor);
+        }
+
+        var filterSymbol = !string.IsNullOrEmpty(_filterSymbol) ? _filterSymbol[0] : '*';
+        foreach (var filter in _filters)
+        {
+            msg.WrappedMessage = filter.Replace(msg.WrappedMessage, match => new string(filterSymbol, match.Length));
         }
 
         // Color any codewords for minds that have roles that use them

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml
@@ -17,6 +17,18 @@
                 </PanelContainer>
                 <Button Name="HighlightButton" Text="{Loc 'hud-chatbox-highlights-button'}" ToolTip="{Loc 'hud-chatbox-highlights-tooltip'}"/>
             </BoxContainer>
+            <BoxContainer Name="WordFiltersVBox" MinWidth="120" Margin="0 10" Orientation="Vertical" SeparationOverride="4">
+                <Label Text="{Loc 'hud-chatbox-word-filters'}"/>
+                <PanelContainer>
+                    <!-- Begin custom background for TextEdit -->
+                    <PanelContainer.PanelOverride>
+                        <gfx:StyleBoxFlat BackgroundColor="#323446"/>
+                    </PanelContainer.PanelOverride>
+                    <!-- End custom background -->
+                    <TextEdit Name="WordFilterEdit" MinHeight="150" Margin="5 5"/>
+                </PanelContainer>
+                <Button Name="WordFilterButton" Text="{Loc 'hud-chatbox-word-filters-button'}" ToolTip="{Loc 'hud-chatbox-word-filters-tooltip'}"/>
+            </BoxContainer>
         </BoxContainer>
     </PanelContainer>
 </controls:ChannelFilterPopup>

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -33,14 +33,18 @@ public sealed partial class ChannelFilterPopup : Popup
 
     public event Action<ChatChannel, bool>? OnChannelFilter;
     public event Action<string>? OnNewHighlights;
+    public event Action<string>? OnNewFilters;
 
     public ChannelFilterPopup()
     {
         RobustXamlLoader.Load(this);
 
         HighlightButton.OnPressed += HighlightsEntered;
+        WordFilterButton.OnPressed += WordFiltersEntered;
         // Add a placeholder text to the highlights TextEdit.
         HighlightEdit.Placeholder = new Rope.Leaf(Loc.GetString("hud-chatbox-highlights-placeholder"));
+        // Add a placeholder text to the word filters TextEdit.
+        WordFilterEdit.Placeholder = new Rope.Leaf(Loc.GetString("hud-chatbox-word-filters-placeholder"));
 
         // Load highlights if any were saved.
         var cfg = IoCManager.Resolve<IConfigurationManager>();
@@ -49,6 +53,14 @@ public sealed partial class ChannelFilterPopup : Popup
         if (!string.IsNullOrEmpty(highlights))
         {
             UpdateHighlights(highlights);
+        }
+
+        // Load word filters if any were saved.
+        string wordFilters = cfg.GetCVar(CCVars.ChatWordFilters);
+
+        if (!string.IsNullOrEmpty(wordFilters))
+        {
+            UpdateWordFilters(wordFilters);
         }
     }
 
@@ -114,6 +126,11 @@ public sealed partial class ChannelFilterPopup : Popup
         HighlightEdit.TextRope = new Rope.Leaf(highlights);
     }
 
+    public void UpdateWordFilters(string wordFilters)
+    {
+        WordFilterEdit.TextRope = new Rope.Leaf(wordFilters);
+    }
+
     private void CheckboxPressed(ButtonEventArgs args)
     {
         var checkbox = (ChannelFilterCheckbox) args.Button;
@@ -123,6 +140,11 @@ public sealed partial class ChannelFilterPopup : Popup
     private void HighlightsEntered(ButtonEventArgs _args)
     {
         OnNewHighlights?.Invoke(Rope.Collapse(HighlightEdit.TextRope));
+    }
+
+    private void WordFiltersEntered(ButtonEventArgs _args)
+    {
+        OnNewFilters?.Invoke(Rope.Collapse(WordFilterEdit.TextRope));
     }
 
     public void UpdateUnread(ChatChannel channel, int? unread)

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -42,9 +42,11 @@ public partial class ChatBox : UIWidget
         ChatInput.ChannelSelector.OnChannelSelect += OnChannelSelect;
         ChatInput.FilterButton.Popup.OnChannelFilter += OnChannelFilter;
         ChatInput.FilterButton.Popup.OnNewHighlights += OnNewHighlights;
+        ChatInput.FilterButton.Popup.OnNewFilters += OnNewFilters;
         _controller = UserInterfaceManager.GetUIController<ChatUIController>();
         _controller.MessageAdded += OnMessageAdded;
         _controller.HighlightsUpdated += OnHighlightsUpdated;
+        _controller.WordFiltersUpdated += OnWordFiltersUpdated;
         _controller.RegisterChat(this);
     }
 
@@ -74,6 +76,11 @@ public partial class ChatBox : UIWidget
     private void OnHighlightsUpdated(string highlights)
     {
         ChatInput.FilterButton.Popup.UpdateHighlights(highlights);
+    }
+
+    private void OnWordFiltersUpdated(string wordFilters)
+    {
+        ChatInput.FilterButton.Popup.UpdateWordFilters(wordFilters);
     }
 
     private void OnChannelSelect(ChatSelectChannel channel)
@@ -109,6 +116,11 @@ public partial class ChatBox : UIWidget
     private void OnNewHighlights(string highlighs)
     {
         _controller.UpdateHighlights(highlighs);
+    }
+
+    private void OnNewFilters(string wordFilters)
+    {
+        _controller.UpdateWordFilters(wordFilters);
     }
 
     public void AddLine(string message, Color color)

--- a/Content.IntegrationTests/Tests/Chat/ChatFilteringTest.cs
+++ b/Content.IntegrationTests/Tests/Chat/ChatFilteringTest.cs
@@ -1,0 +1,116 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Content.Client.UserInterface.Systems.Chat;
+using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
+using Content.Shared.CCVar;
+using Content.Shared.Chat;
+using NUnit.Framework;
+using Robust.Client.UserInterface;
+using Robust.Shared.Configuration;
+
+namespace Content.IntegrationTests.Tests.Chat;
+
+public sealed class ChatFilteringTest : GameTest
+{
+    [SidedDependency(Side.Client)] private readonly IConfigurationManager _configManager = null!;
+    [SidedDependency(Side.Client)] private readonly IUserInterfaceManager _uiManager = null!;
+
+    [Test]
+    [RunOnSide(Side.Client)]
+    public async Task TestCustomWordFiltersSaved()
+    {
+        var chatController = _uiManager.GetUIController<ChatUIController>();
+
+        // 1. Set custom word filters
+        var customFilters = "ling\nrev\n\"syndicate\"";
+        chatController.UpdateWordFilters(customFilters);
+
+        // 2. Verify they are saved to CVar
+        Assert.That(_configManager.GetCVar(CCVars.ChatWordFilters), Is.EqualTo(customFilters));
+
+        // 3. Verify internal active regex filters
+        var filtersField = chatController.GetType().GetField(
+            "_filters",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        Assert.That(filtersField, Is.Not.Null);
+        var activeFilters = (List<Regex>)filtersField.GetValue(chatController)!;
+
+        Assert.That(activeFilters.Count, Is.EqualTo(3));
+
+        // Sorted by length descending: "syndicate" (9), "ling" (4), "rev" (3)
+        var patterns = activeFilters.ConvertAll(r => r.ToString());
+        Assert.That(patterns[0], Does.Contain("(?<!\\w)syndicate(?!\\w)"));
+        Assert.That(patterns[1], Does.Contain("ling"));
+        Assert.That(patterns[2], Does.Contain("rev"));
+    }
+
+    [Test]
+    [RunOnSide(Side.Client)]
+    public async Task TestWordFilteringMasksMessage()
+    {
+        var chatController = _uiManager.GetUIController<ChatUIController>();
+
+        // 1. Set custom word filters: "ling", exact word "rev", and "Captain"
+        var customFilters = "ling\n\"rev\"\nCaptain";
+        chatController.UpdateWordFilters(customFilters);
+
+        // 2. Create message with matches
+        var originalText = "The Captain saw a ling and revolution!";
+        var msg = new ChatMessage(
+            ChatChannel.Local,
+            originalText,
+            originalText,
+            default,
+            null
+        );
+
+        // 3. Process the chat message
+        chatController.ProcessChatMessage(msg);
+
+        // 4. Assertions:
+        // - "Captain" (7 chars) -> "*******"
+        // - "ling" (4 chars) -> "****"
+        // - "revolution" must NOT be masked because "rev" is quoted as whole word
+        Assert.That(msg.WrappedMessage, Is.EqualTo("The ******* saw a **** and revolution!"));
+    }
+
+    [Test]
+    [RunOnSide(Side.Client)]
+    public async Task TestWordFilteringPreservesTagsAndCustomSymbol()
+    {
+        var chatController = _uiManager.GetUIController<ChatUIController>();
+
+        // 1. Set custom filter symbol to '#'
+        _configManager.SetCVar(CCVars.ChatWordFiltersSymbol, "#");
+
+        // 2. Set custom word filters
+        chatController.UpdateWordFilters("red\nfool");
+
+        // 3. Create message with rich text tags
+        var originalText = "[color=red]You red fool![/color]";
+        var msg = new ChatMessage(
+            ChatChannel.Local,
+            originalText,
+            originalText,
+            default,
+            null
+        );
+
+        // 4. Process the chat message
+        chatController.ProcessChatMessage(msg);
+
+        // 5. Assertions:
+        // - Tag "[color=red]" must remain untouched
+        // - "red" inside text -> "###"
+        // - "fool" inside text -> "####"
+        Assert.That(msg.WrappedMessage, Is.EqualTo("[color=red]You ### ####![/color]"));
+
+        // Reset filter symbol back to default
+        _configManager.SetCVar(CCVars.ChatWordFiltersSymbol, "*");
+    }
+}

--- a/Content.Shared/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/CCVar/CCVars.Chat.cs
@@ -83,4 +83,13 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<string> ChatHighlightsColor =
         CVarDef.Create("chat.highlights_color", "#17FFC1FF", CVar.CLIENTONLY | CVar.ARCHIVE, "The color in which the highlights will be displayed.");
+
+    /// <summary>
+    /// A string containing a list of newline-separated words to be masked in the chat.
+    /// </summary>
+    public static readonly CVarDef<string> ChatWordFilters =
+        CVarDef.Create("chat.word_filters", "", CVar.CLIENTONLY | CVar.ARCHIVE, "A list of newline-separated words to be masked in the chat.");
+
+    public static readonly CVarDef<string> ChatWordFiltersSymbol = 
+        CVarDef.Create("chat.word_filters_symbol", "*", CVar.CLIENTONLY | CVar.ARCHIVE, "The symbol used to mask words in the chat.");
 }

--- a/Resources/Locale/en-US/chat/ui/chat-box.ftl
+++ b/Resources/Locale/en-US/chat/ui/chat-box.ftl
@@ -40,3 +40,12 @@ hud-chatbox-highlights-tooltip = The words need to be separated by a newline,
 hud-chatbox-highlights-placeholder = @McHands
                                      "Judge"
                                      Medical
+
+hud-chatbox-word-filters = Word Filters:
+hud-chatbox-word-filters-button = Submit
+hud-chatbox-word-filters-tooltip = The words need to be separated by a newline,
+                                   if wrapped around " they will be masked
+                                   only if separated by spaces or punctuation.
+hud-chatbox-word-filters-placeholder = Silly
+                                       "Idiot"
+                                       Noobie


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Chat filters were added in order to allow streamers or other bloggers to create content without any problems with censoring chat. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
About the idea, according to the rules of the one server, it's forbidden to use n-words or other words which are prohibited to use on Twitch. I thought that I just can make game admins' life better if I would implement this. And also you can filter some words, if you need this. Just useful feature. 

## Technical details
<!-- Summary of code changes for easier review. -->
Usage of this feature is similar to highlighting. You need to open chat filter popup and then write words into the textedit.
ChatUIController was extended with one more file for WordFiltering. And you can also configure the masking symbol (default is *) in Accessibility tab in settings. 

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
I've written 3 tests and also tested this feature using localhost. You can  only connect to your localhost, open the chat menu and "censor" anything you need. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
[Youtube video if needed](https://youtu.be/h-e4ex35eEE)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added in-game personalized chat filters. 
