### PR TITLE
Allow feedback pop-ups to show always when opening the feedback window

### DIFF
--- a/Content.Client/FeedbackPopup/ClientFeedbackManager.cs
+++ b/Content.Client/FeedbackPopup/ClientFeedbackManager.cs
@@ -34,7 +34,6 @@ public sealed class ClientFeedbackManager : SharedFeedbackManager
         if (prototypes == null)
             return;
 
-        var count = _displayedPopups.Count;
         _displayedPopups.UnionWith(prototypes);
         InvokeDisplayedPopupsChanged(false);
     }

--- a/Content.Client/FeedbackPopup/ClientFeedbackManager.cs
+++ b/Content.Client/FeedbackPopup/ClientFeedbackManager.cs
@@ -36,7 +36,7 @@ public sealed class ClientFeedbackManager : SharedFeedbackManager
 
         var count = _displayedPopups.Count;
         _displayedPopups.UnionWith(prototypes);
-        InvokeDisplayedPopupsChanged(_displayedPopups.Count > count);
+        InvokeDisplayedPopupsChanged(false);
     }
 
     /// <inheritdoc />

--- a/Content.Shared/FeedbackSystem/FeedbackPopupPrototype.cs
+++ b/Content.Shared/FeedbackSystem/FeedbackPopupPrototype.cs
@@ -46,10 +46,20 @@ public sealed partial class FeedbackPopupPrototype : IPrototype
     public string? ResponseLink;
 
     /// <summary>
+    /// Should this feedback always be shown upon opening the feedback window?
+    /// Ignores <see cref="ShowRoundEnd"/> and <see cref="RuleWhitelist"/>.
+    /// </summary>
+    /// <remarks>
+    /// Still requires a valid origin to display.
+    /// </remarks>
+    [DataField]
+    public bool AlwaysShow = false;
+
+    /// <summary>
     /// Should this feedback be shown when the round ends.
     /// </summary>
     /// <remarks>
-    /// If this is false popups have to be shown to players by running the <pre>feedback:add</pre> command.<br />
+    /// If this and <see cref="AlwaysShow"/> are false, popups have to be shown to players by running the <pre>feedback:add</pre> command.<br />
     /// This allows admins to show popups to only specific people.
     /// </remarks>
     [DataField]

--- a/Content.Shared/FeedbackSystem/SharedFeedbackManager.Events.cs
+++ b/Content.Shared/FeedbackSystem/SharedFeedbackManager.Events.cs
@@ -17,5 +17,6 @@ public abstract partial class SharedFeedbackManager : IEntityEventSubscriber
     private void OnFeedbackOriginsUpdated(string newOrigins)
     {
         _validOrigins = newOrigins.Split(' ').ToList();
+        Display(GetOriginFeedbackPrototypes(false));
     }
 }

--- a/Content.Shared/FeedbackSystem/SharedFeedbackManager.cs
+++ b/Content.Shared/FeedbackSystem/SharedFeedbackManager.cs
@@ -101,6 +101,7 @@ public abstract partial class SharedFeedbackManager : ISharedFeedbackManager
     public virtual void Initialize()
     {
         InitSubscriptions();
+        Display(GetOriginFeedbackPrototypes(false));
     }
 
     /// <inheritdoc />
@@ -137,7 +138,7 @@ public abstract partial class SharedFeedbackManager : ISharedFeedbackManager
     public List<ProtoId<FeedbackPopupPrototype>> GetOriginFeedbackPrototypes(bool roundEndOnly, bool ruleSpecific = false)
     {
         var feedbackProtypes = _proto.EnumeratePrototypes<FeedbackPopupPrototype>()
-            .Where(x => (!roundEndOnly || x.ShowRoundEnd) && ruleSpecific == (x.RuleWhitelist != null) && _validOrigins.Contains(x.PopupOrigin))
+            .Where(x => (roundEndOnly && x.ShowRoundEnd && ruleSpecific == (x.RuleWhitelist != null) || x.AlwaysShow) && _validOrigins.Contains(x.PopupOrigin))
             .Select(x => new ProtoId<FeedbackPopupPrototype>(x.ID))
             .OrderBy(x => x.Id)
             .ToList();

--- a/Resources/Prototypes/FeedbackPopup/feedbackpopups.yml
+++ b/Resources/Prototypes/FeedbackPopup/feedbackpopups.yml
@@ -1,22 +1,12 @@
 ﻿- type: feedbackPopup
-  id: FeedbackPopup
-  popupOrigin: wizden_master
-  title: "[bold]Feedback on the new feedback popup system[/bold]"
-  description: |-
-    This window you are seeing is a new system to get feedback on features. It will give popups at the end of the round (mostly on our testing server Vulture)!
-    Please share your thoughts through the forums below! Log in with your Space Station 14 account!
-  responseType: "Feedback Thread"
-  responseLink: "https://forum.spacestation14.com/t/feedback-popup-feedback/22858"
-
-- type: feedbackPopup
   id: GeneralFeedback
   popupOrigin: wizden_master
-  title: "[bold]General feedback for the game[/bold]"
+  title: "[bold]General feedback for Space Station 14[/bold]"
   description: >-
-    If you have any feedback on the game, feel free to create a thread in the feedback forum category.
-  responseType: "General Feedback"
+    If you have any feedback on the game, please create a thread in the Feedback forum category. Thank you!
+  responseType: "Forum Link"
   responseLink: "https://forum.spacestation14.com/c/development/feedback/51"
-  showRoundEnd: false
+  alwaysShow: true
 
 - type: feedbackPopup
   id: XenoborgExtractorFeedback


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR allows feedback pop-ups to show whenever you open the Feedback window from the Escape Menu, using the new property `AlwaysShow`.

Always sends over pop-ups if there are changes, as well as when the client first starts the game.

It also removes the old feedback popup feedback popup since that's been in there for a long time now. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Previously Feedback pop-ups only populated the window upon the round ending, and only if they had `ShowOnEnd` set to true. Otherwise you could only view pop-ups if an admin explicitly enabled it for you.

Now pop-ups can always show in the feedback window if they have `AlwaysShow` to true. Additionally, pop-ups are updated on the client when relevant changes are made, such as when the client first starts, when the valid origins are updated, or when prototypes are reloaded. Unlike before, this does not force open the feedback pop-up window.

## Technical details
<!-- Summary of code changes for easier review. -->

The main difference is that `Display` no longer invokes `InvokeDisplayedPopupsChanged` set to true, which means the popups update on the client without opening up the display window. The rest is pretty standard boolean stuff.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Go ingame
2. Check Feedback popups via the Escape Menu
3. End the round
4. Observe the end-of-round popups

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

When using the `feedback:add` toolshed command, it no longer automatically opens the feedback window for the targetted sessions. The command must now be followed up with the `feedback:show` command.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
Not exactly playerchanging.