### PR TITLE
Map Box - replace empty sink with full one

### DIFF
--- a/Resources/Maps/box.yml
+++ b/Resources/Maps/box.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 289.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/22/2026 17:50:29
+  time: 08/30/2026 10:30:27
   entityCount: 28909
 maps:
 - 780
@@ -155307,6 +155307,12 @@ entities:
       parent: 8364
       rot: -1.5707963267948966 rad
       pos: -45.5,-11.5
+  - uid: 16331
+    components:
+    - type: Transform
+      parent: 8364
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-17.5
   - uid: 19232
     components:
     - type: Transform
@@ -155355,12 +155361,6 @@ entities:
     - type: Transform
       parent: 8364
       pos: -36.5,-54.5
-  - uid: 16331
-    components:
-    - type: Transform
-      parent: 8364
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-17.5
   - uid: 20883
     components:
     - type: Transform


### PR DESCRIPTION
## About the PR
title

## Why / Balance
Annoyed chem on box, now should be much easier to start there

## Technical details
someone mapped a sink that starts empty instead of a full sink (why do we have empty sinks if they regenerate anyway?)

## Test plan

## Media
sink looks practically the same, no need to show the map again

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
MAPS:
- fix: Box - sink in chem starts fully filled
