### PR TITLE
Remove maxPlayers cap from Sushi Station

### DIFF
--- a/Resources/Prototypes/Maps/sushi.yml
+++ b/Resources/Prototypes/Maps/sushi.yml
@@ -3,7 +3,6 @@
   mapName: 'Sushi Station'
   mapPath: /Maps/sushi.yml
   minPlayers: 45
-  maxPlayers: 70
   stations:
     Sushi:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed maxPlayers cap from Sushi Station

## Why / Balance
To bring it in line with other mid-high pop maps such as Box, Bagel, Exo, etc.
