### PR TITLE
fix some station events targeting off-station grids

### DIFF
--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -60,6 +60,43 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
         return true;
     }
 
+    /// <summary>
+    /// Get all entities with <see cref="TComponent"/> that are on the station. Ignore entities outside the station.
+    /// </summary>
+    /// <param name="checkIfAnchored">Whether to only get anchored entities.
+    /// Good check for air vents, bad for containers.</param>
+    /// <returns>All matching entities.</returns>
+    protected HashSet<EntityUid> GetEntitiesWithComponentOnStation<TComponent>(bool checkIfAnchored)
+        where TComponent : IComponent
+    {
+        HashSet<EntityUid> entities = [];
+
+        if (!TryGetRandomStation(out var station))
+        {
+            return entities;
+        }
+
+        var grid = StationSystem.GetLargestGrid(station.Value);
+
+        var locations = EntityQueryEnumerator<TComponent, TransformComponent>();
+        while (locations.MoveNext(out var uid, out _, out var transform))
+        {
+            if (checkIfAnchored && !transform.Anchored)
+            {
+                continue;
+            }
+
+            if (transform.GridUid != grid)
+            {
+                continue;
+            }
+
+            entities.Add(uid);
+        }
+
+        return entities;
+    }
+
     protected bool TryFindRandomTile(out Vector2i tile,
         [NotNullWhen(true)] out EntityUid? targetStation,
         out EntityUid targetGrid,

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -66,20 +66,32 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
     /// <param name="checkIfAnchored">Whether to only get anchored entities.
     /// Good check for air vents, bad for containers.</param>
     /// <returns>All matching entities.</returns>
-    protected HashSet<EntityUid> GetEntitiesWithComponentOnStation<TComponent>(bool checkIfAnchored)
+    protected HashSet<Entity<TComponent>> GetEntitiesWithComponentOnStation<TComponent>(bool checkIfAnchored) where TComponent : IComponent
+    {
+        return GetEntitiesWithComponentOnStation<TComponent>(checkIfAnchored, out _);
+    }
+
+    /// <param name="station">Optional station to search. If null, a random eligible station is used.</param>
+    /// <inheritdoc cref="GetEntitiesWithComponentOnStation{TComponent}(bool)" />
+    protected HashSet<Entity<TComponent>> GetEntitiesWithComponentOnStation<TComponent>(bool checkIfAnchored,
+        out EntityUid? station)
         where TComponent : IComponent
     {
-        HashSet<EntityUid> entities = [];
+        HashSet<Entity<TComponent>> entities = [];
 
-        if (!TryGetRandomStation(out var station))
+        if (!TryGetRandomStation(out station))
         {
             return entities;
         }
 
         var grid = StationSystem.GetLargestGrid(station.Value);
+        if (grid is null)
+        {
+            return entities;
+        }
 
         var locations = EntityQueryEnumerator<TComponent, TransformComponent>();
-        while (locations.MoveNext(out var uid, out _, out var transform))
+        while (locations.MoveNext(out var uid, out var component, out var transform))
         {
             if (checkIfAnchored && !transform.Anchored)
             {
@@ -91,7 +103,7 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
                 continue;
             }
 
-            entities.Add(uid);
+            entities.Add((uid, component));
         }
 
         return entities;
@@ -124,89 +136,45 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
         int numAttempts = 10)
     {
         tile = default;
-        targetCoords = EntityCoordinates.Invalid;
         targetGrid = EntityUid.Invalid;
+        targetCoords = EntityCoordinates.Invalid;
 
-        // Weight grid choice by tilecount
-        var totalTiles = 0;
-        var grids = new List<(Entity<MapGridComponent> Entity, int Count, List<TileRef> Tiles)>();
-        foreach (var possibleTarget in station.Comp.Grids)
+        var targetGridMaybe = StationSystem.GetLargestGrid(station.Owner);
+        if (targetGridMaybe is null)
         {
-            if (!TryComp<MapGridComponent>(possibleTarget, out var comp))
-                continue;
-
-            // Get the tile count for the given grid.
-            var tileCount = _map.GetFilledTileCount((possibleTarget, comp));
-
-            // Just to be sure, no empty elements.
-            if (tileCount > 0)
-            {
-                grids.Add(((possibleTarget, comp), tileCount, new()));
-                totalTiles += tileCount;
-            }
-        }
-
-        if (grids.Count == 0)
-        {
-            targetGrid = EntityUid.Invalid;
             return false;
         }
 
+        if (!TryComp<MapGridComponent>(targetGridMaybe.Value, out var comp))
+        {
+            return false;
+        }
+
+        targetGrid = targetGridMaybe.Value;
+        var grid = new Entity<MapGridComponent>(targetGrid, comp);
+
+        var gridTiles = _map.GetAllTiles(targetGrid, grid.Comp).ToList();
+        var totalTiles = gridTiles.Count;
+
         for (var i = 0; i < numAttempts; i++)
         {
-            // Find random tile within list.
             var nextTileIndex = RobustRandom.Next(totalTiles);
-            TileRef? randomTileRef = null;
-            MapGridComponent gridComp = default!;
-            var startIndex = 0;
-            for (int j = 0; j < grids.Count; j++)
+            var tileRef = gridTiles[nextTileIndex];
+            gridTiles.RemoveSwap(nextTileIndex);
+            totalTiles--;
+
+            if (totalTiles <= 0)
             {
-                var grid = grids[j];
-                // If the index is in this particular grid, find it and remove the tile to prevent selecting it twice.
-                if (nextTileIndex >= startIndex + grid.Count)
-                {
-                    startIndex += grid.Count;
-                    continue;
-                }
-
-                (targetGrid, gridComp) = grid.Entity;
-
-                // Empty list: hasn't been queried yet - get our tiles.
-                if (grid.Tiles.Count <= 0)
-                {
-                    grid.Tiles = _map.GetAllTiles(targetGrid, gridComp).ToList();
-
-                    // Actual list count doesn't match expected count (a bug - return failure).
-                    Debug.Assert(grid.Tiles.Count == grid.Count);
-                    if (grid.Tiles.Count != grid.Count)
-                        return false;
-                }
-
-                var ourTileIndex = nextTileIndex - startIndex;
-                randomTileRef = grid.Tiles[ourTileIndex];
-                grid.Tiles.RemoveSwap(ourTileIndex);
-                grid.Count--;
-                totalTiles--;
-
-                // Empty list, remove element
-                if (grid.Tiles.Count <= 0)
-                    grids.RemoveSwap(j);
-
                 break;
             }
 
-            // Out of valid tiles, return early.
-            if (randomTileRef is not { } tileRef)
-                return false;
-
-            // Invalid tile, try again.
             if (_atmosphere.IsTileSpace(targetGrid, Transform(targetGrid).MapUid, tileRef.GridIndices)
                 || _atmosphere.IsTileAirBlockedCached(targetGrid, tileRef.GridIndices))
             {
                 continue;
             }
 
-            targetCoords = _map.GridTileToLocal(targetGrid, gridComp, tileRef.GridIndices);
+            targetCoords = _map.GridTileToLocal(targetGrid, grid.Comp, tileRef.GridIndices);
             tile = tileRef.GridIndices;
             return true;
         }

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.Utility.cs
@@ -63,17 +63,17 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
     /// <summary>
     /// Get all entities with <see cref="TComponent"/> that are on the station. Ignore entities outside the station.
     /// </summary>
-    /// <param name="checkIfAnchored">Whether to only get anchored entities.
-    /// Good check for air vents, bad for containers.</param>
+    /// <param name="onlyAnchored">Whether to only get anchored entities.
+    /// Good check for air vents, bad for containers like crates.</param>
     /// <returns>All matching entities.</returns>
-    protected HashSet<Entity<TComponent>> GetEntitiesWithComponentOnStation<TComponent>(bool checkIfAnchored) where TComponent : IComponent
+    protected HashSet<Entity<TComponent>> GetEntitiesWithComponentOnStation<TComponent>(bool onlyAnchored) where TComponent : IComponent
     {
-        return GetEntitiesWithComponentOnStation<TComponent>(checkIfAnchored, out _);
+        return GetEntitiesWithComponentOnStation<TComponent>(onlyAnchored, out _);
     }
 
     /// <param name="station">Optional station to search. If null, a random eligible station is used.</param>
     /// <inheritdoc cref="GetEntitiesWithComponentOnStation{TComponent}(bool)" />
-    protected HashSet<Entity<TComponent>> GetEntitiesWithComponentOnStation<TComponent>(bool checkIfAnchored,
+    protected HashSet<Entity<TComponent>> GetEntitiesWithComponentOnStation<TComponent>(bool onlyAnchored,
         out EntityUid? station)
         where TComponent : IComponent
     {
@@ -93,7 +93,7 @@ public abstract partial class GameRuleSystem<T> where T: IComponent
         var locations = EntityQueryEnumerator<TComponent, TransformComponent>();
         while (locations.MoveNext(out var uid, out var component, out var transform))
         {
-            if (checkIfAnchored && !transform.Anchored)
+            if (onlyAnchored && !transform.Anchored)
             {
                 continue;
             }

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Atmos.EntitySystems;
+using Content.Server.Station.Systems;
 using Content.Shared.GameTicking.Components;
 using Robust.Server.GameObjects;
 using Robust.Shared.Random;
@@ -11,6 +12,7 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
     [Dependency] protected IGameTiming Timing = default!;
     [Dependency] protected IRobustRandom RobustRandom = default!;
     [Dependency] protected GameTicker GameTicker = default!;
+    [Dependency] protected StationSystem StationSystem = default!;
 
     // Not protected, just to be used in utility methods
     [Dependency] private AtmosphereSystem _atmosphere = default!;

--- a/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
@@ -33,22 +33,10 @@ public sealed partial class GasLeakRuleComponent : Component
     public float LeakCooldown = 1.0f;
 
     /// <summary>
-    /// The station where the leak is located.
-    /// </summary>
-    [DataField]
-    public EntityUid TargetStation;
-
-    /// <summary>
     /// The specific grid where the leak is located.
     /// </summary>
     [DataField]
     public EntityUid TargetGrid;
-
-    /// <summary>
-    /// The tile coordinates where the leak is located.
-    /// </summary>
-    [DataField]
-    public Vector2i TargetTile;
 
     /// <summary>
     /// The world coordinates of the leak location.

--- a/Content.Server/StationEvents/Components/SolarFlareRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/SolarFlareRuleComponent.cs
@@ -1,4 +1,6 @@
 using Content.Server.StationEvents.Events;
+using Content.Shared.Doors.Components;
+using Content.Shared.Light.Components;
 using Content.Shared.Radio;
 using Robust.Shared.Prototypes;
 
@@ -39,6 +41,19 @@ public sealed partial class SolarFlareRuleComponent : Component
     /// </remarks>
     [DataField("extraCount")]
     public uint ExtraCount;
+
+    /// <summary>
+    ///    The collection of lights that will be affected by the solar flare event.
+    /// </summary>
+    [DataField]
+    public HashSet<(EntityUid, PoweredLightComponent)> AffectedLights = [];
+
+    /// <summary>
+    ///     The collection of airlocks that will be affected by the solar flare event.
+    /// </summary>
+    [DataField]
+    public HashSet<(EntityUid, AirlockComponent)> AffectedAirlocks = [];
+
 
     /// <summary>
     ///     Chance light bulb breaks per second during event

--- a/Content.Server/StationEvents/Events/BreakerFlipRule.cs
+++ b/Content.Server/StationEvents/Events/BreakerFlipRule.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.StationEvents.Components;
@@ -30,18 +31,7 @@ public sealed partial class BreakerFlipRule : StationEventSystem<BreakerFlipRule
     {
         base.Started(uid, component, gameRule, args);
 
-        if (!TryGetRandomStation(out var chosenStation, uid => _whitelist.IsWhitelistFailOrNull(component.Blacklist, uid)))
-            return;
-
-        var stationApcs = new List<Entity<ApcComponent>>();
-        var query = EntityQueryEnumerator<ApcComponent, TransformComponent>();
-        while (query.MoveNext(out var apcUid, out var apc, out var xform))
-        {
-            if (apc.MainBreakerEnabled && CompOrNull<StationMemberComponent>(xform.GridUid)?.Station == chosenStation)
-            {
-                stationApcs.Add((apcUid, apc));
-            }
-        }
+        var stationApcs = GetEntitiesWithComponentOnStation<ApcComponent>(true).ToList();
 
         var toDisable = Math.Min(RobustRandom.Next(3, 7), stationApcs.Count);
         if (toDisable == 0)

--- a/Content.Server/StationEvents/Events/GasLeakRule.cs
+++ b/Content.Server/StationEvents/Events/GasLeakRule.cs
@@ -1,5 +1,5 @@
 using Content.Server.Atmos.EntitySystems;
-using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Atmos.Piping.Unary.Components;
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Robust.Shared.Audio;
@@ -20,20 +20,27 @@ namespace Content.Server.StationEvents.Events
             if (!TryComp<StationEventComponent>(uid, out var stationEvent))
                 return;
 
-            // Essentially we'll pick out a target amount of gas to leak, then a rate to leak it at, then work out the duration from there.
-            if (TryFindRandomTile(out component.TargetTile, out var target, out component.TargetGrid, out component.TargetCoords))
+            var stationVents = GetEntitiesWithComponentOnStation<GasVentScrubberComponent>(true);
+            if (stationVents.Count == 0)
             {
-                component.TargetStation = target.Value;
-                component.FoundTile = true;
-
-                component.LeakGas = RobustRandom.Pick(component.LeakableGases);
-                // Was 50-50 on using normal distribution.
-                var totalGas = RobustRandom.Next(component.MinimumGas, component.MaximumGas);
-                component.MolesPerSecond = RobustRandom.Next(component.MinimumMolesPerSecond, component.MaximumMolesPerSecond);
-
-                if (gameRule.Delay is {} startAfter)
-                    stationEvent.EndTime = _timing.CurTime + TimeSpan.FromSeconds(totalGas / component.MolesPerSecond + startAfter.Next(RobustRandom));
+                ForceEndSelf(uid, gameRule);
+                return;
             }
+
+            var targetVent = RobustRandom.Pick(stationVents);
+
+            component.FoundTile = true;
+            component.TargetCoords = Transform(targetVent).Coordinates;
+            component.TargetGrid = Transform(targetVent).GridUid!.Value;
+
+            // Essentially we'll pick out a target amount of gas to leak, then a rate to leak it at, then work out the duration from there.
+            component.LeakGas = RobustRandom.Pick(component.LeakableGases);
+            // Was 50-50 on using normal distribution.
+            var totalGas = RobustRandom.Next(component.MinimumGas, component.MaximumGas);
+            component.MolesPerSecond = RobustRandom.Next(component.MinimumMolesPerSecond, component.MaximumMolesPerSecond);
+
+            if (gameRule.Delay is {} startAfter)
+                stationEvent.EndTime = _timing.CurTime + TimeSpan.FromSeconds(totalGas / component.MolesPerSecond + startAfter.Next(RobustRandom));
 
             // Look technically if you wanted to guarantee a leak you'd do this in announcement but having the announcement
             // there just to fuck with people even if there is no valid tile is funny.
@@ -57,7 +64,7 @@ namespace Content.Server.StationEvents.Events
                 return;
             }
 
-            var environment = _atmosphere.GetTileMixture(component.TargetGrid, null, component.TargetTile, true);
+            var environment = _atmosphere.GetTileMixture(component.TargetGrid, null, (Vector2i)component.TargetCoords.Position, true);
 
             environment?.AdjustMoles(component.LeakGas, component.LeakCooldown * component.MolesPerSecond);
         }
@@ -82,7 +89,7 @@ namespace Content.Server.StationEvents.Events
 
                 // Don't want it to be so obnoxious as to instantly murder anyone in the area but enough that
                 // it COULD start potentially start a bigger fire.
-                _atmosphere.HotspotExpose(component.TargetGrid, component.TargetTile, 700f, 50f, null, true);
+                _atmosphere.HotspotExpose(component.TargetGrid, (Vector2i)component.TargetCoords.Position, 700f, 50f, null, true);
                 Audio.PlayPvs(new SoundPathSpecifier("/Audio/Effects/sparks4.ogg"), component.TargetCoords);
             }
         }

--- a/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
+++ b/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
@@ -32,29 +32,25 @@ namespace Content.Server.StationEvents.Events
         {
             base.Started(uid, component, gameRule, args);
 
-            if (!TryGetRandomStation(out var chosenStation))
+            var apcs = GetEntitiesWithComponentOnStation<ApcComponent>(true, out var chosenStation);
+
+            if (chosenStation is null)
+            {
                 return;
+            }
 
             component.AffectedStation = chosenStation.Value;
 
-            var largestGrid = _stationSystem.GetLargestGrid(chosenStation.Value);
-
-            if (largestGrid == null)
-                return;
-
-            var query = AllEntityQuery<ApcComponent, TransformComponent>();
-            while (query.MoveNext(out var apcUid, out var apc, out var transform))
+            foreach (var apc in apcs)
             {
-                if (!apc.MainBreakerEnabled)
+                if (apc.Comp.MainBreakerEnabled)
                     continue;
 
-                if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station != chosenStation)
+                var apcTransform = Transform(apc);
+                if (apcTransform.GridUid != component.AffectedStation)
                     continue;
 
-                if (transform.GridUid != largestGrid.Value)
-                    continue;
-
-                component.Powered.Add(apcUid);
+                component.Powered.Add(apc);
             }
 
             RobustRandom.Shuffle(component.Powered);

--- a/Content.Server/StationEvents/Events/RandomEntityStorageSpawnRule.cs
+++ b/Content.Server/StationEvents/Events/RandomEntityStorageSpawnRule.cs
@@ -15,22 +15,17 @@ public sealed partial class RandomEntityStorageSpawnRule : StationEventSystem<Ra
     {
         base.Started(uid, comp, gameRule, args);
 
-        if (!TryGetRandomStation(out var station))
-            return;
-
-        var validLockers = new List<(EntityUid, EntityStorageComponent)>();
+        var validLockers = new List<Entity<EntityStorageComponent>>();
         var spawn = Spawn(comp.Prototype, MapCoordinates.Nullspace);
 
-        var query = EntityQueryEnumerator<EntityStorageComponent, TransformComponent>();
-        while (query.MoveNext(out var ent, out var storage, out var xform))
+        foreach (var ent in GetEntitiesWithComponentOnStation<EntityStorageComponent>(false))
         {
-            if (StationSystem.GetOwningStation(ent, xform) != station)
+            if (!_entityStorage.CanInsert(spawn, ent, ent.Comp))
+            {
                 continue;
+            }
 
-            if (!_entityStorage.CanInsert(spawn, ent, storage))
-                continue;
-
-            validLockers.Add((ent, storage));
+            validLockers.Add(ent);
         }
 
         if (validLockers.Count == 0)
@@ -39,8 +34,8 @@ public sealed partial class RandomEntityStorageSpawnRule : StationEventSystem<Ra
             return;
         }
 
-        var (locker, storageComp) = RobustRandom.Pick(validLockers);
-        if (!_entityStorage.Insert(spawn, locker, storageComp))
+        var locker = RobustRandom.Pick(validLockers);
+        if (!_entityStorage.Insert(spawn, locker, locker.Comp))
         {
             Del(spawn);
         }

--- a/Content.Server/StationEvents/Events/SolarFlareRule.cs
+++ b/Content.Server/StationEvents/Events/SolarFlareRule.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Light.EntitySystems;
 using Content.Server.StationEvents.Components;
 using Content.Shared.Doors.Components;
@@ -32,6 +33,9 @@ public sealed partial class SolarFlareRule : StationEventSystem<SolarFlareRuleCo
             var channel = RobustRandom.Pick(comp.ExtraChannels);
             comp.AffectedChannels.Add(channel);
         }
+
+        comp.AffectedLights = GetEntitiesWithComponentOnStation<PoweredLightComponent>(true).Select(e => (e.Owner, e.Comp)).ToHashSet();
+        comp.AffectedAirlocks = GetEntitiesWithComponentOnStation<AirlockComponent>(true).Select(e => (e.Owner, e.Comp)).ToHashSet();
     }
 
     protected override void ActiveTick(EntityUid uid, SolarFlareRuleComponent component, GameRuleComponent gameRule, float frameTime)
@@ -42,17 +46,16 @@ public sealed partial class SolarFlareRule : StationEventSystem<SolarFlareRuleCo
         if (_effectTimer < 0)
         {
             _effectTimer += 1;
-            var lightQuery = EntityQueryEnumerator<PoweredLightComponent>();
-            while (lightQuery.MoveNext(out var lightEnt, out var light))
+            foreach (var light in component.AffectedLights)
             {
                 if (RobustRandom.Prob(component.LightBreakChancePerSecond))
-                    _poweredLight.TryDestroyBulb(lightEnt, light);
+                    _poweredLight.TryDestroyBulb(light.Item1, light.Item2);
             }
-            var airlockQuery = EntityQueryEnumerator<AirlockComponent, DoorComponent>();
-            while (airlockQuery.MoveNext(out var airlockEnt, out var airlock, out var door))
+
+            foreach (var airlockEnt in component.AffectedAirlocks)
             {
-                if (airlock.AutoClose && RobustRandom.Prob(component.DoorToggleChancePerSecond))
-                    _door.TryToggleDoor(airlockEnt, door);
+                if (airlockEnt.Item2.AutoClose && RobustRandom.Prob(component.DoorToggleChancePerSecond))
+                    _door.TryToggleDoor(airlockEnt.Item1, Comp<DoorComponent>(airlockEnt.Item1));
             }
         }
     }

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -19,7 +19,6 @@ public abstract partial class StationEventSystem<T> : GameRuleSystem<T> where T 
     [Dependency] protected IAdminLogManager AdminLogManager = default!;
     [Dependency] protected ChatSystem ChatSystem = default!;
     [Dependency] protected SharedAudioSystem Audio = default!;
-    [Dependency] protected StationSystem StationSystem = default!;
 
     protected ISawmill Sawmill = default!;
 

--- a/Content.Server/StationEvents/Events/VentClogRule.cs
+++ b/Content.Server/StationEvents/Events/VentClogRule.cs
@@ -22,21 +22,14 @@ public sealed partial class VentClogRule : StationEventSystem<VentClogRuleCompon
     {
         base.Started(uid, component, gameRule, args);
 
-        if (!TryGetRandomStation(out var chosenStation))
-            return;
-
         // TODO: "safe random" for chems. Right now this includes admin chemicals.
         var allReagents = ProtoMan.EnumeratePrototypes<ReagentPrototype>()
             .Where(x => !x.Abstract)
             .Select(x => new ProtoId<ReagentPrototype>(x.ID)).ToList();
 
-        foreach (var (_, transform) in EntityQuery<GasVentPumpComponent, TransformComponent>())
+        foreach (var ventPump in GetEntitiesWithComponentOnStation<GasVentPumpComponent>(true))
         {
-            if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station != chosenStation)
-            {
-                continue;
-            }
-
+            var tragetCoords = Transform(ventPump).Coordinates;
             var solution = new Solution();
 
             if (!RobustRandom.Prob(0.33f))
@@ -49,10 +42,10 @@ public sealed partial class VentClogRule : StationEventSystem<VentClogRuleCompon
             var quantity = weak ? component.WeakReagentQuantity : component.ReagentQuantity;
             solution.AddReagent(reagent, quantity);
 
-            var foamEnt = Spawn(ChemicalReactionSystem.FoamReaction, transform.Coordinates);
+            var foamEnt = Spawn(ChemicalReactionSystem.FoamReaction, tragetCoords);
             var spreadAmount = weak ? component.WeakSpread : component.Spread;
             _smoke.StartSmoke(foamEnt, solution, component.Time, spreadAmount);
-            Audio.PlayPvs(component.Sound, transform.Coordinates);
+            Audio.PlayPvs(component.Sound, tragetCoords);
         }
     }
 }

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -22,6 +22,11 @@ public sealed partial class VentCrittersRule : StationEventSystem<VentCrittersRu
         {
             return;
         }
+        if (!TryComp<StationDataComponent>(station, out var stationData))
+        {
+            return;
+        }
+        var grid = StationSystem.GetLargestGrid((station.Value, stationData));
 
         var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
         var validLocations = new List<EntityCoordinates>();
@@ -30,7 +35,7 @@ public sealed partial class VentCrittersRule : StationEventSystem<VentCrittersRu
             if (!transform.Anchored)
                 continue;
 
-            if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station)
+            if (transform.GridUid == grid)
             {
                 validLocations.Add(transform.Coordinates);
                 foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -22,11 +22,7 @@ public sealed partial class VentCrittersRule : StationEventSystem<VentCrittersRu
         {
             return;
         }
-        if (!TryComp<StationDataComponent>(station, out var stationData))
-        {
-            return;
-        }
-        var grid = StationSystem.GetLargestGrid((station.Value, stationData));
+        var grid = StationSystem.GetLargestGrid(station.Value);
 
         var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
         var validLocations = new List<EntityCoordinates>();
@@ -35,13 +31,13 @@ public sealed partial class VentCrittersRule : StationEventSystem<VentCrittersRu
             if (!transform.Anchored)
                 continue;
 
-            if (transform.GridUid == grid)
+            if (transform.GridUid != grid)
+                continue;
+
+            validLocations.Add(transform.Coordinates);
+            foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
             {
-                validLocations.Add(transform.Coordinates);
-                foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
-                {
-                    Spawn(spawn, transform.Coordinates);
-                }
+                Spawn(spawn, transform.Coordinates);
             }
         }
 

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -1,8 +1,7 @@
+using System.Linq;
 using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
-using Content.Shared.Station.Components;
 using Content.Shared.Storage;
-using Robust.Shared.Map;
 using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
@@ -10,36 +9,18 @@ namespace Content.Server.StationEvents.Events;
 public sealed partial class VentCrittersRule : StationEventSystem<VentCrittersRuleComponent>
 {
     /*
-     * DO NOT COPY PASTE THIS TO MAKE YOUR MOB EVENT.
+     * DO NOT COPY AND PASTE THIS TO MAKE YOUR MOB EVENT.
      * USE THE PROTOTYPE.
      */
 
-    protected override void Started(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    protected override void Started(EntityUid uid,
+        VentCrittersRuleComponent component,
+        GameRuleComponent gameRule,
+        GameRuleStartedEvent args)
     {
         base.Started(uid, component, gameRule, args);
 
-        if (!TryGetRandomStation(out var station))
-        {
-            return;
-        }
-        var grid = StationSystem.GetLargestGrid(station.Value);
-
-        var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
-        var validLocations = new List<EntityCoordinates>();
-        while (locations.MoveNext(out _, out _, out var transform))
-        {
-            if (!transform.Anchored)
-                continue;
-
-            if (transform.GridUid != grid)
-                continue;
-
-            validLocations.Add(transform.Coordinates);
-            foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
-            {
-                Spawn(spawn, transform.Coordinates);
-            }
-        }
+        var validLocations = GetEntitiesWithComponentOnStation<VentCritterSpawnLocationComponent>(true);
 
         if (component.SpecialEntries.Count == 0 || validLocations.Count == 0)
         {
@@ -48,14 +29,17 @@ public sealed partial class VentCrittersRule : StationEventSystem<VentCrittersRu
 
         // guaranteed spawn
         var specialEntry = RobustRandom.Pick(component.SpecialEntries);
-        var specialSpawn = RobustRandom.Pick(validLocations);
+        var specialSpawn = Transform(RobustRandom.Pick(validLocations)).Coordinates;
         Spawn(specialEntry.PrototypeId, specialSpawn);
 
         foreach (var location in validLocations)
         {
-            foreach (var spawn in EntitySpawnCollection.GetSpawns(component.SpecialEntries, RobustRandom))
+            var spawns = EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom)
+                .Concat(EntitySpawnCollection.GetSpawns(component.SpecialEntries, RobustRandom));
+
+            foreach (var spawn in spawns)
             {
-                Spawn(spawn, location);
+                Spawn(spawn, Transform(location).Coordinates);
             }
         }
     }

--- a/Content.Server/StationEvents/Events/VentHordeRule.cs
+++ b/Content.Server/StationEvents/Events/VentHordeRule.cs
@@ -88,30 +88,8 @@ public sealed partial class VentHordeRule : StationEventSystem<VentHordeRuleComp
 
     private EntityUid? ChooseVent()
     {
-        // Get a station
-        if (!TryGetRandomStation(out var station))
-        {
-            return null;
-        }
-
-        // Query the possible locations
-        var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
-        var validLocations = new List<EntityUid>();
-
-        // Filter to things on the same station
-        while (locations.MoveNext(out var uid, out _, out var transform))
-        {
-            if (!transform.Anchored)
-                continue;
-
-            if (HasComp<VentHordeSpawnerComponent>(uid))
-                continue;
-
-            if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station)
-            {
-                validLocations.Add(uid);
-            }
-        }
+        var validLocations = GetEntitiesWithComponentOnStation<VentCritterSpawnLocationComponent>(true);
+        validLocations.RemoveWhere(uid => HasComp<VentHordeSpawnerComponent>(uid));
 
         // Pick one at random
         if (validLocations.Count != 0)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
~Fix vent critters rule picking vents off station, like on the ATS.~
Fix many station events targeting entities off-station, like skeletons, spiders, rat kings, bluespace artifacts, and more spawning at ATS, gas leaks leaking at ATS, and vents clogging at ATS.

gas leak event now targets scrubbers instead of a random position on the station.

## Why
fix https://github.com/space-wizards/space-station-14/issues/45809
fix https://github.com/space-wizards/space-station-14/issues/26707
fix https://github.com/space-wizards/space-station-14/issues/17082
fix https://github.com/space-wizards/space-station-14/issues/31715
fix https://github.com/space-wizards/space-station-14/issues/14481
fix https://github.com/space-wizards/space-station-14/issues/32202


## Technical details
<!-- Summary of code changes for easier review. -->
Vent critters rule has a check to only pick station vents, but it was comparing the vent grid StationMemberComponent's `Station` variable to the station. The problem is that this `Station` variable is always the main station, even for other grids like the ATS. Maybe someone thought the `Station` variable is the containing grid. Anyway, now it compares the vent's grid to the station's grid so it skips vents that are off station.
  - I also extracted this logic into a new method called `GetEntitiesWithComponentOnStation` and made other station events use it, because a few of them were re-implementing this same logic and allowed the event to target non-station grids like ATS and random debris. Now any future tweaks to stuff like identifying the station grid will only have to target this one method.
- I also changed `TryFindRandomTileOnStation` because it was doing the same thing and targeted other grids. This prevents BluespaceArtifactRule and GasLeakRule from happening on grids outside the station. 

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. run command `i 1 to 30 do "addgamerule GasLeak VentClog SpiderSpawnHorde KingRatMigration BluespaceArtifact"`
2. Everything happens on the station now, never on ATS.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
<!--
:cl:
- add: Crowbars now randomly spawn in maintenance lockers.
- remove: Crowbars no longer spawn in maintenance crates.
- tweak: Crowbar spawn rates have been increased for tool lockers.
- fix: Crowbars no longer accidentally spawn in microwaves.
-->
:cl:
- fix: Rat kings, vent critters, Bluespace artifacts, gas leaks, closet skeletons, and other station events no longer happen on the automated trade station or other locations outside the station.