### PR TITLE
Guidebook: Fix Diona comments about reduced thirst

### DIFF
--- a/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
@@ -5,14 +5,14 @@
     <GuideEntityEmbed Entity="MobDiona" Caption=""/>
   </Box>
 
-  They can't wear shoes, but are not slowed by Kudzu.
+  Diona can't wear shoes, but are not slowed by Kudzu.
   They get hungry slower than most species, but get thirsty faster.
-  Their "blood" is tree sap and can't be metabolised from Iron.
+  Diona have tree sap for blood, which can't be metabolized from Iron.
   Being plants, Weed Killer poisons them, while Robust Harvest heals them (but not without risk when overused!)
 
   They take [color=#1e90ff]30% less Blunt damage and 20% less Slash damage[/color];
   but [color=#ffa500]50% more Heat damage, 20% more Shock damage, and they can easily
-  catch on fire when receiving enough Heat damage from *any* source.[/color]
+  catch on fire when receiving enough Heat damage from [bold]any[/bold] source.[/color]
 
   ## Make Like A Tree And Leave
   <Box>

--- a/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
@@ -7,7 +7,7 @@
 
   Diona can't wear shoes, but are not slowed by Kudzu.
   They get hungry slower than most species, but get thirsty faster.
-  Diona have tree sap for blood, which can't be metabolized from Iron.
+  Diona have tree sap for blood, which can't be metabolised from Iron.
   Being plants, Weed Killer poisons them, while Robust Harvest heals them (but not without risk when overused!)
 
   They take [color=#1e90ff]30% less Blunt damage and 20% less Slash damage[/color];

--- a/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
@@ -6,7 +6,7 @@
   </Box>
 
   They can't wear shoes, but are not slowed by Kudzu.
-  They get hungry and thirsty slower.
+  They get hungry slower than most species, but get thirsty faster.
   Their "blood" is tree sap and can't be metabolised from Iron.
   Being plants, Weed Killer poisons them, while Robust Harvest heals them (but not without risk when overused!)
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Fixes the guidebook text for Diona after #45230.  They do, in fact, get thirstier than your average mob.

Minor text touchups: Use "Diona" alternating with "they", use bold tags for emphasis rather than asterisks, rewrite the [sentence] on having tree sap for blood.

## Why / Balance

Oversight on my part.  My mistake.

## Technical details

Guidebook ops.

## Test plan

Read.  See Media section below.

## Media

Guidebook entry presented at standard window dimensions.
<img width="817" height="638" alt="image" src="https://github.com/user-attachments/assets/c1c25ec0-feb5-4698-96bf-4ae0f901658b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
_could_
