### PR TITLE
Buff changeling devour and windup damage (resubmit of #45743)

### DIFF
--- a/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
@@ -91,9 +91,8 @@ public sealed partial class ChangelingDevourComponent : Component
     {
         DamageDict = new()
         {
-            { "Slash", 10},
-            { "Piercing", 10 },
-            { "Blunt", 5 },
+            { "Slash", 25},
+            { "Piercing", 25 },
         },
     };
 
@@ -105,9 +104,9 @@ public sealed partial class ChangelingDevourComponent : Component
     {
         DamageDict = new()
         {
-            { "Slash", 20},
-            { "Piercing", 20 },
-            { "Blunt", 10 },
+            { "Slash", 50},
+            { "Piercing", 50 },
+            { "Caustic", 100 },
         },
     };
 

--- a/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
@@ -91,8 +91,8 @@ public sealed partial class ChangelingDevourComponent : Component
     {
         DamageDict = new()
         {
-            { "Slash", 25},
-            { "Piercing", 25 },
+            { "Slash", 15},
+            { "Piercing", 15 },
         },
     };
 
@@ -104,8 +104,8 @@ public sealed partial class ChangelingDevourComponent : Component
     {
         DamageDict = new()
         {
-            { "Slash", 50},
-            { "Piercing", 50 },
+            { "Slash", 60},
+            { "Piercing", 60 },
             { "Caustic", 100 },
         },
     };


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->\
copy of #45743
scar told me to buff the devour and windup damage
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Scar said so.... in all seriousness
Reviving someone after devour is as simple as using a few brutepacks on them, or some cryomed
this makes any linged body sustain AT LEAST 450 damage at the time of writing this PR
## Technical details
<!-- Summary of code changes for easier review. -->
i changed 6 numbers in a C# file
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

devour a urist in localhost to see the new values
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="699" height="482" alt="image" src="https://github.com/user-attachments/assets/fff118bf-e657-4585-8ec6-a74151fed539" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A
## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Buffed Changeling's devour damage to deal additional caustic damage.