### PR TITLE
Make living tissue contain the changeling's DNA

### DIFF
--- a/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
@@ -2,6 +2,8 @@ using Content.Shared.Actions;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Armor;
 using Content.Shared.Atmos.Rotting;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
 using Content.Shared.Changeling.Components;
 using Content.Shared.Store;
 using Content.Shared.Damage.Systems;
@@ -22,6 +24,7 @@ namespace Content.Shared.Changeling.Systems;
 
 public sealed partial class ChangelingDevourSystem : EntitySystem
 {
+    [Dependency] private BloodstreamSystem _bloodstream = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private INetManager _net = default!;
@@ -187,7 +190,14 @@ public sealed partial class ChangelingDevourSystem : EntitySystem
         EnsureComp<RecentlyDevouredComponent>(target);
 
         if (ent.Comp.DevourSpill != null)
-            _puddle.TrySpillAt(target, ent.Comp.DevourSpill, out _, false);
+        {
+            // Spilled solution should have the same DNA as the changeling at the time of devouring
+            var spill = ent.Comp.DevourSpill.Clone();
+            if (TryComp<BloodstreamComponent>(ent, out var bloodstream))
+                spill.SetReagentData(_bloodstream.GetEntityBloodData((ent, bloodstream)));
+
+            _puddle.TrySpillAt(target, spill, out _, false);
+        }
 
         // Grants the DNA reward associated with a successful unique devour.
         if (willGrantDna && TryComp<StoreComponent>(ent, out var store))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
When living tissue is spilled after a changeling devours someone, the resulting reagent now has the DNA of whatever identity the changeling was transformed into.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #45559 

## Technical details
<!-- Summary of code changes for easier review. -->

**ChangelingDevourSystem**:

`OnDevourConsume`, when spilling a puddle, now:
- If the devouring entity has a bloodstream, adds the DNA of their blood to the spilled solution
- Clones the `DevourSpill` solution instead of using it directly, to hopefully prevent cases of "devour someone -> transform -> `DevourSpill` field in `ChangelingDevourComponent` now stores the DNA of a previous identity instead of no DNA
  - (In practice, I don't think this actually causes any problems, but the scenario I gave seemed weird enough to try and avoid)

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Boot up dev environment
2. Have three Urists, make one a changeling
3. Use a syringe to draw blood from the changeling, spill on ground somewhere and print out the DNA scan
4. Kill and devour one of the two other Urists, scan DNA of resulting puddle. The DNA from step 3 should be present
5. Transform into freshly-devoured Urist, repeat step 4 with the last remaining one. DNA from step 3 should _not_ be present, while DNA from step 4 _is_

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/092d502d-b6f7-4b91-a408-25f652070a3a

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Living tissue spilled when a changeling devours someone now contains the DNA of the changeling at the time of devouring
