### PR TITLE
FTL: Consistency in device linking port caps

### DIFF
--- a/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
+++ b/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
@@ -90,11 +90,11 @@ signal-port-description-logic-memory-input = Signal to load into the memory cell
 signal-port-name-logic-enable = Enable
 signal-port-description-logic-enable = Only loads the input signal into the memory cell when HIGH.
 
-signal-port-name-logic-random-input = Input Signal
+signal-port-name-logic-random-input = Input signal
 signal-port-description-logic-random-input = Receives any signal to trigger a random output.
 
 signal-port-name-target-receiver = Target receiver
 signal-port-description-target-receiver = Receives target information from a target finder.
 
-signal-port-name-target-source = Target Finder
+signal-port-name-target-source = Target finder
 signal-port-description-target-source = Sends target information to a target receiver.

--- a/Resources/Locale/en-US/machine-linking/transmitter_ports.ftl
+++ b/Resources/Locale/en-US/machine-linking/transmitter_ports.ftl
@@ -31,16 +31,16 @@ signal-port-description-trigger-sender = This port is invoked whenever the devic
 signal-port-name-timer-trigger = Timer
 signal-port-description-timer-trigger = This port is invoked whenever the timer is up.
 
-signal-port-name-timer-start = Timer Start
+signal-port-name-timer-start = Timer start
 signal-port-description-timer-start = This port is invoked whenever the timer starts.
 
 signal-port-name-logic-output = Output
 signal-port-description-logic-output = This port is invoked with HIGH or LOW depending on the selected gate and inputs.
 
-signal-port-name-logic-output-high = High Output
+signal-port-name-logic-output-high = High output
 signal-port-description-logic-output-high = This port is invoked whenever the input has a rising edge.
 
-signal-port-name-logic-output-low = Low Output
+signal-port-name-logic-output-low = Low output
 signal-port-description-logic-output-low = This port is invoked whenever the input has a falling edge.
 
 signal-port-name-air-danger = Danger


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Changes device port names to always be `Upper lower lower...` (e.g. `Door status`, `Target receiver`) for consistency.

## Why / Balance

Said I would.

You've heard of YAML warriors, but what about FTL fighters?

## Technical details

I let go of the shift key.

## Test plan

Expand the receiver_ports.ftl and transmitter_ports.ftl, check I haven't missed any `Upper Upper` cases.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
brother