### PR TITLE
Dragon can no longer Ash and can Properly Gib

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -86,6 +86,14 @@
     thresholds:
       0: Alive
       500: Dead
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Blunt
+        damage: 600
+      behaviors:
+      - !type:GibBehavior
   - type: Metabolizer
     solutionOnBody: false
     updateInterval: 0.25

--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: [ SimpleSpaceMobBase, FlyingMobBase, MobCombat, BaseSlicingRefinable, BaseMobDestructible ]
+  parent: [ SimpleSpaceMobBase, FlyingMobBase, MobCombat, BaseSlicingRefinable ]
   id: BaseMobBehonker
   name: behonker
   description: A floating demon aspect of the honkmother.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/behonker.yml
@@ -88,8 +88,7 @@
       500: Dead
   - type: Destructible
     thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
+    - trigger: !type:DamageTypeTrigger
         damageType: Blunt
         damage: 600
       behaviors:

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ SimpleSpaceMobBase, FlyingMobBase, BaseSlicingRefinable, MobNightVision, BaseMobDestructible ]
+  parent: [ SimpleSpaceMobBase, FlyingMobBase, BaseSlicingRefinable, MobNightVision ]
   id: BaseMobDragon
   suffix: ""
   name: space dragon
@@ -93,6 +93,29 @@
       0: Alive
       450: Critical
       500: Dead
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Blunt
+        damage: 600
+      behaviors:
+      - !type:GibBehavior
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Radiation
+        damage: 15
+      behaviors:
+      - !type:PopupBehavior
+        popup: mouth-taste-metal
+        popupType: LargeCaution
+        targetOnly: true
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Radiation
+        damage: 40
+      behaviors:
+      - !type:VomitBehavior
   - type: SlowOnDamage
     speedModifierThresholds:
       250: 0.7

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -95,14 +95,12 @@
       500: Dead
   - type: Destructible
     thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
+    - trigger: !type:DamageTypeTrigger
         damageType: Blunt
         damage: 600
       behaviors:
       - !type:GibBehavior
-    - trigger:
-        !type:DamageTypeTrigger
+    - trigger: !type:DamageTypeTrigger
         damageType: Radiation
         damage: 15
       behaviors:
@@ -110,8 +108,7 @@
         popup: mouth-taste-metal
         popupType: LargeCaution
         targetOnly: true
-    - trigger:
-        !type:DamageTypeTrigger
+    - trigger: !type:DamageTypeTrigger
         damageType: Radiation
         damage: 40
       behaviors:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Previously, dragon used to parent off of BaseMobDestructible and would gib from pure blunt before hitting it's crit or death thresholds. Not sure if this is the best way to go about it for Behonker, somewhat unsure if they should be able to ash and vomit or not, however they still shouldn't parent off of BaseMobDestructible. See related discord discussion in the combat workgroup.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
You shouldn't gib before dying.  Dragons shouldn't ash because they're, well, dragons. Fireproof already, ashing doesn't particularly happen either unless you're spamming a heat weapon. Dragon *should* still vomit because it comes up often enough with irradiated artifacts, rad-weapons, etc.
## Technical details
<!-- Summary of code changes for easier review. -->
Lines added to ``dragon.yml``, few added to ``behonker.yml`` as well. Unparents BaseMobDestructible from both.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Boot into a localhost
2. Spawn a dragon
3. Deal enough damage with pure blunt (susbox, toolboxes, bangstick, etc.)
4. Observe that dragon will go crit (450) and die (500) before gibbing (600).
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="392" height="384" alt="image" src="https://github.com/user-attachments/assets/54f8ca8b-04c1-490e-a18d-f6dabe2145de" />
<img width="394" height="384" alt="image" src="https://github.com/user-attachments/assets/922f464f-1d4b-403d-9167-361b40438858" />
<img width="1895" height="265" alt="image" src="https://github.com/user-attachments/assets/2de769fd-2ec9-4715-b543-8ddebf1df541" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A
## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: jckspjf
- fix: Dragons and Behonkers can now be gibbed after (instead of previously before) death.
- tweak: Dragon can no longer be ashed.
