### PR TITLE
Allow toggling shuttle docks via network linking

### DIFF
--- a/Content.Server/Shuttles/Components/DockingSignalControlComponent.cs
+++ b/Content.Server/Shuttles/Components/DockingSignalControlComponent.cs
@@ -11,4 +11,10 @@ public sealed partial class DockingSignalControlComponent : Component
     /// </summary>
     [DataField]
     public ProtoId<SourcePortPrototype> DockStatusSignalPort = "DockStatus";
+
+    /// <summary>
+    /// Input port that toggles the docking status
+    /// </summary>
+    [DataField]
+    public ProtoId<SinkPortPrototype> DockTogglePort = "DockToggle";
 }

--- a/Content.Server/Shuttles/Systems/DockingSignalControlSystem.cs
+++ b/Content.Server/Shuttles/Systems/DockingSignalControlSystem.cs
@@ -47,7 +47,7 @@ public sealed partial class DockingSignalControlSystem : EntitySystem
 
             foreach (var dockingEntity in query)
             {
-                if (_dockingSystem.CanDock((ent, dock), dockingEntity))
+                if (!_dockingSystem.CanDock((ent, dock), dockingEntity))
                     continue;
 
                 _dockingSystem.Dock((ent, dock), dockingEntity);

--- a/Content.Server/Shuttles/Systems/DockingSignalControlSystem.cs
+++ b/Content.Server/Shuttles/Systems/DockingSignalControlSystem.cs
@@ -1,28 +1,66 @@
+using Content.Server.Database.Migrations.Postgres;
 using Content.Server.DeviceLinking.Systems;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
+using Content.Shared.DeviceLinking;
+using Content.Shared.DeviceLinking.Events;
+using Content.Shared.DeviceNetwork;
 
 namespace Content.Server.Shuttles.Systems;
 
 public sealed partial class DockingSignalControlSystem : EntitySystem
 {
     [Dependency] private DeviceLinkSystem _deviceLinkSystem = default!;
+    [Dependency] private DockingSystem _dockingSystem = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
+    #region Subscriptions
 
-        SubscribeLocalEvent<DockingSignalControlComponent, DockEvent>(OnDocked);
-        SubscribeLocalEvent<DockingSignalControlComponent, UndockEvent>(OnUndocked);
-    }
-
+    [SubscribeLocalEvent]
     private void OnDocked(Entity<DockingSignalControlComponent> ent, ref DockEvent args)
     {
         _deviceLinkSystem.SendSignal(ent, ent.Comp.DockStatusSignalPort, signal: true);
     }
 
+    [SubscribeLocalEvent]
     private void OnUndocked(Entity<DockingSignalControlComponent> ent, ref UndockEvent args)
     {
         _deviceLinkSystem.SendSignal(ent, ent.Comp.DockStatusSignalPort, signal: false);
     }
+
+    [SubscribeLocalEvent]
+    private void OnSignalRecieved(Entity<DockingSignalControlComponent> ent, ref SignalReceivedEvent args)
+    {
+        if (!TryComp<DockingComponent>(ent, out var dock))
+            return;
+
+        if (args.Port != ent.Comp.DockTogglePort)
+            return;
+
+        var state = SignalState.Momentary;
+        args.Data?.TryGetValue(DeviceNetworkConstants.LogicState, out state);
+
+        var shouldDock = state == SignalState.High || (state == SignalState.Momentary && !dock.Docked);
+
+        if (shouldDock)
+        {
+            var query = AllEntityQuery<DockingComponent>();
+
+            foreach (var dockingEntity in query)
+            {
+                if (_dockingSystem.CanDock((ent, dock), dockingEntity))
+                {
+                    _dockingSystem.Dock((ent, dock), dockingEntity);
+                }
+            }
+        }
+        else
+        {
+            if (!_dockingSystem.CanUndock((ent, dock)))
+                return;
+
+            _dockingSystem.Undock((ent, dock));
+        }
+    }
+
+    #endregion
 }

--- a/Content.Server/Shuttles/Systems/DockingSignalControlSystem.cs
+++ b/Content.Server/Shuttles/Systems/DockingSignalControlSystem.cs
@@ -48,9 +48,10 @@ public sealed partial class DockingSignalControlSystem : EntitySystem
             foreach (var dockingEntity in query)
             {
                 if (_dockingSystem.CanDock((ent, dock), dockingEntity))
-                {
-                    _dockingSystem.Dock((ent, dock), dockingEntity);
-                }
+                    continue;
+
+                _dockingSystem.Dock((ent, dock), dockingEntity);
+                break;
             }
         }
         else

--- a/Content.Server/Shuttles/Systems/DockingSystem.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.cs
@@ -418,6 +418,9 @@ public sealed partial class DockingSystem : SharedDockingSystem
         var xformA = Transform(dockA);
         var xformB = Transform(dockB);
 
+        if (xformA.GridUid == xformB.GridUid)
+            return false;
+
         if (!xformA.Anchored || !xformB.Anchored)
             return false;
 

--- a/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
+++ b/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
@@ -5,7 +5,7 @@ signal-port-name-toggle = Toggle
 signal-port-description-toggle = Toggles the state of a device.
 
 signal-port-name-dock-toggle = Toggle docking
-signal-port-description-dock-toggle = Toggles the state of the docking clamp of a device.
+signal-port-description-dock-toggle = Enables the docking clamp of a device when HIGH.
 
 signal-port-name-on-receiver = On
 signal-port-description-on-receiver = Turns a device on.

--- a/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
+++ b/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
@@ -4,6 +4,9 @@ signal-port-description-autoclose = Toggles whether the device should automatica
 signal-port-name-toggle = Toggle
 signal-port-description-toggle = Toggles the state of a device.
 
+signal-port-name-dock-toggle = Toggle Docking
+signal-port-description-dock-toggle = Toggles the state of the docking clamp of a device.
+
 signal-port-name-on-receiver = On
 signal-port-description-on-receiver = Turns a device on.
 

--- a/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
+++ b/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
@@ -4,7 +4,7 @@ signal-port-description-autoclose = Toggles whether the device should automatica
 signal-port-name-toggle = Toggle
 signal-port-description-toggle = Toggles the state of a device.
 
-signal-port-name-dock-toggle = Toggle Docking
+signal-port-name-dock-toggle = Toggle docking
 signal-port-description-dock-toggle = Toggles the state of the docking clamp of a device.
 
 signal-port-name-on-receiver = On

--- a/Resources/Prototypes/DeviceLinking/sink_ports.yml
+++ b/Resources/Prototypes/DeviceLinking/sink_ports.yml
@@ -9,6 +9,11 @@
   description: signal-port-description-toggle
 
 - type: sinkPort
+  id: DockToggle
+  name: signal-port-name-dock-toggle
+  description: signal-port-description-dock-toggle
+
+- type: sinkPort
   id: On
   name: signal-port-name-on-receiver
   description: signal-port-description-on-receiver
@@ -117,7 +122,7 @@
   id: RandomGateInput
   name: signal-port-name-logic-random-input
   description: signal-port-description-logic-random-input
-  
+
 - type: sinkPort
   id: SetParticleDelta
   name: signal-port-name-set-particle-delta

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -7,6 +7,14 @@
   components:
   - type: Docking
   - type: DockingSignalControl
+  - type: DeviceLinkSink
+    ports:
+    - Open
+    - Close
+    - Toggle
+    - AutoClose
+    - DoorBolt
+    - DockToggle
   - type: DeviceLinkSource
     ports:
       - DoorStatus


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Docking airlocks now get a network sink that can toggle its docking clamp. 

High will engage the clamp, Low will disengage the clamp, and Momentary will toggle the clamp.

## Why / Balance
Because I got trolled as CE one time when trying to reconnect the chapelroid to the station.

## Technical details
Pretty easy C#, just adding some datafields and stuff

Also, CanDock now checks that the docks are on different grids.

## Test plan
1. Open dev
2. Put a directional button on the shuttle
3. Link it to the dock with a multitool
4. It works!

## Media
<img width="212" height="330" alt="image" src="https://github.com/user-attachments/assets/046d9186-fc4c-4bcf-b78a-b81d9ac47c99" />
<img width="1253" height="491" alt="image" src="https://github.com/user-attachments/assets/d0640dc0-a9e4-41ff-9707-ec670b119758" />

[video](https://github.com/user-attachments/assets/d73252f1-b82e-4771-81c3-3a80febdae09)


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
DockingSystem.CanDock now checks that the two docks are on separate grids.

## Changelog
:cl:
- add: Docking clamps can now be toggled via network linking.
