### PR TITLE
Fix logic for gestation check in AnimalHusbandrySystem

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/AnimalHusbandrySystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/AnimalHusbandrySystem.cs
@@ -149,10 +149,7 @@ public sealed partial class AnimalHusbandrySystem : EntitySystem
         if (_failedAttempts.Contains(uid))
             return false;
 
-        if (!Resolve(uid, ref component, false))
-            return false;
-
-        if (component.Gestating)
+        if (!Resolve(uid, ref component, false) || component.Gestating)
             return false;
 
         if (HasComp<InfantComponent>(uid))
@@ -163,12 +160,9 @@ public sealed partial class AnimalHusbandrySystem : EntitySystem
 
         // If no satiations, no limit to reproduction
         if (!TryComp<SatiationComponent>(uid, out var satiation))
-        {
             return true;
-        }
 
-        // Check minimum hunger requirement
-        if (component!.MinHungerThreshold is { } minHunger)
+        if (component.MinHungerThreshold is { } minHunger)
         {
             if (!satiation.Has(SatiationSystem.Hunger) ||
                 _satiation.IsValueInRange((uid, satiation), SatiationSystem.Hunger, below: minHunger))

--- a/Content.Server/Nutrition/EntitySystems/AnimalHusbandrySystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/AnimalHusbandrySystem.cs
@@ -149,7 +149,10 @@ public sealed partial class AnimalHusbandrySystem : EntitySystem
         if (_failedAttempts.Contains(uid))
             return false;
 
-        if (Resolve(uid, ref component, false) && component.Gestating)
+        if (!Resolve(uid, ref component, false))
+            return false;
+
+        if (component.Gestating)
             return false;
 
         if (HasComp<InfantComponent>(uid))


### PR DESCRIPTION
About the PR
(I don’t know English well; I did the translation using AI.)
Fixes a NullReferenceException in AnimalHusbandrySystem.CanReproduce.

Why / Balance

No balance changes, is bug fix only. The crash occurred during the server tick in AnimalHusbandrySystem.Update, aborting reproduction processing.

Technical details

CanReproduce(uid, component = null) Resolve(uid, ref component, false). Because of the && short-circuit, when the entity has no ReproductiveComponent the component stays null and the method continues instead of bailing out. The later satiation checks then dereference component!.MinHungerThreshold / component.MinThirstThreshold, so any entity that has a SatiationComponent but no ReproductiveComponent (e.g. a human standing next to a animal, reached via TryReproduceNearby -> isValidPartner -> CanReproduce(partner)) throws a NRE.

Fix: return false immediately when the component can't be resolved an entity without ReproductiveComponent can't reproduce anyway which guarantees the subsequent component.* accesses are non-null. The soft (no-log) resolve is kept so checking arbitrary nearby partners doesn't spam warnings.

Test plan

dotnet test Content.IntegrationTests 
SpawnAndDeleteAllEntities

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

