### PR TITLE
Rework foam to not do reagent duplication

### DIFF
--- a/Content.Server/EntityEffects/Effects/Solution/AreaReactionEntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/Effects/Solution/AreaReactionEntityEffectSystem.cs
@@ -30,7 +30,7 @@ public sealed partial class AreaReactionEntityEffectsSystem : EntityEffectSystem
     {
         var xform = Transform(entity);
         var mapCoords = _xform.GetMapCoordinates(entity);
-        var spreadAmount = (int) Math.Max(0, Math.Ceiling(args.Scale / args.Effect.OverflowThreshold));
+        var spreadAmount = (int) Math.Max(0, Math.Floor(args.Scale / args.Effect.OverflowThreshold));
         var effect = args.Effect;
 
         if (!_map.TryFindGridAt(mapCoords, out var gridUid, out var grid) ||

--- a/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
@@ -49,18 +49,6 @@ public sealed partial class SmokeSystem : EntitySystem
     [Dependency] private EntityQuery<SmokeAffectedComponent> _smokeAffectedQuery = default!;
 
     /// <inheritdoc/>
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<SmokeComponent, StartCollideEvent>(OnStartCollide);
-        SubscribeLocalEvent<SmokeComponent, EndCollideEvent>(OnEndCollide);
-        SubscribeLocalEvent<SmokeComponent, ReactionAttemptEvent>(OnReactionAttempt);
-        SubscribeLocalEvent<SmokeComponent, SolutionRelayEvent<ReactionAttemptEvent>>(OnReactionAttempt);
-        SubscribeLocalEvent<SmokeComponent, SpreadNeighborsEvent>(OnSmokeSpread);
-    }
-
-    /// <inheritdoc/>
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -77,6 +65,16 @@ public sealed partial class SmokeSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
+    private void OnComponentInit(Entity<SmokeComponent> entity, ref ComponentInit args)
+    {
+        if (entity.Comp.StartingContents == null)
+            return;
+
+        StartSmoke(entity, entity.Comp.StartingContents, entity.Comp.Duration, entity.Comp.SpreadAmount, entity.Comp);
+    }
+
+    [SubscribeLocalEvent]
     private void OnStartCollide(Entity<SmokeComponent> entity, ref StartCollideEvent args)
     {
         if (_smokeAffectedQuery.HasComponent(args.OtherEntity))
@@ -87,6 +85,7 @@ public sealed partial class SmokeSystem : EntitySystem
         smokeAffected.NextSecond = _timing.CurTime + TimeSpan.FromSeconds(1);
     }
 
+    [SubscribeLocalEvent]
     private void OnEndCollide(Entity<SmokeComponent> entity, ref EndCollideEvent args)
     {
         // if we are already in smoke, make sure the thing we are exiting is the current smoke we are in.
@@ -118,6 +117,7 @@ public sealed partial class SmokeSystem : EntitySystem
             RemComp(args.OtherEntity, smokeAffectedComponent);
     }
 
+    [SubscribeLocalEvent]
     private void OnSmokeSpread(Entity<SmokeComponent> entity, ref SpreadNeighborsEvent args)
     {
         if (entity.Comp.SpreadAmount == 0)
@@ -142,7 +142,14 @@ public sealed partial class SmokeSystem : EntitySystem
         foreach (var neighbor in args.NeighborFreeTiles)
         {
             var coords = _map.GridTileToLocal(neighbor.Tile.GridUid, neighbor.Grid, neighbor.Tile.GridIndices);
-            var ent = Spawn(prototype.ID, coords);
+            var ent = EntityManager.CreateEntityUninitialized(prototype.ID, coords);
+            // If the smoke entity has starting contents, new entities spawned from it should not include it.
+            if (entity.Comp.StartingContents != null && TryComp<SmokeComponent>(ent, out var newSmoke))
+            {
+                newSmoke.StartingContents = null;
+            }
+            EntityManager.InitializeAndStartEntity(ent);
+
             var spreadAmount = Math.Max(0, smokePerSpread);
             entity.Comp.SpreadAmount -= args.NeighborFreeTiles.Count;
 
@@ -191,6 +198,7 @@ public sealed partial class SmokeSystem : EntitySystem
 
     }
 
+    [SubscribeLocalEvent]
     private void OnReactionAttempt(Entity<SmokeComponent> entity, ref ReactionAttemptEvent args)
     {
         if (args.Cancelled)
@@ -207,6 +215,7 @@ public sealed partial class SmokeSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnReactionAttempt(Entity<SmokeComponent> entity, ref SolutionRelayEvent<ReactionAttemptEvent> args)
     {
         if (args.Solution.Comp.Id == SmokeComponent.SolutionName)

--- a/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Content.Server.Administration.Logs;
 using Content.Server.Body.Systems;
 using Content.Server.Spreader;
@@ -6,7 +7,6 @@ using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reaction;
-using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Database;
 using Content.Shared.FixedPoint;
 using Content.Shared.Smoking;
@@ -20,7 +20,9 @@ using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using System.Linq;
 using Content.Shared.Body.Systems;
+using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.EntityEffects.Effects.Solution;
+using Robust.Shared.Map;
 using TimedDespawnComponent = Robust.Shared.Spawners.TimedDespawnComponent;
 
 namespace Content.Server.Fluids.EntitySystems;
@@ -118,7 +120,7 @@ public sealed partial class SmokeSystem : EntitySystem
 
     private void OnSmokeSpread(Entity<SmokeComponent> entity, ref SpreadNeighborsEvent args)
     {
-        if (entity.Comp.SpreadAmount == 0 || !_solutionContainerSystem.ResolveSolution(entity.Owner, SmokeComponent.SolutionName, ref entity.Comp.Solution, out var solution))
+        if (entity.Comp.SpreadAmount == 0)
         {
             RemCompDeferred<ActiveEdgeSpreaderComponent>(entity);
             return;
@@ -144,7 +146,7 @@ public sealed partial class SmokeSystem : EntitySystem
             var spreadAmount = Math.Max(0, smokePerSpread);
             entity.Comp.SpreadAmount -= args.NeighborFreeTiles.Count;
 
-            StartSmoke(ent, solution.Clone(), timer?.Lifetime ?? entity.Comp.Duration, spreadAmount);
+            SpreadSmoke(ent, entity.AsNullable(), spreadAmount, timer?.Lifetime ?? entity.Comp.Duration);
 
             if (entity.Comp.SpreadAmount == 0)
             {
@@ -154,6 +156,16 @@ public sealed partial class SmokeSystem : EntitySystem
         }
 
         args.Updates--;
+
+
+        if (entity.Comp.SmokeSourceEntity != null)
+        {
+            var smokeSrcComp = entity.Comp.SmokeSourceEntity.Value.Comp;
+
+            // If smoke has spread, we need to re-calculate the transfer rate.
+            if (smokeSrcComp.DirtyTransferRateCalc)
+                smokeSrcComp.TransferRate = CalculateTransferRate(smokeSrcComp.OriginalVolume, smokeSrcComp.SpreadCount, smokeSrcComp.Duration);
+        }
 
         if (args.NeighborFreeTiles.Count > 0 || args.Neighbors.Count == 0 || entity.Comp.SpreadAmount < 1)
             return;
@@ -211,24 +223,88 @@ public sealed partial class SmokeSystem : EntitySystem
 
         component.SpreadAmount = spreadAmount;
         component.Duration = duration;
-        component.TransferRate = solution.Volume / duration;
-        TryAddSolution(uid, solution);
+
+        SetUpSmokePhysics(uid, duration);
         Dirty(uid, component);
-        EnsureComp<ActiveEdgeSpreaderComponent>(uid);
 
-        if (TryComp<PhysicsComponent>(uid, out var body) && TryComp<FixturesComponent>(uid, out var fixtures))
-        {
-            var xform = Transform(uid);
-            _physics.SetBodyType(uid, BodyType.Dynamic, fixtures, body, xform);
-            _physics.SetCanCollide(uid, true, manager: fixtures, body: body);
-            _broadphase.RegenerateContacts((uid, body, fixtures, xform));
-        }
+        if (!TryAddSolution(uid, solution, out var smokeSrcEnt, out var volume))
+            return;
 
-        var timer = EnsureComp<TimedDespawnComponent>(uid);
-        timer.Lifetime = duration;
+        var smokeSrcComp = smokeSrcEnt.Value.Comp;
+
+        smokeSrcComp.SpreadCount++;
+        smokeSrcComp.OriginalVolume = volume;
+        smokeSrcComp.Duration = duration;
+        smokeSrcComp.TransferRate =  CalculateTransferRate(smokeSrcComp.OriginalVolume, smokeSrcComp.SpreadCount, smokeSrcComp.Duration);
+
+        var solutionTimer = EnsureComp<TimedDespawnComponent>(smokeSrcEnt.Value);
+        solutionTimer.Lifetime = duration;
 
         // The tile reaction happens here because it only occurs once.
         ReactOnTile(uid, component);
+    }
+
+    private void SpreadSmoke(Entity<SmokeComponent?> newEntity, Entity<SmokeComponent?> sourceEntity, int spreadAmount, float duration)
+    {
+        if (!Resolve(newEntity, ref newEntity.Comp))
+            return;
+
+        if (!Resolve(sourceEntity, ref sourceEntity.Comp))
+            return;
+
+        newEntity.Comp.SpreadAmount = spreadAmount;
+        newEntity.Comp.Duration = duration;
+        newEntity.Comp.SmokeSourceEntity = sourceEntity.Comp.SmokeSourceEntity;
+
+        SetUpSmokePhysics(newEntity, duration);
+
+        UpdateVisuals(newEntity);
+        Dirty(newEntity);
+
+        // Handle everything related to contained reagents
+
+        if (sourceEntity.Comp.SmokeSourceEntity == null)
+            return;
+
+        var smokeSrcComp = sourceEntity.Comp.SmokeSourceEntity.Value.Comp;
+        smokeSrcComp.SpreadCount++;
+        smokeSrcComp.DirtyTransferRateCalc = true;
+
+        var solutionTimer = EnsureComp<TimedDespawnComponent>(sourceEntity.Comp.SmokeSourceEntity.Value);
+        if (solutionTimer.Lifetime < duration)
+            solutionTimer.Lifetime = duration;
+
+        // The tile reaction happens here because it only occurs once.
+        ReactOnTile(newEntity, newEntity.Comp);
+    }
+
+    private void SetUpSmokePhysics(EntityUid entity, float duration)
+    {
+        EnsureComp<ActiveEdgeSpreaderComponent>(entity);
+
+        if (TryComp<PhysicsComponent>(entity, out var body) && TryComp<FixturesComponent>(entity, out var fixtures))
+        {
+            var xform = Transform(entity);
+            _physics.SetBodyType(entity, BodyType.Dynamic, fixtures, body, xform);
+            _physics.SetCanCollide(entity, true, manager: fixtures, body: body);
+            _broadphase.RegenerateContacts((entity, body, fixtures, xform));
+        }
+
+        var timer = EnsureComp<TimedDespawnComponent>(entity);
+        timer.Lifetime = duration;
+    }
+
+    /// <summary>
+    /// Smoke spreads outwards in what's known as a "centered square number" pattern.
+    /// The transfer rate is the reverse of that formula, so that smoke that spreads out in a 3 tile radius returns vol / 3 * duration.
+    /// This should give a somewhat correct correlation where a bigger cloud = diluted more.
+    /// </summary>
+    private FixedPoint2 CalculateTransferRate(FixedPoint2 originalVolume, int spreadCount, float duration)
+    {
+        if (duration == 0)
+            return FixedPoint2.Zero;
+
+        return originalVolume / (((1 + MathF.Sqrt(2 * spreadCount - 1)) / 2) * duration);
     }
 
     /// <summary>
@@ -239,11 +315,10 @@ public sealed partial class SmokeSystem : EntitySystem
         if (!Resolve(smokeUid, ref component))
             return;
 
-        if (!_solutionContainerSystem.ResolveSolution(smokeUid, SmokeComponent.SolutionName, ref component.Solution, out var solution) ||
+        if (component.SmokeSourceEntity == null ||
+            !_solutionContainerSystem.TryGetSolution((component.SmokeSourceEntity.Value, null), SmokeComponent.SolutionName, out _, out var solution) ||
             solution.Contents.Count == 0)
-        {
             return;
-        }
 
         ReactWithEntity(entity, smokeUid, solution, component);
         UpdateVisuals((smokeUid, component));
@@ -254,6 +329,9 @@ public sealed partial class SmokeSystem : EntitySystem
         if (!Resolve(smokeUid, ref component))
             return;
 
+        if (component.SmokeSourceEntity == null)
+            return;
+
         if (!TryComp<BloodstreamComponent>(entity, out var bloodstream))
             return;
 
@@ -262,10 +340,9 @@ public sealed partial class SmokeSystem : EntitySystem
 
         var blockIngestion = _internals.AreInternalsWorking(entity);
 
-        var cloneSolution = solution.Clone();
-        var availableTransfer = FixedPoint2.Min(cloneSolution.Volume, component.TransferRate);
+        var availableTransfer = FixedPoint2.Min(solution.Volume, component.SmokeSourceEntity.Value.Comp.TransferRate);
         var transferAmount = FixedPoint2.Min(availableTransfer, bloodSolution.AvailableVolume);
-        var transferSolution = cloneSolution.SplitSolution(transferAmount);
+        var transferSolution = solution.SplitSolution(transferAmount);
 
         foreach (var reagentQuantity in transferSolution.Contents.ToArray())
         {
@@ -292,7 +369,8 @@ public sealed partial class SmokeSystem : EntitySystem
         if (!Resolve(uid, ref component, ref xform))
             return;
 
-        if (!_solutionContainerSystem.ResolveSolution(uid, SmokeComponent.SolutionName, ref component.Solution, out var solution) || !solution.Any())
+        if (component.SmokeSourceEntity == null ||
+            !_solutionContainerSystem.TryGetSolution((component.SmokeSourceEntity.Value, null), SmokeComponent.SolutionName, out _, out var solution) || !solution.Any())
             return;
 
         if (!TryComp<MapGridComponent>(xform.GridUid, out var mapGrid))
@@ -305,7 +383,7 @@ public sealed partial class SmokeSystem : EntitySystem
             if (reagentQuantity.Quantity == FixedPoint2.Zero)
                 continue;
 
-            var reagent = ProtoMan.Index<ReagentPrototype>(reagentQuantity.Reagent.Prototype);
+            var reagent = ProtoMan.Index(reagentQuantity.Reagent.Prototype);
             reagent.ReactionTile(tile, reagentQuantity.Quantity, EntityManager, reagentQuantity.Reagent.Data);
         }
     }
@@ -313,30 +391,50 @@ public sealed partial class SmokeSystem : EntitySystem
     /// <summary>
     /// Adds the specified solution to the relevant smoke solution.
     /// </summary>
-    private void TryAddSolution(Entity<SmokeComponent?> smoke, Solution solution)
+    private bool TryAddSolution(Entity<SmokeComponent?> smoke, Solution solution, [NotNullWhen(true)] out Entity<SmokeSourceComponent>? smokeSource, out FixedPoint2 volume)
     {
-        if (solution.Volume == FixedPoint2.Zero)
-            return;
+        smokeSource = null;
+        volume = 0f;
 
         if (!Resolve(smoke, ref smoke.Comp))
-            return;
+            return false;
 
-        if (!_solutionContainerSystem.ResolveSolution(smoke.Owner, SmokeComponent.SolutionName, ref smoke.Comp.Solution, out var solutionArea))
-            return;
+        if (smoke.Comp.SmokeSourceEntity != null) // SolutionManager entity already exists?
+        {
+            Log.Error($"Attempted to create a new smoke source entity for a smoke entity that already has one? Smoke entity: {smoke.ToString()}; Existing smoke source entity: {smoke.Comp.SmokeSourceEntity.Value.ToString()}");
+            return false;
+        }
 
-        var addSolution = solution.SplitSolution(FixedPoint2.Min(solution.Volume, solutionArea.AvailableVolume));
-        _solutionContainerSystem.TryAddSolution(smoke.Comp.Solution.Value, addSolution);
+        var smokeSrcEnt = Spawn(null, MapCoordinates.Nullspace);
+        var solManComp = EnsureComp<SolutionManagerComponent>(smokeSrcEnt);
+        var smokeSrcComp = EnsureComp<SmokeSourceComponent>(smokeSrcEnt);
+        _solutionContainerSystem.EnsureSolution((smokeSrcEnt, solManComp), SmokeComponent.SolutionName, out var solEnt);
+        _solutionContainerSystem.SetCapacity(solEnt, smokeSrcComp.MaxVolume);
+
+        // If the solution is empty (i.e. pure foam) we skip this, but we let the foam spread still.
+        if (solution.Volume != FixedPoint2.Zero)
+        {
+            var addSolution =
+                solution.SplitSolution(FixedPoint2.Min(solution.Volume, solEnt.Comp.Solution.AvailableVolume));
+            _solutionContainerSystem.TryAddSolution(solEnt, addSolution);
+        }
+
+        smokeSrcComp.SmokeColor = solEnt.Comp.Solution.Volume == 0 ? Color.White : solEnt.Comp.Solution.GetColor(ProtoMan);
+
+        smoke.Comp.SmokeSourceEntity = (smokeSrcEnt, smokeSrcComp);
+
+        volume = solEnt.Comp.Solution.Volume;
+        smokeSource = smoke.Comp.SmokeSourceEntity;
 
         UpdateVisuals(smoke);
+        return true;
     }
 
     private void UpdateVisuals(Entity<SmokeComponent?, AppearanceComponent?> smoke)
     {
-        if (!Resolve(smoke, ref smoke.Comp1, ref smoke.Comp2) ||
-            !_solutionContainerSystem.ResolveSolution(smoke.Owner, SmokeComponent.SolutionName, ref smoke.Comp1.Solution, out var solution))
+        if (!Resolve(smoke, ref smoke.Comp1, ref smoke.Comp2) || smoke.Comp1.SmokeSourceEntity == null)
             return;
 
-        var color = solution.GetColor(ProtoMan);
-        _appearance.SetData(smoke.Owner, SmokeVisuals.Color, color, smoke.Comp2);
+        _appearance.SetData(smoke.Owner, SmokeVisuals.Color, smoke.Comp1.SmokeSourceEntity.Value.Comp.SmokeColor, smoke.Comp2);
     }
 }

--- a/Content.Shared/Chemistry/Components/SmokeComponent.cs
+++ b/Content.Shared/Chemistry/Components/SmokeComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
 using Content.Shared.Fluids.Components;
 using Robust.Shared.GameStates;
@@ -13,7 +14,17 @@ namespace Content.Shared.Chemistry.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class SmokeComponent : Component
 {
+    /// <summary>
+    /// Name of the solution used for the shared smoke.
+    /// </summary>
     public const string SolutionName = "solutionArea";
+
+    /// <summary>
+    /// If set, adds the provided reagents to the initial smoke entity spawned.
+    /// If spawned via other smoke, these reagents are not set.
+    /// </summary>
+    [DataField]
+    public Solution? StartingContents;
 
     /// <summary>
     /// The entity containing shared smoke source data and reagents.

--- a/Content.Shared/Chemistry/Components/SmokeComponent.cs
+++ b/Content.Shared/Chemistry/Components/SmokeComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.FixedPoint;
 using Content.Shared.Fluids.Components;
 using Robust.Shared.GameStates;
@@ -5,8 +6,9 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.Chemistry.Components;
 
 /// <summary>
-/// Stores solution on an anchored entity that has touch and ingestion reactions
+/// Spawns and spreads entities that can contain and deliver reagents
 /// to entities that collide with it. Similar to <see cref="PuddleComponent"/>
+/// <seealso cref="SmokeSourceComponent"/>
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class SmokeComponent : Component
@@ -14,23 +16,17 @@ public sealed partial class SmokeComponent : Component
     public const string SolutionName = "solutionArea";
 
     /// <summary>
-    /// The solution on the entity with touch and ingestion reactions.
+    /// The entity containing shared smoke source data and reagents.
+    /// If not set, the smoke will not work.
     /// </summary>
     [ViewVariables]
-    public Entity<SolutionComponent>? Solution = null;
+    public Entity<SmokeSourceComponent>? SmokeSourceEntity;
 
     /// <summary>
     /// The max amount of tiles this smoke cloud can spread to.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public int SpreadAmount;
-
-    /// <summary>
-    /// The max rate at which chemicals are transferred from the smoke to the person inhaling it.
-    /// Calculated as (total volume of chemicals in smoke) / (<see cref="Duration"/>)
-    /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public FixedPoint2 TransferRate;
 
     /// <summary>
     /// The total lifespan of the smoke.

--- a/Content.Shared/Chemistry/Components/SmokeSourceComponent.cs
+++ b/Content.Shared/Chemistry/Components/SmokeSourceComponent.cs
@@ -1,0 +1,62 @@
+using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.Chemistry.Components;
+
+/// <summary>
+/// Stores a smoke solution on a nullspace entity that distributes the reagents to related smoke entities.
+/// <seealso cref="SmokeComponent"/>
+/// </summary>
+[RegisterComponent]
+public sealed partial class SmokeSourceComponent : Component
+{
+    /// <summary>
+    /// The solution container containing the shared solution.
+    /// </summary>
+    [ViewVariables]
+    public Entity<SolutionManagerComponent>? SolutionContainer = null;
+
+    /// <summary>
+    /// The color of the smoke. Determined by the reagents when initially spawned.
+    /// </summary>
+    [DataField]
+    public Color SmokeColor;
+
+    /// <summary>
+    /// The number of tiles that this smoke has spread to.
+    /// Used to calculate the transfer rate.
+    /// </summary>
+    [DataField]
+    public int SpreadCount = 0;
+
+    /// <summary>
+    /// Max volume of solution that the smoke holds.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 MaxVolume = 600f;
+
+    /// <summary>
+    /// The starting volume of the solution in the smoke.
+    /// Used to calculate the transfer rate.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 OriginalVolume = 0f;
+
+    /// <summary>
+    /// When set to true, the transfer rate will be re-calculated after the tick's spreading has completed.
+    /// </summary>
+    [ViewVariables]
+    public bool DirtyTransferRateCalc;
+
+    /// <summary>
+    /// The max rate at which chemicals are transferred from the smoke to the person inhaling it.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 TransferRate;
+
+    /// <summary>
+    /// The total lifespan of the smoke.
+    /// </summary>
+    [DataField]
+    public float Duration = 10;
+}

--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -25,11 +25,6 @@
   - type: ActiveEdgeSpreader
   - type: EdgeSpreader
     id: Smoke
-  - type: Solution
-    id: solutionArea
-    solution:
-      maxVol: 600 # Required for it to spawn correctly, but should be removed in the future:tm: Arguably could move the solution to SmokeComponent as well considering it's nonreactive
-      canReact: false
 
 - type: entity
   parent: BaseFoam

--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -36,8 +36,6 @@
   - type: Sprite
     sprite: Effects/chemsmoke.rsi
     state: chemsmoke
-  - type: TimedDespawn
-    lifetime: 10
   - type: Tag
     tags:
     - HideContextMenu
@@ -51,8 +49,6 @@
   - type: Sprite
     sprite: Effects/chemsmoke.rsi
     state: chemsmoke
-  - type: TimedDespawn
-    lifetime: 10
   - type: Tag
     tags:
     - HideContextMenu

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/canister_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/canister_grenades.yml
@@ -62,7 +62,7 @@
     solution:
       reagents:
       - ReagentId: TearGas
-        Quantity: 20
+        Quantity: 120
 
 - type: entity
   parent: [ BaseEngineeringContraband, SmokeGrenade ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This experimental PR reworks how Foam/Smoke handles chemicals.

Previously each smoke cloud would individually contain the same amount of reagent as what was mixed into the foam. This would then be absorbed by any entity inside any of the smoke clouds, at a rate of `startingVolume / duration` (duration almost always being 10). This meant you essentially duplicated reagents by the number of entities consuming it, provided they all stood in the cloud for the full duration. 

All smoke now share a single reagent source, and the absorption rate is based on how many smoke clouds have been spawned as well as the duration. It follows a centered square numbers pattern, e.g. if the cloud has spread out a radius of 3 tiles, it will be absorbed at `startingVolume / (3 * duration)`. Since the smoke clouds share source, it also means you can no longer get more reagents than what you put in.

With this PR, you can also do 1-tile foam when using <1u fluorosurfactant. 

Note that this PR is **experimental** to test the new formula, and is to be followed up with by changes to reagents to compensate for the new values based on testing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Foam duplication has led to some very cool strategies involving acid and poisons, but this is purely based on the fact that it manages to deliver high dosages through its reagent duplication. It has also led to some very broken strategies involving Nukies where they can huff up 600u of Trico or Omnizine across the entire team.

This change ensures there's a cap, and also makes an approximation to spread out the absorption to entities consuming the smoke via lowering the absorption if the cloud spreads out. 

There may be deeper ramifications to this method hence why it's being tested as an experimental PR. 

Note that this PR does ***not*** change:
- The spreading code. Clouds should spread the exact same way as before. The only difference is that you can now create 1-tile foam when using <2.5u foam mixes.
- Tile reactions. This means reagents are still duplicated when making puddles, but this does preserve the viability of lube foam. May be changed in the future.
- Public methods for triggering smoke.

---

Inevitable follow-up question: What is the point of foam/smoke if it doesn't duplicate reagents? 

If we assume that foam doesn't just magic out reagents out of nowhere, I think it can put a higher emphasis on being:
- A multi-person vector for touch reagent effects (walking through a cloud of smoke = being spritzed with spray bottle, but more). This would necessitate stronger touch reagent effects, which to be fair are pretty lacking.
- A multi-person vector for smaller doseages. You can still trico-foam Medical, it just will be more around the 15u mark rather than 150u.
- A small-area quick-inject; in small clouds, inhaling foam will still be faster than directly injecting. 

If you got a suggestion how to make foam more unique as a reagent delivery method without duplication, or if you have suggestions on how to improve the feel of the foam, voice it down below.

## Technical details
<!-- Summary of code changes for easier review. -->

***Note: The duration being 10 seconds conflicts with how reagents are delivered, meaning that unless a lot of people pile into the cloud, there will always be some reagent loss. Gonna look into this.***

When smoke is started there is now an entity spawned in nullspace with a `SmokeSourceComponent`. This entity keeps tracks of the solution information and handles absorption for entities in the smoke. If a smoke entity does not have a source entity, it still spreads as normal. 

Prototypes with the smoke component can contain starting reagents via the `StartingContents` property.

The effect to generate foam/smoke now uses Floor instead of Ceiling. This allows 1-tile foam effects and shouldn't make a noticeable difference for larger volumes.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

You can perform tests by spawning in a jug, giving it the reagent you want to test (I tend to type "water" and add 10u watermelon juice) and then equal parts water and fluorosurfactant. 

Try in different scenarios; small amounts of foam, large amounts of foam, etc. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/d9e39423-ad6c-48f7-b543-94f0e67f8253

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

`SmokeSystem` uses a new formula and method to deliver reagents, with smoke/foam clouds having a shared solution to draw from.
`SmokeComponent`'s `Solution` property has been removed.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The formula for smoke/foam behavior has been changed to no longer duplicate ingredients, and basing the absorption on the size of the cloud. Reagent changes will follow to adjust for the new formula.