### PR TITLE
Carps love chomping on steel ❤️👄

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -70,6 +70,7 @@
         types:
           Blunt: 5
           Slash: 7
+          Structural: 8
     - type: TypingIndicator
       proto: alien
     - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Carps now deal structural damage.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This allows carps to destroy walls and other structures after amassing a massive swarm, and prevents walling off carp rifts indefinitely.

Before:

https://github.com/user-attachments/assets/d33e4d11-764b-4518-a143-f0a45cad20eb

Carps still cannot destroy other structures meaningfully faster.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Space carp now deal low damage to walls and other resistant structures, instead of zero damage.
