### PR TITLE
Refactor Unbuckling to have an optional doAfter

### DIFF
--- a/Content.Shared/Buckle/Components/StrapComponent.cs
+++ b/Content.Shared/Buckle/Components/StrapComponent.cs
@@ -85,6 +85,9 @@ public sealed partial class StrapComponent : Component
     [DataField]
     public float BuckleDoafterTime = 2f;
 
+    [DataField]
+    public TimeSpan UnbuckleDoAfterTime = TimeSpan.Zero;
+
     /// <summary>
     /// Whether InteractHand will buckle the user to the strap.
     /// </summary>

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -468,12 +468,12 @@ public abstract partial class SharedBuckleSystem
     /// <returns>Does the Unbuckle require Extrication</returns>
     private bool IsUnbuckleRequiresExtrication(Entity<BuckleComponent?> buckle, EntityUid? user, Entity<StrapComponent> strap)
     {
-        var cuffed = !TryComp<CuffableComponent>(buckle, out var targetCuffableComp) &&
-                     targetCuffableComp!.CuffedHandCount > 0;
+        var cuffed = TryComp<CuffableComponent>(buckle, out var targetCuffableComp) &&
+                     targetCuffableComp!.CuffedHandCouxnt > 0;
 
         return !strap.Comp.UnbuckleDoAfterTime.Equals(TimeSpan.Zero)
                && buckle != user
-               && _mobState.IsIncapacitated(buckle)
+               && !_mobState.IsIncapacitated(buckle)
                && !cuffed
                && !HasComp<StunnedComponent>(buckle);
     }

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -7,6 +7,7 @@ using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Events;
@@ -41,7 +42,6 @@ public abstract partial class SharedBuckleSystem
 
         SubscribeLocalEvent<BuckleComponent, StartPullAttemptEvent>(OnPullAttempt);
         SubscribeLocalEvent<BuckleComponent, BeingPulledAttemptEvent>(OnBeingPulledAttempt);
-        SubscribeLocalEvent<BuckleComponent, PullStartedMessage>(OnPullStarted);
         SubscribeLocalEvent<BuckleComponent, UnbuckleAlertEvent>(OnUnbuckleAlert);
 
         SubscribeLocalEvent<BuckleComponent, InsertIntoEntityStorageAttemptEvent>(OnBuckleInsertIntoEntityStorageAttempt);
@@ -78,13 +78,22 @@ public abstract partial class SharedBuckleSystem
         if (args.Cancelled || !ent.Comp.Buckled)
             return;
 
-        if (!CanUnbuckle(ent!, args.Puller, false))
+        if (!CanUnbuckle(ent!, args.Puller, false, out var strap))
+        {
             args.Cancel();
-    }
+            return;
+        }
 
-    private void OnPullStarted(Entity<BuckleComponent> ent, ref PullStartedMessage args)
-    {
-        Unbuckle(ent!, args.PullerUid);
+        if (UnbuckleRequiresExtrication(ent!, args.Puller, strap))
+        {
+            var message = Loc.GetString("buckle-component-resist-rapid-extrication",
+                ("owner", Identity.Entity(ent, EntityManager)));
+
+            _popup.PopupEntity(message, args.Puller, args.Puller);
+            args.Cancel();
+            return;
+        }
+        Unbuckle(ent!, args.Puller);
     }
 
     private void OnUnbuckleAlert(Entity<BuckleComponent> ent, ref UnbuckleAlertEvent args)
@@ -268,7 +277,7 @@ public abstract partial class SharedBuckleSystem
             return false;
         }
 
-        if (buckleComp.Buckled && !TryUnbuckle(buckleUid, user, buckleComp))
+        if (buckleComp.Buckled)
         {
             if (popup && user != null)
             {
@@ -427,8 +436,54 @@ public abstract partial class SharedBuckleSystem
         if (!CanUnbuckle(buckle, user, popup, out var strap))
             return false;
 
-        Unbuckle(buckle!, strap, user);
+        //Same deal as pulling, if it's a complicated extrication with someone who can resist, extricate
+        //if they can't resist, just yoink em.
+        //Also let the buckled person out immediately
+        if (!UnbuckleRequiresExtrication(buckle, user, strap))
+        {
+            Unbuckle(buckle, user);
+            return true;
+        }
+
+        _doAfter.TryStartDoAfter(new DoAfterArgs(
+                EntityManager,
+                user!.Value,
+                strap.Comp.UnbuckleDoAfterTime,
+                new UnbuckleDoAfterEvent(),
+                buckle,
+                buckle,
+                buckle)
+        {
+                BreakOnMove = true,
+                CancelDuplicate = true,
+                DuplicateCondition = DuplicateConditions.None,
+        });
         return true;
+    }
+
+    /// <summary>
+    /// Check if a particular Unbuckle requires Extrication
+    /// I.E If the strap requires a DoAfter to remove someone: check if they're the one doing the unbuckle, dead, or stunned.
+    /// </summary>
+    /// <returns>Does the Unbuckle require Extrication</returns>
+    private bool UnbuckleRequiresExtrication(Entity<BuckleComponent?> buckle, EntityUid? user, Entity<StrapComponent> strap)
+    {
+        return !strap.Comp.UnbuckleDoAfterTime.Equals(TimeSpan.Zero)
+               && buckle != user
+               && !_mobState.IsDead(buckle)
+               && !HasComp<StunnedComponent>(buckle);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnDoAfterUnbuckle(Entity<BuckleComponent> buckle, ref UnbuckleDoAfterEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (!CanUnbuckle(buckle!, args.User, true, out var strap))
+            return;
+
+        Unbuckle(buckle, strap, args.User);
     }
 
     public void Unbuckle(Entity<BuckleComponent?> buckle, EntityUid? user)

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -84,7 +84,7 @@ public abstract partial class SharedBuckleSystem
             return;
         }
 
-        if (UnbuckleRequiresExtrication(ent!, args.Puller, strap))
+        if (IsUnbuckleRequiresExtrication(ent!, args.Puller, strap))
         {
             var message = Loc.GetString("buckle-component-resist-rapid-extrication",
                 ("owner", Identity.Entity(ent, EntityManager)));
@@ -439,7 +439,7 @@ public abstract partial class SharedBuckleSystem
         //Same deal as pulling, if it's a complicated extrication with someone who can resist, extricate
         //if they can't resist, just yoink em.
         //Also let the buckled person out immediately
-        if (!UnbuckleRequiresExtrication(buckle, user, strap))
+        if (!IsUnbuckleRequiresExtrication(buckle, user, strap))
         {
             Unbuckle(buckle, user);
             return true;
@@ -463,14 +463,18 @@ public abstract partial class SharedBuckleSystem
 
     /// <summary>
     /// Check if a particular Unbuckle requires Extrication
-    /// I.E If the strap requires a DoAfter to remove someone: check if they're the one doing the unbuckle, dead, or stunned.
+    /// I.E If the strap requires a DoAfter to remove someone: check if they're the one doing the unbuckle, incapacitated, or stunned.
     /// </summary>
     /// <returns>Does the Unbuckle require Extrication</returns>
-    private bool UnbuckleRequiresExtrication(Entity<BuckleComponent?> buckle, EntityUid? user, Entity<StrapComponent> strap)
+    private bool IsUnbuckleRequiresExtrication(Entity<BuckleComponent?> buckle, EntityUid? user, Entity<StrapComponent> strap)
     {
+        var cuffed = !TryComp<CuffableComponent>(buckle, out var targetCuffableComp) &&
+                     targetCuffableComp!.CuffedHandCount > 0;
+
         return !strap.Comp.UnbuckleDoAfterTime.Equals(TimeSpan.Zero)
                && buckle != user
-               && !_mobState.IsDead(buckle)
+               && _mobState.IsIncapacitated(buckle)
+               && !cuffed
                && !HasComp<StunnedComponent>(buckle);
     }
 

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -469,7 +469,7 @@ public abstract partial class SharedBuckleSystem
     private bool IsUnbuckleRequiresExtrication(Entity<BuckleComponent?> buckle, EntityUid? user, Entity<StrapComponent> strap)
     {
         var cuffed = TryComp<CuffableComponent>(buckle, out var targetCuffableComp) &&
-                     targetCuffableComp!.CuffedHandCouxnt > 0;
+                     targetCuffableComp!.CuffedHandCount > 0;
 
         return !strap.Comp.UnbuckleDoAfterTime.Equals(TimeSpan.Zero)
                && buckle != user

--- a/Content.Shared/Buckle/SharedBuckleSystem.Event.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Event.cs
@@ -1,0 +1,8 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Buckle;
+
+[Serializable, NetSerializable]
+public sealed partial class UnbuckleDoAfterEvent : SimpleDoAfterEvent;
+

--- a/Resources/Locale/en-US/buckle/components/buckle-component.ftl
+++ b/Resources/Locale/en-US/buckle/components/buckle-component.ftl
@@ -5,3 +5,4 @@ buckle-component-cannot-buckle-message = You can't buckle yourself there!
 buckle-component-other-cannot-buckle-message = You can't buckle {$owner} there!
 buckle-component-cannot-fit-message = You can't fit there!
 buckle-component-other-cannot-fit-message = {$owner} can't fit there!
+buckle-component-resist-rapid-extrication = {$owner} resists your attempt to pull them from their strap

--- a/Resources/Prototypes/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/vehicles.yml
@@ -14,6 +14,7 @@
     canAttack: true
   - type: StrapVehicle
   - type: Strap
+    unbuckleDoAfterTime: 2s
   - type: MovementSpeedModifier
     weightlessModifier: 0
     acceleration: 2

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -78,6 +78,8 @@
     bodyType: KinematicController
   - type: Vehicle
     requiresHands: false # you use your feet!
+  - type: Strap # Redeclare strap, you can just get pulled right off a office chair
+    unbuckleDoAfterTime: 0s
   - type: MovementSpeedModifier
     baseAcceleration: 2
     baseFriction: 2


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Refactor Bucklesystems pulling and unbuckle to take in a UnbuckleDoAfterTime which if set above Zero will cause the unbuckle to happen after a DoAfter.

- Make pulling buckled people who are in a state where it requires time to pull them out completely fail to grab hold of them, requiring you to either take the time to pull them out, stun them, cuff them or incapacitate them.

- Make it so you can't directly transfer one buckled person to another strap, this was causing issues with Extrication targets getting instantly unbuckled because of how it handles the states. Just unbuckle first
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/space-wizards/space-station-14/pull/45680 required admin input and the admin consensus was that Wheelchairs (and further Janicarts) need to not have their occupants expelled with one click
## Technical details
<!-- Summary of code changes for easier review. -->
Add a TimeSpan to StrapComponent that when above 0 will make the unbuckler do a doAfter to unbuckle the target.

Additionally, remove OnPullStarted as the Unbuckle call within it was redundant and checking in several places was unnecessary.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Spawn a Wheelchair and a Urist
Place Urist in Wheelchair

Checklist:
1. attempt to pull urist (resists attempt)
2. attempt to clickDrag Urist into another chair (resists attempt)
3. put urist on a regular chair Pull Urist (doesn't resist)
4. confirm doafter when unbuckling
5. Cuff urist, unbuckle instantly
6. Stun urist, unbuckle instantly
7. Crit urist, Unbuckle instantly
8. put urist in a office chair, confirm urist can be unbuckled instantly


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/cc7e49fc-41a7-4c41-89a2-74a2d875e4ce
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Kickguy223
- add: Vehicles like Wheelchairs and JaniCarts now take time to forcibly remove occupants and resist being pulled off (Office chairs don't)
- tweak: Any Buckle that takes time to remove someone from can instead have the occupant removed immediately if they are Dead, Cuffed or Stunned.
- tweak: You are no longer able to drag yourself between Buckles, nor can anyone else.