### PR TITLE
Bugfix: Personal AI actions now apply to the mob

### DIFF
--- a/Resources/Prototypes/Catalog/pai_catalog.yml
+++ b/Resources/Prototypes/Catalog/pai_catalog.yml
@@ -8,6 +8,7 @@
   name: pai-mass-scanner-name
   description: pai-mass-scanner-desc
   productAction: ActionPAIMassScanner
+  applyToMob: true
   cost:
     SiliconMemory: 10
   categories:
@@ -21,6 +22,7 @@
   name: pai-midi-player-name
   description: pai-midi-player-desc
   productAction: ActionPAIPlayMidi
+  applyToMob: true
   cost:
     SiliconMemory: 5
   categories:
@@ -34,6 +36,7 @@
   name: pai-station-map-name
   description: pai-station-map-desc
   productAction: ActionPAIOpenMap
+  applyToMob: true
   cost:
     SiliconMemory: 5
   categories:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Makes personal AI actions apply to the mob, not the mind.

## Why / Balance

It's in your damn RAM.  Also, it really sucks not being able to do anything after somebody else ghosts from the device.

Closes https://github.com/space-wizards/space-station-14/issues/41548 (not a refund, just persistence)
Fixes https://github.com/space-wizards/space-station-14/issues/37407

## Technical details

applyToMob ops

## Test plan

1. Spawn pAI.
2. Turn it on.
3. Ghost.
4. Take over the pAI.
5. Buy stuff.
6. Right click on your old body, assume control.
7. Turn on pAI again.
8. Repeat 3-7 until you're sufficiently convinced.

## Media

Fumbled the video recording in such a _blinding, seething, white-hot rage_ at the lack of pAI actions.  But really - this is steps 3-8 of the test plan.  The actions have already been purchased.

https://github.com/user-attachments/assets/6ec4eab2-6e6d-4a44-b756-c615d0b7f1f2

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- fix: Purchased pAI abilities remain on the device after ghosting or rebooting it.