### PR TITLE
feat: hyperlink text link tags

### DIFF
--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
@@ -42,10 +42,10 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IA
         };
     }
 
-    public void HandleClick(string link)
+    public bool HandleClick(string link)
     {
         if (!_entries.TryGetValue(link, out var entry))
-            return;
+            return false;
 
         if (Tree.TryGetIndexFromMetadata(entry, out var index))
         {
@@ -54,6 +54,8 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IA
         }
         else
             ShowGuide(entry);
+
+        return true;
     }
 
     public void HandleAnchor(IPrototypeLinkControl prototypeLinkControl)

--- a/Content.Client/Guidebook/Richtext/TextLinkTag.cs
+++ b/Content.Client/Guidebook/Richtext/TextLinkTag.cs
@@ -10,8 +10,12 @@ using Content.Client.UserInterface.ControlExtensions;
 namespace Content.Client.Guidebook.RichText;
 
 [UsedImplicitly]
-public sealed class TextLinkTag : IMarkupTagHandler
+public sealed partial class TextLinkTag : IMarkupTagHandler
 {
+    [Dependency] private IUriOpener _uriOpener = default!;
+
+    private readonly ISawmill _sawmill = Logger.GetSawmill("TextLinkTag");
+
     public static Color LinkColor => Color.CornflowerBlue;
 
     public string Name => "textlink";
@@ -50,14 +54,28 @@ public sealed class TextLinkTag : IMarkupTagHandler
         if (control == null)
             return;
 
-        if (control.TryGetParentHandler<ILinkClickHandler>(out var handler))
-            handler.HandleClick(link);
-        else
-            Logger.Warning("Warning! No valid ILinkClickHandler found.");
+        var isHttpLink = link.StartsWith("http://") || link.StartsWith("https://");
+
+        if (!control.TryGetParentHandler<ILinkClickHandler>(out var handler) && !isHttpLink)
+        {
+            _sawmill.Warning("No valid ILinkClickHandler found.");
+            return;
+        }
+
+        if (handler is not null && handler.HandleClick(link))
+            return;
+
+        if (isHttpLink)
+            _uriOpener.OpenUri(link);
     }
 }
 
 public interface ILinkClickHandler
 {
-    public void HandleClick(string link);
+    /// <summary>
+    /// Fired when a nested TextLinkTag is clicked.
+    /// </summary>
+    /// <param name="link">string value of tag's link parameter</param>
+    /// <returns>true to prevent opening HTTP links</returns>
+    bool HandleClick(string link);
 }

--- a/Content.Client/Info/RulesControl.xaml.cs
+++ b/Content.Client/Info/RulesControl.xaml.cs
@@ -13,6 +13,7 @@ namespace Content.Client.Info;
 public sealed partial class RulesControl : BoxContainer, ILinkClickHandler
 {
     [Dependency] private DocumentParsingManager _parsingMan = default!;
+    [Dependency] private IPrototypeManager _prototypeManager = default!;
 
     private string? _currentEntry;
     private readonly Stack<string> _priorEntries = new();
@@ -29,9 +30,13 @@ public sealed partial class RulesControl : BoxContainer, ILinkClickHandler
         BackButton.OnPressed += _ => SetGuide(_priorEntries.Pop(), false);
     }
 
-    public void HandleClick(string link)
+    public bool HandleClick(string link)
     {
+        if (!_prototypeManager.HasIndex<GuideEntryPrototype>(link))
+            return false;
+
         SetGuide(link);
+        return true;
     }
 
     private void SetGuide(ProtoId<GuideEntryPrototype>? entry = null, bool addToPrior = true)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
TextLinkTag now handles HTTP links.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->


## Technical details
<!-- Summary of code changes for easier review. -->
Low complexity change.

`ILinkClickHandler` implementations now return a boolean dictating if HTTP links should be suppressed. Existing implementations have been updated to support this. 

### Note
- `UriOpener` forbids non-HTTP URIs.[^forbidden-uri]
- `[textlink]` isn't usable by players.[^player-tags]

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
### Rules Popup
- Edit `Resources/ServerInfo/Guidebook/ServerRules/DefaultRules.xml` and add the following:
```
[textlink="Test link" link="https://example.com/"]

[textlink="Cyborg" link="Cyborgs"]

[textlink="Invalid URI" link="steam://open"]
```
- Run `showrules localhost@JoeGenero`
- Click the first link and verify the site is opened in your browser.
- Click the second link and verify the guidebook entry is displayed.
- Click the third link and verify nothing happens.

### Guidebook
- Edit `Resources/ServerInfo/Guidebook/Science/Robotics.xml` and add a test link.
- Open the guidebook page, click the test link, and verify the site is opened in your browser.
- Click the guidebook entry link for Cyborgs and verify the correct guidebook entry is opened.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="680" height="162" alt="image" src="https://github.com/user-attachments/assets/c193fc23-9150-45e4-ad3a-9f62cb534dfd" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
`ILinkClickHandler.HandleClick` now returns a boolean value. Return `true` to suppress opening HTTP links in the player's browser. 

[^forbidden-uri]: https://github.com/space-wizards/RobustToolbox/blob/1433cb3a6d1c7e75129c92db14b1f77dda5d783d/Robust.Client/UserInterface/UriOpener.cs#L47-L50
[^player-tags]: https://github.com/space-wizards/space-station-14/blob/a0ebe115072a34c2b49dc44aaf3d853aef0aaa6b/Content.Client/RichText/UserFormattableTags.cs#L11-L24

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->