### PR TITLE
Fix extra spaces when printing a .txt file on a fax machine

### DIFF
--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -293,6 +293,8 @@ public sealed partial class FaxSystem : EntitySystem
     private void OnFileButtonPressed(EntityUid uid, FaxMachineComponent component, FaxFileMessage args)
     {
         args.Label = args.Label?[..Math.Min(args.Label.Length, FaxFileMessageValidation.MaxLabelSize)];
+        // Text files often use CRLF line endings, and the paper renderer draws a stray CR as a space.
+        args.Content = args.Content.ReplaceLineEndings("\n");
         args.Content = args.Content[..Math.Min(args.Content.Length, FaxFileMessageValidation.MaxContentSize)];
         PrintFile(uid, component, args);
     }


### PR DESCRIPTION
## About the PR
Printing a `.txt` file through a fax machine no longer adds a trailing space to every line after the first.

## Why / Balance
Fixes #44224. The client reads the first line of the file with `ReadLine`, which strips the terminator, but the rest with `ReadToEnd`, so Windows `\r\n` endings survive from the second line on. The paper renderer has no special case for `\r`, so each one shows up as a stray space at the end of the line.

## Technical details
`FaxSystem.OnFileButtonPressed` now runs the content through `string.ReplaceLineEndings("\n")` right before the length is clamped, so a tampered client can't slip a CR past it either. This is the same call `DiscordChatLink` already uses, and it also handles a lone `\r`. Two lines in `Content.Server/Fax/FaxSystem.cs`.

## Test plan
Save a text file with Windows line endings, print it from a fax machine's file button and read the resulting paper: before the change every line except the first ends in a space, after it none do. A file with Unix endings prints the same as before.

## Media
No in-game visuals beyond the missing trailing spaces.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

## Changelog
:cl:
- fix: Printing a .txt file on a fax machine no longer adds a trailing space to every line.
