### PR TITLE
Avoid exception in ActionButton.UpdateBackground

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -288,8 +288,8 @@ public sealed class ActionButton : Control, IEntityControl
     public void UpdateBackground()
     {
         _controller ??= UserInterfaceManager.GetUIController<ActionUIController>();
-        if (Action != null ||
-            _controller.IsDragging && GetPositionInParent() == Parent?.ChildCount - 1)
+        if (Action != null
+            || _controller.IsDragging && (Parent == null || GetPositionInParent() == Parent?.ChildCount - 1))
         {
             Button.Texture = _slotBackground;
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Adds a check if the current Parent is null.

I could make this a hotfix, but I don't know if it fixes the issue described in https://discord.com/channels/310555209753690112/1545635398624084098 - trying to reproduce this in release doesn't work.  If there was a case where this isn't transient and you continued to have a null parent, maybe?

## Why / Balance

Closes #45291 (should've been closed earlier, original bug fixed, this fixes https://github.com/space-wizards/space-station-14/issues/45291#issuecomment-5553778932)

Found this in investigating https://discord.com/channels/310555209753690112/1545635398624084098

## Technical details

GetPositionInParent throws an exception when Parent is null, so we check if Parent is null.  If you wanted the new condition moved into a little function, I could do that - or -> and -> or is a bit odd.

## Test plan

1. Build master (or stable) in debug.
2. Remove all items from your action bar.
3. Open the action menu with K.
4. Drag an action onto the action bar.  You should get an exception.
5. Build master on the PR branch.
6. Repeat steps 2-4.  You should not get an exception.

## Media

Test step 6.  No exception after adding an action onto the bar.

https://github.com/user-attachments/assets/f90d15fe-af27-4d22-9577-73312d189756

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
ehh, I'd rather not overpromise on what this delivers.
