### PR TITLE
Alternative Dispense for Ghost Vending Machine

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -143,7 +143,7 @@ public sealed partial class VendingMachineSystem : SharedVendingMachineSystem
             return;
 
         args.Handled = true;
-        EjectRandom((entity.Owner, entity.Comp), throwItem: true, forceEject: false);
+        EjectRandom((entity.Owner, entity.Comp), throwItem: args.ThrowItem, forceEject: false);
     }
 
     [SubscribeLocalEvent]

--- a/Content.Shared/VendingMachines/Components/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/Components/VendingMachineComponent.cs
@@ -46,8 +46,14 @@ public sealed partial class VendingMachineComponent : Component
     public EntityUid? RestockStream;
 }
 
+/// <summary>
+/// A simple event to signal to the Vending Machine that it should spawn a random item from its inventory.
+/// </summary>
 public sealed partial class VendingMachineSelfDispenseEvent : InstantActionEvent
 {
+    /// <summary>
+    /// Should the spawn item be thrown or just put down?
+    /// </summary>
     [DataField]
     public bool ThrowItem { get; set; } = true;
 }

--- a/Content.Shared/VendingMachines/Components/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/Components/VendingMachineComponent.cs
@@ -46,4 +46,8 @@ public sealed partial class VendingMachineComponent : Component
     public EntityUid? RestockStream;
 }
 
-public sealed partial class VendingMachineSelfDispenseEvent : InstantActionEvent;
+public sealed partial class VendingMachineSelfDispenseEvent : InstantActionEvent
+{
+    [DataField]
+    public bool ThrowItem { get; set; } = true;
+}

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -323,13 +323,33 @@
 - type: entity
   parent: BaseAction
   id: ActionVendingThrow
+  name: Eject Item
+  description: Randomly ejects an item from your stock.
+  components:
+  - type: Sprite
+    color: "#FF8000"
+    layers:
+      - texture: Interface/eject.png
+  - type: Action
+    useDelay: 15
+  - type: InstantAction
+    event: !type:VendingMachineSelfDispenseEvent
+
+- type: entity
+  parent: BaseAction
+  id: ActionVendingDispense
   name: Dispense Item
   description: Randomly dispense an item from your stock.
   components:
   - type: Action
-    useDelay: 30
+    useDelay: 15
+  - type: Sprite
+    color: "#00FF00"
+    layers:
+      - texture: Interface/eject.png
   - type: InstantAction
     event: !type:VendingMachineSelfDispenseEvent
+      throwItem: false
 
 - type: entity
   parent: BaseToggleAction

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -10,6 +10,7 @@
   - type: ActionGrant
     actions:
     - ActionVendingThrow
+    - ActionVendingDispense
   - type: StationAiWhitelist
   - type: AmbientOnPowered
   - type: AmbientSound


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
When ghosting into a vending machine, you can now simply dispense in edition to ejecting items. 
Also reduced cooldown.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This makes "solar's best" ghost more enjoyable, as they would spill all drinks they try to give.
Also the cooldown was really long when you have a busy corner and just want to serve items to people.

## Technical details
<!-- Summary of code changes for easier review. -->
Added throw field to VendingMachineSelfDispenseEvent which handler evaluates. 
Added new action, that uses not throw version of the event.
gaven action prototypes an icon and adjusted name and description.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Get Vending Machine
2. Control It
3. Check Actions

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
[Screencast from 2026-09-05 12-52-43.webm](https://github.com/user-attachments/assets/9980953c-84ed-4eda-a6c0-080a5e25476b)


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

- Added "ThrowItem" to VendingMachineSelfDispenseEvent. But its default value matches the default behavior of this event.


## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
:cl:
- tweak: Sentient vending machines can now safely dispense their content in addition to throwing it at people.
- tweak: Sentient vending machines can more frequently dispense items.

