### PR TITLE
Fix duplicated scurret palette colour

### DIFF
--- a/Resources/Prototypes/Palettes/critters.yml
+++ b/Resources/Prototypes/Palettes/critters.yml
@@ -50,7 +50,7 @@
     Innocent: "#f6f439" # Monky
     Angry: "#dc5864" # Hunty
     Perceptive: "#222222" # Watchy
-    Eldritch: "#dc5864"
+    Eldritch: "#084678"
     Fat: "#fefcab"
     Violent: "#ab3430"
     Speedy: "#679cfe"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Adds a new colour of scurret, it's dark blue.

## Why / Balance

Current palette has duplicated values for "Eldritch" and "Angry".

## Technical details

Colour sampled from picture here: https://static.wikitide.net/rainworldwiki/3/3d/Inv_select_screen_layer.png, works alright.

Inv's colour in-game seems to be `#1a2651` (judging by https://static.wikitide.net/rainworldwiki/4/45/Inv_spoiler.png), which is fine, but a bit dark.  As-is, it's _roughly_ the same "brightness" as Spearmaster/Artificer.

<details>
<summary>Darker colour</summary>

Unlit
<img width="1282" height="759" alt="image" src="https://github.com/user-attachments/assets/f7b55b2e-cd53-4e39-8ee0-f03a46418818" />

Lit
<img width="1282" height="758" alt="image" src="https://github.com/user-attachments/assets/ebffbd8a-a7fd-4b5b-8245-991f2650fa4a" />

</details>

## Test plan

Grid spawn scurrets.  Pick out the darker blue ones.

## Media

Unlit
<img width="1282" height="757" alt="image" src="https://github.com/user-attachments/assets/9f52def2-c761-40a4-bdae-a1d975fde9ce" />

Lit
<img width="1282" height="759" alt="image" src="https://github.com/user-attachments/assets/a1548f1a-8c16-4bb7-885a-5257471f8254" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
small