### PR TITLE
StripeBack: clamp edge insets

### DIFF
--- a/Content.Client/UserInterface/Controls/StripeBack.cs
+++ b/Content.Client/UserInterface/Controls/StripeBack.cs
@@ -71,19 +71,13 @@ namespace Content.Client.UserInterface.Controls
 
         protected override Vector2 ArrangeOverride(Vector2 finalSize)
         {
-            var box = new UIBox2(Vector2.Zero, finalSize);
-
             var padSize = HasMargins ? PadSize : 0;
+            var top = HasTopEdge ? padSize + EdgeSize : 0;
+            var bottom = HasBottomEdge ? padSize + EdgeSize : 0;
 
-            if (HasTopEdge)
-            {
-                box += (0, padSize + EdgeSize, 0, 0);
-            }
-
-            if (HasBottomEdge)
-            {
-                box += (0, 0, 0, -(padSize + EdgeSize));
-            }
+            // Clamp so the box stays valid when finalSize is smaller than the edge insets
+            top = MathF.Min(top, finalSize.Y);
+            var box = new UIBox2(0, top, finalSize.X, MathF.Max(top, finalSize.Y - bottom));
 
             foreach (var child in Children)
             {
@@ -96,19 +90,24 @@ namespace Content.Client.UserInterface.Controls
 
         protected override void Draw(DrawingHandleScreen handle)
         {
-            UIBox2 centerBox = PixelSizeBox;
-
             var padSize = HasMargins ? PadSize : 0;
+            var edgeSize = (padSize + EdgeSize) * UIScale;
+            var top = HasTopEdge ? edgeSize : 0;
+            var bottom = HasBottomEdge ? edgeSize : 0;
+
+            // Too small to fit the edges, don't draw anything
+            if (top + bottom > PixelHeight)
+                return;
+
+            var centerBox = new UIBox2(0, top, PixelWidth, PixelHeight - bottom);
 
             if (HasTopEdge)
             {
-                centerBox += (0, (padSize + EdgeSize) * UIScale, 0, 0);
                 handle.DrawRect(new UIBox2(0, padSize * UIScale, PixelWidth, centerBox.Top), EdgeColor);
             }
 
             if (HasBottomEdge)
             {
-                centerBox += (0, 0, 0, -((padSize + EdgeSize) * UIScale));
                 handle.DrawRect(new UIBox2(0, centerBox.Bottom, PixelWidth, PixelHeight - padSize * UIScale),
                     EdgeColor);
             }


### PR DESCRIPTION
## About the PR
Fixes a debug client crash in `StripeBack` where the control could be laid out with an inverted rectangle when it is given less height than its own top/bottom edge insets.

## Why / Balance
A debug client fails assertion.

```
Process terminated.
Assertion failed.
Top cannot be greater than Bottom.
   at Robust.Shared.Maths.UIBox2.Validate(Single left, Single top, Single right, Single bottom) in 
   at Robust.Shared.Maths.UIBox2..ctor(Single left, Single top, Single right, Single bottom) in 
   at Robust.Shared.Maths.UIBox2.op_Addition(UIBox2 box, ValueTuple`4 offsets) in 
   at Content.Client.UserInterface.Controls.StripeBack.ArrangeOverride(Vector2 finalSize) in 
```

`StripeBack` reserves `PadSize + EdgeSize` at the top and again at the bottom, so its desired height is 12px. `ArrangeOverride` applied both insets unconditionally, and when the parent arranges it shorter than that (the gas analyzer builds its column headers out of childless `StripeBack`s, `GasAnalyzerWindow.xaml.cs:321-323`) the resulting box has `Top > Bottom` and `UIBox2`'s ctor assertion kills the client. `Draw` had the same problem one step later.

Constant crashes are annoying when debugging atmos UIs.

## Technical details
Both places now derive the box from clamped insets instead of mutating a box in place:

- `ArrangeOverride`: `top` is clamped to `finalSize.Y` and the bottom edge to at least `top`, so the child box is always valid, degenerate at worst.
- `Draw`: bails out early when `top + bottom > PixelHeight`, so `centerBox` and the two edge rects can't invert either. Nothing meaningful is visible at that size anyway.

No behaviour change at any size that fit before.

## Test plan
1. Run client in Debug configuration
2. Go to Atmos
3. Use Gas Analyzer on any pump.
4. Client dies on failed assertion
5. Apply suggested fix
6. Follow steps 2 and 3 again - client should not crash anymore

## Media
_None_

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
_None_
