### PR TITLE
Readds random rotation and offset to dev map

### DIFF
--- a/Resources/Prototypes/Maps/debug.yml
+++ b/Resources/Prototypes/Maps/debug.yml
@@ -18,7 +18,6 @@
   mapName: Dev
   mapPath: /Maps/Test/dev_map.yml
   maxRandomOffset: 0
-  randomRotation: false
   minPlayers: 0
   stations:
     Dev:

--- a/Resources/Prototypes/Maps/debug.yml
+++ b/Resources/Prototypes/Maps/debug.yml
@@ -17,7 +17,6 @@
   id: Dev
   mapName: Dev
   mapPath: /Maps/Test/dev_map.yml
-  maxRandomOffset: 0
   minPlayers: 0
   stations:
     Dev:


### PR DESCRIPTION
## About the PR
Dev map will now start with random rotation and offset again

## Why / Balance
I first removed it as it was annoying for me that the deletion area was based on world rotation and to make it simpler to remove a bunch of stuff i just disabled it
and i guess i put the no offset for dev to be more uniform
Now per request of Fildrance on discord, and kontakt im readding them. as they mentioned that some it was important for catching some bugs from grid rotation and offset

## Technical details

## Test plan
go to dev
go in to space 
straight up your camera (num8)
if the screen rotated you it works

open your map viewer, see that station is rotated

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
no
