### PR TITLE
Botany Cryoxadone Age+SeedRevert Fix

### DIFF
--- a/.run/Content Server+Client.run.xml
+++ b/.run/Content Server+Client.run.xml
@@ -1,7 +1,5 @@
 ﻿<component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Content Server+Client" type="CompoundRunConfigurationType">
-    <toRun name="Content.Client" type="DotNetProject" />
-    <toRun name="Content.Server" type="DotNetProject" />
     <method v="2" />
   </configuration>
 </component>

--- a/Content.Shared/Botany/Systems/BotanySystem.Seed.cs
+++ b/Content.Shared/Botany/Systems/BotanySystem.Seed.cs
@@ -179,4 +179,30 @@ public sealed partial class BotanySystem : EntitySystem
         _hands.TryPickupAnyHand(user, seedItem);
         return seedItem;
     }
+    /// <summary>
+    /// Reverts a planted plant back into a seed packet while preserving its genetics.
+    /// </summary>
+    [PublicAPI]
+    public bool TryRevertPlantToSeed(Entity<PlantComponent?, PlantDataComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp1, ref ent.Comp2, false))
+            return false;
+
+        if (!_plant.TryGetTray(ent.Owner, out var tray))
+            return false;
+
+        var plantProto = MetaData(ent.Owner).EntityPrototype;
+        if (plantProto == null)
+            return false;
+
+        SpawnSeedPacket(
+            ent.Comp2,
+            plantProto.ID,
+            ent.Owner,
+            Transform(tray.Owner).Coordinates,
+            tray.Owner);
+
+        _plant.RemovePlant(ent.Owner);
+        return true;
+    }
 }

--- a/Content.Shared/Botany/Systems/PlantHarvestSystem.cs
+++ b/Content.Shared/Botany/Systems/PlantHarvestSystem.cs
@@ -161,6 +161,19 @@ public sealed partial class PlantHarvestSystem : EntitySystem
     }
 
     /// <summary>
+    /// Resets harvest progress to the plant's current age.
+    /// </summary>
+    [PublicAPI]
+    public void ResetHarvestProgress(Entity<PlantHolderComponent?> ent)
+    {
+        if (!Resolve(ent.Owner, ref ent.Comp, false))
+            return;
+
+        ent.Comp.LastHarvest = ent.Comp.Age;
+        DirtyField(ent, nameof(ent.Comp.LastHarvest));
+    }
+
+    /// <summary>
     /// Affects the growth of a plant by modifying its age or production timing.
     /// </summary>
     [PublicAPI]

--- a/Content.Shared/EntityEffects/Effects/Botany/PlantAttributes/PlantCryoxadoneEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/Botany/PlantAttributes/PlantCryoxadoneEntityEffectSystem.cs
@@ -16,7 +16,7 @@ public sealed partial class PlantCryoxadoneEntityEffectSystem : EntityEffectSyst
     [Dependency] private PlantHolderSystem _plantHolder = default!;
     [Dependency] private PlantHarvestSystem _plantHarvest = default!;
     [Dependency] private IGameTiming _timing = default!;
-
+    [Dependency] private BotanySystem _botany = default!;
     protected override void Effect(Entity<PlantComponent> entity, ref EntityEffectEvent<PlantCryoxadone> args)
     {
         if (_plantHolder.IsDead(entity.Owner))
@@ -29,8 +29,13 @@ public sealed partial class PlantCryoxadoneEntityEffectSystem : EntityEffectSyst
         var deviation = plantHolder.Age > entity.Comp.Maturation
             ? (int)Math.Max(entity.Comp.Maturation - 1, plantHolder.Age - random.Next(7, 10))
             : (int)(entity.Comp.Maturation / entity.Comp.GrowthStages);
-
-        _plantHarvest.AffectGrowth(entity.Owner, -deviation);
+        if (plantHolder.Age - deviation < 0)
+        {
+            _botany.TryRevertPlantToSeed(entity.Owner);
+            return;
+        }
+        _plantHolder.AdjustsAge((entity.Owner, plantHolder), -deviation);
+        _plantHarvest.ResetHarvestProgress((entity.Owner, plantHolder));
         _plant.ForceUpdate(entity.AsNullable());
     }
 }


### PR DESCRIPTION
Botany Cryoxadone Age+SeedRevert Fix

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Fixes Cryoxadone plant de-aging and restores its old seed reversion behavior.

## Why / Balance

Cryoxadone stopped properly reducing plant age after the recent botany changes because it was using `AffectGrowth()` instead of modifying the plant's actual age. This restores the previous behavior rather than introducing a balance change.

## Technical details

* Changed Cryoxadone to use `AdjustsAge()` instead of `AffectGrowth()`.
* Added a harvest progress reset so `LastHarvest` stays synchronized after de-aging.
* Restored the old behavior where de-aging a plant below age 0 returns it to a seed packet while preserving its genetics.
* Kept the existing forced update behavior.

## Test plan

* Grew plants to multiple ages and applied Cryoxadone.
* Confirmed plant age decreases and growth stages regress correctly.
* Confirmed harvest progress remains correct after de-aging.
* Repeated Cryoxadone until the plant would go below age 0 and confirmed it returns to a seed packet with its genetics preserved.

## Media

N/A - small bug fix.

## Requirements

* [x] I have read and am following the Pull Request and Changelog Guidelines.
* [x] I have tested this pull request and written instructions on how to test it.
* [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

## Changelog

:cl:

* fix: Fixed Cryoxadone no longer properly de-aging plants or reverting sufficiently de-aged plants back into seeds.
