### PR TITLE
Filter out Nukeops from Ling Impersonate Objective

### DIFF
--- a/Resources/Prototypes/Objectives/changeling.yml
+++ b/Resources/Prototypes/Objectives/changeling.yml
@@ -75,6 +75,7 @@
       whitelist:
         components:
         - ChangelingRole
+        - NukeopsRole # Nukies are basically impossible to devour under normal gameplay. Killing them is still on the table.
 
 - type: entity
   parent: [BaseChangelingObjective, BaseLivingObjective]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added Nukeops role to the filtered out roles in Lings Devour objective.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Devouring a nuclear operative is basically impossible due to Acidifiers and Macrobombs.

While a kill objective on a Nuclear Operative can make for some reasonable roleplay opportunities and opportunistic feasting for a changeling (choosing either to figure out a way to inform the crew and save itself and/or take advantage of the chaos to get a good meal), expecting the ling rely upon the statistically thin likelyhood that a Changeling Gets a Nuclear operative objective AND that nuclear operative doesn't use their anti-capture devices for the entire devour is just unfair to the ling.

## Technical details
<!-- Summary of code changes for easier review. -->
Added NukeOpsRole to the changeling devour objective filter .
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Remove all other humanoids from the station
Connect with second client
Make second client a Nuclear operative
Add in a Urist
Use first/or a third client to inhabit the Urist
Apply changeling role to Ling Urist
Check changeling objectives

(recommended to check multiple times, you can clear an objective using `rmobjective <player> <id>`)
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Kickguy223
- fix: Changelings are no longer expected to devour a Nuclear Operatives as an objective
