### PR TITLE
Fix angry bees in a worn backpack gibbing the player

### DIFF
--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Combat/EscapeOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Combat/EscapeOperator.cs
@@ -10,7 +10,7 @@ namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators.Combat.Melee;
 public sealed partial class EscapeOperator : HTNOperator, IHtnConditionalShutdown
 {
     [Dependency] private IEntityManager _entManager = default!;
-    private ContainerSystem _container = default!;
+    private ContainerSystem _containerSystem = default!;
     private EntityStorageSystem _entityStorage = default!;
 
     [DataField("shutdownState")]
@@ -22,7 +22,7 @@ public sealed partial class EscapeOperator : HTNOperator, IHtnConditionalShutdow
     public override void Initialize(IEntitySystemManager sysManager)
     {
         base.Initialize(sysManager);
-        _container = sysManager.GetEntitySystem<ContainerSystem>();
+        _containerSystem = sysManager.GetEntitySystem<ContainerSystem>();
         _entityStorage = sysManager.GetEntitySystem<EntityStorageSystem>();
     }
 
@@ -52,12 +52,12 @@ public sealed partial class EscapeOperator : HTNOperator, IHtnConditionalShutdow
             return (false, null);
         }
 
-        if (!_container.IsEntityInContainer(owner))
+        if (!_containerSystem.TryGetContainingContainer(owner, out var container))
         {
             return (false, null);
         }
 
-        if (_entityStorage.TryOpenStorage(owner, target))
+        if (!_entityStorage.CanOpen(owner, container.Owner))
         {
             return (false, null);
         }
@@ -98,14 +98,14 @@ public sealed partial class EscapeOperator : HTNOperator, IHtnConditionalShutdow
         {
             combat.Target = target;
 
-            // Success
-            if (!_container.IsEntityInContainer(owner))
+            if (!_containerSystem.TryGetContainingContainer(owner, out var container))
             {
+                // Success. We are not in a container.
                 status = HTNOperatorStatus.Finished;
             }
             else
             {
-                if (_entityStorage.TryOpenStorage(owner, target))
+                if (_entityStorage.TryOpenStorage(owner, container.Owner))
                 {
                     status = HTNOperatorStatus.Finished;
                 }

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Combat/EscapeOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Combat/EscapeOperator.cs
@@ -3,9 +3,10 @@ using System.Threading.Tasks;
 using Content.Server.NPC.Components;
 using Content.Server.Storage.EntitySystems;
 using Content.Shared.CombatMode;
+using Content.Shared.Storage.Components;
 using Robust.Server.Containers;
 
-namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators.Combat.Melee;
+namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators.Combat;
 
 public sealed partial class EscapeOperator : HTNOperator, IHtnConditionalShutdown
 {
@@ -15,9 +16,6 @@ public sealed partial class EscapeOperator : HTNOperator, IHtnConditionalShutdow
 
     [DataField("shutdownState")]
     public HTNPlanState ShutdownState { get; private set; } = HTNPlanState.TaskFinished;
-
-    [DataField("targetKey", required: true)]
-    public string TargetKey = default!;
 
     public override void Initialize(IEntitySystemManager sysManager)
     {
@@ -30,34 +28,35 @@ public sealed partial class EscapeOperator : HTNOperator, IHtnConditionalShutdow
     {
         base.Startup(blackboard);
         var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
-        var target = blackboard.GetValue<EntityUid>(TargetKey);
 
-        if (_entityStorage.TryOpenStorage(owner, target))
+        if (!_containerSystem.TryGetContainingContainer(owner, out var container))
         {
-            TaskShutdown(blackboard, HTNOperatorStatus.Finished);
             return;
         }
 
         var melee = _entManager.EnsureComponent<NPCMeleeCombatComponent>(owner);
         melee.MissChance = blackboard.GetValueOrDefault<float>(NPCBlackboard.MeleeMissChance, _entManager);
-        melee.Target = target;
+        melee.Target = container.Owner;
     }
 
     public override async Task<(bool Valid, Dictionary<string, object>? Effects)> Plan(NPCBlackboard blackboard,
         CancellationToken cancelToken)
     {
         var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
-        if (!blackboard.TryGetValue<EntityUid>(TargetKey, out var target, _entManager))
-        {
-            return (false, null);
-        }
 
         if (!_containerSystem.TryGetContainingContainer(owner, out var container))
         {
             return (false, null);
         }
 
-        if (!_entityStorage.CanOpen(owner, container.Owner))
+        if (!_entManager.HasComponent<EntityStorageComponent>(container.Owner))
+        {
+            // We must be in a backpack or something that we can't open or attack to escape from.
+            // It could be possible to mirror some of the Resist.EscapeInventorySystem logic in this case.
+            return (false, null);
+        }
+
+        if (!_containerSystem.IsEntityInContainer(owner))
         {
             return (false, null);
         }
@@ -70,7 +69,6 @@ public sealed partial class EscapeOperator : HTNOperator, IHtnConditionalShutdow
         var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
         _entManager.System<SharedCombatModeSystem>().SetInCombatMode(owner, false);
         _entManager.RemoveComponent<NPCMeleeCombatComponent>(owner);
-        blackboard.Remove<EntityUid>(TargetKey);
     }
 
     public override void TaskShutdown(NPCBlackboard blackboard, HTNOperatorStatus status)
@@ -91,50 +89,28 @@ public sealed partial class EscapeOperator : HTNOperator, IHtnConditionalShutdow
     {
         base.Update(blackboard, frameTime);
         var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
-        HTNOperatorStatus status;
 
-        if (_entManager.TryGetComponent<NPCMeleeCombatComponent>(owner, out var combat) &&
-            blackboard.TryGetValue<EntityUid>(TargetKey, out var target, _entManager))
+        if (!_containerSystem.TryGetContainingContainer(owner, out var container)
+            || _entityStorage.TryOpenStorage(owner, container.Owner))
         {
-            combat.Target = target;
-
-            if (!_containerSystem.TryGetContainingContainer(owner, out var container))
-            {
-                // Success. We are not in a container.
-                status = HTNOperatorStatus.Finished;
-            }
-            else
-            {
-                if (_entityStorage.TryOpenStorage(owner, container.Owner))
-                {
-                    status = HTNOperatorStatus.Finished;
-                }
-                else
-                {
-                    switch (combat.Status)
-                    {
-                        case CombatStatus.TargetOutOfRange:
-                        case CombatStatus.Normal:
-                            status = HTNOperatorStatus.Continuing;
-                            break;
-                        default:
-                            status = HTNOperatorStatus.Failed;
-                            break;
-                    }
-                }
-            }
-        }
-        else
-        {
-            status = HTNOperatorStatus.Failed;
+            return HTNOperatorStatus.Finished;
         }
 
-        // Mark it as finished to continue the plan.
-        if (status == HTNOperatorStatus.Continuing && ShutdownState == HTNPlanState.PlanFinished)
+        // We failed to open it... Perhaps violence is the answer?
+        if (!_entManager.TryGetComponent<NPCMeleeCombatComponent>(owner, out var combat))
         {
-            status = HTNOperatorStatus.Finished;
+            return HTNOperatorStatus.Failed;
         }
 
-        return status;
+        combat.Target = container.Owner;
+
+        switch (combat.Status)
+        {
+            case CombatStatus.TargetOutOfRange:
+            case CombatStatus.Normal:
+                return HTNOperatorStatus.Continuing;
+            default:
+                return HTNOperatorStatus.Failed;
+        }
     }
 }

--- a/Resources/Prototypes/NPCs/Combat/melee.yml
+++ b/Resources/Prototypes/NPCs/Combat/melee.yml
@@ -169,7 +169,6 @@
         shutdownState: TaskFinished
     - !type:HTNPrimitiveTask
       operator: !type:EscapeOperator
-        targetKey: Target
       preconditions:
       - !type:InContainerPrecondition
         isInContainer: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes #45441

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Behavior was clearly not intended.

## Technical details
<!-- Summary of code changes for easier review. -->
When the bees are in the player's backpack, the HTN system is trying to plan an escape-from-container task like over and over and over again, but failing because bees don't have hands and can't open the backpack anyway. The bees then never check if they still want to attack the target because they never make a combat plan, and so they never notice that the target is crit/dead.

What specifically was wrong was the file I modified was trying to open the combat target as though they were the container to escape from when that is not necessarily the case, and also it seems like the file was only intended to handle EntityContainer objects like crates and lockers, and didn't consider the fact that a hostile mob could be placed into a container that wasn't one of these. I rewrote a lot of the logic with this updated assumption.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
The big thing is, spawn an angry bee, try your best to pick it up, and then put it in your backpack and make sure it gives up trying to kill you when you get crit/close to crit. Also, for good measure, I tested that angry monkeys were still able to use the EscapeOperator to get out of a crate, for example.

Edit: Thanks to K-Dynamic's comment I have learned Killer Tomatoes also can be put in a backpack and are therefore also a case of the bug that this fixes! (Tested it just now)

Edit 2: The first commit broke gorillas breaking their way out of lockers, fixed now.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Hostile mobs trapped in a backpack or pocket will no longer gib the wearer.