### PR TITLE
Buff the China Lake to be stronger and more lethal (resubmit of #45685)

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog/ammo.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog/ammo.ftl
@@ -26,3 +26,9 @@ uplink-sniper-ammo-desc = A box of 10 cartridges for the Hristov sniper rifle.
 
 uplink-ammo-bundle-name = Ammo Bundle
 uplink-ammo-bundle-desc = Reloading! Contains 4 magazines for the C-20r, 4 drums for the Bulldog, 3 magazines for the Estoc DMR, and 2 ammo boxes for the L6 SAW.
+
+uplink-ammo-frag-name = Frag Grenade
+uplink-ammo-frag-desc = A spare frag grenade for your China Lake grenade launcher.
+
+uplink-ammo-blast-name = Blast Grenade
+uplink-ammo-blast-desc = A spare blast grenade for your China Lake grenade launcher.

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -133,9 +133,9 @@
         children:
         - id: WeaponLauncherChinaLake
         - id: GrenadeBlast
-          amount: 4
+          amount: 3
         - id: GrenadeFrag
-          amount: 4
+          amount: 5
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateAmmo

--- a/Resources/Prototypes/Catalog/UplinkCatalog/ammo.yml
+++ b/Resources/Prototypes/Catalog/UplinkCatalog/ammo.yml
@@ -109,3 +109,24 @@
       blacklist:
         components:
           - SurplusBundle
+
+# for the clake:
+- type: listing
+  id: GrenadeFrag
+  name: uplink-ammo-frag-name
+  description: uplink-ammo-frag-desc
+  productEntity: GrenadeFrag
+  cost:
+    Telecrystal: 3
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: GrenadeBlast
+  name: uplink-ammo-blast-name
+  description: uplink-ammo-blast-desc
+  productEntity: GrenadeBlast
+  cost:
+    Telecrystal: 3
+  categories:
+    - UplinkAmmo

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -62,6 +62,8 @@
   - type: GunRequiresWield
   - type: StaticPrice
     price: 10000
+  - type: Gun
+    fireRate: 0.67
 
 - type: entity
   parent: [ BaseWeaponLauncher, BaseMajorContraband ]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Explosives/explosives.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Explosives/explosives.yml
@@ -73,10 +73,10 @@
     - state: grenade
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Default
-    totalIntensity: 150 # a ~2 tile radius
+    explosionType: Clake
+    totalIntensity: 150 # a ~3 tile radius
     intensitySlope: 5
-    maxIntensity: 10
+    maxIntensity: 20
     canCreateVacuum: false
 
 - type: entity
@@ -108,9 +108,9 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    totalIntensity: 50
-    intensitySlope: 1
-    maxIntensity: 5
+    totalIntensity: 120
+    intensitySlope: 5
+    maxIntensity: 9
     canCreateVacuum: false
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -14,6 +14,23 @@
   temperature: 800
 
 - type: explosion
+  id: Clake
+  damagePerIntensity:
+    types:
+      Heat: 2
+      Blunt: 2
+      Piercing: 3
+      Structural: 65
+  tileBreakChance: [ 0, 0.5, 1 ]
+  tileBreakIntensity: [ 0, 50, 75 ]
+  tileBreakRerollReduction: 25
+  lightColor: Orange
+  fireColor: Red
+  texturePath: /Textures/Effects/fire_greyscale.rsi
+  fireStates: 3
+  temperature: 800
+
+- type: explosion
   id: DemolitionCharge
   damagePerIntensity:
     types:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
COPY OF #45685
Added clake grenades into uplink
Buffed clake frag grenade
Buffed clake blast grenade
Tweaked Clake nukeops bundle
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The china lake has been a joke weapon ever since it got ultra nerfed. The structure rebalance perpetuates this. The combat workgroup thinks it needs a buff and has set specifications for me to buff it to a useable state. their specifications were:

Clake ammo gets added to uplink for 3tc/shot

Blast nade destroys 1 r-wall and girders 2 surrounding ones
Blast nade does ~50 damage to a human secoff with helmet and vest (meatshot)

Frag nade does barely any damage to structures
Frag nade does 120 damage to a human secoff with helmet and vest (meatshot)
## Technical details
<!-- Summary of code changes for easier review. -->
YAML SLOP I LOVE YAML
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Boot up local host
make a 2x3 of r-walls 
fire 5 frag nades at it
nod your head
Spawn travelling secoff
fire frag and nod when it does ~120 damage

make 2x3 of r walls
fire 1 blast nade
nod once it deletes one r-wall and girders 2
spawn travelling secoff
fire blast nade at it
nod when it does ~45-55 damage

Open uplink
nod once you see a blast and frag nade with their respective prices (3tc/pop)
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
DM ME ON DISCORD IF YOU WANT EVEN MORE MEDIA / LIVESTREAM
<img width="341" height="202" alt="image" src="https://github.com/user-attachments/assets/b4a0e206-f868-40d4-8382-7f4208eff0db" />
<img width="290" height="153" alt="image" src="https://github.com/user-attachments/assets/754413be-e513-4e6e-8327-da449d4261f1" />
<img width="704" height="672" alt="image" src="https://github.com/user-attachments/assets/c9da2e67-5628-4712-9cc3-0bf1bebc00da" />
FRAG GRENADE (secoff)
<img width="370" height="466" alt="image" src="https://github.com/user-attachments/assets/a075a6ed-fb7f-4d72-8494-560cce49e55f" />
BLAST GRENADE VS r-WALL
<img width="800" height="387" alt="image" src="https://github.com/user-attachments/assets/1ed8bed6-d46f-410a-9495-ce024eb89cdc" />
BLAST VS SECOFF
IGNORE AIRLOSS THE ROOM HAS 0 OXYGEN
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A
## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: Added Frag and blast grenades into traitor and nukeops uplink for 3 telecrystals each.
- tweak: Buffed both blast and frag grenade damage. Blast for structures, and Frag as anti-personnel.
- tweak: Reduced the number of blast grenades in the 25TC clake bundle to 3 (from 4) and increased the number of frag grenades to 5 (from 4).