### PR TITLE
Fix FollowerComponent reparenting

### DIFF
--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -56,6 +56,12 @@ public sealed partial class FollowerSystem : EntitySystem
         SubscribeLocalEvent<FollowedComponent, StationAiRemoteEntityReplacementEvent>(OnFollowedStationAiRemoteEntityReplaced);
     }
 
+    [SubscribeLocalEvent]
+    private void OnFollowedReparent(Entity<FollowerComponent> ent, ref EntParentChangedMessage args)
+    {
+        _transform.SetParent(ent, ent.Comp.Following);
+    }
+
     private void OnFollowedAttempt(Entity<FollowedComponent> ent, ref ComponentGetStateAttemptEvent args)
     {
         if (args.Cancelled)

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -57,7 +57,7 @@ public sealed partial class FollowerSystem : EntitySystem
     }
 
     [SubscribeLocalEvent]
-    private void OnFollowedReparent(Entity<FollowerComponent> ent, ref EntParentChangedMessage args)
+    private void OnFollowerReparent(Entity<FollowerComponent> ent, ref EntParentChangedMessage args)
     {
         _transform.SetParent(ent, ent.Comp.Following);
     }


### PR DESCRIPTION
## About the PR
Title
I'm not sure about this solution, but followers anyway should be parented to followed, so... Probably okey.

## Why / Balance
Anomaly cores and ghost plushies have problems with reparenting

## Test plan
1. Start dev
2. Spawn locker and anomaly core
3. Alt-click it and interact with locker

## Media
<img width="800" height="450" alt="anomalycore" src="https://github.com/user-attachments/assets/2a010976-bad1-425c-8b82-6b454eb82f1a" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- fix: Anomaly cores and ghost plushies no longer stick to the containers when exiting them.