### PR TITLE
Un-hardcode full replacement punctuation

### DIFF
--- a/Content.Shared/Speech/EntitySystems/ReplacementAccentSystem.cs
+++ b/Content.Shared/Speech/EntitySystems/ReplacementAccentSystem.cs
@@ -90,7 +90,6 @@ public sealed partial class ReplacementAccentSystem : RelayAccentSystem<Replacem
                 return replacement + prototype.DefaultPunctuation;
 
             return replacement + punctuation;
-
         }
 
         // Prohibition of repeated word replacements.

--- a/Content.Shared/Speech/EntitySystems/ReplacementAccentSystem.cs
+++ b/Content.Shared/Speech/EntitySystems/ReplacementAccentSystem.cs
@@ -19,6 +19,11 @@ public sealed partial class ReplacementAccentSystem : RelayAccentSystem<Replacem
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IRobustRandom _random = default!;
 
+    /// <summary>
+    /// Matches between 1 and 3 .?! punctuation marks at the end of a string
+    /// </summary>
+    private static readonly Regex PunctuationRegex = new(@"[!\?\.]{1,3}$", RegexOptions.Compiled);
+
     private readonly Dictionary<ProtoId<ReplacementAccentPrototype>, (Regex regex, string replacement)[]>
         _cachedReplacements = new();
 
@@ -74,7 +79,18 @@ public sealed partial class ReplacementAccentSystem : RelayAccentSystem<Replacem
         // ideally both aren't used at the same time (but we don't have a way to enforce that in serialization yet)
         if (prototype.FullReplacements != null)
         {
-            return prototype.FullReplacements.Length != 0 ? Loc.GetString(random.Pick(prototype.FullReplacements)) : "";
+            if (prototype.FullReplacements.Length == 0)
+                return "";
+
+            var replacement = Loc.GetString(random.Pick(prototype.FullReplacements));
+            var punctuation = PunctuationRegex.Match(message).ToString();
+
+            // no special punctuation
+            if (punctuation == null || punctuation == ".")
+                return replacement + prototype.DefaultPunctuation;
+
+            return replacement + punctuation;
+
         }
 
         // Prohibition of repeated word replacements.

--- a/Content.Shared/Speech/EntitySystems/ReplacementAccentSystem.cs
+++ b/Content.Shared/Speech/EntitySystems/ReplacementAccentSystem.cs
@@ -86,7 +86,7 @@ public sealed partial class ReplacementAccentSystem : RelayAccentSystem<Replacem
             var punctuation = PunctuationRegex.Match(message).ToString();
 
             // no special punctuation
-            if (punctuation == null || punctuation == ".")
+            if (string.IsNullOrEmpty(punctuation) || punctuation == ".")
                 return replacement + prototype.DefaultPunctuation;
 
             return replacement + punctuation;

--- a/Content.Shared/Speech/Prototypes/ReplacementAccentPrototype.cs
+++ b/Content.Shared/Speech/Prototypes/ReplacementAccentPrototype.cs
@@ -17,6 +17,12 @@ public sealed partial class ReplacementAccentPrototype : IPrototype
     public string[]? FullReplacements;
 
     /// <summary>
+    /// Default to use with FullReplacements if the text doesn't end with special punctuation
+    /// </summary>
+    [DataField]
+    public string DefaultPunctuation = ".";
+
+    /// <summary>
     /// If this dictionary is non-null and <see cref="FullReplacements"/> is null, any keys surrounded by spaces
     /// (words) will be replaced by the value, attempting to intelligently keep capitalization.
     /// </summary>

--- a/Resources/Locale/en-US/accent/accents.ftl
+++ b/Resources/Locale/en-US/accent/accents.ftl
@@ -1,155 +1,134 @@
 # Cat accent
-accent-words-cat-1 = Meow!
-accent-words-cat-2 = Mow.
-accent-words-cat-3 = Mrrrow!
-accent-words-cat-4 = Hhsss!
-accent-words-cat-5 = Brrow.
-accent-words-cat-6 = Meow?
-accent-words-cat-7 = Miau.
+accent-words-cat-1 = Meow
+accent-words-cat-2 = Mow
+accent-words-cat-3 = Mrrrow
+accent-words-cat-4 = Hhsss
+accent-words-cat-5 = Brrow
+accent-words-cat-6 = Miau
 
 # Dog accent
-accent-words-dog-1 = Bark!
-accent-words-dog-2 = Bork!
-accent-words-dog-3 = Woof!
-accent-words-dog-4 = Arf.
-accent-words-dog-5 = Grrr.
+accent-words-dog-1 = Bark
+accent-words-dog-2 = Bork
+accent-words-dog-3 = Woof
+accent-words-dog-4 = Arf
+accent-words-dog-5 = Grrr
 
 # Mouse
-accent-words-mouse-1 = Squeak!
-accent-words-mouse-2 = Piep!
-accent-words-mouse-3 = Chuu!
-accent-words-mouse-4 = Eeee!
-accent-words-mouse-5 = Pip!
-accent-words-mouse-6 = Fwiep!
-accent-words-mouse-7 = Heep!
+accent-words-mouse-1 = Squeak
+accent-words-mouse-2 = Piep
+accent-words-mouse-3 = Chuu
+accent-words-mouse-4 = Eeee
+accent-words-mouse-5 = Pip
+accent-words-mouse-6 = Fwiep
+accent-words-mouse-7 = Heep
 
 # Mumble
-accent-words-mumble-1 = Mmfph!
-accent-words-mumble-2 = Mmmf mrrfff!
-accent-words-mumble-3 = Mmmf mnnf!
+accent-words-mumble-1 = Mmfph
+accent-words-mumble-2 = Mmmf mrrfff
+accent-words-mumble-3 = Mmmf mnnf
 
 # Silicon
-accent-words-silicon-1 = Beep.
-accent-words-silicon-2 = Boop.
-accent-words-silicon-3 = Whirr.
-accent-words-silicon-4 = Beep-boop.
+accent-words-silicon-1 = Beep
+accent-words-silicon-2 = Boop
+accent-words-silicon-3 = Whirr
+accent-words-silicon-4 = Beep-boop
 
 # Xeno
-accent-words-xeno-1 = Hiss.
-accent-words-xeno-2 = Hisssss!
-accent-words-xeno-3 = Hisssuuu...
-accent-words-xeno-4 = Hiss...!
+accent-words-xeno-1 = Hiss
+accent-words-xeno-2 = Hisssss
+accent-words-xeno-3 = Hisssuuu
+accent-words-xeno-4 = Hiss
 
 # Zombie
-accent-words-zombie-1 = Gruaahhhh...
-accent-words-zombie-2 = Mmuaaaa..
-accent-words-zombie-3 = Braainnssss...
-accent-words-zombie-4 = Grrrrr...
-accent-words-zombie-5 = Ouuaahhhhh...
-accent-words-zombie-6 = Graaaaaooohhlll...
-accent-words-zombie-7 = Brainsss... Braaaiiinnsss..
-accent-words-zombie-8 = Braughhh...
-accent-words-zombie-9 = Breshhhh...
-accent-words-zombie-10 = Graaaaaa...
+accent-words-zombie-1 = Gruaahhhh
+accent-words-zombie-2 = Mmuaaaa
+accent-words-zombie-3 = Braainnssss
+accent-words-zombie-4 = Grrrrr
+accent-words-zombie-5 = Ouuaahhhhh
+accent-words-zombie-6 = Graaaaaooohhlll
+accent-words-zombie-7 = Brainsss... Braaaiiinnsss
+accent-words-zombie-8 = Braughhh
+accent-words-zombie-9 = Breshhhh
+accent-words-zombie-10 = Graaaaaa
 
 # Moth Zombie
-accent-words-zombie-moth-1 = Clothessss...
-accent-words-zombie-moth-2 = Shooooesss...
-accent-words-zombie-moth-3 = Liiiiight...
-accent-words-zombie-moth-4 = Laaamps...
-accent-words-zombie-moth-5 = Haaaatsss... Hatttssss...
-accent-words-zombie-moth-6 = Scarffsss...
+accent-words-zombie-moth-1 = Clothessss
+accent-words-zombie-moth-2 = Shooooesss
+accent-words-zombie-moth-3 = Liiiiight
+accent-words-zombie-moth-4 = Laaamps
+accent-words-zombie-moth-5 = Haaaatsss... Hatttssss
+accent-words-zombie-moth-6 = Scarffsss
 
 # Generic Aggressive
-accent-words-generic-aggressive-1 = Grr!
-accent-words-generic-aggressive-2 = Rrrr!
-accent-words-generic-aggressive-3 = Grr...
-accent-words-generic-aggressive-4 = Grrow!!
+accent-words-generic-aggressive-1 = Grr
+accent-words-generic-aggressive-2 = Rrrr
+accent-words-generic-aggressive-3 = Grrow
 
 # Duck
-accent-words-duck-1 = Quack!
-accent-words-duck-2 = Quack.
-accent-words-duck-3 = Quack?
-accent-words-duck-4 = Quack quack!
+accent-words-duck-1 = Quack
+accent-words-duck-2 = Quack quack
+accent-words-duck-3 = Quack quack quack
 
 # Chicken
-accent-words-chicken-1 = Cluck!
-accent-words-chicken-2 = Cluck.
-accent-words-chicken-3 = Cluck?
-accent-words-chicken-4 = Cluck cluck!
+accent-words-chicken-1 = Cluck
+accent-words-chicken-2 = Cluck cluck
+accent-words-chicken-3 = Cluck cluck cluck
 
 # Pig
-accent-words-pig-1 = Oink.
-accent-words-pig-2 = Oink?
-accent-words-pig-3 = Oink!
-accent-words-pig-4 = Oink oink!
+accent-words-pig-1 = Oink
+accent-words-pig-2 = Oink oink
+accent-words-pig-3 = Oink oink oink
 
 # Kangaroo
-accent-words-kangaroo-1 = Grr!
-accent-words-kangaroo-2 = Hisss!
-accent-words-kangaroo-3 = Shreak!
-accent-words-kangaroo-4 = Chuu!
+accent-words-kangaroo-1 = Grr
+accent-words-kangaroo-2 = Hisss
+accent-words-kangaroo-3 = Shreak
+accent-words-kangaroo-4 = Chuu
 
 # Slimes
-accent-words-slimes-1 = Blyump.
-accent-words-slimes-2 = Blimpuf?
-accent-words-slimes-3 = Blump!
-accent-words-slimes-4 = Bluuump...
-accent-words-slimes-5 = Blabl blump!
+accent-words-slimes-1 = Blyump
+accent-words-slimes-2 = Blimpuf
+accent-words-slimes-3 = Blump
+accent-words-slimes-4 = Bluuump
+accent-words-slimes-5 = Blabl blump
 
 # Mothroach
-accent-words-mothroach-1 = Chirp!
+accent-words-mothroach-1 = Chirp
 
 # Crab
-accent-words-crab-1 = Click.
-accent-words-crab-2 = Click-clack!
-accent-words-crab-3 = Clack?
-accent-words-crab-4 = Tipi-tap!
-accent-words-crab-5 = Clik-tap.
-accent-words-crab-6 = Cliliick.
+accent-words-crab-1 = Click
+accent-words-crab-2 = Click-clack
+accent-words-crab-3 = Clack
+accent-words-crab-4 = Tipi-tap
+accent-words-crab-5 = Clik-tap
+accent-words-crab-6 = Cliliick
 
 # Kobold
-accent-words-kobold-1 = Yip!
-accent-words-kobold-2 = Grrar.
-accent-words-kobold-3 = Yap!
-accent-words-kobold-4 = Bip.
-accent-words-kobold-5 = Screet?
-accent-words-kobold-6 = Gronk!
-accent-words-kobold-7 = Hiss!
-accent-words-kobold-8 = Eeee!
-accent-words-kobold-9 = Yip.
+accent-words-kobold-1 = Yip
+accent-words-kobold-2 = Grrar
+accent-words-kobold-3 = Yap
+accent-words-kobold-4 = Bip
+accent-words-kobold-5 = Screet
+accent-words-kobold-6 = Gronk
+accent-words-kobold-7 = Hiss
+accent-words-kobold-8 = Eeee
 
 # Nymph
-accent-words-nymph-1 = Chirp!
-accent-words-nymph-2 = Churr...
-accent-words-nymph-3 = Cheep?
-accent-words-nymph-4 = Chrrup!
+accent-words-nymph-1 = Chirp
+accent-words-nymph-2 = Churr
+accent-words-nymph-3 = Cheep
+accent-words-nymph-4 = Chrrup
 
 # TomatoKiller
-accent-words-tomato-1 = Totato!
+accent-words-tomato-1 = Totato
 accent-words-tomato-2 = Trotect
-accent-words-tomato-3 = Mastet?
-accent-words-tomato-4 = Reaty!
-accent-words-tomato-5 = Water...
+accent-words-tomato-3 = Mastet
+accent-words-tomato-4 = Reaty
+accent-words-tomato-5 = Water
 
 # Scurret
-accent-words-scurret-1 = Wa!
-accent-words-scurret-2 = Wa?
-accent-words-scurret-3 = Wa.
-accent-words-scurret-4 = Wa...
-accent-words-scurret-5 = Wawa!
-accent-words-scurret-6 = Wawa?
-accent-words-scurret-7 = Wawa.
-accent-words-scurret-8 = Wawa...
-accent-words-scurret-9 = Wa wawa!
-accent-words-scurret-10 = Wa wawa?
-accent-words-scurret-11 = Wa wawa.
-accent-words-scurret-12 = Wa wawa...
-accent-words-scurret-13 = Wawa wa!
-accent-words-scurret-14 = Wawa wa?
-accent-words-scurret-15 = Wawa wa.
-accent-words-scurret-16 = Wawa wa...
-accent-words-scurret-17 = Waaaaaa.
-accent-words-scurret-18 = Waaaaaa!
-accent-words-scurret-19 = Waaaaaa?
-accent-words-scurret-20 = Waaaaaa...
+accent-words-scurret-1 = Wa
+accent-words-scurret-2 = Wawa
+accent-words-scurret-3 = Wa wawa
+accent-words-scurret-4 = Wawa wa
+accent-words-scurret-5 = Waaaaaa

--- a/Resources/Prototypes/Accents/full_replacements.yml
+++ b/Resources/Prototypes/Accents/full_replacements.yml
@@ -9,7 +9,6 @@
   - accent-words-cat-4
   - accent-words-cat-5
   - accent-words-cat-6
-  - accent-words-cat-7
 
 - type: accent
   id: dog
@@ -19,6 +18,7 @@
   - accent-words-dog-3
   - accent-words-dog-4
   - accent-words-dog-5
+  defaultPunctuation: '!'
 
 - type: accent
   id: mouse
@@ -30,6 +30,7 @@
   - accent-words-mouse-5
   - accent-words-mouse-6
   - accent-words-mouse-7
+  defaultPunctuation: '!'
 
 - type: accent
   id: mothroach
@@ -39,6 +40,7 @@
   - accent-words-mouse-2
   - accent-words-mouse-3
   - accent-words-mouse-4
+  defaultPunctuation: '!'
 
 - type: accent
   id: mumble
@@ -46,6 +48,7 @@
   - accent-words-mumble-1
   - accent-words-mumble-2
   - accent-words-mumble-3
+  defaultPunctuation: '!'
 
 - type: accent
   id: silicon
@@ -76,6 +79,7 @@
   - accent-words-zombie-8
   - accent-words-zombie-9
   - accent-words-zombie-10
+  defaultPunctuation: '...'
 
 - type: accent
   id: zombieMoth
@@ -94,6 +98,7 @@
   - accent-words-zombie-8
   - accent-words-zombie-9
   - accent-words-zombie-10
+  defaultPunctuation: '...'
 
 - type: accent
   id: genericAggressive
@@ -101,7 +106,7 @@
   - accent-words-generic-aggressive-1
   - accent-words-generic-aggressive-2
   - accent-words-generic-aggressive-3
-  - accent-words-generic-aggressive-4
+  defaultPunctuation: '!'
 
 - type: accent
   id: duck
@@ -109,7 +114,6 @@
   - accent-words-duck-1
   - accent-words-duck-2
   - accent-words-duck-3
-  - accent-words-duck-4
 
 - type: accent
   id: chicken
@@ -117,7 +121,6 @@
   - accent-words-chicken-1
   - accent-words-chicken-2
   - accent-words-chicken-3
-  - accent-words-chicken-4
 
 - type: accent
   id: pig
@@ -125,7 +128,6 @@
   - accent-words-pig-1
   - accent-words-pig-2
   - accent-words-pig-3
-  - accent-words-pig-4
 
 - type: accent
   id: kangaroo
@@ -134,6 +136,7 @@
   - accent-words-kangaroo-2
   - accent-words-kangaroo-3
   - accent-words-kangaroo-4
+  defaultPunctuation: '!'
 
 - type: accent
   id: slimes
@@ -165,7 +168,6 @@
   - accent-words-kobold-6
   - accent-words-kobold-7
   - accent-words-kobold-8
-  - accent-words-kobold-9
 
 - type: accent
   id: nymph
@@ -192,18 +194,3 @@
   - accent-words-scurret-3
   - accent-words-scurret-4
   - accent-words-scurret-5
-  - accent-words-scurret-6
-  - accent-words-scurret-7
-  - accent-words-scurret-8
-  - accent-words-scurret-9
-  - accent-words-scurret-10
-  - accent-words-scurret-11
-  - accent-words-scurret-12
-  - accent-words-scurret-13
-  - accent-words-scurret-14
-  - accent-words-scurret-15
-  - accent-words-scurret-16
-  - accent-words-scurret-17
-  - accent-words-scurret-18
-  - accent-words-scurret-19
-  - accent-words-scurret-20


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Un-hardcodes the punctuation used with full-replacement accents, it now relays final punctuation used in the original message.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I like playing simple mobs, but i don't like how my messages end with random punctuation with no input from myself. It makes roleplaying more annoying than it should be.

## Technical details
<!-- Summary of code changes for easier review. -->
In ReplacementAccentSystem: Adds a regex for finding and isolating punctuation used at the end of a message (max of 3). Adds it at the end of a chosen replacement word.

In ReplacementAccentPrototype: Adds ability to define default punctuation to use if the player didn't use any

Modified list of replacement words to remove punctuation and now redundant phrases

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. Spawn and control a cat
2. Send messages ending in different punctuations
3. See that the replacement words relay your punctuation
4. Spawn and control a mouse
5. Send messages ending in different punctuations
6. See that in addition to relaying your punctuation, messages with no punctuation end with "!"

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/7b9b117b-0b9c-43a7-947a-701882874d45


https://github.com/user-attachments/assets/98305f37-ce0d-40e6-8ee9-68ddf8cff6d6



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
fullReplacement accents now append the last punctuation the player used when sending a message (or use a predefined default if no punctuation was used)

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->

:cl:
- tweak: Speaking as a species with a full message replacement accent (e.g. Cats, Slimes, Scurrets) will now mirror the ending punctuation of your message


