### PR TITLE
Make discarded condiment packets slippery

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
@@ -1,4 +1,4 @@
-# TODO: Removes the icon components from all these when that gets fixed.
+﻿# TODO: Removes the icon components from all these when that gets fixed.
 
 - type: entity
   parent: [SolutionFood, BaseItem]
@@ -75,6 +75,29 @@
       - Packet
   - type: ExaminableSolution
     exactVolume: true
+  - type: Slippery
+  - type: StepTrigger
+    intersectRatio: 0.2
+  - type: CollisionWake
+    enabled: false
+  - type: Physics
+    bodyType: Dynamic
+  - type: Fixtures
+    fixtures:
+      slips:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.2,-0.2,0.2,0.2"
+        hard: false
+        layer:
+        - SlipLayer
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.2,-0.2,0.2,0.2"
+        density: 5
+        mask:
+        - ItemMask
 
 - type: entity
   parent: BaseFoodCondimentPacket


### PR DESCRIPTION
## About
Discarded condiment packets can trip you if you sprint over them, same idea as banana peels.

## Test Plan
- [ ] Spawn a ketchup/mustard packet on the floor
- [ ] Walk over it normally ? no slip
- [ ] Sprint over it ? slip