### PR TITLE
Hushpup Spread Tweak

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -326,4 +326,4 @@
         rolloffFactor: 1.3
     fireRate: 2
   - type: GunSpreadModifier
-    spread: 1.2
+    spread: 0.8


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Hushpup spread reduced from 120% spread multiplier down to a 80% multiplier.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Hushpup in its current state is intended to be an assassination weapon however its extremely expensive for what is essentially a worse enforcer. As it stands, there's no reason to take a hushpup over a cobra or viper for a quick assassination as hushpup will cost you 10tc for the gun itself and then another 5tc for an emag to be able to kill more than one enemy with it. 

My aim is to allow the hushpup to be more of a midground between the enforcer and Kammerer so syndicates might be able to get more value from it. Its important to note that, this is still outranged by the kammerer and, both crew shotguns have 3 more shots. 

Hopefully by making the hushpup more combat viable, it will start to justify its own price and this cool long arm can be seen more in rounds. 

(Also more of a nitpicky reasoning perhaps but the sprite for hushpup has a longer barrel than the enforcer, see media) 
## Technical details
I altered the spread value for the hushpup.

## Test plan
Inspect weapons, shoot stuff, check spread. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="180" height="112" alt="barrel longer" src="https://github.com/user-attachments/assets/d0280b07-e3ff-471f-a0d9-0085a80bed1d" />
<img width="500" height="361" alt="hushpup inspect" src="https://github.com/user-attachments/assets/67158a6c-5c06-451a-acc2-d2507faba393" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have tested this pull request and written instructions on how to test it
- [X ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

## Changelog
- tweak: Reduced hushpup spread by 40%.
