### PR TITLE
Camera AI static rework

### DIFF
--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -15,10 +15,11 @@ namespace Content.Client.Silicons.StationAi;
 
 public sealed partial class StationAiOverlay : Overlay
 {
-    private static readonly ProtoId<ShaderPrototype> CameraStaticShader = "CameraStatic";
+    private static readonly ProtoId<ShaderPrototype> StationAiStaticShader = "StationAiStatic";
     private static readonly ProtoId<ShaderPrototype> CameraStaticAccessibleShader = "CameraStaticAccessible";
+    private static readonly ProtoId<ShaderPrototype> StationAiStaticStencilDrawShader = "StationAiStaticStencilDraw";
+    private static readonly ProtoId<ShaderPrototype> StencilClearShader = "StencilClear";
     private static readonly ProtoId<ShaderPrototype> StencilMaskShader = "StencilMask";
-    private static readonly ProtoId<ShaderPrototype> StencilDrawShader = "StencilDraw";
 
     [Dependency] private IClyde _clyde = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
@@ -32,21 +33,28 @@ public sealed partial class StationAiOverlay : Overlay
     private readonly HashSet<Vector2i> _visibleTiles = new();
 
     private readonly OverlayResourceCache<CachedResources> _resources = new();
+    private readonly ShaderInstance _cameraStaticShader;
+    private readonly ShaderInstance _cameraStaticAccessibleShader;
 
-    private ProtoId<ShaderPrototype> _activeShader = CameraStaticShader;
+    private ShaderInstance _activeShader;
     private float _updateRate = 1f / 30f;
     private float _accumulator;
 
     public StationAiOverlay()
     {
         IoCManager.InjectDependencies(this);
+
+        _cameraStaticShader = _proto.Index(StationAiStaticShader).InstanceUnique();
+        _cameraStaticAccessibleShader = _proto.Index(CameraStaticAccessibleShader).InstanceUnique();
+        _activeShader = _cameraStaticShader;
+
         _cfg.OnValueChanged(CCVars.DisableAiStatic, OnAiStaticChanged, invokeImmediately: true);
 
     }
 
     private void OnAiStaticChanged(bool toggle)
     {
-        _activeShader = toggle ? CameraStaticAccessibleShader : CameraStaticShader;
+        _activeShader = toggle ? _cameraStaticAccessibleShader : _cameraStaticShader;
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -109,8 +117,20 @@ public sealed partial class StationAiOverlay : Overlay
             () =>
             {
                 worldHandle.SetTransform(invMatrix);
-                var shader = _proto.Index(_activeShader).Instance();
-                worldHandle.UseShader(shader);
+                worldBounds.GetCorners(out var bottomLeft, out var bottomRight, out _, out var topLeft);
+                var worldXAxis = bottomRight - bottomLeft;
+                var worldYAxis = topLeft - bottomLeft;
+                _cameraStaticShader.SetParameter("worldOriginAndCellSize", new Vector4(
+                    bottomLeft.X,
+                    bottomLeft.Y,
+                    1f / EyeManager.PixelsPerMeter,
+                    0f));
+                _cameraStaticShader.SetParameter("worldAxes", new Vector4(
+                    worldXAxis.X,
+                    worldXAxis.Y,
+                    worldYAxis.X,
+                    worldYAxis.Y));
+                worldHandle.UseShader(_activeShader);
                 worldHandle.DrawRect(worldBounds, Color.White);
             },
             Color.Black);
@@ -131,12 +151,15 @@ public sealed partial class StationAiOverlay : Overlay
             }, Color.Black);
         }
 
-        // Use the lighting as a mask
+        worldHandle.UseShader(_proto.Index(StencilClearShader).Instance());
+        worldHandle.DrawRect(worldBounds, Color.White);
+
+        // Use the AI vision tile mask as a stencil.
         worldHandle.UseShader(_proto.Index(StencilMaskShader).Instance());
         worldHandle.DrawTextureRect(res.StencilTexture!.Texture, worldBounds);
 
         // Draw the static
-        worldHandle.UseShader(_proto.Index(StencilDrawShader).Instance());
+        worldHandle.UseShader(_proto.Index(StationAiStaticStencilDrawShader).Instance());
         worldHandle.DrawTextureRect(res.StaticTexture!.Texture, worldBounds);
 
         worldHandle.SetTransform(Matrix3x2.Identity);
@@ -146,6 +169,9 @@ public sealed partial class StationAiOverlay : Overlay
 
     protected override void DisposeBehavior()
     {
+        _cfg.UnsubValueChanged(CCVars.DisableAiStatic, OnAiStaticChanged);
+        _cameraStaticShader.Dispose();
+        _cameraStaticAccessibleShader.Dispose();
         _resources.Dispose();
 
         base.DisposeBehavior();

--- a/Resources/Prototypes/Shaders/shaders.yml
+++ b/Resources/Prototypes/Shaders/shaders.yml
@@ -59,6 +59,20 @@
   path: "/Textures/Shaders/camera_static.swsl"
 
 - type: shader
+  id: StationAiStatic
+  kind: source
+  path: "/Textures/Shaders/station_ai_static.swsl"
+
+- type: shader
+  id: StationAiStaticStencilDraw
+  kind: canvas
+  light_mode: unshaded
+  stencil:
+    ref: 1
+    op: Keep
+    func: NotEqual
+
+- type: shader
   id: CameraStaticAccessible
   kind: source
   path: "/Textures/Shaders/camera_static_accessible.swsl"

--- a/Resources/Textures/Shaders/camera_static_accessible.swsl
+++ b/Resources/Textures/Shaders/camera_static_accessible.swsl
@@ -1,3 +1,5 @@
+light_mode unshaded;
+
 void fragment() {
     highp vec2 coords = FRAGCOORD.xy;
     highp vec2 value = vec2(coords * SCREEN_PIXEL_SIZE);

--- a/Resources/Textures/Shaders/station_ai_static.swsl
+++ b/Resources/Textures/Shaders/station_ai_static.swsl
@@ -1,0 +1,31 @@
+light_mode unshaded;
+
+uniform highp vec4 worldOriginAndCellSize;
+uniform highp vec4 worldAxes;
+
+const highp float MinCellSize = 0.0001;
+const mediump float StaticFrameRate = 30.0;
+const mediump float HashScale = 0.1031;
+const mediump float HashOffset = 33.33;
+const mediump float HashWrap = 8192.0;
+const mediump vec2 FrameOffset = vec2(197.0, 311.0);
+const mediump float StaticBaseBrightness = 0.05;
+const mediump float StaticBrightnessRange = 0.2;
+
+mediump float aiStaticHash(highp vec2 value) {
+    mediump vec3 p3 = fract(vec3(value.xyx) * HashScale);
+    p3 += dot(p3, p3.yzx + HashOffset);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+void fragment() {
+    highp vec2 worldOrigin = worldOriginAndCellSize.xy;
+    highp vec2 worldXAxis = worldAxes.xy;
+    highp vec2 worldYAxis = worldAxes.zw;
+    highp vec2 worldPos = worldOrigin + worldXAxis * UV2.x + worldYAxis * UV2.y;
+    highp vec2 coords = floor(worldPos / max(worldOriginAndCellSize.z, MinCellSize));
+    mediump float frame = mod(floor(TIME * StaticFrameRate), HashWrap);
+    mediump float value = aiStaticHash(mod(coords + frame * FrameOffset, HashWrap));
+    mediump vec3 color = vec3(StaticBaseBrightness + value * StaticBrightnessRange);
+    COLOR = vec4(color, 1.0);
+}


### PR DESCRIPTION
- Made the shader look more like the original texture.
- Fix the shader having lighting applied as I don't think that was intended.
- Fixed the banding problems by not using zRandom and using static noise. This was causing the flashes as it wrapped around (easiest way to repro is bump the resolution and you can watch the bands come in and out in 30s cycles).

It's still somewhat annoying and we could probably drop the framerate down to like 5 or whatever it was in the ss13 texture but tried to keep as parity as possible, it's just the old shader fundamentally had issues.

<img width="1030" height="888" alt="image" src="https://github.com/user-attachments/assets/8dfeaafd-ed71-46b8-9f61-e14569cbd94b" />

## Changelog
:cl:
- tweak: Tweak AI static to be less migraine inducing.