### PR TITLE
Fix airlock default layer from WallLayer to AirlockLayer

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -168,6 +168,11 @@
   - type: LayerChangeOnWeld
     unWeldedLayer: AirlockLayer
     weldedLayer: WallLayer
+  - type: Fixtures
+    fixtures:
+      fix1:
+        layer:
+        - AirlockLayer
   - type: DoorSignalControl
   - type: DeviceNetwork
     deviceNetId: Wireless


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changes default fixture on the airlock prototype
#45611 modified the base airlock prototype to inherit wall layer, which means mice and other similar critters cannot go through them
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix
## Technical details
<!-- Summary of code changes for easier review. -->
Changed fixture layer for airlocks
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Launch dev environment
2. Throw mouse at airlock
3. Mouse should pass through airlock

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
🐁
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
:cl: Minemoder
- fix: Mice and similar small critters can pass through airlocks again.
