### PR TITLE
Fix MapText component

### DIFF
--- a/Content.Client/MapText/MapTextSystem.cs
+++ b/Content.Client/MapText/MapTextSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.MapText;
+using Content.Shared.MapText;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
@@ -45,7 +45,7 @@ public sealed partial class MapTextSystem : SharedMapTextSystem
         if (args.Current is not MapTextComponentState state)
             return;
 
-        ent.Comp.Text = state.Text;
+        ent.Comp.Text = state.Text ?? "";
         ent.Comp.LocText = state.LocText;
         ent.Comp.Color = state.Color;
         ent.Comp.FontId = state.FontId;

--- a/Content.Shared/MapText/SharedMapTextComponent.cs
+++ b/Content.Shared/MapText/SharedMapTextComponent.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 
@@ -17,7 +17,7 @@ public abstract partial class SharedMapTextComponent : Component
     /// The text to display. This will override <see cref="LocText"/>.
     /// </summary>
     [DataField]
-    public string? Text;
+    public string Text = "";
 
     /// <summary>
     /// The localized-id of the text that should be displayed.

--- a/Resources/Prototypes/Entities/Markers/map_text.yml
+++ b/Resources/Prototypes/Entities/Markers/map_text.yml
@@ -6,7 +6,7 @@
     mode: PlaceFree
   components:
   - type: MapText
-    text: "Use VV to change the displayed text"
+    text: "Use VV to change the displayed text" # remove if "null" fields will be editable in component view
   - type: Sprite
     state: pink
 

--- a/Resources/Prototypes/Entities/Markers/map_text.yml
+++ b/Resources/Prototypes/Entities/Markers/map_text.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: MapText
   parent: MarkerBase
   name: map text
@@ -6,7 +6,6 @@
     mode: PlaceFree
   components:
   - type: MapText
-    text: "" # remove if "null" fields will be editable in component view
   - type: Sprite
     state: pink
 

--- a/Resources/Prototypes/Entities/Markers/map_text.yml
+++ b/Resources/Prototypes/Entities/Markers/map_text.yml
@@ -6,7 +6,7 @@
     mode: PlaceFree
   components:
   - type: MapText
-    text: "Use VV to change the displayed text" # remove if "null" fields will be editable in component view
+    text: "" # remove if "null" fields will be editable in component view
   - type: Sprite
     state: pink
 

--- a/Resources/Prototypes/Entities/Markers/map_text.yml
+++ b/Resources/Prototypes/Entities/Markers/map_text.yml
@@ -6,6 +6,7 @@
     mode: PlaceFree
   components:
   - type: MapText
+    text: "Use VV to change the displayed text"
   - type: Sprite
     state: pink
 


### PR DESCRIPTION
## About the PR
Fixes map text component so the area in it wouldn't be `null` when you try to edit it by fallowing it instructions

## Why / Balance
just because if you would fallow the text instructions of trying to edit text with VV you would find out that the text field is just "null" and you cant edit it over there

## Technical details
TODO

## Test plan
spawn map text proto, or add a maptext component to bascially anything
fallow the text instruction
you will now be able to type in there

## Media
<img width="779" height="104" alt="image" src="https://github.com/user-attachments/assets/f5ed89ad-cc85-42ac-81fa-0483ac89f4c9" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
#morepowertothemappers
