### PR TITLE
Make sure guns don't try to shoot at an invalid map

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -76,7 +76,7 @@ public sealed partial class GunSystem : SharedGunSystem
             ? TransformSystem.WithEntityId(fromCoordinates, gridUid)
             : new EntityCoordinates(_map.GetMapOrInvalid(fromMap.MapId), fromMap.Position);
 
-        if (fromEnt.EntityId == EntityUid.Invalid)
+        if (!fromEnt.EntityId.Valid)
         {
             Log.Warning($"Tried to fire gun {ToPrettyString(gun)} at entity coordinates with an invalid EntityUid.");
             return;

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -76,6 +76,12 @@ public sealed partial class GunSystem : SharedGunSystem
             ? TransformSystem.WithEntityId(fromCoordinates, gridUid)
             : new EntityCoordinates(_map.GetMapOrInvalid(fromMap.MapId), fromMap.Position);
 
+        if (fromEnt.EntityId == EntityUid.Invalid)
+        {
+            Log.Warning($"Tried to fire gun {ToPrettyString(gun)} from an invalid parent EntityUid.");
+            return;
+        }
+
         // Update shot based on the recoil
         toMap = fromMap.Position + angle.ToVec() * mapDirection.Length();
         mapDirection = toMap - fromMap.Position;

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -78,7 +78,7 @@ public sealed partial class GunSystem : SharedGunSystem
 
         if (fromEnt.EntityId == EntityUid.Invalid)
         {
-            Log.Warning($"Tried to fire gun {ToPrettyString(gun)} from an invalid parent EntityUid.");
+            Log.Warning($"Tried to fire gun {ToPrettyString(gun)} at entity coordinates with an invalid EntityUid.");
             return;
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a check to server-side GunSystem's Shoot method to make sure it isn't trying to shoot from some EntityCoordinates with an invalid EntityUid, and log a warning if this occurs
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
If you're using a method that could potentially return an invalid value it makes sense to make sure it isn't invalid before continuing onward. (prevents a weird test fail I got once)
## Technical details
<!-- Summary of code changes for easier review. -->
The method uses GetMapOrInvalid for getting the EntityUid of the map its shooting from in the event it can't find the EntityUid for a grid, but it has no check to make sure that GetMapOrInvalid didn't return an Invalid EntityUid. When it spawns a bullet projectile later, if the EntityUid is invalid, a fatal exception occurs. All you need to do is add a check and return early if this occurs to prevent this from happening. This check happens before the Shoot method actually does anything, so this is fine.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
On master, spawn an N1984 pistol, teleport it to entuid 1, fire it somehow (I like to vv it and set BurstActivated to true on its gun component) and observe a fatal exception and crash.
On this PR, do the same and observe that instead all that occurs is a warning.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1043" height="51" alt="Screenshot_20260903_004616" src="https://github.com/user-attachments/assets/23b37781-56e9-41bd-99e5-99e739b45661" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
<!--
:cl:
- add: Crowbars now randomly spawn in maintenance lockers.
- remove: Crowbars no longer spawn in maintenance crates.
- tweak: Crowbar spawn rates have been increased for tool lockers.
- fix: Crowbars no longer accidentally spawn in microwaves.
-->
Shouldn't affect players at all.