### PR TITLE
Make publish-testing.yml push the last working commit to a backup branch

### DIFF
--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -98,4 +98,6 @@ jobs:
         COMMIT_SHA="${{ steps.get_commit.outputs.sha }}"
 
         git fetch origin $COMMIT_SHA --depth=1
-        git push origin $COMMIT_SHA:refs/heads/$TARGET_BRANCH --force
+        git checkout $COMMIT_SHA
+        git commit --allow-empty -m "Backup separation commit"
+        git push origin HEAD:refs/heads/$TARGET_BRANCH --force

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -66,3 +66,35 @@ jobs:
       run: Tools/actions_changelog_rss.py
       env:
         CHANGELOG_RSS_KEY: ${{ secrets.CHANGELOG_RSS_KEY }}
+
+    - name: Get Previous Successful Run Commit
+      id: get_commit
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Github doesn't support giving workflow filenames, despite needing it for the REST API. So we gotta regex it out.
+        # Yes, there's a 4 year old issue for it... https://github.com/orgs/community/discussions/10052
+        WORKFLOW_FILENAME=$(echo "${{ github.workflow_ref }}" | grep -oP '(?<=.github/workflows/)[^@]+')
+        PREVIOUS_SHA=$(gh api \
+          -H "Accept: application/vnd.github+json" \
+          "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_FILENAME}/runs?branch=${{ github.ref_name }}&status=success&per_page=2" \
+          --jq '.workflow_runs[0].head_sha')
+
+        # If there is no previous run, .workflow_runs[1] will return null
+        if [ "$PREVIOUS_SHA" = "null" ] || [ -z "$PREVIOUS_SHA" ]; then
+          echo "No previous successful workflow run found."
+          echo "update=false" >> $GITHUB_OUTPUT
+        else
+          echo "Found previous successful commit: $PREVIOUS_SHA"
+          echo "update=true" >> $GITHUB_OUTPUT
+          echo "sha=$PREVIOUS_SHA" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Force Update Backup Branch
+      if: steps.get_commit.outputs.update == 'true'
+      run: |
+        TARGET_BRANCH="master-publish-backup"
+        COMMIT_SHA="${{ steps.get_commit.outputs.sha }}"
+
+        git fetch origin $COMMIT_SHA --depth=1
+        git push origin $COMMIT_SHA:refs/heads/$TARGET_BRANCH --force

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -71,6 +71,7 @@ jobs:
       id: get_commit
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: github.ref_name != 'master-publish-backup'
       run: |
         # Github doesn't support giving workflow filenames, despite needing it for the REST API. So we gotta regex it out.
         # Yes, there's a 4 year old issue for it... https://github.com/orgs/community/discussions/10052


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR makes the Publish Testing workflow push the *previous* successful workflow commit to a "backup" branch `master-publish-backup` upon successfully publishing.

Example:

Publish Testing is run on September 2nd with commit abc123.
The previous time Publish Testing was ran successfully, was on September 1st with commit def456.
When the workflow completes, `master-publish-backup` is set to commit def456.
Next time Publish Testing is ran again, `master-publish-backup` will be set to commit abc123.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This should make `master-publish-backup` effectively work as a backup branch of the previous time publish was ran. If `master` ever encounters a gamebreaking issue that isn't caught through CI, admins will be able to run publish on the backup branch to very quickly restore the game servers to a playable state. 

This should only be a temporary measure while the gamebreaking issue is being resolved as a priority issue, but hopefully it'll reduce downtime.

## Technical details
<!-- Summary of code changes for easier review. -->

1. Get the name of the workflow running (Github API is stinky so we gotta regex)
2. Get the SHA of the previous successful run
3. Push the branch `master-publish-backup` to that SHA

We also do a check to see if the branch itself is `master-publish-backup`, so that we don't do a backup when we publish the backup.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Run Publish Testing and check that `master-publish-backup` goes to the previous publish's commit.

Since I do not have a server to publish to on my own repo, I had to run it via a testing script:
https://github.com/SlamBamActionman/space-station-14/blob/master-publish-backup/.github/workflows/publish-testing-backup.yml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
<!--
:cl:
- add: Crowbars now randomly spawn in maintenance lockers.
- remove: Crowbars no longer spawn in maintenance crates.
- tweak: Crowbar spawn rates have been increased for tool lockers.
- fix: Crowbars no longer accidentally spawn in microwaves.
-->
