### PR TITLE
HOTFIX Set AI camera static to accessible variant by default

### DIFF
--- a/Content.Shared/CCVar/CCVars.Accessibility.Motion.cs
+++ b/Content.Shared/CCVar/CCVars.Accessibility.Motion.cs
@@ -21,7 +21,7 @@ public sealed partial class CCVars
     ///     Replaces the AI static camera effect with a plain gradient.
     /// </summary>
     public static readonly CVarDef<bool> DisableAiStatic =
-        CVarDef.Create("accessibility.disable_ai_static", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+        CVarDef.Create("accessibility.disable_ai_static", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     /// <summary>
     ///     Replaces the movement in the blurry shader for a static effect.

--- a/Content.Shared/CCVar/CCVars.Accessibility.Motion.cs
+++ b/Content.Shared/CCVar/CCVars.Accessibility.Motion.cs
@@ -22,6 +22,8 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> DisableAiStatic =
         CVarDef.Create("accessibility.disable_ai_static", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+        //TODO return default value to False
+        // This was set to True pending evaluation of the static effect visuals, due to headache potential of the current static shader
 
     /// <summary>
     ///     Replaces the movement in the blurry shader for a static effect.


### PR DESCRIPTION
## About the PR
Sets the AI Camera Static to be off by default. It can still be reactivated under accessibility features

## Why / Balance
The static shader is kinda harsh and can induce motion sickness. It has not been changed recently, but we might have simply missed it being an issue. It's also possible that recent shader or lighting changes might have made it indirectly more disruptive. We should stop making it the default option until it is reviewed

## Technical details
Sets the DisableAiStatic cvar to True by default

## Test plan
Spawn AI core, take control, no static
Switch 

## Media
<img width="2281" height="1564" alt="image" src="https://github.com/user-attachments/assets/a697d106-ea64-45f5-8579-f6a455291f03" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl: Errant
- tweak: The AI camera's static overlay has been switched to it's accessible alternative by default, pending evaluation of the static effect visuals. It can be changed back under Accessibility settings.