### PR TITLE
StealthSystem: disable InteractionOutline when turning the stealth shader on.

### DIFF
--- a/Content.Client/Stealth/StealthSystem.cs
+++ b/Content.Client/Stealth/StealthSystem.cs
@@ -57,15 +57,18 @@ public sealed partial class StealthSystem : SharedStealthSystem
             _sprite.RemovePostShader((uid, sprite), ContentPostShaderIds.Stealth);
         }
 
-        if (!enabled)
+        if (enabled)
+        {
+            component.HadOutline = RemCompDeferred<InteractionOutlineComponent>(uid);
+        }
+        else
         {
             if (component.HadOutline && !TerminatingOrDeleted(uid))
+            {
                 EnsureComp<InteractionOutlineComponent>(uid);
-            return;
+                component.HadOutline = false;
+            }
         }
-
-        if (HasComp<InteractionOutlineComponent>(uid))
-            component.HadOutline = true;
     }
 
     private void OnStartup(EntityUid uid, StealthComponent component, ComponentStartup args)

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -1,13 +1,13 @@
 ﻿- type: entity
-  abstract: true
   parent: StructureHealthContainerFlimsy
-  id: BaseBigBox
+  id: BigBox
   name: cardboard box #it's still just a box
   description: Huh? Just a box...
   components:
     - type: Transform
       noRot: true
     - type: Clickable
+    - type: InteractionOutline
     - type: Physics
       bodyType: KinematicController
     - type: Fixtures
@@ -81,9 +81,9 @@
       frictionNoInput: 6
 
 - type: entity
+  parent: BigBox
   id: StealthBox
   suffix: stealth
-  parent: BaseBigBox
   description: Kept ya waiting, huh?
   components:
     - type: Damageable
@@ -96,12 +96,6 @@
     - type: StealthOnMove
       passiveVisibilityRate: -1 # very useful for going around the station concealed, if you start jitterstrafing you get seen
       movementVisibilityRate: 0.20
-
-- type: entity
-  id: BigBox
-  parent: BaseBigBox
-  components:
-  - type: InteractionOutline
 
 #For admin spawning only
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -867,7 +867,6 @@
   suffix: Stealth
   components:
   - type: Stealth
-    hadOutline: true
     shimmerFrequency: 0.05
   - type: StealthOnMove
     passiveVisibilityRate: -0.10

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -755,7 +755,6 @@
   - type: XAEApplyComponents
     components:
     - type: Stealth
-      hadOutline: true
     - type: StealthOnMove
       passiveVisibilityRate: -0.10
       movementVisibilityRate: 0.10


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Returning the interaction between the StealthSystem and InteractionOutlineComponent - when the stealth shader is activated, the interaction outline component should be removed.

## Why / Balance

Minor regression from #44735.

## Technical details

Restores the RemCompDeferred call removed in #44735.  Changes the condition in its block to remove the negation and early return for ease of reading.

HadOutline should be set and cleared based on the presence of InteractionOutlineComponent, and it is set/cleared in SetShader, which turns the stealth shader on or off.

Cleans up definitions a bit - HadOutline should not be set in any EntityPrototype (saved maps, great; entity prototypes, weird).
Removes `BaseBigBox`, the only field that it had that was useful was moved into BigBox, which StealthBox inherits from.

One possible issue is that repeated `SetShader(true)` calls will overwrite HadOutline with false.  Changing `=` to `|=` should fix that - it could hold whether any `SetShader` call removed the `InteractionOutlineComponent`.

One funny detail - the stealth crate, like stealthy artifacts, cannot currently be turned off, so it will never have an interaction outline.

## Test plan

1. Spawn a stealth box, a stealth crate, a Urist, and a stealth xenoborg.
2. Turn the Urist into a ninja through the `Antag ctrl` context menu option - you'll have to drag them back into the test.
3. All of the entities should have their interaction outline when unstealthed (note: the stealth crate is _never_ unstealthed), and should _not_ have their interaction outline when stealthed (even if partially visible)

## Media

Part of the test plan: interacting with a stealth box, crate, ninja and xenoborg with and without stealth.

https://github.com/user-attachments/assets/bb88ab7f-271b-482a-bbe6-1d5bd4aa7d75

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

The `BaseBigBox` entity has been removed.  Use `BaseBox` directly instead.  Entity prototypes with the `StealthComponent` _should have InteractionOutlineComponent_ defined if they should _ever_ have an interaction outline.

## Changelog
:cl:
- fix: Ninjas, xenoborgs, stealth boxes and artifacts no longer have an interaction outline when stealthy.