### PR TITLE
Plant enviromental damage scaling

### DIFF
--- a/Content.Server/Botany/Systems/PlantAtmosphericSystem.cs
+++ b/Content.Server/Botany/Systems/PlantAtmosphericSystem.cs
@@ -34,8 +34,8 @@ public sealed partial class PlantAtmosphericSystem : SharedPlantAtmosphericSyste
             //Take HeatToleranceDamage at HeatToleranceDifference degrees above or below the threshold, increasing as
             //the differential increases. A decrease in steepness will increase damage taken at higher differentials
            return (float) (ent.Comp.HeatToleranceDamage *
-                  Math.Log(ent.Comp.HeatToleranceSteepness * tempThresholdDiff + 1) /
-                  Math.Log(ent.Comp.HeatToleranceSteepness * ent.Comp.HeatToleranceDifference + 1));
+                  Math.Log(ent.Comp.HeatToleranceInvScaling * tempThresholdDiff + 1) /
+                  Math.Log(ent.Comp.HeatToleranceInvScaling * ent.Comp.HeatToleranceDifference + 1));
         }
 
         return 0f;
@@ -62,8 +62,8 @@ public sealed partial class PlantAtmosphericSystem : SharedPlantAtmosphericSyste
             //Take PressureToleranceDamage at PressureToleranceDifference kPA above or below the threshold, increasing
             //as the differential increases. A decrease in steepness will increase damage taken at higher differentials
             return (float) (ent.Comp.PressureToleranceDamage *
-                            Math.Log(ent.Comp.PressureToleranceSteepness * pressureThresholdDiff + 1) /
-                            Math.Log(ent.Comp.PressureToleranceSteepness * ent.Comp.PressureToleranceDifference + 1));
+                            Math.Log(ent.Comp.PressureToleranceInvScaling * pressureThresholdDiff + 1) /
+                            Math.Log(ent.Comp.PressureToleranceInvScaling * ent.Comp.PressureToleranceDifference + 1));
         }
 
         return 0f;

--- a/Content.Server/Botany/Systems/PlantAtmosphericSystem.cs
+++ b/Content.Server/Botany/Systems/PlantAtmosphericSystem.cs
@@ -13,6 +13,10 @@ public sealed partial class PlantAtmosphericSystem : SharedPlantAtmosphericSyste
 
     [Dependency] private EntityQuery<PlantHolderComponent> _holderQuery = default!;
 
+
+    /// <summary>
+    /// Calculates the damage that a plant should take due to improper temperature in a given environment
+    /// </summary>
     private static float CalculatePlantTemperatureDamage(Entity<PlantAtmosphericComponent> ent, GasMixture environment)
     {
         var tempThresholdDiff = 0f;
@@ -27,7 +31,8 @@ public sealed partial class PlantAtmosphericSystem : SharedPlantAtmosphericSyste
 
         if (tempThresholdDiff > 0)
         {
-            //Take HeatToleranceDamage at 20 degrees above or below the threshold, increasing as the differential does
+            //Take HeatToleranceDamage at HeatToleranceDifference degrees above or below the threshold, increasing as
+            //the differential increases. A decrease in steepness will increase damage taken at higher differentials
            return (float) (ent.Comp.HeatToleranceDamage *
                   Math.Log(ent.Comp.HeatToleranceSteepness * tempThresholdDiff + 1) /
                   Math.Log(ent.Comp.HeatToleranceSteepness * ent.Comp.HeatToleranceDifference + 1));
@@ -36,6 +41,9 @@ public sealed partial class PlantAtmosphericSystem : SharedPlantAtmosphericSyste
         return 0f;
     }
 
+    /// <summary>
+    /// Calculates the damage that a plant should take due to improper pressure in a given environment
+    /// </summary>
     private static float CalculatePlantPressureDamage(Entity<PlantAtmosphericComponent> ent, GasMixture environment)
     {
         var pressureThresholdDiff = 0f;
@@ -51,7 +59,8 @@ public sealed partial class PlantAtmosphericSystem : SharedPlantAtmosphericSyste
 
         if (pressureThresholdDiff > 0)
         {
-            //Take HeatToleranceDamage at 20 degrees above or below the threshold, increasing as the differential does
+            //Take PressureToleranceDamage at PressureToleranceDifference kPA above or below the threshold, increasing
+            //as the differential increases. A decrease in steepness will increase damage taken at higher differentials
             return (float) (ent.Comp.PressureToleranceDamage *
                             Math.Log(ent.Comp.PressureToleranceSteepness * pressureThresholdDiff + 1) /
                             Math.Log(ent.Comp.PressureToleranceSteepness * ent.Comp.PressureToleranceDifference + 1));

--- a/Content.Server/Botany/Systems/PlantAtmosphericSystem.cs
+++ b/Content.Server/Botany/Systems/PlantAtmosphericSystem.cs
@@ -13,6 +13,53 @@ public sealed partial class PlantAtmosphericSystem : SharedPlantAtmosphericSyste
 
     [Dependency] private EntityQuery<PlantHolderComponent> _holderQuery = default!;
 
+    private static float CalculatePlantTemperatureDamage(Entity<PlantAtmosphericComponent> ent, GasMixture environment)
+    {
+        var tempThresholdDiff = 0f;
+        if (environment.Temperature < ent.Comp.LowHeatTolerance)
+        {
+            tempThresholdDiff = ent.Comp.LowHeatTolerance - environment.Temperature;
+        }
+        else if (environment.Temperature > ent.Comp.HighHeatTolerance)
+        {
+            tempThresholdDiff = environment.Temperature - ent.Comp.HighHeatTolerance;
+        }
+
+        if (tempThresholdDiff > 0)
+        {
+            //Take HeatToleranceDamage at 20 degrees above or below the threshold, increasing as the differential does
+           return (float) (ent.Comp.HeatToleranceDamage *
+                  Math.Log(ent.Comp.HeatToleranceSteepness * tempThresholdDiff + 1) /
+                  Math.Log(ent.Comp.HeatToleranceSteepness * ent.Comp.HeatToleranceDifference + 1));
+        }
+
+        return 0f;
+    }
+
+    private static float CalculatePlantPressureDamage(Entity<PlantAtmosphericComponent> ent, GasMixture environment)
+    {
+        var pressureThresholdDiff = 0f;
+
+        if (environment.Pressure < ent.Comp.LowPressureTolerance)
+        {
+            pressureThresholdDiff = ent.Comp.LowPressureTolerance - environment.Pressure;
+        }
+        else if (environment.Pressure > ent.Comp.HighPressureTolerance)
+        {
+            pressureThresholdDiff = environment.Pressure - ent.Comp.HighPressureTolerance;
+        }
+
+        if (pressureThresholdDiff > 0)
+        {
+            //Take HeatToleranceDamage at 20 degrees above or below the threshold, increasing as the differential does
+            return (float) (ent.Comp.PressureToleranceDamage *
+                            Math.Log(ent.Comp.PressureToleranceSteepness * pressureThresholdDiff + 1) /
+                            Math.Log(ent.Comp.PressureToleranceSteepness * ent.Comp.PressureToleranceDifference + 1));
+        }
+
+        return 0f;
+    }
+
     [SubscribeLocalEvent]
     private void OnPlantGrow(Entity<PlantAtmosphericComponent> ent, ref PlantGrowEvent args)
     {
@@ -20,19 +67,22 @@ public sealed partial class PlantAtmosphericSystem : SharedPlantAtmosphericSyste
             return;
 
         var environment = _atmosphere.GetContainingMixture(ent.Owner, true, true) ?? GasMixture.SpaceGas;
-        if (environment.Temperature < ent.Comp.LowHeatTolerance || environment.Temperature > ent.Comp.HighHeatTolerance)
+
+        var tempDamage = CalculatePlantTemperatureDamage(ent, environment);
+        if (tempDamage > 0)
         {
-            _plantHolder.AdjustsHealth((ent.Owner, holder), -ent.Comp.HeatToleranceDamage);
             holder.ImproperHeat = true;
+            _plantHolder.AdjustsHealth((ent.Owner, holder), -tempDamage);
         }
         else
             holder.ImproperHeat = false;
 
-        var pressure = environment.Pressure;
-        if (pressure < ent.Comp.LowPressureTolerance || pressure > ent.Comp.HighPressureTolerance)
+
+        var pressureDamage = CalculatePlantPressureDamage(ent, environment);
+        if (pressureDamage > 0)
         {
-            _plantHolder.AdjustsHealth((ent.Owner, holder), -ent.Comp.PressureToleranceDamage);
             holder.ImproperPressure = true;
+            _plantHolder.AdjustsHealth((ent.Owner, holder), -pressureDamage);
         }
         else
             holder.ImproperPressure = false;

--- a/Content.Shared/Botany/Components/PlantAtmosphericComponent.cs
+++ b/Content.Shared/Botany/Components/PlantAtmosphericComponent.cs
@@ -11,10 +11,25 @@ namespace Content.Shared.Botany.Components;
 public sealed partial class PlantAtmosphericComponent : Component
 {
     /// <summary>
-    /// Damage per unit of heat tolerance exceeded.
+    /// The range a plant needs to be outside it's ideal temperatures to take the standard amount of
+    /// damage (HeatToleranceDamage).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float HeatToleranceDifference = 20f;
+
+    /// <summary>
+    /// Damage taken per growth cycle at exactly HeatToleranceDifference degrees above or below the plant's heat
+    /// thresholds.
     /// </summary>
     [DataField, AutoNetworkedField]
     public float HeatToleranceDamage = 2f;
+
+    /// <summary>
+    /// Lower steepness increases plant damage taken at a high temperature differentials and decreases damage at low
+    /// temperature differentials.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float HeatToleranceSteepness = 1f;
 
     /// <summary>
     /// Minimum temperature tolerance for plant growth.
@@ -29,10 +44,25 @@ public sealed partial class PlantAtmosphericComponent : Component
     public float HighHeatTolerance = 303f; // 30°C
 
     /// <summary>
-    /// Damage per unit of pressure tolerance exceeded.
+    /// The amount a plant needs to be outside it's ideal pressure range to take the standard amount of
+    /// damage (PressureToleranceDamage).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float PressureToleranceDifference = 10f;
+
+    /// <summary>
+    /// Damage taken per growth cycle at exactly PressureToleranceDifference kPa above or below the plant's pressure
+    /// thresholds.
     /// </summary>
     [DataField, AutoNetworkedField]
     public float PressureToleranceDamage = 2f;
+
+    /// <summary>
+    /// Lower steepness increases plant damage taken at a high pressure differentials and decreases damage at low
+    /// pressure differentials.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float PressureToleranceSteepness = 1f;
 
     /// <summary>
     /// Minimum pressure tolerance for plant growth.

--- a/Content.Shared/Botany/Components/PlantAtmosphericComponent.cs
+++ b/Content.Shared/Botany/Components/PlantAtmosphericComponent.cs
@@ -25,11 +25,11 @@ public sealed partial class PlantAtmosphericComponent : Component
     public float HeatToleranceDamage = 2f;
 
     /// <summary>
-    /// Lower steepness increases plant damage taken at a high temperature differentials and decreases damage at low
-    /// temperature differentials.
+    /// Lower inverse scaling increases plant damage taken if a plant is outside it's ideal temperature by a large
+    /// amount and decreases it if it's very close to ideal conditions.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float HeatToleranceSteepness = 1f;
+    public float HeatToleranceInvScaling = 1f;
 
     /// <summary>
     /// Minimum temperature tolerance for plant growth.
@@ -58,11 +58,11 @@ public sealed partial class PlantAtmosphericComponent : Component
     public float PressureToleranceDamage = 2f;
 
     /// <summary>
-    /// Lower steepness increases plant damage taken at a high pressure differentials and decreases damage at low
-    /// pressure differentials.
+    /// Lower inverse scaling increases plant damage taken if a plant is outside it's ideal pressure by a large
+    /// amount and decreases it if it's very close to ideal conditions.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float PressureToleranceSteepness = 1f;
+    public float PressureToleranceInvScaling = 1f;
 
     /// <summary>
     /// Minimum pressure tolerance for plant growth.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The environmental damage of a plant was changed to scale logarithmically based upon how far the conditions are from ideal instead of a constant damage number across all environments.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The issue with body temperature raising room temperature showed that even being 1 degree over ideal temperature could cause issues for plants and yet any plant could also be grown in the vacuum of space indefinitely by adding a vitamin/nutri mix.


## Technical details
<!-- Summary of code changes for easier review. -->
PlantAtmosphericSystem and PlantAtmosphericComponent were adjusted to use logarithmic scaling instead of a constant.

The formula used is
`damage = a * ln(bx + 1) / ln(bc + 1)`

Where 'a' is the base damage a plant will take at 'c' difference of temperature or pressure and 'b' can be used to control how much the damage should scale.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Flood botany with frezon
2. Grow a plant inside frezon botany and in a room with slightly higher temperature than a plant would like
3. Compare the health of the two plants over time


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Plant environmental damage now scales in severity.