### PR TITLE
Energy Gates make a swoosh sound when you walk through them

### DIFF
--- a/Content.Shared/Doors/Components/TurnstileComponent.cs
+++ b/Content.Shared/Doors/Components/TurnstileComponent.cs
@@ -43,7 +43,7 @@ public sealed partial class TurnstileComponent : Component
     /// Sound to play when the turnstile admits a mob through.
     /// </summary>
     [DataField]
-    public SoundSpecifier? TurnSound = new SoundPathSpecifier("/Audio/Items/ratchet.ogg", AudioParams.Default.WithVolume(-6));
+    public SoundSpecifier? TurnSound = new SoundPathSpecifier("/Audio/Effects/teleport_arrival.ogg", AudioParams.Default.WithVolume(-6));
 
     /// <summary>
     /// Sound to play when the turnstile denies entry


### PR DESCRIPTION
Despite swapping out the turnstiles for scifi-magic energy gates the sound didn't change. So now you have this laser firing, atmosphere-blocking barrier of pure energy it sounds like it's mechanically clicking whenever you go through it. What's happening, is there like a set of mechanical gears responsible for firing the laser? Maybe, it doesn't require electricity after all, doesn't really sound right to me though.

## About the PR
Energy gates now make a swoosh sound when you go through them rather than a clicking sound, which feels more thematically in line with what they are.

## Why / Balance
I went through an energy gate and wondered "why is this making a clicking sound".

## Technical details
Swapped the sound out in the component. Credit to Real Mouse for walking through a portal and convincing me it sounded good in the dev environment. Blame them if you disagree with this highly essential contribution.

## Test plan
1. Spawn energy gate.
2. Walk through it.
3. Swoosh.

## Media
https://github.com/user-attachments/assets/f1639aac-860c-40bc-b45e-07d023141c90

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None, hopefully. Literally a one line PR.

## Changelog
:cl:
- add: Energy gates make a swoosh sound rather than a clicking sound when walked through. How futuristic.
