### PR TITLE
Melee sawing fixes + axe and cult item reparenting

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
@@ -1,23 +1,17 @@
 - type: entity
-  name: ritual dagger
-  parent: BaseItem
+  parent: [BaseKnife, BaseHighlyIllegalContraband]
   id: RitualDagger
+  name: ritual dagger
   description: A strange dagger used by sinister groups for rituals and sacrifices.
   components:
-  - type: Tool
-    qualities:
-    - Slicing
   - type: Sprite
     sprite: Objects/Weapons/Melee/cult_dagger.rsi
     state: icon
   - type: MeleeWeapon
-    wideAnimationRotation: -135
     attackRate: 1.5
     damage:
       types:
         Slash: 12
-  - type: Item
-    size: Normal
   - type: Clothing
     sprite: Objects/Weapons/Melee/cult_dagger.rsi
     slots:
@@ -25,25 +19,19 @@
   - type: DisarmMalus
 
 - type: entity
-  name: eldritch blade
-  parent: BaseItem
+  parent: [BaseSword, BaseHighlyIllegalContraband]
   id: EldritchBlade
+  name: eldritch blade
   description: A sword humming with unholy energy.
   components:
-  - type: Tool
-    qualities:
-    - Slicing
   - type: Sprite
     sprite: Objects/Weapons/Melee/cult_blade.rsi
     state: icon
   - type: MeleeWeapon
-    wideAnimationRotation: -135
     attackRate: 0.75
     damage:
       types:
         Slash: 16
-  - type: Item
-    size: Normal
   - type: Clothing
     sprite: Objects/Weapons/Melee/cult_blade.rsi
     slots:
@@ -51,30 +39,20 @@
   - type: DisarmMalus
 
 - type: entity
-  name: unholy halberd
-  parent: BaseItem
+  parent: [BaseAxe, BaseHighlyIllegalContraband]
   id: UnholyHalberd
+  name: unholy halberd
   description: A poleaxe that seems to be linked to its wielder.
   components:
-  - type: Tool
-    qualities:
-    - Slicing
-    - Sawing
-  - type: Tag
-    tags:
-    - FireAxe
   - type: Sprite
     sprite: Objects/Weapons/Melee/cult_halberd.rsi
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: 0.75
     damage:
       types:
         Blunt: 10
         Slash: 10
-    soundHit:
-      collection: MetalThud
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
@@ -82,15 +60,9 @@
         Blunt: 5
         Slash: 5
   - type: Item
-    size: Ginormous
-    shape:
-    - 0,0,2,1
-    - 1,2,1,5
     storedRotation: -45
   - type: Clothing
     sprite: Objects/Weapons/Melee/cult_halberd.rsi
     quickEquip: false
     slots:
     - back
-  - type: UseDelay
-    delay: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -1,17 +1,15 @@
 - type: entity
-  name: fireaxe
-  parent: [BaseItem, BaseEngineeringContraband]
-  id: FireAxe
-  description: Truly, the weapon of a madman. Who would think to fight fire with an axe?
+  parent: BaseItem
+  id: BaseAxe
+  abstract: true
   components:
-  - type: Tag
-    tags:
-    - FireAxe
+  - type: Item
+    shape:
+    - 1,0,2,5
+    - 0,0,0,2
+    size: Ginormous
   - type: Execution
     doAfterDuration: 4.0
-  - type: Sprite
-    sprite: Objects/Weapons/Melee/fireaxe.rsi
-    state: icon
   - type: MeleeWeapon
     wideAnimationRotation: 135
     swingLeft: true
@@ -24,6 +22,27 @@
         Structural: 5
     soundHit:
       collection: MetalThud
+  - type: Tool
+    qualities:
+    - Prying
+    - Slicing
+    - Sawing
+  - type: Prying
+  - type: UseDelay
+    delay: 1
+
+- type: entity
+  name: fireaxe
+  parent: [BaseAxe, BaseEngineeringContraband]
+  id: FireAxe
+  description: Truly, the weapon of a madman. Who would think to fight fire with an axe?
+  components:
+  - type: Tag
+    tags:
+    - FireAxe
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/fireaxe.rsi
+    state: icon
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
@@ -31,28 +50,16 @@
         Slash: 10
         Structural: 15
   - type: Item
-    shape:
-    - 1,0,2,5
-    - 0,0,0,2
     storedSprite:
       state: storage
       sprite: Objects/Weapons/Melee/fireaxe.rsi
-    size: Ginormous
   - type: Clothing
     sprite: Objects/Weapons/Melee/fireaxe.rsi
     quickEquip: false
     slots:
     - back
     - suitStorage
-  - type: Tool
-    qualities:
-    - Prying
-    - Slicing
-    - Sawing
   - type: ToolTileCompatible
-  - type: Prying
-  - type: UseDelay
-    delay: 1
   - type: StealTarget
     stealGroup: FireAxe
   - type: IgniteOnMeleeHit
@@ -64,17 +71,10 @@
   parent: [ BaseSyndicateContraband, FireAxe ]
   description: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle!
   components:
-  - type: MeleeWeapon
-    wideAnimationRotation: 135
-    swingLeft: true
   - type: Item
-    shape:
-    - 1,0,2,5
-    - 0,0,0,2
     storedSprite:
       state: storage
       sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
-    size: Ginormous
   - type: IgniteOnMeleeHit
     fireStacks: 1
   - type: Sprite
@@ -82,7 +82,3 @@
     state: icon
   - type: Clothing
     sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
-    quickEquip: false
-    slots:
-    - back
-    - suitStorage

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -24,6 +24,7 @@
   - type: Tool
     qualities:
     - Slicing
+    - Sawing
     useSound:
       path: /Audio/Items/Culinary/chop.ogg
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -90,6 +90,7 @@
   - type: Tool
     qualities:
     - Slicing
+    - Sawing
   - type: Execution
     doAfterDuration: 4.0
   - type: UnpoweredFlashlight

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -20,6 +20,7 @@
   - type: Tool
     qualities:
     - Slicing
+    - Sawing
 
 #Shortswords
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I made cult items parent off the weapons they're based off and I made the FireAxe parent off BaseAxe, also fixed the oversight of cult items not being contra while I was at it.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fix #45795 Spears and Esword items still no longer saw because uhh use your brain for 5 seconds, also cult items are evil as shit and should be contra
## Technical details
<!-- Summary of code changes for easier review. -->
yaml sloppa
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
try to carve towercap logs with knifes, swords, and crusher items.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/60a86f35-1411-4853-abe7-0302c4761de5


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
the FireAxe and UnholyHalberd now parent off BaseAxe, items in Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml no longer parent off BaseItem
## Changelog
🆑 
- fix: Knife, Sword, and Crusher items can now cut wood again.
- tweak: Cult melee weapons are now contraband.