### PR TITLE
Only let the defib report on the entity it was used on

### DIFF
--- a/Content.IntegrationTests/Tests/Medical/DefibrillatorTest.cs
+++ b/Content.IntegrationTests/Tests/Medical/DefibrillatorTest.cs
@@ -1,5 +1,10 @@
 #nullable enable
+using System.Linq;
+using Content.IntegrationTests.Tests.Helpers;
 using Content.IntegrationTests.Tests.Interaction;
+using Content.Shared.Buckle;
+using Content.Shared.Buckle.Components;
+using Content.Shared.Chat;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
@@ -9,6 +14,7 @@ using Content.Shared.Medical;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Robust.Shared.Localization;
 using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.Medical;
@@ -19,11 +25,14 @@ namespace Content.IntegrationTests.Tests.Medical;
 [TestOf(typeof(DefibrillatorComponent))]
 public sealed class DefibrillatorTest : InteractionTest
 {
+    private sealed class SpeechListenerSystem : TestListenerSystem<EntitySpokeEvent>;
+
     // We need two hands to use a defbrillator.
     protected override string PlayerPrototype => "MobHuman";
 
     private static readonly EntProtoId DefibrillatorProtoId = "Defibrillator";
     private static readonly EntProtoId TargetProtoId = "MobHuman";
+    private static readonly EntProtoId BedProtoId = "Bed";
     private static readonly ProtoId<DamageTypePrototype> BluntDamageTypeId = "Blunt";
 
     /// <summary>
@@ -98,5 +107,61 @@ public sealed class DefibrillatorTest : InteractionTest
 
         // The target should be revived, but in crit.
         Assert.That(targetMobState.CurrentState, Is.EqualTo(MobState.Critical), "Target mob was not revived from being defibrillated.");
+    }
+
+    /// <summary>
+    /// Revives a target mob that is strapped to a bed. The bed gets caught in the zap chain, but the defibrillator
+    /// should only report on the patient, not complain that the bed is an inanimate object.
+    /// </summary>
+    [Test]
+    public async Task ReviveBuckledTest()
+    {
+        var damageableSystem = SEntMan.System<DamageableSystem>();
+        var mobThresholdsSystem = SEntMan.System<MobThresholdSystem>();
+        var buckleSystem = SEntMan.System<SharedBuckleSystem>();
+        var loc = Server.ResolveDependency<ILocalizationManager>();
+
+        // Don't let the player and target suffocate.
+        await AddAtmosphere();
+
+        await SpawnTarget(TargetProtoId);
+        var bed = ToServer(await Spawn(BedProtoId));
+
+        var targetMobState = Comp<MobStateComponent>();
+        var targetDamageable = Comp<DamageableComponent>();
+        var targetBuckle = Comp<BuckleComponent>();
+
+        await Server.WaitPost(() => buckleSystem.TryBuckle(STarget.Value, null, bed));
+        await RunTicks(3);
+        Assert.That(targetBuckle.BuckledTo, Is.EqualTo(bed), "Target mob was not buckled to the bed.");
+
+        // Kill the target, then bring the damage back down to a revivable level.
+        var critThreshold = mobThresholdsSystem.GetThresholdForState(STarget.Value, MobState.Critical);
+        var deathThreshold = mobThresholdsSystem.GetThresholdForState(STarget.Value, MobState.Dead);
+        var critDamage = new DamageSpecifier(ProtoMan.Index(BluntDamageTypeId), (critThreshold + deathThreshold) / 2);
+        var deathDamage = new DamageSpecifier(ProtoMan.Index(BluntDamageTypeId), deathThreshold);
+
+        await Server.WaitPost(() => damageableSystem.SetDamage((STarget.Value, targetDamageable), deathDamage));
+        await RunTicks(3);
+        await Server.WaitPost(() => damageableSystem.SetDamage((STarget.Value, targetDamageable), critDamage));
+        await RunTicks(3);
+        Assert.That(targetMobState.CurrentState, Is.EqualTo(MobState.Dead), "Target mob was not dead before being defibrillated.");
+
+        // Spawn a defib, activate it and record everything it says.
+        var defib = await PlaceInHands(DefibrillatorProtoId, enableToggleable: true);
+        var sDefib = ToServer(defib);
+        await Server.WaitPost(() => SEntMan.EnsureComponent<TestListenerComponent>(sDefib));
+        var cooldown = Comp<DefibrillatorComponent>(defib).ZapDelay;
+        await RunSeconds((float)cooldown.TotalSeconds);
+
+        // ZAP!
+        await Interact();
+
+        Assert.That(targetMobState.CurrentState, Is.EqualTo(MobState.Critical), "Buckled target mob was not revived from being defibrillated.");
+
+        // The dummy has no mind, so the defib complains about that. It must not also complain about the bed.
+        var spoken = GetEvents<EntitySpokeEvent>(sDefib).Select(ev => ev.Message).ToList();
+        Assert.That(spoken, Is.Not.Empty, "Defibrillator did not report on the patient.");
+        Assert.That(spoken, Does.Not.Contain(loc.GetString("defibrillator-not-living")), "Defibrillator reported on the bed instead of the patient.");
     }
 }

--- a/Content.Shared/Medical/SharedDefibrillatorSystem.cs
+++ b/Content.Shared/Medical/SharedDefibrillatorSystem.cs
@@ -189,13 +189,14 @@ public abstract partial class SharedDefibrillatorSystem : EntitySystem
     private bool TryRevive(Entity<DefibrillatorComponent> ent, EntityUid user, EntityUid target, bool isOriginal)
     {
         bool failedRevive = true;
+        string? message = null;
         if (_rotting.IsRotten(target))
         {
-            _chat.TrySendInGameICMessage(ent.Owner, Loc.GetString("defibrillator-rotten"), InGameICChatType.Speak, true);
+            message = Loc.GetString("defibrillator-rotten");
         }
         else if (TryComp<UnrevivableComponent>(target, out var unrevivable))
         {
-            _chat.TrySendInGameICMessage(ent.Owner, Loc.GetString(unrevivable.ReasonMessage), InGameICChatType.Speak, true);
+            message = Loc.GetString(unrevivable.ReasonMessage);
         }
         else
         {
@@ -222,11 +223,16 @@ public abstract partial class SharedDefibrillatorSystem : EntitySystem
             else
             {
                 if (HasComp<MindContainerComponent>(target))
-                    _chat.TrySendInGameICMessage(ent.Owner, Loc.GetString("defibrillator-no-mind"), InGameICChatType.Speak, true); //target can host a mind but doesn't
+                    message = Loc.GetString("defibrillator-no-mind"); //target can host a mind but doesn't
                 else
-                    _chat.TrySendInGameICMessage(ent.Owner, Loc.GetString("defibrillator-not-living"), InGameICChatType.Speak, true); //target couldn't have hosted a mind
+                    message = Loc.GetString("defibrillator-not-living"); //target couldn't have hosted a mind
             }
         }
+
+        // Only report on the entity the pads were actually placed on. Everything else caught in the chain
+        // (the bed the patient is strapped to, whoever is pulling them) still gets zapped, just silently.
+        if (isOriginal && message != null)
+            _chat.TrySendInGameICMessage(ent.Owner, message, InGameICChatType.Speak, true);
 
         _electrocution.TryDoElectrocution(
             target,


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Since #45062 the defib also zaps everything that counts as "interacting" with the patient, and for someone lying on a bed that includes the bed itself. `TryRevive` ran the same diagnosis for every entity in that chain, so after reviving the patient the defib would warn that the target was an inanimate object, because the bed has no mind container.

The diagnosis lines (rotten, unrevivable, no mind, inanimate) now only go out for the entity the pads were actually placed on. Everything else in the chain is still healed and shocked exactly as before, just without the commentary. Added an integration test that revives a mob strapped to a bed and checks the defib doesn't complain about the bed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes #45776

## Technical details
<!-- Summary of code changes for easier review. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->


Spawn urist and bed
Strap urist to bed
Zap Urist, defibrillator will complain about mindlessness, but nothing else.
Zap Bed, defibrillator will complain about inanimate object, but nothing else.


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
<!--
:cl:
- add: Crowbars now randomly spawn in maintenance lockers.
- remove: Crowbars no longer spawn in maintenance crates.
- tweak: Crowbar spawn rates have been increased for tool lockers.
- fix: Crowbars no longer accidentally spawn in microwaves.
-->
:cl:
- fix: The defibrillator no longer complains about an inanimate object when reviving a patient lying on a bed.
