### PR TITLE
Cryopod: sample gas readouts

### DIFF
--- a/Content.Server/Medical/Components/CryoPodAirComponent.cs
+++ b/Content.Server/Medical/Components/CryoPodAirComponent.cs
@@ -12,4 +12,11 @@ public sealed partial class CryoPodAirComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("gasMixture")]
     public GasMixture Air { get; set; } = new GasMixture(1000f);
+
+    /// <summary>
+    /// Snapshot of <see cref="Air"/> from just after the pipenet mix, shown in the UI.
+    /// A patient inside heats the real mixture back up between ticks, so reading it live makes the readout jump around.
+    /// </summary>
+    [ViewVariables]
+    public GasMixture? UiSample;
 }

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -53,7 +53,7 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
             return;
 
         var patient = entity.Comp.BodyContainer.ContainedEntity;
-        var gasMix = _gasAnalyzerSystem.GenerateGasMixEntry("Cryo pod", air.Air);
+        var gasMix = _gasAnalyzerSystem.GenerateGasMixEntry("Cryo pod", air.UiSample ?? air.Air);
         var (beakerCapacity, beaker) = GetBeakerInfo(entity);
         var injecting = GetInjectingReagents(entity);
         var health = _healthAnalyzerSystem.GetHealthAnalyzerUiState(patient);
@@ -81,6 +81,8 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
         {
             _gasCanisterSystem.MixContainerWithPipeNet(cryoPodAir.Air, net.Air);
         }
+
+        cryoPodAir.UiSample = cryoPodAir.Air.Clone();
     }
 
     private void OnGasAnalyzed(Entity<CryoPodComponent> entity, ref GasAnalyzerScanEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The cryopod gas readout jitters. The UI now reads the cryopod air details right after it mixes with the pipenet so the numbers are still(-er).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
No balance change. Since the heat exchange rework patient heat actually mixes up with the cryopod air instead of vanishing so the pod gas gets dragged all the way up to body temperature between coolant mixes. The UI samples on its own 1 second timer and catches whichever half of that cycle it happens to land on. Readings I got on three consecutive seconds were -58C, +23C, -52C. The temperature check in the status list jitters with it which is very annoying and confusing since it tells you whether the cryopod is cold enough to inject chems.

## Technical details
<!-- Summary of code changes for easier review. -->
CryoPodAirComponent.UiSample holds a `Clone()` of the pod air taken at the end of `OnCryoPodUpdateAtmosphere` right after `MixContainerWithPipeNet`. `UpdateUi` builds its GasMixEntry from that instead of the live mixture, falling back to Air for the first tick before a sample exists.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Setup a cryopod
2. Put a body in it and open cryopod UI
3. Observe as the Air values jitter (as much as: -58C -> +23C -> -52C)
4. After fix:  Values sit in the coolant range and only moves as the loop warms up and cools down

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
_None_

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
_None_

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: haze
- fix: Cryopod's gas readouts no longer jitter while body cools down
