### PR TITLE
aghost keybinds + minor removal

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -80,7 +80,6 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.SmartEquipSuitStorage);
             human.AddFunction(ContentKeyFunctions.OpenBackpack);
             human.AddFunction(ContentKeyFunctions.OpenBelt);
-            human.AddFunction(ContentKeyFunctions.MouseMiddle);
             human.AddFunction(ContentKeyFunctions.RotateObjectClockwise);
             human.AddFunction(ContentKeyFunctions.RotateObjectCounterclockwise);
             human.AddFunction(ContentKeyFunctions.FlipObject);
@@ -117,6 +116,27 @@ namespace Content.Client.Input
             aghost.AddFunction(ContentKeyFunctions.TryPullObject);
             aghost.AddFunction(ContentKeyFunctions.MovePulledObject);
             aghost.AddFunction(ContentKeyFunctions.ReleasePulledObject);
+            aghost.AddFunction(ContentKeyFunctions.OpenCharacterMenu);
+            aghost.AddFunction(ContentKeyFunctions.OpenCraftingMenu);
+            aghost.AddFunction(ContentKeyFunctions.OpenInventoryMenu);
+            aghost.AddFunction(ContentKeyFunctions.SmartEquipBackpack);
+            aghost.AddFunction(ContentKeyFunctions.SmartEquipBelt);
+            aghost.AddFunction(ContentKeyFunctions.SmartEquipPocket1);
+            aghost.AddFunction(ContentKeyFunctions.SmartEquipPocket2);
+            aghost.AddFunction(ContentKeyFunctions.SmartEquipSuitStorage);
+            aghost.AddFunction(ContentKeyFunctions.OpenBackpack);
+            aghost.AddFunction(ContentKeyFunctions.OpenBelt);
+            aghost.AddFunction(ContentKeyFunctions.RotateObjectClockwise);
+            aghost.AddFunction(ContentKeyFunctions.RotateObjectCounterclockwise);
+            aghost.AddFunction(ContentKeyFunctions.FlipObject);
+            aghost.AddFunction(ContentKeyFunctions.ArcadeUp);
+            aghost.AddFunction(ContentKeyFunctions.ArcadeDown);
+            aghost.AddFunction(ContentKeyFunctions.ArcadeLeft);
+            aghost.AddFunction(ContentKeyFunctions.ArcadeRight);
+            aghost.AddFunction(ContentKeyFunctions.Arcade1);
+            aghost.AddFunction(ContentKeyFunctions.Arcade2);
+            aghost.AddFunction(ContentKeyFunctions.Arcade3);
+
 
             var ghost = contexts.New("ghost", "human");
             ghost.AddFunction(EngineKeyFunctions.MoveUp);

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -47,7 +47,6 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction TryPullObject = "TryPullObject";
         public static readonly BoundKeyFunction MovePulledObject = "MovePulledObject";
         public static readonly BoundKeyFunction ReleasePulledObject = "ReleasePulledObject";
-        public static readonly BoundKeyFunction MouseMiddle = "MouseMiddle";
         public static readonly BoundKeyFunction RotateObjectClockwise = "RotateObjectClockwise";
         public static readonly BoundKeyFunction RotateObjectCounterclockwise = "RotateObjectCounterclockwise";
         public static readonly BoundKeyFunction FlipObject = "FlipObject";

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -289,9 +289,6 @@ binds:
   type: State
   key: c
   mod1: Alt
-- function: MouseMiddle
-  type: State
-  key: MouseMiddle
   canFocus: true
 - function: RotateObjectClockwise
   type: State


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
1. Removes the MouseMiddle BoundKeyFunction.
2. Adds a bunch of keybinds to aghost that were missing.

Fixes #44450 

## Why / Balance
1. It's poorly named (functions shouldn't be named after the default key for them), and wasn't actually used since a refactor a few years ago, so I just removed it instead of renaming it.
2. I desired smart-equip on aghosts. I ported over most of the human actions, in fact, only excluding those that wouldn't make sense on an aghost (ToggleKnockdown and the emote menu, for instance)

## Technical details
1. Backspace
2. Ctrl+C, Ctrl+V (almost)

## Test plan
- Open dev
- Check that you can now do all these things as aghost. (note that if you CAN'T do some of these actions (like try to smart-equip to suit storage if you don't have that slot in your InventoryComponent), the system handles it automatically)

## Media
I can't record video, it works though!

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The BoundKeyFunction `MouseMiddle` has been removed. If it is still used on your fork, you can re-add the code or rename it. Do note that this is different to the `MouseMiddle` **key**.

## Changelog
