### PR TITLE
Crew-sided stuns rebalance

### DIFF
--- a/Content.IntegrationTests/Tests/Security/StunBatonTest.cs
+++ b/Content.IntegrationTests/Tests/Security/StunBatonTest.cs
@@ -22,7 +22,7 @@ public sealed class StunBatonTests : InteractionTest
     private static readonly EntProtoId HumanProtoId = "MobHuman";
 
     // If you are rebalancing stun batons you will have to change this number.
-    private const int NumberOfHitsToStun = 3;
+    private const int NumberOfHitsToStun = 5;
 
     [SidedDependency(Side.Server)] private readonly SharedBatterySystem _battery = default!;
     [SidedDependency(Side.Server)] private readonly DamageableSystem _damageable = default!;

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -602,7 +602,7 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: BatteryAmmoProvider
-    proto: BulletDisablerSmg
+    proto: BulletDisablerSmgSlowing
     fireCost: 25
   - type: MagazineVisuals
     magState: mag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -565,7 +565,7 @@
       - Belt
   - type: BatteryAmmoProvider
     proto: BulletDisabler
-    fireCost: 62.5
+    fireCost: 40
   - type: GuideHelp
     guides:
     - Security
@@ -1058,7 +1058,7 @@
   id: WeaponRangeFinderXenoborg
   name: xenoborg range finder
   components:
-  - type: Sprite 
+  - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/xenoborg_range_finder.rsi
     layers:
     - state: icon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Energy/stun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Energy/stun.yml
@@ -174,9 +174,9 @@
 
 - type: entity
   parent: BaseBullet
-  id: BulletDisablerSmg
+  id: BulletDisablerSmgBase # this version does zero damage
   categories: [ HideSpawnMenu ]
-  name: disabler bolt smg
+  name: disabler smg bolt
   components:
   - type: Reflective
     reflective:
@@ -205,10 +205,6 @@
         - BulletImpassable
       fly-by: *flybyfixture
   - type: Ammo
-  - type: StunOnCollide
-    slowdownAmount: 1.3
-    walkSpeedModifier: 0.6
-    sprintSpeedModifier: 0.6
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:
@@ -219,13 +215,31 @@
     forceSound: true
 
 - type: entity
-  parent: BulletDisablerSmg
+  parent: BulletDisablerSmgBase
+  id: BulletDisablerSmgSlowing
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: StunOnCollide
+    slowdownAmount: 1.3
+    walkSpeedModifier: 0.6
+    sprintSpeedModifier: 0.6
+
+- type: entity
+  parent: BulletDisablerSmgBase
+  id: BulletDisablerSmgStunning
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: StaminaDamageOnCollide
+    damage: 33
+
+- type: entity
+  parent: BulletDisablerSmgStunning
   id: BulletDisablerSmgSpread
   categories: [ HideSpawnMenu ]
   name: disabling laser barrage
   components:
   - type: ProjectileSpread
-    proto: BulletDisablerSmg
+    proto: BulletDisablerSmgStunning
     count: 3 #bit stronger than a disabler if you hit your shots you goober, still not a 2 hit stun though
     spread: 9
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Energy/stun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Energy/stun.yml
@@ -118,8 +118,10 @@
         - BulletImpassable
       fly-by: *flybyfixture
   - type: Ammo
-  - type: StaminaDamageOnCollide
-    damage: 33
+  - type: StunOnCollide
+    slowdownAmount: 1.3
+    walkSpeedModifier: 0.75
+    sprintSpeedModifier: 0.75
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:
@@ -203,8 +205,10 @@
         - BulletImpassable
       fly-by: *flybyfixture
   - type: Ammo
-  - type: StaminaDamageOnCollide
-    damage: 15
+  - type: StunOnCollide
+    slowdownAmount: 1.3
+    walkSpeedModifier: 0.6
+    sprintSpeedModifier: 0.6
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Energy/stun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/Energy/stun.yml
@@ -230,7 +230,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: StaminaDamageOnCollide
-    damage: 33
+    damage: 15
 
 - type: entity
   parent: BulletDisablerSmgStunning

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -42,17 +42,17 @@
   - type: MeleeBatteryHitsLeft
   - type: StaminaDamageOnHitRequiresToggle
   - type: StaminaDamageOnHitRequiresCharge
-    requiredCharge: 120
+    requiredCharge: 100
   - type: StaminaDamageOnHit
-    damage: 35
+    damage: 23
     sound: /Audio/Weapons/egloves.ogg
   - type: StaminaDamageOnCollide
-    damage: 35
+    damage: 23
     sound: /Audio/Weapons/egloves.ogg
   - type: LandAtCursor # it deals stamina damage when thrown
   - type: Battery
-    maxCharge: 360
-    startingCharge: 360
+    maxCharge: 700
+    startingCharge: 700
   - type: UseDelay
   - type: Item
     heldPrefix: off

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -33,6 +33,7 @@
       types:
         Shock: 5
   - type: MeleeWeapon
+    attackRate: 1.3
     wideAnimationRotation: -135
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -34,6 +34,7 @@
       types:
         Blunt: 0
   - type: MeleeWeapon
+    attackRate: 1.3
     wideAnimationRotation: -135
     damage:
       types:
@@ -45,12 +46,12 @@
   - type: MeleeBatteryHitsLeft
   - type: StaminaDamageOnHitRequiresToggle
   - type: StaminaDamageOnHitRequiresCharge
-    requiredCharge: 50
+    requiredCharge: 40
   - type: StaminaDamageOnHit
-    damage: 35
+    damage: 23
     sound: /Audio/Weapons/egloves.ogg
   - type: StaminaDamageOnCollide
-    damage: 35
+    damage: 23
     sound: /Audio/Weapons/egloves.ogg
   - type: LandAtCursor # it deals stamina damage when thrown
   - type: Battery


### PR DESCRIPTION
Given HESITANT conceptual approval by Slam

## About the PR
1. Reworks disablers to be a slowdown tool instead of a stunning tool.
2. Microbalances stun-batons/stunprods to be slightly worse.

## Why / Balance
1. Disablers (and disabler SMGs, and EMagnums) have a whole host of issues, but the major one is that it's just too damn strong, man. This reworks it so that the disabler will never win a fight on its own, but can allow you to *pick* your fights much more effectively - either by catching up by slowing them down or by running away ... by slowing them down.
2. Stun batons were just a BIT too strong, this accounts for that.

I didn't change disabler turrets nor the eshotty as they're actually pretty Fair and Balanced.

## Technical details
### Value changes
Disabler stamina damage: 33 -> 0
Disabler slowdown: -> 25% for 1.3 seconds, non-stacking
Disabler magazine size: 16 -> 25

Disabler SMG stamina damage: 15 -> 0
Disabler SMG slowdown: -> 40% for 1.3 seconds, non-stacking

Stun baton stamina damage: 35 -> 23
Stun baton attack rate: 1/s -> 1.3/s
Stun baton magazine: 20 -> 25

Stun prod stamina damage: 35 -> 23
Stun prod attack rate: 1/s -> 1.3/s
Stun prod magazine: 3 shots -> 7 shots

### Calculated changes

Stun baton attack interval: ~0.77s
Stun baton TTK: 2s -> ~3.08s
Stun baton TTK on bloodred: 3s -> ~3.84s

## Test plan
1. Launch 2 clients in dev
2. Attack with disabler and then quickly switch to other client to move

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- tweak: Disablers no longer stun the victim, and instead apply a short slowdown.
- tweak: Stun batons now take slightly more hits to stun, but have a slightly faster attack rate.
