### PR TITLE
Bugfix: fix helmets keeping species-specific shape

### DIFF
--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Item;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
+using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.TypeSerializers.Implementations;
 using Robust.Shared.Utility;
 using static Robust.Client.GameObjects.SpriteComponent;
@@ -47,6 +48,7 @@ public sealed partial class ClientClothingSystem : ClothingSystem
     };
 
     [Dependency] private IResourceCache _cache = default!;
+    [Dependency] private ISerializationManager _seriMan = default!;
     [Dependency] private DisplacementMapSystem _displacement = default!;
     [Dependency] private InventorySystem _inventorySystem = default!;
     [Dependency] private SpriteSystem _sprite = default!;
@@ -121,7 +123,11 @@ public sealed partial class ClientClothingSystem : ClothingSystem
             }
 
             ent.Comp.MappedLayer = key;
-            args.Layers.Add((key, layer));
+
+            // Create a copy of the layer, which might get modified.
+            PrototypeLayerData newLayer = new();
+            _seriMan.CopyTo(layer, ref newLayer, notNullableOverride: true);
+            args.Layers.Add((key, newLayer));
         }
     }
 

--- a/Content.Client/Toggleable/ToggleableVisualsSystem.cs
+++ b/Content.Client/Toggleable/ToggleableVisualsSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Item;
 using Content.Shared.Light.Components;
 using Content.Shared.Toggleable;
 using Robust.Client.GameObjects;
+using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Utility;
 
 namespace Content.Client.Toggleable;
@@ -20,6 +21,7 @@ namespace Content.Client.Toggleable;
 /// <see cref="ToggleableVisualsComponent"/>
 public sealed partial class ToggleableVisualsSystem : VisualizerSystem<ToggleableVisualsComponent>
 {
+    [Dependency] private ISerializationManager _seriMan = default!;
     [Dependency] private SharedItemSystem _item = default!;
     [Dependency] private SharedPointLightSystem _pointLight = default!;
 
@@ -104,7 +106,10 @@ public sealed partial class ToggleableVisualsSystem : VisualizerSystem<Toggleabl
             if (modulateColor)
                 layer.Color = color;
 
-            args.Layers.Add((key, layer));
+            // Create a copy of the layer, which might get modified.
+            PrototypeLayerData newLayer = new();
+            _seriMan.CopyTo(layer, ref newLayer, notNullableOverride: true);
+            args.Layers.Add((key, newLayer));
         }
     }
 

--- a/Content.Shared/Clothing/ClothingEvents.cs
+++ b/Content.Shared/Clothing/ClothingEvents.cs
@@ -7,17 +7,22 @@ namespace Content.Shared.Clothing;
 /// <summary>
 /// Raised directed at a piece of clothing to get the set of layers to show on the wearer's sprite.
 /// </summary>
-public sealed class GetEquipmentVisualsEvent : EntityEventArgs
+public sealed class GetEquipmentVisualsEvent(EntityUid equipee, string slot) : EntityEventArgs
 {
     /// <summary>
     /// Entity that is wearing the item.
     /// </summary>
-    public readonly EntityUid Equipee;
+    public readonly EntityUid Equipee = equipee;
 
-    public readonly string Slot;
+    /// <summary>
+    /// The name of slot that the item is being worn in.
+    /// </summary>
+    public readonly string Slot = slot;
 
     /// <summary>
     /// The layers that will be added to the entity that is wearing this item.
+    /// PrototypeLayerData objects passed may be modified, do not pass your component state directly!
+    ///
     /// NOTE: any layers will be checked for species-specific layers automatically inside ClothingSystem.
     /// If you return a state of "equipped-HEAD" and "equipped-HEAD-reptilian" exists,
     /// it will be automatically used by entities with InventoryComponent.SpeciesId set to "reptilian".
@@ -26,12 +31,6 @@ public sealed class GetEquipmentVisualsEvent : EntityEventArgs
     /// Note that the actual ordering of the layers depends on the order in which they are added to this list.
     /// </remarks>
     public List<(string, PrototypeLayerData)> Layers = new();
-
-    public GetEquipmentVisualsEvent(EntityUid equipee, string slot)
-    {
-        Equipee = equipee;
-        Slot = slot;
-    }
 }
 
 /// <summary>
@@ -40,29 +39,25 @@ public sealed class GetEquipmentVisualsEvent : EntityEventArgs
 /// <remarks>
 /// Useful for systems/components that modify the visual layers that an item adds to a player. (e.g. RGB memes)
 /// </remarks>
-public sealed class EquipmentVisualsUpdatedEvent : EntityEventArgs
+public sealed class EquipmentVisualsUpdatedEvent(
+    EntityUid equipee,
+    string slot,
+    HashSet<string> revealedLayers) : EntityEventArgs
 {
     /// <summary>
     /// Entity that is wearing the item.
     /// </summary>
-    public readonly EntityUid Equipee;
+    public readonly EntityUid Equipee = equipee;
 
     /// <summary>
     /// The slot that the equipment is being worn in.
     /// </summary>
-    public readonly string Slot;
+    public readonly string Slot = slot;
 
     /// <summary>
     /// The layers that this item is now revealing.
     /// </summary>
-    public HashSet<string> RevealedLayers;
-
-    public EquipmentVisualsUpdatedEvent(EntityUid equipee, string slot, HashSet<string> revealedLayers)
-    {
-        Equipee = equipee;
-        Slot = slot;
-        RevealedLayers = revealedLayers;
-    }
+    public HashSet<string> RevealedLayers = revealedLayers;
 }
 
 public sealed partial class ToggleMaskEvent : InstantActionEvent;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Fixes a bug introduced in #44189 - GetEquipmentVisualsEvent modifies the layers that are returned into the event, so ToggleableVisualsSystem/ClientClothingSystem now copy their own layers using SerializationManager rather than passing a reference to the component's state that gets mutated.

## Why / Balance

I goofed.  Bugfix for https://discord.com/channels/310555209753690112/1541967096681070672.

Resolves #45723 (90% sure).

## Technical details

SerializationManager.CopyTo used to create new PrototypeLayerData for ClothingSystem and ToggleableClothingSystem.  FlippableClothingSystem and SolutionContainerVisualsSystem, the other systems with handlers for this event, create layers from scratch.

Added a comment onto the event struct saying to make copies to prevent mutating component state.

Also added a few primary constructors for the events in ClothingEvent.cs while we're there.

## Test plan

Spawn a few Urists - a human, a moth, a reptilian and a vox.
`aghost`, then put the suit on each of them.  Toggle the helmet on.
The helmet shape should be correct for each of the species, and _should not get stuck on the first with a species-specific helmet_.

## Media

Going through the test plan.

https://github.com/user-attachments/assets/49e46319-7f6a-45b8-9639-2667a89606d0

An example of the incorrect behaviour currently on master:

<img width="472" height="323" alt="image" src="https://github.com/user-attachments/assets/7bfda1da-0290-49f5-91c8-8f99216b492e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
ehhhhhhh
