### PR TITLE
Improve fire spread for paper, carpets, and plants

### DIFF
--- a/Content.Client/Atmos/Components/FireVisualsComponent.cs
+++ b/Content.Client/Atmos/Components/FireVisualsComponent.cs
@@ -48,4 +48,10 @@ public sealed partial class FireVisualsComponent : Component
     /// </summary>
     [DataField]
     public ProtoId<DisplacementDataPrototype>? CurrentDisplacement;
+
+    /// <summary>
+    /// Cached sprite draw depth so floor entities (carpets) can temporarily render above the floor while burning.
+    /// </summary>
+    public int? OriginalDrawDepth;
 }
+

--- a/Content.Client/Atmos/EntitySystems/FireVisualizerSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/FireVisualizerSystem.cs
@@ -1,6 +1,7 @@
 using Content.Client.Atmos.Components;
 using Content.Client.DisplacementMap;
 using Content.Shared.Atmos;
+using Content.Shared.DrawDepth;
 using Content.Shared.DisplacementMap;
 using Robust.Client.GameObjects;
 using Robust.Shared.Map;
@@ -64,7 +65,14 @@ public sealed partial class FireVisualizerSystem : VisualizerSystem<FireVisualsC
     private void UpdateAppearance(EntityUid uid, FireVisualsComponent component, SpriteComponent sprite, AppearanceComponent appearance)
     {
         if (!SpriteSystem.LayerMapTryGet((uid, sprite), FireVisualLayers.Fire, out var index, false))
-            return;
+        {
+            SpriteSystem.LayerMapReserve((uid, sprite), FireVisualLayers.Fire);
+            sprite.LayerSetShader(FireVisualLayers.Fire, "unshaded");
+            if (component.Sprite != null)
+                SpriteSystem.LayerSetRsi((uid, sprite), FireVisualLayers.Fire, new ResPath(component.Sprite));
+            if (!SpriteSystem.LayerMapTryGet((uid, sprite), FireVisualLayers.Fire, out index, false))
+                return;
+        }
 
         AppearanceSystem.TryGetData<bool>(uid, FireVisuals.OnFire, out var onFire, appearance);
         AppearanceSystem.TryGetData<float>(uid, FireVisuals.FireStacks, out var fireStacks, appearance);
@@ -79,8 +87,25 @@ public sealed partial class FireVisualizerSystem : VisualizerSystem<FireVisualsC
                 component.LightEntity = null;
             }
 
+            if (component.OriginalDrawDepth is { } original)
+            {
+                SpriteSystem.SetDrawDepth((uid, sprite), original);
+                component.OriginalDrawDepth = null;
+            }
+
             return;
         }
+
+        // Floor carpets use FloorTiles depth; lift the whole sprite while burning so the fire layer is visible.
+        if (component.OriginalDrawDepth == null && sprite.DrawDepth <= (int)Content.Shared.DrawDepth.DrawDepth.FloorTiles)
+        {
+            component.OriginalDrawDepth = sprite.DrawDepth;
+            SpriteSystem.SetDrawDepth((uid, sprite), (int)Content.Shared.DrawDepth.DrawDepth.Effects);
+        }
+
+        // IconSmooth corners can be added after our layer; keep fire on top while burning.
+        index = EnsureFireLayerOnTop(uid, component, sprite);
+        SpriteSystem.LayerSetVisible((uid, sprite), index, true);
 
         if (fireStacks > component.FireStackAlternateState && !string.IsNullOrEmpty(component.AlternateState))
             SpriteSystem.LayerSetRsiState((uid, sprite), index, component.AlternateState);
@@ -107,6 +132,29 @@ public sealed partial class FireVisualizerSystem : VisualizerSystem<FireVisualsC
         _lights.SetEnergy(component.LightEntity.Value, Math.Clamp(1 + component.LightEnergyPerStack * fireStacks, 0f, component.MaxLightEnergy), light);
 
         // TODO flickering animation? Or just add a noise mask to the light? But that requires an engine PR.
+    }
+
+    /// <summary>
+    /// Ensures the fire overlay layer is the topmost sprite layer so IconSmooth corners cannot cover it.
+    /// </summary>
+    private int EnsureFireLayerOnTop(EntityUid uid, FireVisualsComponent component, SpriteComponent sprite)
+    {
+        var layerCount = 0;
+        foreach (var _ in sprite.AllLayers)
+            layerCount++;
+
+        if (SpriteSystem.LayerMapTryGet((uid, sprite), FireVisualLayers.Fire, out var index, false)
+            && index == layerCount - 1)
+            return index;
+
+        if (SpriteSystem.LayerMapTryGet((uid, sprite), FireVisualLayers.Fire, out _, false))
+            SpriteSystem.RemoveLayer((uid, sprite), FireVisualLayers.Fire);
+
+        index = SpriteSystem.LayerMapReserve((uid, sprite), FireVisualLayers.Fire);
+        sprite.LayerSetShader(FireVisualLayers.Fire, "unshaded");
+        if (component.Sprite != null)
+            SpriteSystem.LayerSetRsi((uid, sprite), FireVisualLayers.Fire, new ResPath(component.Sprite));
+        return index;
     }
 }
 

--- a/Content.IntegrationTests/Tests/Atmos/FlammableTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/FlammableTest.cs
@@ -1,0 +1,48 @@
+using System.Numerics;
+using Content.IntegrationTests.Fixtures;
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Atmos.Components;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.Atmos;
+
+[TestFixture]
+public sealed class FlammableTest : GameTest
+{
+    [Test]
+    public async Task FireSpreadsOnlyWithinConfiguredRadius()
+    {
+        var server = Pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var flammableSystem = entMan.System<FlammableSystem>();
+        var map = await Pair.CreateTestMap();
+
+        EntityUid source = default;
+        EntityUid nearby = default;
+        EntityUid distant = default;
+
+        await server.WaitPost(() =>
+        {
+            source = entMan.SpawnEntity("Carpet", map.GridCoords);
+            nearby = entMan.SpawnEntity("Carpet", map.GridCoords.Offset(new Vector2(1f, 0f)));
+            distant = entMan.SpawnEntity("Carpet", map.GridCoords.Offset(new Vector2(2f, 0f)));
+
+            var sourceFlammable = entMan.GetComponent<FlammableComponent>(source);
+            sourceFlammable.FireStacks = 4f;
+            sourceFlammable.OnFire = true;
+
+            flammableSystem.SpreadFire((source, sourceFlammable));
+        });
+
+        var nearbyFlammable = entMan.GetComponent<FlammableComponent>(nearby);
+        var distantFlammable = entMan.GetComponent<FlammableComponent>(distant);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(nearbyFlammable.OnFire, Is.True);
+            Assert.That(nearbyFlammable.FireStacks, Is.EqualTo(2f));
+            Assert.That(distantFlammable.OnFire, Is.False);
+            Assert.That(distantFlammable.FireStacks, Is.Zero);
+        }
+    }
+}

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -28,6 +28,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
+using Robust.Shared.Containers;
 using Robust.Shared.Timing;
 
 namespace Content.Server.Atmos.EntitySystems
@@ -50,6 +51,8 @@ namespace Content.Server.Atmos.EntitySystems
         [Dependency] private AudioSystem _audio = default!;
         [Dependency] private IRobustRandom _random = default!;
         [Dependency] private IGameTiming _timing = default!;
+        [Dependency] private EntityLookupSystem _lookup = default!;
+        [Dependency] private SharedContainerSystem _container = default!;
 
         [Dependency] private EntityQuery<InventoryComponent> _inventoryQuery = default!;
         [Dependency] private EntityQuery<PhysicsComponent> _physicsQuery = default!;
@@ -57,6 +60,8 @@ namespace Content.Server.Atmos.EntitySystems
         private static readonly TimeSpan UpdateTime = TimeSpan.FromSeconds(1);
 
         private readonly Dictionary<Entity<FlammableComponent>, float> _fireEvents = new();
+        private readonly HashSet<Entity<FlammableComponent>> _nearbyFlammables = new();
+        private readonly List<Entity<FlammableComponent>> _fireSpreadSources = new();
 
         private const int FirestackEnergy = 37500; // joules release when on fire
 
@@ -435,6 +440,7 @@ namespace Content.Server.Atmos.EntitySystems
             _fireEvents.Clear();
 
             var curTime = _timing.CurTime;
+            _fireSpreadSources.Clear();
 
             // TODO: This needs cleanup to take off the crust from TemperatureComponent and shit.
             var query = EntityQueryEnumerator<FlammableComponent, TransformComponent>();
@@ -488,12 +494,72 @@ namespace Content.Server.Atmos.EntitySystems
 
                     _damageableSystem.TryChangeDamage(uid, flammable.Damage * flammable.FireStacks * ev.Multiplier, interruptsDoAfters: false);
 
+                    if (flammable.FireSpread && flammable.FireSpreadRadius > 0f)
+                        _fireSpreadSources.Add((uid, flammable));
+
                     AdjustFireStacks(uid, flammable.FirestackFade * (flammable.Resisting ? 15f : 1f), flammable, flammable.OnFire);
                 }
                 else
                 {
                     TryExtinguish((uid, flammable));
                 }
+            }
+
+            // Do this after the update loop so newly-ignited entities cannot spread again during the same tick.
+            foreach (var source in _fireSpreadSources)
+                SpreadFire(source);
+
+            IgniteFromIgnitionSources();
+        }
+
+        /// <summary>
+        /// Lit lighters, welders, and other ignition sources ignite nearby combustible entities.
+        /// </summary>
+        private void IgniteFromIgnitionSources()
+        {
+            var query = EntityQueryEnumerator<IgnitionSourceComponent, TransformComponent>();
+            while (query.MoveNext(out var uid, out var source, out var xform))
+            {
+                if (!source.Ignited)
+                    continue;
+
+                // Held / pocketed lighters should not auto-torch the floor under the player.
+                if (_container.IsEntityInContainer(uid))
+                    continue;
+
+                _nearbyFlammables.Clear();
+                _lookup.GetEntitiesInRange(xform.Coordinates, 0.75f, _nearbyFlammables);
+
+                foreach (var target in _nearbyFlammables)
+                {
+                    if (target.Owner == uid || target.Comp.OnFire)
+                        continue;
+
+                    Ignite(target.Owner, uid, target.Comp);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Ignites nearby entities that opt into fire spreading.
+        /// </summary>
+        public void SpreadFire(Entity<FlammableComponent> source)
+        {
+            if (Deleted(source) || !source.Comp.OnFire)
+                return;
+
+            _nearbyFlammables.Clear();
+            _lookup.GetEntitiesInRange(Transform(source).Coordinates, source.Comp.FireSpreadRadius, _nearbyFlammables);
+
+            foreach (var target in _nearbyFlammables)
+            {
+                if (target.Owner == source.Owner || target.Comp.OnFire || !target.Comp.FireSpread)
+                    continue;
+
+                SetFireStacks(target.Owner,
+                    MathF.Max(target.Comp.FirestacksOnIgnite, source.Comp.FireStacks / 2f),
+                    target.Comp,
+                    ignite: true);
             }
         }
 

--- a/Content.Server/Nutrition/EntitySystems/SmokingSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SmokingSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Atmos;
 using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Atmos.Components;
 using Robust.Shared.Audio.Systems;
 using Content.Server.Body.Systems;
 using Content.Shared.Body.Components;
@@ -27,6 +28,8 @@ namespace Content.Server.Nutrition.EntitySystems
         [Dependency] private SharedSolutionContainerSystem _solutionContainerSystem = default!;
         [Dependency] private BloodstreamSystem _bloodstreamSystem = default!;
         [Dependency] private AtmosphereSystem _atmos = default!;
+        [Dependency] private FlammableSystem _flammable = default!;
+        [Dependency] private EntityLookupSystem _lookup = default!;
         [Dependency] private TransformSystem _transformSystem = default!;
         [Dependency] private InventorySystem _inventorySystem = default!;
         [Dependency] private ClothingSystem _clothing = default!;
@@ -39,6 +42,7 @@ namespace Content.Server.Nutrition.EntitySystems
         private const float UpdateTimer = 3f;
 
         private float _timer;
+        private readonly HashSet<Entity<FlammableComponent>> _nearbyFlammables = new();
 
         public override void Initialize()
         {
@@ -135,6 +139,21 @@ namespace Content.Server.Nutrition.EntitySystems
                     {
                         var position = _transformSystem.GetGridOrMapTilePosition(uid, transform);
                         _atmos.HotspotExpose(gridUid, position, smokable.ExposeTemperature, smokable.ExposeVolume, uid, true);
+                    }
+                }
+
+
+                // Dropped lit smokables can ignite nearby always-combustible / stacked flammables (carpets, paper, plants).
+                if (!_container.IsEntityInContainer(uid))
+                {
+                    _nearbyFlammables.Clear();
+                    _lookup.GetEntitiesInRange(Transform(uid).Coordinates, 0.75f, _nearbyFlammables);
+                    foreach (var target in _nearbyFlammables)
+                    {
+                        if (target.Owner == uid || target.Comp.OnFire)
+                            continue;
+
+                        _flammable.Ignite(target.Owner, uid, target.Comp);
                     }
                 }
 

--- a/Content.Shared/Atmos/Components/FlammableComponent.cs
+++ b/Content.Shared/Atmos/Components/FlammableComponent.cs
@@ -60,6 +60,12 @@ namespace Content.Shared.Atmos.Components
         [DataField]
         public bool FireSpread { get; private set; } = false;
 
+        /// <summary>
+        /// How far this entity spreads fire while burning. A value of zero only allows collision-based spreading.
+        /// </summary>
+        [DataField]
+        public float FireSpreadRadius;
+
         [DataField]
         public bool CanResistFire { get; private set; } = false;
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
@@ -75,6 +75,29 @@
       - Packet
   - type: ExaminableSolution
     exactVolume: true
+  - type: Slippery
+  - type: StepTrigger
+    intersectRatio: 0.2
+  - type: CollisionWake
+    enabled: false
+  - type: Physics
+    bodyType: Dynamic
+  - type: Fixtures
+    fixtures:
+      slips:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.2,-0.2,0.2,0.2"
+        hard: false
+        layer:
+        - SlipLayer
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.2,-0.2,0.2,0.2"
+        density: 5
+        mask:
+        - ItemMask
 
 - type: entity
   parent: BaseFoodCondimentPacket

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
@@ -75,29 +75,6 @@
       - Packet
   - type: ExaminableSolution
     exactVolume: true
-  - type: Slippery
-  - type: StepTrigger
-    intersectRatio: 0.2
-  - type: CollisionWake
-    enabled: false
-  - type: Physics
-    bodyType: Dynamic
-  - type: Fixtures
-    fixtures:
-      slips:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.2,-0.2,0.2,0.2"
-        hard: false
-        layer:
-        - SlipLayer
-      fix1:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.2,-0.2,0.2,0.2"
-        density: 5
-        mask:
-        - ItemMask
 
 - type: entity
   parent: BaseFoodCondimentPacket

--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -44,6 +44,37 @@
     damage:
       types:
         Blunt: 1
+  - type: Reactive
+    groups:
+      Flammable: [ Touch ]
+      Extinguish: [ Touch ]
+  - type: ExtinguishableSetCollisionWake
+  - type: Flammable
+    fireSpread: true
+    fireSpreadRadius: 1.1
+    alwaysCombustible: true
+    canExtinguish: true
+    damage:
+      types:
+        Heat: 1
+  - type: FireVisuals
+    sprite: Effects/fire.rsi
+    normalState: fire
+  - type: Damageable
+    damageModifierSet: Wood
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 15
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Ash:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: BaseItem
@@ -66,6 +97,37 @@
     damage:
       types:
         Blunt: 1
+  - type: Reactive
+    groups:
+      Flammable: [ Touch ]
+      Extinguish: [ Touch ]
+  - type: ExtinguishableSetCollisionWake
+  - type: Flammable
+    fireSpread: true
+    fireSpreadRadius: 1.1
+    alwaysCombustible: true
+    canExtinguish: true
+    damage:
+      types:
+        Heat: 1
+  - type: FireVisuals
+    sprite: Effects/fire.rsi
+    normalState: fire
+  - type: Damageable
+    damageModifierSet: Wood
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 15
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Ash:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
   - type: DamageOtherOnHit
     damage:
       types: {}

--- a/Resources/Prototypes/Entities/Objects/Misc/carpets.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/carpets.yml
@@ -18,6 +18,35 @@
     prototype: Carpet
     doAfter: 0.5
     removeOnInteract: true
+  - type: Reactive
+    groups:
+      Flammable: [ Touch ]
+      Extinguish: [ Touch ]
+  - type: ExtinguishableSetCollisionWake
+  - type: Flammable
+    fireSpread: true
+    fireSpreadRadius: 1.1
+    alwaysCombustible: true
+    canExtinguish: true
+    damage:
+      types:
+        Heat: 1
+  - type: FireVisuals
+    sprite: Effects/fire.rsi
+    normalState: fire
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 15
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Ash:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   parent: FloorCarpetItemRed

--- a/Resources/Prototypes/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/folders.yml
@@ -83,6 +83,37 @@
   - type: Tag
     tags:
     - Folder
+  - type: Reactive
+    groups:
+      Flammable: [ Touch ]
+      Extinguish: [ Touch ]
+  - type: ExtinguishableSetCollisionWake
+  - type: Flammable
+    fireSpread: true
+    fireSpreadRadius: 1.1
+    alwaysCombustible: true
+    canExtinguish: true
+    damage:
+      types:
+        Heat: 1
+  - type: FireVisuals
+    sprite: Effects/fire.rsi
+    normalState: fire
+  - type: Damageable
+    damageModifierSet: Wood
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 15
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Ash:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -15,6 +15,7 @@
   - type: ExtinguishableSetCollisionWake
   - type: Flammable
     fireSpread: true
+    fireSpreadRadius: 1.1
     alwaysCombustible: true
     canExtinguish: true
     damage:
@@ -493,6 +494,7 @@
   #- type: Appearance, hide stamp marks until we have some kind of displacement
   - type: Flammable
     fireSpread: true
+    fireSpreadRadius: 1.1
     canResistFire: false
     alwaysCombustible: true
     canExtinguish: true

--- a/Resources/Prototypes/Entities/Structures/Furniture/carpets.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/carpets.yml
@@ -1,290 +1,628 @@
 # TODO move all of this to tiles once tile smoothing is supported
-- type: entity
-  abstract: true
-  parent: [ BaseStructure, StructureHealthFurnitureWeak ]
-  id: CarpetBase
-  name: carpet
-  description: "Fancy walking surface."
-  components:
-  - type: Sprite
-    drawdepth: FloorTiles
-  - type: Icon
-    state: full
-  - type: IconSmooth
-    key: full
-    base: carpet_
-  - type: Tag
-    tags:
-    - Carpet
-    - ForceFixRotations
-  - type: Physics
-    canCollide: false
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.45,-0.45,0.45,0.45"
-        density: 5
-        layer:
-        - DoorPassable
-  - type: Damageable
-    damageModifierSet: ThreadMod
-  - type: TrayScanReveal
-  - type: ToolRefinable
-    refineResult:
-    - id: MaterialCloth1
 
 - type: entity
-  id: Carpet
-  parent: CarpetBase
-  suffix: Red
+
+  abstract: true
+
+  parent: BaseStructure
+
+  id: CarpetBase
+
+  name: carpet
+
+  description: "Fancy walking surface."
+
   components:
+
   - type: Sprite
-    sprite: Structures/Furniture/Carpets/red_carpet.rsi
+
+    drawdepth: FloorTiles
+
   - type: Icon
-    sprite: Structures/Furniture/Carpets/red_carpet.rsi
+
+    state: full
+
+  - type: IconSmooth
+
+    key: full
+
+    base: carpet_
+
+    index: 0
+
+  - type: Tag
+
+    tags:
+
+    - Carpet
+
+    - ForceFixRotations
+
+  - type: Physics
+
+    canCollide: true
+
+  - type: Fixtures
+
+    fixtures:
+
+      fix1:
+
+        shape:
+
+          !type:PhysShapeAabb
+
+          bounds: "-0.45,-0.45,0.45,0.45"
+
+        density: 5
+
+        hard: false
+
+        layer:
+
+        - DoorPassable
+
+        - MidImpassable
+
+  - type: Damageable
+
+    damageModifierSet: ThreadMod
+
+  - type: Injurable
+
+  - type: Flammable
+
+    fireSpread: true
+
+    fireSpreadRadius: 1.1
+
+    alwaysCombustible: true
+
+    canExtinguish: true
+
+    damage:
+
+      types:
+
+        Heat: 1
+
+  - type: Appearance
+
+  - type: Reactive
+
+    groups:
+
+      Flammable: [ Touch ]
+
+      Extinguish: [ Touch ]
+
+  - type: ExtinguishableSetCollisionWake
+
+  - type: FireVisuals
+
+    sprite: Effects/fire.rsi
+
+    normalState: fire
+
+    alternateState: 1
+
   - type: Destructible
+
     thresholds:
-    - trigger: &DamageFurnitureWeak
+
+    - trigger: &CarpetBurnTrigger
+
         !type:DamageTrigger
-        damage: 5
+
+        damage: 15
+
       behaviors:
+
       - !type:SpawnEntitiesBehavior
+
         spawn:
-          FloorCarpetItemRed: &BaseCarpetSpawn
+
+          Ash: &CarpetAshSpawn
+
             min: 1
+
             max: 1
 
+      - !type:DoActsBehavior
+
+        acts: [ "Destruction" ]
+
+  - type: TrayScanReveal
+
+  - type: ToolRefinable
+
+    refineResult:
+
+    - id: MaterialCloth1
+
+
+
 - type: entity
+
+  id: Carpet
+
+  parent: CarpetBase
+
+  suffix: Red
+
+  components:
+
+  - type: Sprite
+
+    sprite: Structures/Furniture/Carpets/red_carpet.rsi
+
+  - type: Icon
+
+    sprite: Structures/Furniture/Carpets/red_carpet.rsi
+
+
+
+- type: entity
+
   id: CarpetBlack
+
   parent: CarpetBase
+
   suffix: Black
+
   components:
+
   - type: Clickable
+
   - type: Sprite
+
     sprite: Structures/Furniture/Carpets/black_carpet.rsi
+
   - type: Icon
+
     sprite: Structures/Furniture/Carpets/black_carpet.rsi
-  - type: Destructible
-    thresholds:
-    - trigger: *DamageFurnitureWeak
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          FloorCarpetItemBlack: *BaseCarpetSpawn
+
+
 
 - type: entity
+
   id: CarpetPink
+
   parent: CarpetBase
+
   suffix: Pink
+
   components:
+
   - type: Clickable
+
   - type: Sprite
+
     sprite: Structures/Furniture/Carpets/pink_carpet.rsi
+
   - type: Icon
+
     sprite: Structures/Furniture/Carpets/pink_carpet.rsi
-  - type: Destructible
-    thresholds:
-    - trigger: *DamageFurnitureWeak
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          FloorCarpetItemPink: *BaseCarpetSpawn
+
+
 
 - type: entity
+
   id: CarpetBlue
+
   parent: CarpetBase
+
   suffix: Blue
+
   components:
+
   - type: Clickable
+
   - type: Sprite
+
     sprite: Structures/Furniture/Carpets/blue_carpet.rsi
+
   - type: Icon
+
     sprite: Structures/Furniture/Carpets/blue_carpet.rsi
-  - type: Destructible
-    thresholds:
-    - trigger: *DamageFurnitureWeak
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          FloorCarpetItemBlue: *BaseCarpetSpawn
+
+
 
 - type: entity
+
   id: CarpetGreen
+
   parent: CarpetBase
+
   suffix: Green
+
   components:
+
   - type: Clickable
+
   - type: Sprite
+
     sprite: Structures/Furniture/Carpets/green_carpet.rsi
+
   - type: Icon
+
     sprite: Structures/Furniture/Carpets/green_carpet.rsi
-  - type: Destructible
-    thresholds:
-    - trigger: *DamageFurnitureWeak
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          FloorCarpetItemGreen: *BaseCarpetSpawn
+
+
 
 - type: entity
+
   id: CarpetOrange
+
   parent: CarpetBase
+
   suffix: Orange
+
   components:
+
   - type: Clickable
+
   - type: Sprite
+
     sprite: Structures/Furniture/Carpets/orange_carpet.rsi
+
   - type: Icon
+
     sprite: Structures/Furniture/Carpets/orange_carpet.rsi
-  - type: Destructible
-    thresholds:
-    - trigger: *DamageFurnitureWeak
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          FloorCarpetItemOrange: *BaseCarpetSpawn
+
+
 
 - type: entity
+
   id: CarpetSBlue
+
   parent: CarpetBase
+
   suffix: Sky Blue
+
   components:
+
   - type: Clickable
+
   - type: Sprite
+
     sprite: Structures/Furniture/Carpets/skyblue_carpet.rsi
+
   - type: Icon
+
     sprite: Structures/Furniture/Carpets/skyblue_carpet.rsi
-  - type: Destructible
-    thresholds:
-    - trigger: *DamageFurnitureWeak
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          FloorCarpetItemSkyBlue: *BaseCarpetSpawn
+
+
 
 - type: entity
+
   id: CarpetPurple
+
   parent: CarpetBase
+
   suffix: Purple
+
   components:
+
   - type: Clickable
+
   - type: Sprite
+
     sprite: Structures/Furniture/Carpets/purple_carpet.rsi
+
   - type: Icon
+
     sprite: Structures/Furniture/Carpets/purple_carpet.rsi
-  - type: Destructible
-    thresholds:
-    - trigger: *DamageFurnitureWeak
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          FloorCarpetItemPurple: *BaseCarpetSpawn
+
+
 
 - type: entity
+
   id: CarpetCyan
+
   parent: CarpetBase
+
   suffix: Cyan
+
   components:
+
   - type: Clickable
+
   - type: Sprite
+
     sprite: Structures/Furniture/Carpets/cyan_carpet.rsi
+
   - type: Icon
+
     sprite: Structures/Furniture/Carpets/cyan_carpet.rsi
-  - type: Destructible
-    thresholds:
-    - trigger: *DamageFurnitureWeak
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          FloorCarpetItemCyan: *BaseCarpetSpawn
+
+
 
 - type: entity
+
   id: CarpetWhite
+
   parent: CarpetBase
+
   suffix: White
+
   components:
+
   - type: Clickable
+
   - type: Sprite
+
     sprite: Structures/Furniture/Carpets/white_carpet.rsi
+
   - type: Icon
+
     sprite: Structures/Furniture/Carpets/white_carpet.rsi
-  - type: Destructible
-    thresholds:
-    - trigger: *DamageFurnitureWeak
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          FloorCarpetItemWhite: *BaseCarpetSpawn
+
+
 
 # TODO nuke this once tiles support rotating sprites
+
 - type: entity
+
   parent: BaseStructure
+
   id: CarpetChapel
+
   name: "chapel's carpet"
+
   components:
+
   - type: Sprite
+
     sprite: Structures/Furniture/Carpets/chapel_carpet.rsi
+
     state: chapel
+
     drawdepth: FloorTiles
+
   - type: Icon
+
     sprite: Structures/Furniture/Carpets/chapel_carpet.rsi
+
     state: chapel
+
   - type: Tag
+
     tags:
+
     - Carpet
+
   - type: Physics
-    canCollide: false
+
+    canCollide: true
+
   - type: Fixtures
+
+    fixtures:
+
+      fix1:
+
+        shape:
+
+          !type:PhysShapeAabb
+
+          bounds: "-0.45,-0.45,0.45,0.45"
+
+        density: 5
+
+        hard: false
+
+        layer:
+
+        - DoorPassable
+
+        - MidImpassable
+
+  - type: Flammable
+
+    fireSpread: true
+
+    fireSpreadRadius: 1.1
+
+    alwaysCombustible: true
+
+    canExtinguish: true
+
+    damage:
+
+      types:
+
+        Heat: 1
+
+  - type: Appearance
+
+  - type: Reactive
+
+    groups:
+
+      Flammable: [ Touch ]
+
+      Extinguish: [ Touch ]
+
+  - type: ExtinguishableSetCollisionWake
+
+  - type: FireVisuals
+
+    sprite: Effects/fire.rsi
+
+    normalState: fire
+
+    alternateState: 1
+
   - type: Damageable
+
+    damageModifierSet: ThreadMod
+
   - type: Injurable
+
     damageContainer: Inorganic
+
   - type: Destructible
+
     thresholds:
-    - trigger: *DamageFurnitureWeak
+
+    - trigger: *CarpetBurnTrigger
+
       behaviors:
+
+      - !type:SpawnEntitiesBehavior
+
+        spawn:
+
+          Ash: *CarpetAshSpawn
+
       - !type:DoActsBehavior
+
         acts: [ "Destruction" ]
+
   - type: TrayScanReveal
+
+
 
 #cardpet
 
 - type: entity
-  parent: [ BaseStructure, StructureHealthFurnitureWeak ]
+
+  parent: BaseStructure
+
   id: CarpetCard
+
   name: cardboard "carpet"
+
   description: "Even lino is better."
+
   components:
+
   - type: Sprite
+
     drawdepth: FloorTiles
+
     sprite: Structures/Furniture/Carpets/card_carpet.rsi
+
   - type: Icon
+
     sprite: Structures/Furniture/Carpets/card_carpet.rsi
+
     state: full
+
   - type: IconSmooth
+
     key: cardpets
+
     additionalKeys:
+
     - cards
+
     base: carpet_
+
+    index: 0
+
   - type: Tag
+
     tags:
+
     - Carpet
+
     - ForceFixRotations
+
   - type: Physics
-    canCollide: false
+
+    canCollide: true
+
   - type: Clickable
+
   - type: Fixtures
+
+    fixtures:
+
+      fix1:
+
+        shape:
+
+          !type:PhysShapeAabb
+
+          bounds: "-0.45,-0.45,0.45,0.45"
+
+        density: 5
+
+        hard: false
+
+        layer:
+
+        - DoorPassable
+
+        - MidImpassable
+
+  - type: Flammable
+
+    fireSpread: true
+
+    fireSpreadRadius: 1.1
+
+    alwaysCombustible: true
+
+    canExtinguish: true
+
+    damage:
+
+      types:
+
+        Heat: 1
+
+  - type: Appearance
+
+  - type: Reactive
+
+    groups:
+
+      Flammable: [ Touch ]
+
+      Extinguish: [ Touch ]
+
+  - type: ExtinguishableSetCollisionWake
+
+  - type: FireVisuals
+
+    sprite: Effects/fire.rsi
+
+    normalState: fire
+
+    alternateState: 1
+
   - type: Damageable
+
     damageModifierSet: CardboardMod
+
+  - type: Injurable
+
   - type: Destructible
+
     thresholds:
-    - trigger: *DamageFurnitureWeak
+
+    - trigger: *CarpetBurnTrigger
+
       behaviors:
+
       - !type:SpawnEntitiesBehavior
+
         spawn:
-          MaterialCardboard: *BaseCarpetSpawn
+
+          Ash: *CarpetAshSpawn
+
+      - !type:DoActsBehavior
+
+        acts: [ "Destruction" ]
+
   - type: ToolRefinable
+
     refineResult:
+
     - id: MaterialCardboard1
+
   - type: TrayScanReveal
+

--- a/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
@@ -16,10 +16,13 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.1
+          radius: 0.25
         density: 190
+        hard: false
         mask:
         - HighImpassable
+        layer:
+        - MidImpassable
   - type: Sprite
     drawdepth: Overdoors
     offset: "0.0,0.3"
@@ -40,7 +43,18 @@
     sprite: Structures/Furniture/potted_plants.rsi
     size: Huge
   - type: Damageable
-    damageModifierSet: RockMod
+    damageModifierSet: WoodMod
+  - type: Flammable
+    fireSpread: true
+    fireSpreadRadius: 1.1
+    alwaysCombustible: true
+    damage:
+      types:
+        Heat: 2
+  - type: Appearance
+  - type: FireVisuals
+    sprite: Effects/fire.rsi
+    normalState: 1
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
## About
Makes fire behave a bit more realistically for common flammables.

- Paper, folders, books, carpets (including chapel/cardboard), and potted plants can catch and spread fire to nearby flammables.
- Carpets show a fire overlay while burning and leave ash when destroyed by fire.
- Dropped lit cigarettes / lighters / similar ignition sources can start nearby fires; held ones should not torch the floor under you.

## Test Plan
- [ ] Sandbox: light paper on carpet and confirm fire spreads to carpet / nearby plant
- [ ] Drop a lit lighter on carpet ? ignites; hold a lit lighter ? floor does not ignite
- [ ] Burning carpet shows fire sprite and leaves ash (not a carpet item)
- [ ] Integration test for flammable spread passes if you run tests