### PR TITLE
Bugfix: RandomSpawnerComponent now spawns rare drops again. 

### DIFF
--- a/Content.Server/Spawners/Components/ConditionalSpawnerComponent.cs
+++ b/Content.Server/Spawners/Components/ConditionalSpawnerComponent.cs
@@ -1,32 +1,28 @@
 using Robust.Shared.Prototypes;
 
-namespace Content.Server.Spawners.Components
+namespace Content.Server.Spawners.Components;
+
+[RegisterComponent, EntityCategory("Spawner")]
+[Virtual]
+public partial class ConditionalSpawnerComponent : Component
 {
-    [RegisterComponent, EntityCategory("Spawner")]
-    [Virtual]
-    public partial class ConditionalSpawnerComponent : Component
-    {
-        /// <summary>
-        /// A list of entities, one of which can spawn in after calling Spawn()
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField]
-        public List<EntProtoId> Prototypes { get; set; } = new();
+    /// <summary>
+    /// A list of entities, one of which can spawn in after calling Spawn()
+    /// </summary>
+    [DataField]
+    public List<EntProtoId> Prototypes { get; set; } = new();
 
-        /// <summary>
-        /// A list of game rules.
-        /// If at least one of them was launched in the game,
-        /// an attempt will occur to spawn one of the objects in the Prototypes list
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField]
-        public List<EntProtoId> GameRules = new();
+    /// <summary>
+    /// A list of game rules.
+    /// If at least one of them was launched in the game,
+    /// an attempt will occur to spawn one of the objects in the Prototypes list
+    /// </summary>
+    [DataField]
+    public List<EntProtoId> GameRules = new();
 
-        /// <summary>
-        /// Chance of spawning an entity
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField]
-        public float Chance { get; set; } = 1.0f;
-    }
+    /// <summary>
+    /// Chance of spawning an entity
+    /// </summary>
+    [DataField]
+    public float Chance { get; set; } = 1.0f;
 }

--- a/Content.Server/Spawners/Components/ConditionalSpawnerComponent.cs
+++ b/Content.Server/Spawners/Components/ConditionalSpawnerComponent.cs
@@ -3,8 +3,11 @@ using Robust.Shared.Prototypes;
 namespace Content.Server.Spawners.Components;
 
 /// <summary>
-/// A spawner that rolls to spawn from of a list of entities on <see cref="MapInitEvent"/> and/or <see cref="GameRuleStartedEvent"/>.
+/// A spawner that rolls to spawn from of a list of entities on <see cref="MapInitEvent"/> and <see cref="GameRuleStartedEvent"/>.
 /// </summary>
+/// <remarks>
+/// For non-trivial lists of prototypes, consider using <see cref="EntityTableSpawnerComponent"/> and an <see cref="EntityTableSelector"/> instead.
+/// </remarks>
 [RegisterComponent, EntityCategory("Spawner")]
 [Virtual]
 public partial class ConditionalSpawnerComponent : Component

--- a/Content.Server/Spawners/Components/ConditionalSpawnerComponent.cs
+++ b/Content.Server/Spawners/Components/ConditionalSpawnerComponent.cs
@@ -2,26 +2,30 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Spawners.Components;
 
+/// <summary>
+/// A spawner that rolls to spawn from of a list of entities on <see cref="MapInitEvent"/> and/or <see cref="GameRuleStartedEvent"/>.
+/// </summary>
 [RegisterComponent, EntityCategory("Spawner")]
 [Virtual]
 public partial class ConditionalSpawnerComponent : Component
 {
     /// <summary>
-    /// A list of entities, one of which can spawn in after calling Spawn()
+    /// A list of entities, one of which can spawn on a spawn roll when calling <see cref="ConditionalSpawnerSystem.Spawn"/>.
     /// </summary>
     [DataField]
     public List<EntProtoId> Prototypes { get; set; } = new();
 
     /// <summary>
-    /// A list of game rules.
-    /// If at least one of them was launched in the game,
-    /// an attempt will occur to spawn one of the objects in the Prototypes list
+    /// A list of game rules - starting any of them causes a spawn roll.
     /// </summary>
+    /// <remarks>
+    /// Currently unused, should be marked obsolete if not removed outright.
+    /// </remarks>
     [DataField]
     public List<EntProtoId> GameRules = new();
 
     /// <summary>
-    /// Chance of spawning an entity
+    /// Chance of spawning an entity on each spawn roll.
     /// </summary>
     [DataField]
     public float Chance { get; set; } = 1.0f;

--- a/Content.Server/Spawners/Components/EntityTableSpawnerComponent.cs
+++ b/Content.Server/Spawners/Components/EntityTableSpawnerComponent.cs
@@ -4,6 +4,9 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Spawners.Components;
 
+/// <summary>
+/// A spawner that randomly spawns entities according to an <see cref="EntityTableSelector"/>.
+/// </summary>
 [RegisterComponent, EntityCategory("Spawner"), Access(typeof(ConditionalSpawnerSystem))]
 public sealed partial class EntityTableSpawnerComponent : Component
 {
@@ -14,8 +17,11 @@ public sealed partial class EntityTableSpawnerComponent : Component
     public EntityTableSelector Table = default!;
 
     /// <summary>
-    /// Scatter of entity spawn coordinates
+    /// Maximum distance in meters to scatter spawned entities from the spawner.
     /// </summary>
+    /// <remarks>
+    /// Spawned entities are created in a disk this size around the spawner.
+    /// </remarks>
     [DataField]
     public float Offset = 0.2f;
 

--- a/Content.Server/Spawners/Components/RandomSpawnerComponent.cs
+++ b/Content.Server/Spawners/Components/RandomSpawnerComponent.cs
@@ -1,38 +1,35 @@
 using Robust.Shared.Prototypes;
 
-namespace Content.Server.Spawners.Components
+namespace Content.Server.Spawners.Components;
+
+[RegisterComponent, EntityCategory("Spawner")]
+public sealed partial class RandomSpawnerComponent : ConditionalSpawnerComponent
 {
-    [RegisterComponent, EntityCategory("Spawner")]
-    public sealed partial class RandomSpawnerComponent : ConditionalSpawnerComponent
-    {
-        /// <summary>
-        /// A list of rarer entities that can spawn with the RareChance
-        /// instead of one of the entities in the Prototypes list.
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField]
-        public List<EntProtoId> RarePrototypes { get; set; } = new();
+    /// <summary>
+    /// A list of rarer entities that can spawn with the RareChance
+    /// instead of one of the entities in the Prototypes list.
+    /// </summary>
+    [DataField]
+    public List<EntProtoId> RarePrototypes { get; set; } = new();
 
-        /// <summary>
-        /// The chance that a rare prototype may spawn instead of a common prototype
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField]
-        public float RareChance { get; set; } = 0.05f;
+    /// <summary>
+    /// The chance that a rare prototype may spawn instead of a common prototype
+    /// </summary>
+    [DataField]
+    public float RareChance { get; set; } = 0.05f;
 
-        /// <summary>
-        /// Scatter of entity spawn coordinates
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        [DataField]
-        public float Offset { get; set; } = 0.2f;
+    /// <summary>
+    /// Scatter of entity spawn coordinates
+    /// </summary>
+    [DataField]
+    public float Offset { get; set; } = 0.2f;
 
-        /// <summary>
-        /// A variable meaning whether the spawn will
-        /// be able to be used again or whether
-        /// it will be destroyed after the first use
-        /// </summary>
-        [DataField]
-        public bool DeleteSpawnerAfterSpawn = true;
-    }
+    /// <summary>
+    /// A variable meaning whether the spawn will
+    /// be able to be used again or whether
+    /// it will be destroyed after the first use
+    /// </summary>
+    [DataField]
+    public bool DeleteSpawnerAfterSpawn = true;
 }
+

--- a/Content.Server/Spawners/Components/RandomSpawnerComponent.cs
+++ b/Content.Server/Spawners/Components/RandomSpawnerComponent.cs
@@ -32,4 +32,3 @@ public sealed partial class RandomSpawnerComponent : ConditionalSpawnerComponent
     [DataField]
     public bool DeleteSpawnerAfterSpawn = true;
 }
-

--- a/Content.Server/Spawners/Components/RandomSpawnerComponent.cs
+++ b/Content.Server/Spawners/Components/RandomSpawnerComponent.cs
@@ -2,32 +2,39 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Spawners.Components;
 
+/// <summary>
+/// An extended <see cref="ConditionalSpawnerComponent"/> with optional rare prototypes and more configurable spawn behavior.
+/// </summary>
 [RegisterComponent, EntityCategory("Spawner")]
 public sealed partial class RandomSpawnerComponent : ConditionalSpawnerComponent
 {
     /// <summary>
-    /// A list of rarer entities that can spawn with the RareChance
-    /// instead of one of the entities in the Prototypes list.
+    /// A list of rare entities to spawn.
+    /// </summary>
+    /// <remarks>
+    /// On a successful spawn roll, with <see cref="RareChance"/> probability,
+    /// an entity from this list is spawned (vs. the normal Prototypes list).
     /// </summary>
     [DataField]
     public List<EntProtoId> RarePrototypes { get; set; } = new();
 
     /// <summary>
-    /// The chance that a rare prototype may spawn instead of a common prototype
+    /// The chance that a rare prototype may spawn instead of a common prototype.
     /// </summary>
     [DataField]
     public float RareChance { get; set; } = 0.05f;
 
     /// <summary>
-    /// Scatter of entity spawn coordinates
+    /// Maximum distance in meters to scatter spawned entities from the spawner.
     /// </summary>
+    /// <remarks>
+    /// Spawned entities are created in a disk this size around the spawner.
+    /// </remarks>
     [DataField]
     public float Offset { get; set; } = 0.2f;
 
     /// <summary>
-    /// A variable meaning whether the spawn will
-    /// be able to be used again or whether
-    /// it will be destroyed after the first use
+    /// If true, the spawner is deleted on <see cref="MapInitEvent"/>.
     /// </summary>
     [DataField]
     public bool DeleteSpawnerAfterSpawn = true;

--- a/Content.Server/Spawners/Components/RandomSpawnerComponent.cs
+++ b/Content.Server/Spawners/Components/RandomSpawnerComponent.cs
@@ -5,6 +5,9 @@ namespace Content.Server.Spawners.Components;
 /// <summary>
 /// An extended <see cref="ConditionalSpawnerComponent"/> with optional rare prototypes and more configurable spawn behavior.
 /// </summary>
+/// <remarks>
+/// For non-trivial lists of prototypes, consider using <see cref="EntityTableSpawnerComponent"/> and an <see cref="EntityTableSelector"/> instead.
+/// </remarks>
 [RegisterComponent, EntityCategory("Spawner")]
 public sealed partial class RandomSpawnerComponent : ConditionalSpawnerComponent
 {

--- a/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
@@ -15,6 +15,12 @@ namespace Content.Server.Spawners.EntitySystems;
 // TODO: This whole system is a mess. A lot of this should be marked obsolete.
 // TODO: It should probably use interfaces with entity tables *if* more than one component is needed.
 // TODO: Remove the TransformSystem Dependency when engine SpawnAtPosition EntityCoordinates override is fixed.
+/// <summary>
+/// A system for spawning random or conditional entities, either on initializing spawner entities, or on adding GameRules.
+/// </summary>
+/// <seealso cref="ConditionalSpawnerComponent"/>
+/// <seealso cref="RandomSpawnerComponent"/>
+/// <seealso cref="EntityTableSpawnerComponent"/>
 public sealed partial class ConditionalSpawnerSystem : EntitySystem
 {
     [Dependency] private IRobustRandom _robustRandom = default!;

--- a/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
@@ -113,7 +113,7 @@ public sealed partial class ConditionalSpawnerSystem : EntitySystem
         var coordinates = GetRandomOffset(coords, component.Offset);
         var rotation = _xform.GetWorldRotation(xform);
 
-        Spawn(_robustRandom.Pick(component.Prototypes), coordinates, rotation: rotation);
+        Spawn(proto, coordinates, rotation: rotation);
     }
 
     private void Spawn(Entity<EntityTableSpawnerComponent> ent)

--- a/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
+++ b/Content.Shared/EntityTable/EntitySelectors/EntityTableSelector.cs
@@ -7,6 +7,14 @@ using Robust.Shared.Random;
 
 namespace Content.Shared.EntityTable.EntitySelectors;
 
+/// <summary>
+/// An extensible table for configurable entity selection, both random and deterministic.
+/// </summary>
+/// <remarks>
+/// This is currently the favored way to select multiple entities - generally for spawning.
+/// With its children, it supports returning multiple entities, nested selectors,
+/// groups of entities, conditions, and probabilistic spawns.
+/// </remarks>
 [ImplicitDataDefinitionForInheritors, UsedImplicitly(ImplicitUseTargetFlags.WithInheritors)]
 public abstract partial class EntityTableSelector
 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

One-line bugfix to restore rare spawns to RandomSpawnerComponent... plus a little cleanup.

The rest is file-scoping the RandomSpawnerComponent and ConditionalSpawnerComponent and removing redundant VV attributes while we're here.

[Hide whitespace works a treat, highly recommended.]

## Why / Balance

Fixes a regression introduced in #39096.  Bug reported in https://discord.com/channels/310555209753690112/1545241907817484308

## Technical details

`ConditionalSpawnerSystem.Spawn(EntUid, RandomSpawner)` already calls GetPrototype on L108 - this returns the entity that should spawn, which checks the rare prototype.  This is then _not used_ and instead the non-rare prototypes are selected randomly.

Instead, let's use the randomly selected one that respects rare prototypes. :)

## Test plan

Spawn a bunch of random anomaly spawners.
Get some floor traps.  This is good!  Try this on master and you will _not_!

## Media

The test plan in action.  All of the spawner icons with the urists are the rare prototypes.

https://github.com/user-attachments/assets/efea8664-e84f-4e53-975c-1bc774370811

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
:cl:
- fix: Random spawners once again respect their rare prototypes.