### PR TITLE
[HOTFIX] Fix botany temperature tolerance conversion

### DIFF
--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -3778,3 +3778,10 @@ Entries:
   id: 10057
   time: '2026-08-31T09:34:33.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/45692
+- author: SlothBasket
+  changes:
+  - message: Fixed incorrect temperature tolerances on several plants introduced by the botany refactor.
+    type: Fix
+  id: 10058
+  time: '2026-09-02T11:40:02.0000000+00:00'
+  url: https://github.com/space-wizards/space-station-14/pull/45801

--- a/Resources/Prototypes/Hydroponics/plants.yml
+++ b/Resources/Prototypes/Hydroponics/plants.yml
@@ -611,8 +611,8 @@
     waterConsumption: 0.6
     nutrientConsumption: 0.5
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantTraitLigneous
 
 - type: entity
@@ -638,8 +638,8 @@
     waterConsumption: 0.6
     nutrientConsumption: 0.8
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantTraitLigneous
 
 - type: entity
@@ -1022,8 +1022,8 @@
     waterConsumption: 0.6
     nutrientConsumption: 0.5
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Nutriment:
@@ -1062,8 +1062,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Nutriment:
@@ -1102,8 +1102,8 @@
     waterConsumption: 0.6
     nutrientConsumption: 0.5
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Nutriment:
@@ -1375,8 +1375,8 @@
   - type: PlantHarvest
     harvestRepeat: Repeat
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       FrostOil:
@@ -2181,8 +2181,8 @@
     potency: 10
     growthStages: 3
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       PumpkinFlesh:
@@ -2213,8 +2213,8 @@
     potency: 10
     growthStages: 3
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Ammonia:

--- a/Resources/Prototypes/Hydroponics/plants.yml
+++ b/Resources/Prototypes/Hydroponics/plants.yml
@@ -156,8 +156,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Vitamin:
@@ -190,8 +190,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       MuteToxin:
@@ -522,8 +522,8 @@
   - type: PlantHarvest
     harvestRepeat: Repeat
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Sugar:
@@ -554,8 +554,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Vitamin:
@@ -584,8 +584,8 @@
   - type: PlantHarvest
     harvestRepeat: Repeat
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
 
 - type: entity
   parent: BasePlant
@@ -666,8 +666,8 @@
     waterConsumption: 0.6
     nutrientConsumption: 0.4
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Nutriment:
@@ -747,8 +747,8 @@
     waterConsumption: 0.6
     nutrientConsumption: 0.7
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Blood:
@@ -786,8 +786,8 @@
     waterConsumption: 0.6
     nutrientConsumption: 0.7
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Blood:
@@ -821,8 +821,8 @@
   - type: PlantHarvest
     harvestRepeat: Repeat
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Nutriment:
@@ -984,8 +984,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Nutriment:
@@ -1133,8 +1133,8 @@
   - type: PlantGrowth
     nutrientConsumption: 0.5
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Egg:
@@ -1164,8 +1164,8 @@
   - type: PlantGrowth
     waterConsumption: 0.4
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       THC:
@@ -1193,8 +1193,8 @@
   - type: PlantGrowth
     nutrientConsumption: 0.5
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       SpaceDrugs:
@@ -1240,8 +1240,8 @@
   - type: PlantGrowth
     waterConsumption: 0.4
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Nicotine:
@@ -1271,8 +1271,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Histamine:
@@ -1304,8 +1304,8 @@
     waterConsumption: 0.7
     nutrientConsumption: 0.8
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       SulfuricAcid:
@@ -1338,8 +1338,8 @@
   - type: PlantHarvest
     harvestRepeat: Repeat
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       CapsaicinOil:
@@ -2010,8 +2010,8 @@
     waterConsumption: 1.0
     nutrientConsumption: 0.8
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Vitamin:
@@ -2077,8 +2077,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 278 # 5°C
-    highHeatTolerance: 298 # 25°C
+    lowHeatTolerance: 288 # 5°C
+    highHeatTolerance: 308 # 25°C
   - type: PlantChemicals
     chemicals:
       Nutriment:

--- a/Resources/Prototypes/Hydroponics/plants.yml
+++ b/Resources/Prototypes/Hydroponics/plants.yml
@@ -156,8 +156,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Vitamin:
@@ -190,8 +190,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       MuteToxin:
@@ -522,8 +522,8 @@
   - type: PlantHarvest
     harvestRepeat: Repeat
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Sugar:
@@ -554,8 +554,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Vitamin:
@@ -584,8 +584,8 @@
   - type: PlantHarvest
     harvestRepeat: Repeat
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
 
 - type: entity
   parent: BasePlant
@@ -666,8 +666,8 @@
     waterConsumption: 0.6
     nutrientConsumption: 0.4
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Nutriment:
@@ -747,8 +747,8 @@
     waterConsumption: 0.6
     nutrientConsumption: 0.7
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Blood:
@@ -786,8 +786,8 @@
     waterConsumption: 0.6
     nutrientConsumption: 0.7
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Blood:
@@ -821,8 +821,8 @@
   - type: PlantHarvest
     harvestRepeat: Repeat
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Nutriment:
@@ -984,8 +984,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Nutriment:
@@ -1133,8 +1133,8 @@
   - type: PlantGrowth
     nutrientConsumption: 0.5
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Egg:
@@ -1164,8 +1164,8 @@
   - type: PlantGrowth
     waterConsumption: 0.4
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       THC:
@@ -1193,8 +1193,8 @@
   - type: PlantGrowth
     nutrientConsumption: 0.5
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       SpaceDrugs:
@@ -1240,8 +1240,8 @@
   - type: PlantGrowth
     waterConsumption: 0.4
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Nicotine:
@@ -1271,8 +1271,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Histamine:
@@ -1304,8 +1304,8 @@
     waterConsumption: 0.7
     nutrientConsumption: 0.8
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       SulfuricAcid:
@@ -1338,8 +1338,8 @@
   - type: PlantHarvest
     harvestRepeat: Repeat
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       CapsaicinOil:
@@ -2010,8 +2010,8 @@
     waterConsumption: 1.0
     nutrientConsumption: 0.8
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Vitamin:
@@ -2077,8 +2077,8 @@
   - type: PlantGrowth
     waterConsumption: 0.6
   - type: PlantAtmospheric
-    lowHeatTolerance: 288 # 5°C
-    highHeatTolerance: 308 # 25°C
+    lowHeatTolerance: 288 # 15°C
+    highHeatTolerance: 308 # 35°C
   - type: PlantChemicals
     chemicals:
       Nutriment:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Restores the pre-refactor temperature tolerances for plants that previously used `idealHeat: 298`.

Before the botany refactor, these plants used the default `HeatTolerance = 10`, which gave them an effective valid temperature range of 288–308 K.

During the refactor, several of these plants were converted to 278–298 K instead. This shifted their full valid temperature range 10 K colder and made their old ideal temperature the new upper limit.

This PR changes only the affected plants back to 288–308 K.

## Why / Balance
This is a regression fix, not a balance change.

The old temperature check was:

`MathF.Abs(environment.Temperature - ent.Comp.IdealHeat) > ent.Comp.HeatTolerance`

For a plant with:

`IdealHeat = 298`
`HeatTolerance = 10`

the plant was only outside tolerance below 288 K or above 308 K.

The refactored system instead directly checks:

`environment.Temperature < ent.Comp.LowHeatTolerance || environment.Temperature > ent.Comp.HighHeatTolerance`

So the equivalent conversion for the old 298 ± 10 K range is:

`LowHeatTolerance = 288`
`HighHeatTolerance = 308`

Several plants were instead converted to 278–298 K.

Plants that previously used lower ideal temperatures and were correctly converted are not changed.

## Technical details
Changes affected plant prototypes from:

```yaml
lowHeatTolerance: 278
highHeatTolerance: 298
````

to:

```yaml
lowHeatTolerance: 288
highHeatTolerance: 308
```

Only plants that previously had `idealHeat: 298` and were incorrectly converted are changed.

Plants that previously had `idealHeat: 288`, whose correct equivalent range is 278–298 K, are left unchanged.

Plants such as Blue Tomato that were already correctly converted to 288–308 K are also unchanged.

The incorrect conversion originated during the botany refactor in commit `71b14ae` (`predict and API`).

## Test plan

1. Plant an affected plant such as Tomato, Tea, or Banana.
2. Verify the plant does not receive temperature stress between 288 K and 308 K.
3. Verify temperatures below 288 K or above 308 K cause temperature stress.
4. Verify plants that previously used `idealHeat: 288`, such as Towercap, still use the 278–298 K range.

## Media

Not required for this regression fix.

## Requirements

* [x] I have read and am following the [[Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html)](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
* [x] I have tested this pull request and written instructions on how to test it
* [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

None.

## Changelog

:cl: SlothBasket
* fix: Fixed incorrect temperature tolerances on several plants introduced by the botany refactor.
