### PR TITLE
Reorder plasma and tritium fire reactions

### DIFF
--- a/Resources/Prototypes/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/Atmospherics/reactions.yml
@@ -1,6 +1,6 @@
 - type: gasReaction
   id: PlasmaFire
-  priority: -2
+  priority: -1
   minimumTemperature: 373.149 # Same as Atmospherics.FireMinimumTemperatureToExist
   minimumRequirements: # In this case, same as minimum mole count.
     Oxygen: 0.01
@@ -10,7 +10,7 @@
 
 - type: gasReaction
   id: TritiumFire
-  priority: -1
+  priority: -2
   minimumTemperature: 373.149 # Same as Atmospherics.FireMinimumTemperatureToExist
   minimumRequirements: # In this case, same as minimum mole count.
     Oxygen: 0.01


### PR DESCRIPTION
## About the PR
Swaps plasma and tritium fire reactions in the gas reaction order so tritium starts burning the moment it is produced.

## Why / Balance
The goal is to make the discrete timesteps of atmos updates as unnoticeable as possible; to have the simulation be as similar to a continuous calculation as we can. Having tritium start burning the moment it is produced gets closer to that goal.

See attached media for the primary example of why this reorder makes a difference, but with plasma fires occurring second in the order, it's possible to produce tritium without any of it burning so long as you capture it in the next update step. This is not an accurate representation of the continuous calculation since we'd expect a small portion of that tritium to burn on its way to the filter.

With the reversed the order, the simulation is ultimately still imperfect, but is more accurate and less abusable.

### drawbacks
This change does make plasma fires _slightly_ more vigorous since the tritium will start burning half a second faster than before. However, since the majority of plasma fires burn for a significantly longer duration than 1 update (and the total energy release is unchanged), I claim this won't have an impact on balance.

Additionally, this will result in some burn chamber designs, particularly those with poor scrubber coverage, losing more tritium and producing more water than before. The _exact_ consequences of this are harder to quantify as open air burns are more chaotic in general, but I personally was not able to notice a difference in how my burn chambers functioned before and after the change.

## Technical details
Moves the TritiumFire reaction priority down to -2 and the PlasmaFire reaction priority up to -1.
Since the engine process reactions from highest to lowest, this results in plasma fires occurring first.

## Test plan
### pipe trit test
Build an atmos contraption that produces tritium and then filters it in 1 tick.
(See media below for a construction guide).
Observe canister contents using a gas analyzer.
My proposed "correct" behavior will cause both tritium and water vapor mol to increase over time.
The difference between having the patch and not we hope to be obvious.

### burn chamber test
Construct a burn chamber set up to collect tritium as you would normally think to.
Observe how much tritium you are producing.
The difference between having the patch and not we hope to **not** be obvious if present at all.


## Media

### 1 tick pipe trit construction guide
build the following oxygen pipes (painting optional).
ensure that you construct your filter **before** you construct your mixer (device order matters, unfortunately).
<img width="1062" height="587" alt="oxygen loop" src="https://github.com/user-attachments/assets/a7133377-2f3d-4a45-a31d-4932c21e6a9e" />

wait until your oxygen is 1000 Kelvin, then construct the following plasma pipes (painting optional).
<img width="1058" height="678" alt="plasma loop" src="https://github.com/user-attachments/assets/f5d01c42-76a7-466e-8d51-a2e8cc4924d0" />

wait until your oxygen is hotter than 1700 Kelvin, then finish the setup by replacing the heater with a cooler and adding your radiator and storage canister.
<img width="1053" height="872" alt="cooling swap" src="https://github.com/user-attachments/assets/f3bde080-3e14-4c93-9f92-fe37de6d8087" />

### video of pipetrit results
Previous behavior: setup is able to produce tritium with no waste.

https://github.com/user-attachments/assets/43c75313-ce40-40a4-a98c-81165d066399


New behavior: setup always burns a portion of its tritium.

https://github.com/user-attachments/assets/04b48bca-86ae-4171-8ece-586541e6809c



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
N/A

## Changelog
:cl:
- tweak: Plasma now burns before tritium.
