### PR TITLE
Make bolas able to be removed as long as any hand is free, reduce Sec locker bola count

### DIFF
--- a/Content.Shared/DoAfter/DoAfterArgs.cs
+++ b/Content.Shared/DoAfter/DoAfterArgs.cs
@@ -97,6 +97,12 @@ public sealed partial class DoAfterArgs
     public bool NeedFreeHand;
 
     /// <summary>
+    /// Whether or not this do after requires you to have any empty hand,
+    /// </summary>
+    [DataField]
+    public bool NeedAnyFreeHand;
+
+    /// <summary>
     ///     Whether we need to keep our active hand as is (i.e. can't change hand or change item). This also covers
     ///     requiring the hand to be free (if applicable). This does nothing if <see cref="NeedHand"/> is false.
     /// </summary>
@@ -265,6 +271,7 @@ public sealed partial class DoAfterArgs
         Broadcast = other.Broadcast;
         NeedHand = other.NeedHand;
         NeedFreeHand = other.NeedFreeHand;
+        NeedAnyFreeHand = other.NeedAnyFreeHand;
         BreakOnHandChange = other.BreakOnHandChange;
         BreakOnDropItem = other.BreakOnDropItem;
         BreakOnMove = other.BreakOnMove;

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -269,7 +269,7 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
                 return true;
 
             if (args.NeedAnyFreeHand && _hands.GetEmptyHandCount((args.User, hands)) == 0)
-                return false;
+                return true;
         }
 
         if (args.RequireCanInteract && !_actionBlocker.CanInteract(args.User, args.Target))

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.Update.cs
@@ -267,6 +267,9 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             //If the user's hand is no longer empty, interrupt the do-after.
             if (args.NeedFreeHand & !_hands.ActiveHandIsEmpty(args.User))
                 return true;
+
+            if (args.NeedAnyFreeHand && _hands.GetEmptyHandCount((args.User, hands)) == 0)
+                return false;
         }
 
         if (args.RequireCanInteract && !_actionBlocker.CanInteract(args.User, args.Target))

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -301,6 +301,9 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             if (args.NeedFreeHand && !_hands.ActiveHandIsEmpty(args.User))
                 return false;
 
+            if (args.NeedAnyFreeHand && _hands.GetEmptyHandCount((args.User, handsComponent)) == 0)
+                return false;
+
             doAfter.InitialHand = handsComponent.ActiveHandId;
             doAfter.InitialItem = _hands.GetActiveItem((args.User, handsComponent));
         }

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -290,10 +290,8 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
         doAfter.NetUserPosition = GetNetCoordinates(doAfter.UserPosition);
         doAfter.NetMovementEntity = GetNetEntity(doAfter.MovementEntity);
 
-        // For this we need to stay on the same hand slot and need the same item in that hand slot
-        // (or if there is no item there we need to keep it free).
-        // The NeedFreeHand arg requires us to have our active hand empty.
-        if (args.NeedHand && (args.BreakOnHandChange || args.BreakOnDropItem))
+        // Check hand statuses; whether you have one, if its free (or any), and set up for breaking on change/drop.
+        if (args.NeedHand)
         {
             if (!TryComp(args.User, out HandsComponent? handsComponent))
                 return false;
@@ -304,8 +302,11 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
             if (args.NeedAnyFreeHand && _hands.GetEmptyHandCount((args.User, handsComponent)) == 0)
                 return false;
 
-            doAfter.InitialHand = handsComponent.ActiveHandId;
-            doAfter.InitialItem = _hands.GetActiveItem((args.User, handsComponent));
+            if (args.BreakOnHandChange || args.BreakOnDropItem)
+            {
+                doAfter.InitialHand = handsComponent.ActiveHandId;
+                doAfter.InitialItem = _hands.GetActiveItem((args.User, handsComponent));
+            }
         }
 
         doAfter.NetInitialItem = GetNetEntity(doAfter.InitialItem);

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -162,8 +162,8 @@ public abstract partial class SharedEnsnareableSystem : EntitySystem
             BreakOnDamage = false,
             NeedHand = true,
             BreakOnDropItem = false,
-            NeedFreeHand = true,
-            BreakOnHandChange = true,
+            NeedAnyFreeHand = true,
+            BreakOnHandChange = false,
         };
 
         if (!_doAfter.TryStartDoAfter(doAfterEventArgs))

--- a/Resources/Locale/en-US/alerts/alerts.ftl
+++ b/Resources/Locale/en-US/alerts/alerts.ftl
@@ -37,7 +37,7 @@ alerts-handcuffed-name = [color=yellow]Handcuffed[/color]
 alerts-handcuffed-desc = You're [color=yellow]handcuffed[/color] and can't use your hands. If anyone drags you, you won't be able to resist.
 
 alerts-ensnared-name = [color=yellow]Ensnared[/color]
-alerts-ensnared-desc = You're [color=yellow]ensnared[/color] and is impairing your ability to move.
+alerts-ensnared-desc = You're [color=yellow]ensnared[/color] and is impairing your ability to move. Click with a free hand to remove.
 
 alerts-buckled-name = [color=yellow]Buckled[/color]
 alerts-buckled-desc = You've been [color=yellow]buckled[/color] to something. Click the alert to unbuckle unless you're [color=yellow]handcuffed.[/color]

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -73,8 +73,6 @@
     - id: FlashlightSeclite
       prob: 0.8
     - id: WeaponDisabler
-    - id: SecurityBola
-      amount: 2
     - id: ClothingUniformJumpsuitSecGrey
       prob: 0.3
     - id: ClothingHeadHelmetBasic


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Some bola adjustments. Bolas now only require *a* free hand to remove, instead of needing it to be the active empty hand during removal. If your hands fill at any point, removal gets cancelled.

Bolas have also been removed from Security *lockers*; they're now only available in the SecTech (6x) or printable in the lathe.

Also touched up the alert to indicate you can click it to remove the bola.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bolas requiring a free hand was the impetus for the recent changes to it, but the fact that this renders you completely unable to do anything but shuffle away while removing it meant it could shut down antagonist pushes very hard, as they're given the pretty rough choice of 4s of doing nothing or attacking while sticking with the 50% slowdown.

The overabundance of bolas in the Security department also means they are a lot more common, rather than being an optional tool Security may choose to utilize. Lowering the bola count to just what's in the Sectech should help balance that out.

## Technical details
<!-- Summary of code changes for easier review. -->

A new DoAfter arg that just requires any hand to be free.

Did you know the hands system has two basically identical functions to get the free hand count? Wild.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Bola a Urist
2. Try removing the bola with your hands full
3. Try removing the bola with a hand empty
4. Switch hands, and then switch back, observe it keeps going
5. Pick up an item, observe that it stops

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->

:cl:
- remove: Security bolas no longer spawn in Security lockers.
- tweak: Bolas can now be removed as long as any hand is empty, not necessarily just the active hand. This also allows switching hands while removing the bola.