### PR TITLE
Bugfix: Global comms consoles work without a station check.

### DIFF
--- a/Content.Client/Communications/UI/CommunicationsConsoleBoundUserInterface.cs
+++ b/Content.Client/Communications/UI/CommunicationsConsoleBoundUserInterface.cs
@@ -21,10 +21,13 @@ public sealed partial class CommunicationsConsoleBoundUserInterface(EntityUid ow
     [Dependency] private SharedStationSystem _station = default!;
     [Dependency] private AlertLevelSystem _alertLevel = default!;
 
+    [Dependency] private EntityQuery<AlertLevelComponent> _alertLevelQuery;
+
     [ViewVariables]
     private CommunicationsConsoleMenu? _menu;
 
     private static readonly EntProtoId FallbackScreen = "Screen";
+    private static readonly ProtoId<AlertLevelPrototype> UnknownAlertLevel = "Unknown";
 
     /// <inheritdoc/>
     protected override void Open()
@@ -81,21 +84,30 @@ public sealed partial class CommunicationsConsoleBoundUserInterface(EntityUid ow
     {
         base.UpdateState(state);
 
+        if (_menu == null)
+            return;
+
         if (state is not CommunicationsConsoleInterfaceState commsState)
             return;
 
         var stationUid = _station.GetOwningStation(Owner);
 
-        if (!EntMan.TryGetComponent<AlertLevelComponent>(stationUid, out var alertComp))
-            return;
-
-        if (_menu != null)
+        ProtoId<AlertLevelPrototype> currentAlertLevel;
+        List<ProtoId<AlertLevelPrototype>> selectableAlertLevels;
+        bool canChangeAlertLevel;
+        if (_alertLevelQuery.TryGetComponent(stationUid, out var alertComp))
         {
-            var currentAlertLevel = alertComp.CurrentAlertLevel;
-            var selectableAlertLevels = _alertLevel.GetSelectableAlertLevels((stationUid.Value, alertComp));
-            var canChangeAlertLevel = _alertLevel.CanChangeAlertLevel((stationUid.Value, alertComp));
-
-            _menu.UpdateState(commsState, currentAlertLevel, selectableAlertLevels, canChangeAlertLevel);
+            currentAlertLevel = alertComp.CurrentAlertLevel;
+            selectableAlertLevels = _alertLevel.GetSelectableAlertLevels((stationUid.Value, alertComp));
+            canChangeAlertLevel = _alertLevel.CanChangeAlertLevel((stationUid.Value, alertComp));
         }
+        else
+        {
+            currentAlertLevel = UnknownAlertLevel;
+            selectableAlertLevels = new() { UnknownAlertLevel };
+            canChangeAlertLevel = false;
+        }
+
+        _menu.UpdateState(commsState, currentAlertLevel, selectableAlertLevels, canChangeAlertLevel);
     }
 }

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -18,24 +18,23 @@ using Content.Shared.Popups;
 using Content.Shared.Screens;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Communications
 {
     public sealed partial class CommunicationsConsoleSystem : EntitySystem
     {
+        [Dependency] private IAdminLogManager _adminLogger = default!;
+        [Dependency] private IConfigurationManager _cfg = default!;
         [Dependency] private AccessReaderSystem _accessReaderSystem = default!;
         [Dependency] private AlertLevelSystem _alertLevelSystem = default!;
         [Dependency] private ChatSystem _chatSystem = default!;
         [Dependency] private DeviceNetworkSystem _deviceNetworkSystem = default!;
         [Dependency] private EmergencyShuttleSystem _emergency = default!;
+        [Dependency] private IdentitySystem _identity = default!;
         [Dependency] private PopupSystem _popupSystem = default!;
         [Dependency] private RoundEndSystem _roundEndSystem = default!;
         [Dependency] private StationSystem _stationSystem = default!;
         [Dependency] private UserInterfaceSystem _uiSystem = default!;
-        [Dependency] private IConfigurationManager _cfg = default!;
-        [Dependency] private IAdminLogManager _adminLogger = default!;
-        [Dependency] private IdentitySystem _identity = default!;
 
         private const float UIUpdateInterval = 5.0f;
 
@@ -44,7 +43,7 @@ namespace Content.Server.Communications
             // All events that refresh the BUI
             SubscribeLocalEvent<AlertLevelChangedEvent>(OnAlertLevelChanged);
             SubscribeLocalEvent<RoundEndSystemChangedEvent>(_ => OnGenericBroadcastEvent());
-            SubscribeLocalEvent<AlertLevelDelayFinishedEvent>((ref AlertLevelDelayFinishedEvent ev) => OnGenericBroadcastEvent());
+            SubscribeLocalEvent((ref AlertLevelDelayFinishedEvent ev) => OnGenericBroadcastEvent());
 
             // Messages from the BUI
             SubscribeLocalEvent<CommunicationsConsoleComponent, CommunicationsConsoleSelectAlertLevelMessage>(OnSelectAlertLevelMessage);
@@ -134,15 +133,18 @@ namespace Content.Server.Communications
         {
             // TODO: Use component states and predict the UI
             _uiSystem.SetUiState(uid, CommunicationsConsoleUiKey.Key, new CommunicationsConsoleInterfaceState(
-                CanAnnounce(comp),
+                CanAnnounce((uid, comp)),
                 CanCallOrRecall(comp),
                 _roundEndSystem.ExpectedCountdownEnd
             ));
         }
 
-        private static bool CanAnnounce(CommunicationsConsoleComponent comp)
+        private bool CanAnnounce(Entity<CommunicationsConsoleComponent> ent, EntityUid? station = null)
         {
-            return comp.AnnouncementCooldownRemaining <= 0f;
+            if (station == null)
+                station = _stationSystem.GetOwningStation(ent) ?? EntityUid.Invalid;
+
+            return (station.Value.Valid || ent.Comp.Global) && ent.Comp.AnnouncementCooldownRemaining <= 0f;
         }
 
         private bool CanUse(EntityUid user, EntityUid console)
@@ -205,7 +207,7 @@ namespace Content.Server.Communications
             var author = Loc.GetString("comms-console-announcement-unknown-sender");
             if (message.Actor is { Valid: true } mob)
             {
-                if (!CanAnnounce(comp))
+                if (!CanAnnounce((uid, comp)))
                 {
                     return;
                 }

--- a/Resources/Locale/en-US/alert-levels/alert-levels.ftl
+++ b/Resources/Locale/en-US/alert-levels/alert-levels.ftl
@@ -1,6 +1,7 @@
 alert-level-announcement = Attention! Station alert level is now {$name}! {$announcement}
 
-alert-level-unknown = Unknown.
+alert-level-unknown = Unknown
+alert-level-unknown-announcement = This is a test of the alert broadcast system.
 alert-level-unknown-instructions = Unknown.
 
 alert-level-green = Green

--- a/Resources/Locale/en-US/alert-levels/alert-levels.ftl
+++ b/Resources/Locale/en-US/alert-levels/alert-levels.ftl
@@ -1,6 +1,6 @@
 alert-level-announcement = Attention! Station alert level is now {$name}! {$announcement}
 
-alert-level-unknown = Unknown
+# unknown name uses generic-unknown-title
 alert-level-unknown-announcement = This is a test of the alert broadcast system.
 alert-level-unknown-instructions = Unknown.
 

--- a/Resources/Locale/en-US/communications/communications-console-component.ftl
+++ b/Resources/Locale/en-US/communications/communications-console-component.ftl
@@ -47,3 +47,4 @@ comms-console-level-Red-flavour-label = Remain vigilant
 comms-console-level-Gamma-flavour-label = Suggest extreme caution
 comms-console-level-Delta-flavour-label = Good luck
 comms-console-level-Epsilon-flavour-label = You're fired
+comms-console-level-Unknown-flavour-label = Stay vigilent

--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -105,3 +105,13 @@
   color: PaleVioletRed
   emergencyLightColor: PaleVioletRed
   forceEnableEmergencyLights: true
+
+# Placeholder for the comms console in case of failure.
+- type: alertLevel
+  parent: Green
+  id: Unknown
+  name: alert-level-unknown
+  announcement: alert-level-unknown-announcement
+  instructions: alert-level-unknown-instructions
+  selectable: false
+  color: Gray

--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -110,7 +110,7 @@
 - type: alertLevel
   parent: Green
   id: Unknown
-  name: alert-level-unknown
+  name: generic-unknown-title
   announcement: alert-level-unknown-announcement
   instructions: alert-level-unknown-instructions
   selectable: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Fixes an issue where the communications console would have to be on a station in order to update its state at all.

## Why / Balance

The lone ops shuttle's comms console doesn't work without a valid station (it doesn't have one, it's an independent grid).

Updating the state shouldn't be controlled by the presence of a station or not - the state should update properly, and the controls should reflect the ability of the console to function.

## Technical details

The bug was directly caused by the check on CommunicationsConsoleBoundUserInterface.cs:L89.  This PR continues into the update function - passing a default value for the alert (introducing a new alert value, Unknown, that is used as this placeholder).  In such a state, only the shuttle call/recall function should work (and this works globally - if you can power a console capable of calling the shuttle, you can call the shuttle).

The state of the Announce button also now respects the actual capability of the console to make an announcement - global consoles can make an announcement from anywhere, otherwise the announcement consoles have to exist on a station.

The Broadcast buttons do not currently disable, though they _should_ when absent a station.

Similarly, there is no display for how long the console will take to return to a known working state, and the error message displayed when a non-global console is off of a station implies that the state is transient (it is not, you will continue to have no station without any action).  I can change these, either in this PR or in a subsequent one, but it has not yet been done.

## Test plan
1. Add the loneops game rule.
2. aghost, take the ghost role.
3. Use your communications console - after 30 seconds, it should be able to make a message.  Send off an announcement, it should function properly.  Your call/recall buttons should be disabled, the alert level should be Unknown, with the message of "Stay vigilent" displayed onscreen.
4. Warp back to the station, spawn a normal comms console.  Use the comms console - you should be able to make an announcement.
5. Enable godmode on yourself, walk into space.  Spawn a little lattice, an LV APU, a few cables and a comms console.
6. Use the comms console.  You should once again see the Unknown state, but your shuttle call button should be active.  Your Announce button should _not_ reactivate after 30 seconds, as you are not on a station.

## Media

The test plan being followed.

https://github.com/user-attachments/assets/bba5df61-27f7-4517-b14e-c3d252f935fc

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
- fix: Syndicate and wizard communications consoles should now be able to make announcements off-station.