### PR TITLE
Added the ability for cargo to order a crate of mosins

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -22,7 +22,7 @@
   id: ArmoryMosin
   icon:
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
-    state: icon
+    state: base
   product: CrateArmoryMosin
   cost: 3500
   category: cargoproduct-category-name-armory

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -19,6 +19,16 @@
   group: market
 
 - type: cargoProduct
+  id: ArmoryMosin
+  icon:
+    sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
+    state: icon
+  product: CrateArmoryMosin
+  cost: 3500
+  category: cargoproduct-category-name-armory
+  group: market
+
+- type: cargoProduct
   id: SecurityRiot
   icon:
     sprite: Clothing/OuterClothing/Armor/riot.rsi

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -30,6 +30,21 @@
 
 - type: entity
   parent: [ CrateWeaponSecure, BaseSecurityContraband ]
+  id: CrateArmoryMosin
+  name: mosin crate
+  description: Reliable, dirt cheap, and loud as hell. Contains three mosin rifles and 12 speedloaders of .30 rifle ammunition. Requires Armory access to open.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: WeaponSniperMosin
+          amount: 3
+        - id: SpeedLoaderLightRifle
+          amount: 12
+
+- type: entity
+  parent: [ CrateWeaponSecure, BaseSecurityContraband ]
   id: CrateTrackingImplants
   name: tracking implants
   description: Contains a handful of tracking implanters. Good for prisoners you'd like to release but still keep track of.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -84,7 +84,7 @@
     speedModifier: 0.5 #It's a bayonet
   - type: GunRequiresWield
   - type: StaticPrice
-    price: 500
+    price: 50
 
 - type: entity
   name: Hristov

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -84,7 +84,7 @@
     speedModifier: 0.5 #It's a bayonet
   - type: GunRequiresWield
   - type: StaticPrice
-    price: 50
+    price: 500
 
 - type: entity
   name: Hristov


### PR DESCRIPTION
## About the PR
Added the mosin crate to cargo. Each crate costs 3500 spesos, comes with three rifles and sixty rounds of ammunition. Lowers Mosin value to 50.

## Why / Balance
While not as effective as other combat options when it comes to firearms, Mosins can still offer a unique and interesting combat dynamic when versus group antags (as well as a cheaper firearm option for other activities, such as salvaging).

Mosin value lowered to 50 to reduce resale value. It's not meant to resell well, they're Mosins.

_also because ordering like thirty mosins is funni_
## Technical details


## Test plan
Spawn in.
Go to cargo console, ensure enough funds are present.
Order mosins crate.
Go to ATS/delivery area.
Open crate.
The tider with the rifle shoots.

## Media


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes


## Changelog

:cl:
- add: Cargo is now able to order a crate of Kardashev-Mosin rifles. Three Mosins, sixty rounds, at a cost of 3500 spesos.
