### PR TITLE
changeling store update

### DIFF
--- a/Content.Server/Store/Systems/StoreSystem.cs
+++ b/Content.Server/Store/Systems/StoreSystem.cs
@@ -33,7 +33,7 @@ public sealed partial class StoreSystem : SharedStoreSystem
 
         // Add the bui key if it does not exist already (the check is needed to make sure that we don't overwrite existing InterfaceData).
         if (!UI.HasUi(uid, StoreUiKey.Key))
-            UI.SetUi(uid, StoreUiKey.Key, new InterfaceData("StoreBoundUserInterface"));
+            UI.SetUi(uid, StoreUiKey.Key, new InterfaceData("StoreBoundUserInterface", requireInputValidation: component.InputValidation));
     }
 
     private void OnStartup(EntityUid uid, StoreComponent component, ComponentStartup args)

--- a/Content.Shared/Store/Components/StoreComponent.cs
+++ b/Content.Shared/Store/Components/StoreComponent.cs
@@ -99,7 +99,7 @@ public sealed partial class StoreComponent : Component
     /// Does nothing if the store UI is added seperately via <see cref="UserInterfaceComponent"/>
     /// </summary>
     [DataField]
-    public bool InputValidation;
+    public bool InputValidation = true;
 
     #region audio
     /// <summary>

--- a/Content.Shared/Store/Components/StoreComponent.cs
+++ b/Content.Shared/Store/Components/StoreComponent.cs
@@ -94,6 +94,13 @@ public sealed partial class StoreComponent : Component
     [DataField]
     public EntityUid? StartingMap;
 
+    /// <summary>
+    /// Whether the UI added to the store should require input validation.
+    /// Does nothing if the store UI is added seperately via <see cref="UserInterfaceComponent"/>
+    /// </summary>
+    [DataField]
+    public bool InputValidation;
+
     #region audio
     /// <summary>
     /// The sound played to the buyer when a purchase is succesfully made.

--- a/Resources/Prototypes/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/Roles/Antags/changeling.yml
@@ -46,6 +46,6 @@
     - ChangelingDNA
     balance:
       ChangelingDNA: 60
-    inputValidation: true
+    inputValidation: false
   mindRoles:
   - MindRoleChangeling

--- a/Resources/Prototypes/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/Roles/Antags/changeling.yml
@@ -46,5 +46,6 @@
     - ChangelingDNA
     balance:
       ChangelingDNA: 60
+    inputValidation: true
   mindRoles:
   - MindRoleChangeling

--- a/Resources/Prototypes/Store/presets.yml
+++ b/Resources/Prototypes/Store/presets.yml
@@ -53,6 +53,7 @@
     - ChangelingStoreUtility
     currencyWhitelist:
     - ChangelingDNA
+    inputValidation: true
 
 - type: entity
   parent: StorePresetUplink

--- a/Resources/Prototypes/Store/presets.yml
+++ b/Resources/Prototypes/Store/presets.yml
@@ -53,7 +53,7 @@
     - ChangelingStoreUtility
     currencyWhitelist:
     - ChangelingDNA
-    inputValidation: true
+    inputValidation: false
 
 - type: entity
   parent: StorePresetUplink


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changeling can now use his shop while dead or handcuffed.

Resolves #45518

## Why / Balance
Imagine that you have been cuffed and killed, but you cannot buy biodegrade

## Test plan
become a changeling, kill yourself (In the game), open a store

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl: Golub
- tweak: Changeling can now use the store while dead or in handcuffs.
