### PR TITLE
Telesci Console can be Auth Broken and Access Configed now

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -499,6 +499,7 @@
   - type: StationTeleporterConsole
     portalColor: "#81ddeb"
   - type: Storage
+    clickInsert: false
     grid:
     - 0,0,4,2
     maxItemSize: Small
@@ -532,7 +533,7 @@
   components:
   - type: StationTeleporterConsole
     autoLinkKey: Nanotrasen
-  
+
 - type: entity
   parent: ComputerStationTeleportersControl
   id: ComputerSyndicateTeleportersControl
@@ -558,7 +559,7 @@
     access: [["SyndicateAgent"]]
   - type: StationTeleporterConsole
     portalColor: "#c61414"
-  
+
 - type: entity
   parent: BaseComputerAiAccess
   id: ComputerResearchAndDevelopment


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Telesci console could not be auth broken or access config'd because the game attempted to store the device in the console, failed, and ended the interaction.  This fixes that by removing the click storage behavior for the console.  This does disable click insertion for telesci chips, but that can still be done with right click menus, whereas there is no right click menu option for auth/access.

## Why / Balance
Simple YAML fix that allows the access on the console to be messed with, something that's important for both antag and non-antag gameplay.  For example, right now science without an RD just can't really do telesci, or at least need a scientist to be given command access instead of allowing HoP to access config it to science.

## Technical details
YAML, turned off click storage.

## Test plan
Use access breaker/access config on telesci console.  It works.

## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix:  Telesci consoles can have their access messed with.

