### PR TITLE
Make metal foam preserve tile air

### DIFF
--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -193,6 +193,7 @@
   - type: Transform
     anchored: true
   - type: Airtight
+    noAirWhenFullyAirBlocked: false
   - type: ReplaceFloorOnSpawn
     replaceableTiles:
     - Plating


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR makes the metal foam from metal foam grenades retain the atmospherics of the tile they were on. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Current behavior is to destroy the air as if the tile was blocked by a solid structure. While this would make metal foam grenades somewhat helpful in dealing with e.g. plasma/tritium, they are more often employed to help with spacings (and themed as such). The most common place for this would be Evac, where rapid and dirty fixes are desired.

Issue is that by destroying the air in the tile, metal foam grenades are more often than not used to grief Evac by destroying the limited air in the shuttle. This effectively allows spacing the shuttle without spacing the shuttle.

This won't make the grenades less effective at dealing with spacings since space creates a vacuum on the tile anyways.

## Technical details
<!-- Summary of code changes for easier review. -->

One line of code. Same as what airlocks use.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Make a small room in dev.
2. Throw in metal foam grenade.
3. Destroy foam.
4. Breathe.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/28614fe7-3cbd-4b12-b6d9-767eaab6e61c

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Metal foam no longer destroys the air on the tile it spawns on.