### PR TITLE
Invisible Support Fix + Description

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Decoration/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/mining.yml
@@ -92,6 +92,10 @@
   name: wooden support
   description: Increases your confidence that a rock won't fall on your head.
   components:
+  - type: Sprite
+    layers:
+    - sprite: Objects/Decoration/mines.rsi
+      state: support
   - type: Fixtures
     fixtures:
       fix1:
@@ -108,6 +112,7 @@
   parent: BaseWoodenSupport
   id: WoodenSupportBeam
   name: wooden support beam
+  description: A pair of wooden beams, supportive without blocking your way.
   components:
   - type: Sprite
     state: support_beams

--- a/Resources/Prototypes/Entities/Objects/Decoration/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/mining.yml
@@ -93,9 +93,7 @@
   description: Increases your confidence that a rock won't fall on your head.
   components:
   - type: Sprite
-    layers:
-    - sprite: Objects/Decoration/mines.rsi
-      state: support
+    state: support
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
## About the PR
Commit [d422b4d](https://github.com/space-wizards/space-station-14/commit/d422b4db6f5730f6907ea4caca1d8ddcdcfbced7) changed parenting and caused Wooden Supports to no longer have a proper sprite component.
This PR adds it back, and gives a description for the beams for parity with all other wooden supports.

## Why / Balance
Bug Fix, this was found due to multiple reports of invisible walls on Plasma Station.

## Technical details
All YAML baybeee.

## Test plan
Spawn in all Variants of Wooden Supports (Support/Beam/Wall/BrokenWall)
Ensure all of them are visible
Ensure all of them have a name and descriptions.

## Media
<img width="268" height="182" alt="image" src="https://github.com/user-attachments/assets/2985ff12-e3bc-4761-81e5-48e26c669062" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
:cl:
- fix: Wooden Supports are no longer invisible.
