### PR TITLE
Slight adjustments to department ordering

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -8,41 +8,43 @@
   - Quartermaster
   - SalvageSpecialist
 
-- type: department
-  id: Civilian
-  name: department-Civilian
-  description: department-Civilian-description
-  color: "#7F7F7F"
-  weight: -10
-  ignoreForDepartmentFallback: true
-  roles:
-  - Passenger
-  - Visitor
-
 # Please kill this
 - type: department
   id: CentralCommand
   name: department-CentralCommand
   description: department-CentralCommand-description
   color: "#0c344d"
+  weight: 120 # Highest weight of all NT departments; Central Command's authority is absolute
+  editorHidden: true
   roles:
-  - CentralCommandOfficial
   - CBURN
+  - CentralCommandOfficial
+  - DeathSquad
   - ERTLeader
   - ERTChaplain
   - ERTJanitor
   - ERTMedical
   - ERTSecurity
   - ERTEngineer
-  - DeathSquad
-  editorHidden: true
-  weight: 120
+
+- type: department
+  id: Civilian
+  name: department-Civilian
+  description: department-Civilian-description
+  color: "#7F7F7F"
+  weight: -10 # Lowest weight of all "regular" crew departments
+  ignoreForDepartmentFallback: true
+  roles:
+  - Passenger
+  - Visitor
 
 - type: department
   id: Command
   name: department-Command
   description: department-Command-description
   color: "#334E6D"
+  weight: 100 # Highest weight of all "regular" crew departments
+  primary: false
   roles:
   - Captain
   - ChiefEngineer
@@ -61,8 +63,6 @@
   - ERTSecurity
   - ERTEngineer
   - DeathSquad
-  primary: false
-  weight: 100
 
 - type: department
   id: Engineering
@@ -103,7 +103,7 @@
   name: department-Security
   description: department-Security-description
   color: "#DE3A3A"
-  weight: 20
+  weight: 20 # Raised priority compared to most other crew departments
   roles:
   - HeadOfSecurity
   - SecurityCadet
@@ -137,6 +137,7 @@
   name: department-Silicon
   description: department-Silicon-description
   color: "#D381C9"
+  weight: -20 # Displays after all regular crew departments, including Civilian, both because they're mechanically distinct and because they're subordinate to all crew by default
   roles:
   - Borg
   - StationAi

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -147,7 +147,7 @@
   name: department-Specific
   description: department-Specific-description
   color: "#9FED58"
-  weight: 10
+  weight: -100 # Displays after all other departments, since that makes them obviously distinct in the lobby's jobs list
   ignoreForDepartmentFallback: true
   roles:
   - Reporter


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Slightly adjusted the order that departments display in the lobby menu / crew manifest. After Service, it now displays Civilian -> Silicon -> Station-specific.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Silicon is after Civilian both because silicons are very mechanically distinct from all other roles, and because Civilian roles still count as crew and are therefore still "above" silicons hierarchy-wise (similarly to Command and Security displaying before other departments).
- Station-specific is at the bottom because it kind of just being buried between Security and Cargo felt arbitrary. Putting it at the bottom of the list I think makes more sense, since (depending on the station) it's a category that varies in length to the point of sometimes being entirely absent.

## Technical details
<!-- Summary of code changes for easier review. -->
Just YAML changes to some department weights (and some commenting to clarify the intent of these weights).

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Open the jobs menu in the lobby and verify that all jobs display in the proper order.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1286" height="812" alt="image" src="https://github.com/user-attachments/assets/0c11bbd1-6e76-400f-ab38-bab6a03e43d6" />
<img width="354" height="728" alt="image" src="https://github.com/user-attachments/assets/66ab4e3f-e3c8-401c-90bd-298f9612b014" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
N/A (minor change, CL not warranted)