### PR TITLE
Fix botany temperature tolerance conversion

### DIFF
--- a/Resources/Prototypes/Hydroponics/plants.yml
+++ b/Resources/Prototypes/Hydroponics/plants.yml
@@ -156,8 +156,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Vitamin:
@@ -190,8 +190,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       MuteToxin:
@@ -522,8 +522,8 @@
   - type: PlantHarvest
     harvestRepeat: Repeat
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Sugar:
@@ -554,8 +554,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Vitamin:
@@ -584,8 +584,8 @@
   - type: PlantHarvest
     harvestRepeat: Repeat
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
 
 - type: entity
   parent: BasePlant
@@ -666,8 +666,8 @@
     waterConsumption: 0.6
     nutrientConsumption: 0.4
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Nutriment:
@@ -747,8 +747,8 @@
     waterConsumption: 0.6
     nutrientConsumption: 0.7
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Blood:
@@ -786,8 +786,8 @@
     waterConsumption: 0.6
     nutrientConsumption: 0.7
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Blood:
@@ -821,8 +821,8 @@
   - type: PlantHarvest
     harvestRepeat: Repeat
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Nutriment:
@@ -984,8 +984,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Nutriment:
@@ -1133,8 +1133,8 @@
   - type: PlantGrowth
     nutrientConsumption: 0.5
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Egg:
@@ -1164,8 +1164,8 @@
   - type: PlantGrowth
     waterConsumption: 0.4
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       THC:
@@ -1193,8 +1193,8 @@
   - type: PlantGrowth
     nutrientConsumption: 0.5
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       SpaceDrugs:
@@ -1240,8 +1240,8 @@
   - type: PlantGrowth
     waterConsumption: 0.4
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Nicotine:
@@ -1271,8 +1271,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Histamine:
@@ -1304,8 +1304,8 @@
     waterConsumption: 0.7
     nutrientConsumption: 0.8
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       SulfuricAcid:
@@ -1338,8 +1338,8 @@
   - type: PlantHarvest
     harvestRepeat: Repeat
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       CapsaicinOil:
@@ -2010,8 +2010,8 @@
     waterConsumption: 1.0
     nutrientConsumption: 0.8
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Vitamin:
@@ -2077,8 +2077,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Nutriment:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Restores the temperature tolerances of plants that had `idealHeat: 298` before the botany refactor.

Before the refactor, these plants used the default `HeatTolerance = 10`, giving them an effective temperature range of 288–308 K.

During the refactor, several of these plants were converted to 278–298 K instead, shifting their entire valid temperature range 10 K colder and making their previous ideal temperature the new upper limit.

This PR changes only the affected plants from 278–298 K back to the equivalent pre-refactor range of 288–308 K. Plants that previously had lower ideal temperatures are left unchanged.

## Why / Balance
This is a regression fix rather than a balance change.

Previously the temperature check was:

`MathF.Abs(environment.Temperature - ent.Comp.IdealHeat) > ent.Comp.HeatTolerance`

With `IdealHeat = 298` and the default `HeatTolerance = 10`, a plant tolerated temperatures from 288–308 K.

The refactored system instead directly checks:

`environment.Temperature < ent.Comp.LowHeatTolerance || environment.Temperature > ent.Comp.HighHeatTolerance`

The equivalent conversion for the old 298 ± 10 K range is therefore 288–308 K. Several prototypes were instead converted to 278–298 K.

This restores their previous effective tolerances without changing the behavior of plants that were converted correctly.

The incorrect values were introduced during the botany refactor in commit `71b14ae` (`predict and API`).

## Technical details
Changes affected plant prototypes with:

```yaml
lowHeatTolerance: 278
highHeatTolerance: 298
````

that previously used:

```yaml
idealHeat: 298
```

to:

```yaml
lowHeatTolerance: 288
highHeatTolerance: 308
```

Plants that previously used `idealHeat: 288`, whose correct equivalent range is already 278–298 K, are unchanged.

Plants such as Blue Tomato that were already correctly converted to 288–308 K are also unchanged.

## Test plan

1. Plant one of the affected plants, such as Tomato, Tea, or Banana.
2. Verify that temperatures within 288–308 K do not cause temperature stress.
3. Verify that temperatures below 288 K or above 308 K cause temperature stress.
4. Confirm that plants which previously used `idealHeat: 288`, such as Towercap, retain their 278–298 K range.

## Media

Not required for this regression fix.

## Requirements

* [x] I have read and am following the [[Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html)](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
* [x] I have tested this pull request and written instructions on how to test it
* [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

## Changelog

:cl:

* fix: Fixed incorrect temperature tolerances on several plants introduced by the botany refactor.

