### PR TITLE
Cleanup ElectrocutionSystem and make TryDoElectrocution accept FixedPoint and DamageSpecifier instean of the int

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Damage.Prototypes;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
 using Content.Shared.Electrocution;
+using Content.Shared.FixedPoint;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
@@ -58,7 +59,6 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
     [Dependency] private TurfSystem _turf = default!;
 
     private static readonly ProtoId<StatusEffectPrototype> StatusKeyIn = "Electrocution";
-    private static readonly ProtoId<DamageTypePrototype> DamageType = "Shock";
     private static readonly ProtoId<TagPrototype> WindowTag = "Window";
 
     // Multiply and shift the log scale for shock damage.
@@ -289,7 +289,7 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
                     entity,
                     uid,
                     node,
-                    (int) (electrified.ShockDamage * MathF.Pow(RecursiveDamageMultiplier, depth) * damageScalar),
+                    (electrified.ShockDamage * MathF.Pow(RecursiveDamageMultiplier, depth) * damageScalar),
                     TimeSpan.FromSeconds(electrified.ShockTime * MathF.Pow(RecursiveTimeMultiplier, depth) * timeScalar),
                     true,
                     electrified.SiemensCoefficient);
@@ -319,7 +319,7 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
 
     /// <inheritdoc/>
     public override bool TryDoElectrocution(
-        EntityUid uid, EntityUid? sourceUid, int shockDamage, TimeSpan time, bool refresh, float siemensCoefficient = 1f,
+        EntityUid uid, EntityUid? sourceUid, DamageSpecifier shockDamage, TimeSpan time, bool refresh, float siemensCoefficient = 1f,
         StatusEffectsComponent? statusEffects = null, bool ignoreInsulation = false)
     {
         if (!DoCommonElectrocutionAttempt(uid, sourceUid, ref siemensCoefficient, ignoreInsulation)
@@ -334,7 +334,7 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
         EntityUid uid,
         EntityUid sourceUid,
         Node node,
-        int shockDamage,
+        FixedPoint2 shockDamage,
         TimeSpan time,
         bool refresh,
         float siemensCoefficient = 1f,
@@ -396,18 +396,29 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
         return true;
     }
 
+    private bool DoCommonElectrocution(EntityUid uid,
+        EntityUid? sourceUid,
+        FixedPoint2 shockDamage,
+        TimeSpan time,
+        bool refresh,
+        float siemensCoefficient = 1f,
+        StatusEffectsComponent? statusEffects = null)
+    {
+        return DoCommonElectrocution(uid, sourceUid, new DamageSpecifier(ProtoMan.Index(DamageType), shockDamage), time, refresh, siemensCoefficient, statusEffects);
+    }
+
     private bool DoCommonElectrocution(EntityUid uid, EntityUid? sourceUid,
-        int? shockDamage, TimeSpan time, bool refresh, float siemensCoefficient = 1f,
+        DamageSpecifier shockDamage, TimeSpan time, bool refresh, float siemensCoefficient = 1f,
         StatusEffectsComponent? statusEffects = null)
     {
         if (siemensCoefficient <= 0)
             return false;
 
-        if (shockDamage != null)
+        if (!shockDamage.AnyPositive())
         {
-            shockDamage = (int) (shockDamage * siemensCoefficient);
+            shockDamage *= siemensCoefficient;
 
-            if (shockDamage.Value <= 0)
+            if (!shockDamage.AnyPositive())
                 return false;
         }
 
@@ -431,14 +442,10 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
 
 
         // TODO: Sparks here.
-
-        if (shockDamage is { } dmg)
+        if (_damageable.TryChangeDamage(uid, shockDamage, out var damage, origin: sourceUid))
         {
-            if (_damageable.TryChangeDamage(uid, new DamageSpecifier(ProtoMan.Index(DamageType), dmg), out var damage, origin: sourceUid))
-            {
-                _adminLogger.Add(LogType.Electrocution,
-                    $"{ToPrettyString(uid):entity} received {damage:damage} powered electrocution damage{(sourceUid != null ? " from " + ToPrettyString(sourceUid.Value) : ""):source}");
-            }
+            _adminLogger.Add(LogType.Electrocution,
+                $"{ToPrettyString(uid):entity} received {damage:damage} powered electrocution damage{(sourceUid != null ? " from " + ToPrettyString(sourceUid.Value) : ""):source}");
         }
 
         _stuttering.DoStutter(uid, time * StutteringTimeMultiplier, refresh);

--- a/Content.Shared/Electrocution/SharedElectrocutionSystem.cs
+++ b/Content.Shared/Electrocution/SharedElectrocutionSystem.cs
@@ -1,97 +1,123 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.FixedPoint;
 using Content.Shared.Inventory;
 using Content.Shared.StatusEffect;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
-namespace Content.Shared.Electrocution
+namespace Content.Shared.Electrocution;
+
+public abstract partial class SharedElectrocutionSystem : EntitySystem
 {
-    public abstract partial class SharedElectrocutionSystem : EntitySystem
+    [Dependency] private SharedAppearanceSystem _appearance = default!;
+    [Dependency] private IGameTiming _timing = default!;
+
+    protected static readonly ProtoId<DamageTypePrototype> DamageType = "Shock";
+
+    public override void Initialize()
     {
-        [Dependency] private SharedAppearanceSystem _appearance = default!;
-        [Dependency] private IGameTiming _timing = default!;
+        base.Initialize();
+        // as long as legally distinct electric-mice are never added, this should be fine (otherwise a mouse-hat will transfer it's power to the wearer).
+        SubscribeLocalEvent<InsulatedComponent, InventoryRelayedEvent<ElectrocutionAttemptEvent>>((e, ref ev) => OnInsulatedElectrocutionAttempt(e, ref ev.Args));
+    }
 
-        public override void Initialize()
+    /// <summary>
+    /// Tries to set Siemens Coefficient on an entity's insulated component.
+    /// </summary>
+    public void SetInsulatedSiemensCoefficient(EntityUid uid, float siemensCoefficient, InsulatedComponent? insulated = null)
+    {
+        if (!Resolve(uid, ref insulated))
+            return;
+
+        insulated.Coefficient = siemensCoefficient;
+        Dirty(uid, insulated);
+    }
+
+    /// <summary>
+    /// Sets electrified value of component and marks dirty if required.
+    /// </summary>
+    public void SetElectrified(Entity<ElectrifiedComponent> ent, bool value)
+    {
+        if (ent.Comp.Enabled == value)
         {
-            base.Initialize();
-
-            SubscribeLocalEvent<InsulatedComponent, ElectrocutionAttemptEvent>(OnInsulatedElectrocutionAttempt);
-            // as long as legally distinct electric-mice are never added, this should be fine (otherwise a mouse-hat will transfer it's power to the wearer).
-            SubscribeLocalEvent<InsulatedComponent, InventoryRelayedEvent<ElectrocutionAttemptEvent>>((e, c, ev) => OnInsulatedElectrocutionAttempt(e, c, ev.Args));
-
-            SubscribeLocalEvent<ElectrifiedComponent, MapInitEvent>(OnInit);
+            return;
         }
 
-        /// <summary>
-        /// Tries to set Siemens Coefficient on an entity's insulated component.
-        /// </summary>
-        public void SetInsulatedSiemensCoefficient(EntityUid uid, float siemensCoefficient, InsulatedComponent? insulated = null)
-        {
-            if (!Resolve(uid, ref insulated))
-                return;
+        ent.Comp.Enabled = value;
+        Dirty(ent, ent.Comp);
 
-            insulated.Coefficient = siemensCoefficient;
-            Dirty(uid, insulated);
+        _appearance.SetData(ent.Owner, ElectrifiedVisuals.IsElectrified, value);
+    }
+
+    /// <summary>
+    /// Set a wire's cut state.
+    /// </summary>
+    public void SetElectrifiedWireCut(Entity<ElectrifiedComponent> ent, bool value)
+    {
+        if (ent.Comp.IsWireCut == value)
+        {
+            return;
         }
 
-        /// <summary>
-        /// Sets electrified value of component and marks dirty if required.
-        /// </summary>
-        public void SetElectrified(Entity<ElectrifiedComponent> ent, bool value)
-        {
-            if (ent.Comp.Enabled == value)
-            {
-                return;
-            }
+        ent.Comp.IsWireCut = value;
+        Dirty(ent);
+    }
 
-            ent.Comp.Enabled = value;
-            Dirty(ent, ent.Comp);
+    /// <summary>
+    /// Attempts to electrocute an entity interacting with electrified components.
+    /// Only call server side.
+    /// </summary>
+    /// <param name="uid">Entity being electrocuted.</param>
+    /// <param name="sourceUid">Source entity of the electrocution.</param>
+    /// <param name="shockDamage">How much shock damage the entity takes.</param>
+    /// <param name="time">How long the entity will be stunned.</param>
+    /// <param name="refresh">Should <paramref>time</paramref> be refreshed (instead of accumulated) if the entity is already electrocuted?</param>
+    /// <param name="siemensCoefficient">How insulated the entity is from the shock. 0 means completely insulated, and 1 means no insulation.</param>
+    /// <param name="statusEffects">Status effects to apply to the entity.</param>
+    /// <param name="ignoreInsulation">Should the electrocution bypass the Insulated component?</param>
+    /// <returns>Whether the entity <see cref="uid"/> was stunned by the shock.</returns>
+    [PublicAPI]
+    public bool TryDoElectrocution(
+        EntityUid uid,
+        EntityUid? sourceUid,
+        FixedPoint2 shockDamage,
+        TimeSpan time,
+        bool refresh,
+        float siemensCoefficient = 1f,
+        StatusEffectsComponent? statusEffects = null,
+        bool ignoreInsulation = false)
+    {
+        var damage = new DamageSpecifier(ProtoMan.Index(DamageType), shockDamage);
+        return TryDoElectrocution(uid, sourceUid, damage, time, refresh, siemensCoefficient, statusEffects, ignoreInsulation);
+    }
 
-            _appearance.SetData(ent.Owner, ElectrifiedVisuals.IsElectrified, value);
-        }
+    [PublicAPI]
+    public virtual bool TryDoElectrocution(
+        EntityUid uid,
+        EntityUid? sourceUid,
+        DamageSpecifier damage,
+        TimeSpan time,
+        bool refresh,
+        float siemensCoefficient = 1f,
+        StatusEffectsComponent? statusEffects = null,
+        bool ignoreInsulation = false)
+    {
+        // only done serverside
+        return false;
+    }
 
-        /// <summary>
-        /// Set a wire's cut state.
-        /// </summary>
-        public void SetElectrifiedWireCut(Entity<ElectrifiedComponent> ent, bool value)
-        {
-            if (ent.Comp.IsWireCut == value)
-            {
-                return;
-            }
+    [SubscribeLocalEvent]
+    private static void OnInsulatedElectrocutionAttempt(Entity<InsulatedComponent> ent, ref ElectrocutionAttemptEvent args)
+    {
+        args.SiemensCoefficient *= ent.Comp.Coefficient;
+    }
 
-            ent.Comp.IsWireCut = value;
-            Dirty(ent);
-        }
-
-        /// <summary>
-        /// Attempts to electrocute an entity interacting with electrified components.
-        /// Only call server side.
-        /// </summary>
-        /// <param name="uid">Entity being electrocuted.</param>
-        /// <param name="sourceUid">Source entity of the electrocution.</param>
-        /// <param name="shockDamage">How much shock damage the entity takes.</param>
-        /// <param name="time">How long the entity will be stunned.</param>
-        /// <param name="refresh">Should <paramref>time</paramref> be refreshed (instead of accumulated) if the entity is already electrocuted?</param>
-        /// <param name="siemensCoefficient">How insulated the entity is from the shock. 0 means completely insulated, and 1 means no insulation.</param>
-        /// <param name="statusEffects">Status effects to apply to the entity.</param>
-        /// <param name="ignoreInsulation">Should the electrocution bypass the Insulated component?</param>
-        /// <returns>Whether the entity <see cref="uid"/> was stunned by the shock.</returns>
-        public virtual bool TryDoElectrocution(
-            EntityUid uid, EntityUid? sourceUid, int shockDamage, TimeSpan time, bool refresh, float siemensCoefficient = 1f,
-            StatusEffectsComponent? statusEffects = null, bool ignoreInsulation = false)
-        {
-            // only done serverside
-            return false;
-        }
-
-        private void OnInsulatedElectrocutionAttempt(EntityUid uid, InsulatedComponent insulated, ElectrocutionAttemptEvent args)
-        {
-            args.SiemensCoefficient *= insulated.Coefficient;
-        }
-
-        private void OnInit(Entity<ElectrifiedComponent> entity, ref MapInitEvent args)
-        {
-            entity.Comp.NextShock = _timing.CurTime;
-            Dirty(entity);
-        }
+    [SubscribeLocalEvent]
+    private void OnInit(Entity<ElectrifiedComponent> entity, ref MapInitEvent args)
+    {
+        entity.Comp.NextShock = _timing.CurTime;
+        Dirty(entity);
     }
 }


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
int in the TryDoElectrocution always looked really strange and hardcoded for me, that's prevented from dealing not-rounded damage and also hardcodes shock damage into this system itself. I mean, it's okay, but what if I, for example, want to do magic lightning that deals holy damage?

## Technical details
Made SharedElectrocutionSystem blockscoped, replaced int with damageSpec, and added incapsulation copy with fixedpoint for them.

## Test plan
1. Start dev
2. Spawn RTG
3. Attack it via melee weapon without insults

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
ElectrocutionSystem methods that are used int as damage argument (including TryDoElectrocution) now use DamageSpecifier and FixedPoint2 (for the default shock damage) instead.

## Changelog
Not player facing