### PR TITLE
Remove TemporarySlotMap from ClientClothingSystem

### DIFF
--- a/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
+++ b/Content.Client/Chemistry/Visualizers/SolutionContainerVisualsSystem.cs
@@ -177,8 +177,8 @@ public sealed partial class SolutionContainerVisualsSystem : VisualizerSystem<So
             return;
 
         var equippedPrefix = clothing.EquippedPrefix == null
-            ? $"equipped-{args.Slot}"
-            : $" {clothing.EquippedPrefix}-equipped-{args.Slot}";
+            ? $"equipped-{args.Slot.Name}"
+            : $" {clothing.EquippedPrefix}-equipped-{args.Slot.Name}";
         var layerKeyPrefix = equippedPrefix + ent.Comp.EquippedFillBaseName;
 
         if (GetVisualsLayer(ent, layerKeyPrefix, ent.Comp.EquippedMaxFillLevels) is { } layer)

--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -72,7 +72,7 @@ public sealed partial class ClientClothingSystem : ClothingSystem
 
         // first attempt to get species specific data.
         if (inventory.SpeciesId != null)
-            ent.Comp.ClothingVisuals.TryGetValue($"{args.Slot}-{inventory.SpeciesId}", out layers);
+            ent.Comp.ClothingVisuals.TryGetValue($"{args.Slot.Name}-{inventory.SpeciesId}", out layers);
 
         // if that returned nothing, attempt to find generic data
         if (layers == null && !ent.Comp.ClothingVisuals.TryGetValue(args.Slot.Name, out layers))
@@ -90,7 +90,7 @@ public sealed partial class ClientClothingSystem : ClothingSystem
             if (key == null)
             {
                 // using the $"{args.Slot}" layer key as the "bookmark" for layer ordering until layer draw depths get added
-                key = $"{args.Slot}-{i}";
+                key = $"{args.Slot.Name}-{i}";
                 i++;
             }
 

--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -20,6 +20,32 @@ namespace Content.Client.Clothing;
 
 public sealed partial class ClientClothingSystem : ClothingSystem
 {
+    public const string Jumpsuit = "jumpsuit";
+
+    /// <summary>
+    /// This is a shitty hotfix written by me (Paul) to save me from renaming all files.
+    /// For some context, im currently refactoring inventory. Part of that is slots not being indexed by a massive enum anymore, but by strings.
+    /// Problem here: Every rsi-state is using the old enum-names in their state. I already used the new inventoryslots ALOT. tldr: its this or another week of renaming files.
+    /// </summary>
+    private static readonly Dictionary<string, string> TemporarySlotMap = new()
+    {
+        {"head", "HELMET"},
+        {"eyes", "EYES"},
+        {"ears", "EARS"},
+        {"mask", "MASK"},
+        {"outerClothing", "OUTERCLOTHING"},
+        {Jumpsuit, "INNERCLOTHING"},
+        {"neck", "NECK"},
+        {"back", "BACKPACK"},
+        {"belt", "BELT"},
+        {"gloves", "HAND"},
+        {"shoes", "FEET"},
+        {"id", "IDCARD"},
+        {"pocket1", "POCKET1"},
+        {"pocket2", "POCKET2"},
+        {"suitstorage", "SUITSTORAGE"},
+    };
+
     [Dependency] private IResourceCache _cache = default!;
     [Dependency] private DisplacementMapSystem _displacement = default!;
     [Dependency] private InventorySystem _inventorySystem = default!;
@@ -165,10 +191,13 @@ public sealed partial class ClientClothingSystem : ClothingSystem
         if (rsi == null)
             return false;
 
-        var state = $"equipped-{slot}";
+        var correctedSlot = slot;
+        TemporarySlotMap.TryGetValue(correctedSlot, out correctedSlot);
+
+        var state = $"equipped-{correctedSlot}";
 
         if (!string.IsNullOrEmpty(ent.Comp.EquippedPrefix))
-            state = $"{ent.Comp.EquippedPrefix}-equipped-{slot}";
+            state = $"{ent.Comp.EquippedPrefix}-equipped-{correctedSlot}";
 
         if (ent.Comp.EquippedState != null)
             state = $"{ent.Comp.EquippedState}";

--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -20,32 +20,6 @@ namespace Content.Client.Clothing;
 
 public sealed partial class ClientClothingSystem : ClothingSystem
 {
-    public const string Jumpsuit = "jumpsuit";
-
-    /// <summary>
-    /// This is a shitty hotfix written by me (Paul) to save me from renaming all files.
-    /// For some context, im currently refactoring inventory. Part of that is slots not being indexed by a massive enum anymore, but by strings.
-    /// Problem here: Every rsi-state is using the old enum-names in their state. I already used the new inventoryslots ALOT. tldr: its this or another week of renaming files.
-    /// </summary>
-    private static readonly Dictionary<string, string> TemporarySlotMap = new()
-    {
-        {"head", "HELMET"},
-        {"eyes", "EYES"},
-        {"ears", "EARS"},
-        {"mask", "MASK"},
-        {"outerClothing", "OUTERCLOTHING"},
-        {Jumpsuit, "INNERCLOTHING"},
-        {"neck", "NECK"},
-        {"back", "BACKPACK"},
-        {"belt", "BELT"},
-        {"gloves", "HAND"},
-        {"shoes", "FEET"},
-        {"id", "IDCARD"},
-        {"pocket1", "POCKET1"},
-        {"pocket2", "POCKET2"},
-        {"suitstorage", "SUITSTORAGE"},
-    };
-
     [Dependency] private IResourceCache _cache = default!;
     [Dependency] private DisplacementMapSystem _displacement = default!;
     [Dependency] private InventorySystem _inventorySystem = default!;
@@ -101,7 +75,7 @@ public sealed partial class ClientClothingSystem : ClothingSystem
             ent.Comp.ClothingVisuals.TryGetValue($"{args.Slot}-{inventory.SpeciesId}", out layers);
 
         // if that returned nothing, attempt to find generic data
-        if (layers == null && !ent.Comp.ClothingVisuals.TryGetValue(args.Slot, out layers))
+        if (layers == null && !ent.Comp.ClothingVisuals.TryGetValue(args.Slot.Name, out layers))
         {
             // No generic data either. Attempt to generate defaults from the item's RSI & item-prefixes
             if (!TryGetDefaultVisuals(ent, args.Slot, inventory.SpeciesId, out layers))
@@ -176,7 +150,7 @@ public sealed partial class ClientClothingSystem : ClothingSystem
     /// <remarks>
     /// Useful for lazily adding clothing sprites without modifying yaml. And for backwards compatibility.
     /// </remarks>
-    private bool TryGetDefaultVisuals(Entity<ClothingComponent> ent, string slot, string? speciesId,
+    private bool TryGetDefaultVisuals(Entity<ClothingComponent> ent, SlotDefinition slot, string? speciesId,
         [NotNullWhen(true)] out List<PrototypeLayerData>? layers)
     {
         layers = null;
@@ -191,13 +165,11 @@ public sealed partial class ClientClothingSystem : ClothingSystem
         if (rsi == null)
             return false;
 
-        var correctedSlot = slot;
-        TemporarySlotMap.TryGetValue(correctedSlot, out correctedSlot);
-
-        var state = $"equipped-{correctedSlot}";
+        var slotFlagName = slot.SlotFlags.ToString();
+        var state = $"equipped-{slotFlagName}";
 
         if (!string.IsNullOrEmpty(ent.Comp.EquippedPrefix))
-            state = $"{ent.Comp.EquippedPrefix}-equipped-{correctedSlot}";
+            state = $"{ent.Comp.EquippedPrefix}-equipped-{slotFlagName}";
 
         if (ent.Comp.EquippedState != null)
             state = $"{ent.Comp.EquippedState}";
@@ -303,12 +275,12 @@ public sealed partial class ClientClothingSystem : ClothingSystem
         // Cache the clothing sprite, used later.
         _spriteQuery.TryComp(equipment, out var clothingSprite);
 
-        var ev = new GetEquipmentVisualsEvent(equipee, slot);
+        var ev = new GetEquipmentVisualsEvent(equipee, slotDef);
         RaiseLocalEvent(equipment, ev);
 
         if (ev.Layers.Count == 0)
         {
-            RaiseLocalEvent(equipment, new EquipmentVisualsUpdatedEvent(equipee, slot, revealedLayers), true);
+            RaiseLocalEvent(equipment, new EquipmentVisualsUpdatedEvent(equipee, slotDef, revealedLayers), true);
             return;
         }
 
@@ -391,7 +363,7 @@ public sealed partial class ClientClothingSystem : ClothingSystem
             }
         }
 
-        RaiseLocalEvent(equipment, new EquipmentVisualsUpdatedEvent(equipee, slot, revealedLayers), true);
+        RaiseLocalEvent(equipment, new EquipmentVisualsUpdatedEvent(equipee, slotDef, revealedLayers), true);
     }
     #endregion Internal
 }

--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -20,32 +20,6 @@ namespace Content.Client.Clothing;
 
 public sealed partial class ClientClothingSystem : ClothingSystem
 {
-    public const string Jumpsuit = "jumpsuit";
-
-    /// <summary>
-    /// This is a shitty hotfix written by me (Paul) to save me from renaming all files.
-    /// For some context, im currently refactoring inventory. Part of that is slots not being indexed by a massive enum anymore, but by strings.
-    /// Problem here: Every rsi-state is using the old enum-names in their state. I already used the new inventoryslots ALOT. tldr: its this or another week of renaming files.
-    /// </summary>
-    private static readonly Dictionary<string, string> TemporarySlotMap = new()
-    {
-        {"head", "HELMET"},
-        {"eyes", "EYES"},
-        {"ears", "EARS"},
-        {"mask", "MASK"},
-        {"outerClothing", "OUTERCLOTHING"},
-        {Jumpsuit, "INNERCLOTHING"},
-        {"neck", "NECK"},
-        {"back", "BACKPACK"},
-        {"belt", "BELT"},
-        {"gloves", "HAND"},
-        {"shoes", "FEET"},
-        {"id", "IDCARD"},
-        {"pocket1", "POCKET1"},
-        {"pocket2", "POCKET2"},
-        {"suitstorage", "SUITSTORAGE"},
-    };
-
     [Dependency] private IResourceCache _cache = default!;
     [Dependency] private DisplacementMapSystem _displacement = default!;
     [Dependency] private InventorySystem _inventorySystem = default!;
@@ -191,13 +165,10 @@ public sealed partial class ClientClothingSystem : ClothingSystem
         if (rsi == null)
             return false;
 
-        var correctedSlot = slot;
-        TemporarySlotMap.TryGetValue(correctedSlot, out correctedSlot);
-
-        var state = $"equipped-{correctedSlot}";
+        var state = $"equipped-{slot}";
 
         if (!string.IsNullOrEmpty(ent.Comp.EquippedPrefix))
-            state = $"{ent.Comp.EquippedPrefix}-equipped-{correctedSlot}";
+            state = $"{ent.Comp.EquippedPrefix}-equipped-{slot}";
 
         if (ent.Comp.EquippedState != null)
             state = $"{ent.Comp.EquippedState}";

--- a/Content.Client/Toggleable/ToggleableVisualsSystem.cs
+++ b/Content.Client/Toggleable/ToggleableVisualsSystem.cs
@@ -83,10 +83,10 @@ public sealed partial class ToggleableVisualsSystem : VisualizerSystem<Toggleabl
 
         // attempt to get species specific data
         if (inventory.SpeciesId != null)
-            component.ClothingVisuals.TryGetValue($"{args.Slot}-{inventory.SpeciesId}", out layers);
+            component.ClothingVisuals.TryGetValue($"{args.Slot.Name}-{inventory.SpeciesId}", out layers);
 
-        // No species specific data.  Try to default to generic data.
-        if (layers == null && !component.ClothingVisuals.TryGetValue(args.Slot, out layers))
+        // No species specific data.  Try to defautlt to generic data.
+        if (layers == null && !component.ClothingVisuals.TryGetValue(args.Slot.Name, out layers))
             return;
 
         var modulateColor = AppearanceSystem.TryGetData<Color>(uid, ToggleableVisuals.Color, out var color, appearance);
@@ -97,7 +97,7 @@ public sealed partial class ToggleableVisualsSystem : VisualizerSystem<Toggleabl
             var key = layer.MapKeys?.FirstOrDefault();
             if (key == null)
             {
-                key = i == 0 ? $"{args.Slot}-toggle" : $"{args.Slot}-toggle-{i}";
+                key = i == 0 ? $"{args.Slot.Name}-toggle" : $"{args.Slot.Name}-toggle-{i}";
                 i++;
             }
 

--- a/Content.Shared/Clothing/ClothingEvents.cs
+++ b/Content.Shared/Clothing/ClothingEvents.cs
@@ -1,6 +1,7 @@
 
 using Content.Shared.Actions;
 using Content.Shared.Clothing.Components;
+using Content.Shared.Inventory;
 
 namespace Content.Shared.Clothing;
 
@@ -14,7 +15,7 @@ public sealed class GetEquipmentVisualsEvent : EntityEventArgs
     /// </summary>
     public readonly EntityUid Equipee;
 
-    public readonly string Slot;
+    public readonly SlotDefinition Slot;
 
     /// <summary>
     /// The layers that will be added to the entity that is wearing this item.
@@ -27,7 +28,7 @@ public sealed class GetEquipmentVisualsEvent : EntityEventArgs
     /// </remarks>
     public List<(string, PrototypeLayerData)> Layers = new();
 
-    public GetEquipmentVisualsEvent(EntityUid equipee, string slot)
+    public GetEquipmentVisualsEvent(EntityUid equipee, SlotDefinition slot)
     {
         Equipee = equipee;
         Slot = slot;
@@ -50,14 +51,14 @@ public sealed class EquipmentVisualsUpdatedEvent : EntityEventArgs
     /// <summary>
     /// The slot that the equipment is being worn in.
     /// </summary>
-    public readonly string Slot;
+    public readonly SlotDefinition Slot;
 
     /// <summary>
     /// The layers that this item is now revealing.
     /// </summary>
     public HashSet<string> RevealedLayers;
 
-    public EquipmentVisualsUpdatedEvent(EntityUid equipee, string slot, HashSet<string> revealedLayers)
+    public EquipmentVisualsUpdatedEvent(EntityUid equipee, SlotDefinition slot, HashSet<string> revealedLayers)
     {
         Equipee = equipee;
         Slot = slot;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
TemporarySlotMap was being used to convert SlotDefinition ``Name`` fields to SlotFlags enum value names from ``InventoryTemplatePrototype`` definitions. This is disgusting.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Cleanup
The dictionary named TemporarySlotMap was here for 5 years.

## Technical details
<!-- Summary of code changes for easier review. -->
removed a "Temporary" dictionary that was there for 5 years
``GetEquipmentVisualsEvent`` and ``EquipmentVisualsUpdatedEvent`` had the type of Slot changed from a string to SlotDefinition. The equivalent to using args.Slot before would be using args.Slot.Name instead now.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
``GetEquipmentVisualsEvent`` and ``EquipmentVisualsUpdatedEvent`` had the type of Slot changed from a string to SlotDefinition. The equivalent to using args.Slot before would be using args.Slot.Name instead now.