### PR TITLE
Update for new render API

### DIFF
--- a/Content.Client/Access/AccessOverlay.cs
+++ b/Content.Client/Access/AccessOverlay.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Content.Client.Resources;
 using Content.Shared.Access.Components;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Shared.Enums;
@@ -13,12 +14,12 @@ public sealed class AccessOverlay : Overlay
     private const int TextFontSize = 12;
 
     private readonly IEntityManager _entityManager;
-    private readonly SharedTransformSystem _transformSystem;
+    private readonly TransformSystem _transformSystem;
     private readonly Font _font;
 
     public override OverlaySpace Space => OverlaySpace.ScreenSpace;
 
-    public AccessOverlay(IEntityManager entityManager, IResourceCache resourceCache, SharedTransformSystem transformSystem)
+    public AccessOverlay(IEntityManager entityManager, IResourceCache resourceCache, TransformSystem transformSystem)
     {
         _entityManager = entityManager;
         _transformSystem = transformSystem;
@@ -87,7 +88,7 @@ public sealed class AccessOverlay : Overlay
             }
 
             var accessInfoText = textBuffer.ToString();
-            var screenPos = args.ViewportControl.WorldToScreen(_transformSystem.GetWorldPosition(transform));
+            var screenPos = args.ViewportControl.WorldToScreen(_transformSystem.GetRenderWorldPosition((uid, transform)));
             args.ScreenHandle.DrawString(_font, screenPos, accessInfoText, Color.Gold);
         }
     }

--- a/Content.Client/Access/Commands/ShowAccessReadersCommand.cs
+++ b/Content.Client/Access/Commands/ShowAccessReadersCommand.cs
@@ -1,3 +1,4 @@
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Shared.Console;
@@ -8,7 +9,7 @@ public sealed partial class ShowAccessReadersCommand : LocalizedEntityCommands
 {
     [Dependency] private IOverlayManager _overlay = default!;
     [Dependency] private IResourceCache _cache = default!;
-    [Dependency] private SharedTransformSystem _xform = default!;
+    [Dependency] private TransformSystem _xform = default!;
 
     public override string Command => "showaccessreaders";
 

--- a/Content.Client/Buckle/BuckleSystem.cs
+++ b/Content.Client/Buckle/BuckleSystem.cs
@@ -24,7 +24,7 @@ internal sealed partial class BuckleSystem : SharedBuckleSystem
         if (HasComp<StrapComponent>(args.Transform.ParentUid) ||
             args.OldParent is { } oldParent && HasComp<StrapComponent>(oldParent))
         {
-            _xformSystem.SnapRenderPose(ent, true);
+            _xformSystem.SnapRenderPoseAfterParentChange(ent, true);
         }
     }
 

--- a/Content.Client/Buckle/BuckleSystem.cs
+++ b/Content.Client/Buckle/BuckleSystem.cs
@@ -12,12 +12,21 @@ internal sealed partial class BuckleSystem : SharedBuckleSystem
 {
     [Dependency] private RotationVisualizerSystem _rotationVisualizerSystem = default!;
     [Dependency] private IEyeManager _eye = default!;
-    [Dependency] private SharedTransformSystem _xformSystem = default!;
+    [Dependency] private TransformSystem _xformSystem = default!;
     [Dependency] private SpriteSystem _sprite = default!;
 
     [Dependency] private EntityQuery<SpriteComponent> _spriteQuery = default!;
 
     #region Event Handlers
+
+    protected override void AfterBuckleParentChanged(Entity<BuckleComponent> ent, ref EntParentChangedMessage args)
+    {
+        if (HasComp<StrapComponent>(args.Transform.ParentUid) ||
+            args.OldParent is { } oldParent && HasComp<StrapComponent>(oldParent))
+        {
+            _xformSystem.SnapRenderPose(ent, true);
+        }
+    }
 
     [SubscribeLocalEvent]
     private void OnStrapMoveEvent(Entity<StrapComponent> ent, ref MoveEvent args)
@@ -90,6 +99,8 @@ internal sealed partial class BuckleSystem : SharedBuckleSystem
     [SubscribeLocalEvent]
     private void OnBuckledEvent(Entity<BuckleComponent> ent, ref BuckledEvent args)
     {
+        _xformSystem.SnapRenderPose(ent, true);
+
         if (!args.Strap.Comp.ModifyBuckleDrawDepth)
             return;
 
@@ -114,6 +125,8 @@ internal sealed partial class BuckleSystem : SharedBuckleSystem
     [SubscribeLocalEvent]
     private void OnUnbuckledEvent(Entity<BuckleComponent> ent, ref UnbuckledEvent args)
     {
+        _xformSystem.SnapRenderPose(ent, true);
+
         if (!args.Strap.Comp.ModifyBuckleDrawDepth)
             return;
 

--- a/Content.Client/Buckle/BuckleSystem.cs
+++ b/Content.Client/Buckle/BuckleSystem.cs
@@ -24,7 +24,7 @@ internal sealed partial class BuckleSystem : SharedBuckleSystem
         if (HasComp<StrapComponent>(args.Transform.ParentUid) ||
             args.OldParent is { } oldParent && HasComp<StrapComponent>(oldParent))
         {
-            _xformSystem.SnapRenderPoseAfterParentChange(ent, true);
+            _xformSystem.SnapRenderTransformAfterParentChange(ent, true);
         }
     }
 
@@ -99,7 +99,7 @@ internal sealed partial class BuckleSystem : SharedBuckleSystem
     [SubscribeLocalEvent]
     private void OnBuckledEvent(Entity<BuckleComponent> ent, ref BuckledEvent args)
     {
-        _xformSystem.SnapRenderPose(ent, true);
+        _xformSystem.SnapRenderTransform(ent, true);
 
         if (!args.Strap.Comp.ModifyBuckleDrawDepth)
             return;
@@ -125,7 +125,7 @@ internal sealed partial class BuckleSystem : SharedBuckleSystem
     [SubscribeLocalEvent]
     private void OnUnbuckledEvent(Entity<BuckleComponent> ent, ref UnbuckledEvent args)
     {
-        _xformSystem.SnapRenderPose(ent, true);
+        _xformSystem.SnapRenderTransform(ent, true);
 
         if (!args.Strap.Comp.ModifyBuckleDrawDepth)
             return;

--- a/Content.Client/Chat/UI/SpeechBubble.cs
+++ b/Content.Client/Chat/UI/SpeechBubble.cs
@@ -4,6 +4,7 @@ using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Speech;
 using Robust.Client.Graphics;
+using Robust.Client.GameObjects;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Configuration;
@@ -18,7 +19,7 @@ namespace Content.Client.Chat.UI
         [Dependency] private IEyeManager _eyeManager = default!;
         [Dependency] private IEntityManager _entityManager = default!;
         [Dependency] protected IConfigurationManager ConfigManager = default!;
-        private readonly SharedTransformSystem _transformSystem;
+        private readonly TransformSystem _transformSystem;
 
         public enum SpeechType : byte
         {
@@ -89,7 +90,7 @@ namespace Content.Client.Chat.UI
         {
             IoCManager.InjectDependencies(this);
             _senderEntity = senderEntity;
-            _transformSystem = _entityManager.System<SharedTransformSystem>();
+            _transformSystem = _entityManager.System<TransformSystem>();
 
             // Use text clipping so new messages don't overlap old ones being pushed up.
             RectClipContent = true;
@@ -153,7 +154,7 @@ namespace Content.Client.Chat.UI
                 baseOffset = speech.SpeechBubbleOffset;
 
             var offset = (-_eyeManager.CurrentEye.Rotation).ToWorldVec() * -(EntityVerticalOffset + baseOffset);
-            var worldPos = _transformSystem.GetWorldPosition(xform) + offset;
+            var worldPos = _transformSystem.GetRenderWorldPosition((_senderEntity, xform)) + offset;
 
             var lowerCenter = _eyeManager.WorldToScreen(worldPos) / UIScale;
             var screenPos = lowerCenter - new Vector2(ContentSize.X / 2, ContentSize.Y + _verticalOffsetAchieved);

--- a/Content.Client/DoAfter/DoAfterOverlay.cs
+++ b/Content.Client/DoAfter/DoAfterOverlay.cs
@@ -19,7 +19,7 @@ public sealed class DoAfterOverlay : Overlay
     private readonly IEntityManager _entManager;
     private readonly IGameTiming _timing;
     private readonly IPlayerManager _player;
-    private readonly SharedTransformSystem _transform;
+    private readonly TransformSystem _transform;
     private readonly MetaDataSystem _meta;
     private readonly ProgressColorSystem _progressColor;
     private readonly SharedContainerSystem _container;
@@ -53,7 +53,7 @@ public sealed class DoAfterOverlay : Overlay
         _entManager = entManager;
         _timing = timing;
         _player = player;
-        _transform = _entManager.EntitySysManager.GetEntitySystem<SharedTransformSystem>();
+        _transform = _entManager.EntitySysManager.GetEntitySystem<TransformSystem>();
         _meta = _entManager.EntitySysManager.GetEntitySystem<MetaDataSystem>();
         _container = _entManager.EntitySysManager.GetEntitySystem<SharedContainerSystem>();
         _progressColor = _entManager.System<ProgressColorSystem>();
@@ -68,8 +68,6 @@ public sealed class DoAfterOverlay : Overlay
     {
         var handle = args.WorldHandle;
         var rotation = args.Viewport.Eye?.Rotation ?? Angle.Zero;
-        var xformQuery = _entManager.GetEntityQuery<TransformComponent>();
-
         // If you use the display UI scale then need to set max(1f, displayscale) because 0 is valid.
         const float scale = 1f;
         var scaleMatrix = Matrix3Helpers.CreateScale(new Vector2(scale, scale));
@@ -90,7 +88,7 @@ public sealed class DoAfterOverlay : Overlay
             if (comp.DoAfters.Count == 0)
                 continue;
 
-            var worldPosition = _transform.GetWorldPosition(xform, xformQuery);
+            var worldPosition = _transform.GetRenderWorldPosition((uid, xform));
             if (!bounds.Contains(worldPosition))
                 continue;
 

--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -29,6 +29,7 @@ namespace Content.Client.Hands.Systems
 
         [Dependency] private StrippableSystem _stripSys = default!;
         [Dependency] private SpriteSystem _sprite = default!;
+        [Dependency] private TransformSystem _renderTransforms = default!;
         [Dependency] private ExamineSystem _examine = default!;
         [Dependency] private DisplacementMapSystem _displacement = default!;
 
@@ -112,9 +113,15 @@ namespace Content.Client.Hands.Systems
             EntityCoordinates? targetDropLocation = null
         )
         {
+            TryGetHeldItem(ent, handId, out var held);
             base.DoDrop(ent, handId, doDropInteraction, log, targetDropLocation);
 
-            if (TryGetHeldItem(ent, handId, out var held) && TryComp(held, out SpriteComponent? sprite))
+            if (held == null || IsHolding(ent, held.Value))
+                return;
+
+            _renderTransforms.SnapRenderPose(held.Value, true);
+
+            if (TryComp(held, out SpriteComponent? sprite))
                 sprite.RenderOrder = EntityManager.CurrentTick.Value;
         }
 

--- a/Content.Client/Hands/Systems/HandsSystem.cs
+++ b/Content.Client/Hands/Systems/HandsSystem.cs
@@ -119,7 +119,7 @@ namespace Content.Client.Hands.Systems
             if (held == null || IsHolding(ent, held.Value))
                 return;
 
-            _renderTransforms.SnapRenderPose(held.Value, true);
+            _renderTransforms.SnapRenderTransform(held.Value, true);
 
             if (TryComp(held, out SpriteComponent? sprite))
                 sprite.RenderOrder = EntityManager.CurrentTick.Value;

--- a/Content.Client/Interactable/InteractionSystem.cs
+++ b/Content.Client/Interactable/InteractionSystem.cs
@@ -1,9 +1,24 @@
+using System.Numerics;
 using Content.Shared.Interaction;
 using Content.Shared.Storage;
+using Robust.Client.GameObjects;
 using Robust.Shared.Containers;
 
 namespace Content.Client.Interactable
 {
     // TODO Remove Shared prefix
-    public sealed partial class InteractionSystem : SharedInteractionSystem;
+    public sealed partial class InteractionSystem : SharedInteractionSystem
+    {
+        [Dependency] private TransformSystem _clientTransform = default!;
+
+        protected override bool TryFaceInteraction(EntityUid user, Vector2 coordinates)
+        {
+            var faced = base.TryFaceInteraction(user, coordinates);
+
+            if (faced)
+                _clientTransform.SnapRenderRotation(user);
+
+            return faced;
+        }
+    }
 }

--- a/Content.Client/Light/SunShadowOverlay.cs
+++ b/Content.Client/Light/SunShadowOverlay.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Client.Graphics;
 using Content.Shared.Light.Components;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
@@ -21,7 +22,7 @@ public sealed partial class SunShadowOverlay : Overlay
     [Dependency] private IPrototypeManager _protoManager = default!;
     private readonly EntityLookupSystem _lookup;
     private readonly SharedMapSystem _mapSys;
-    private readonly SharedTransformSystem _xformSys;
+    private readonly TransformSystem _xformSys;
 
     private readonly HashSet<Entity<SunShadowCastComponent>> _shadows = new();
 
@@ -30,7 +31,7 @@ public sealed partial class SunShadowOverlay : Overlay
     public SunShadowOverlay()
     {
         IoCManager.InjectDependencies(this);
-        _xformSys = _entManager.System<SharedTransformSystem>();
+        _xformSys = _entManager.System<TransformSystem>();
         _mapSys = _entManager.System<SharedMapSystem>();
         _lookup = _entManager.System<EntityLookupSystem>();
         ZIndex = AfterLightTargetOverlay.ContentZIndex + 1;
@@ -119,7 +120,7 @@ public sealed partial class SunShadowOverlay : Overlay
                     foreach (var ent in _shadows)
                     {
                         var xform = _entManager.GetComponent<TransformComponent>(ent.Owner);
-                        var (worldPos, worldRot) = _xformSys.GetWorldPositionRotation(xform);
+                        var (worldPos, worldRot) = _xformSys.GetRenderWorldPositionRotation((ent.Owner, xform));
                         // Need no rotation on matrix as sun shadow direction doesn't care.
                         var worldMatrix = Matrix3x2.CreateTranslation(worldPos);
                         var renderMatrix = Matrix3x2.Multiply(worldMatrix, invMatrix);

--- a/Content.Client/MapText/MapTextOverlay.cs
+++ b/Content.Client/MapText/MapTextOverlay.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using Content.Shared.MapText;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
@@ -19,14 +20,13 @@ public sealed class MapTextOverlay : Overlay
     private readonly IConfigurationManager _configManager;
     private readonly IEntityManager _entManager;
     private readonly IUserInterfaceManager _uiManager;
-    private readonly SharedTransformSystem _transform;
+    private readonly TransformSystem _transform;
     public override OverlaySpace Space => OverlaySpace.ScreenSpace;
 
-    public MapTextOverlay(
-        IConfigurationManager configManager,
+    public MapTextOverlay(IConfigurationManager configManager,
         IEntityManager entManager,
         IUserInterfaceManager uiManager,
-        SharedTransformSystem transform,
+        TransformSystem transform,
         IResourceCache resourceCache,
         IPrototypeManager prototypeManager)
     {
@@ -66,7 +66,7 @@ public sealed class MapTextOverlay : Overlay
 
         while(query.MoveNext(out var uid, out var mapText))
         {
-            var mapPos = _transform.GetMapCoordinates(uid);
+            var mapPos = _transform.GetRenderMapCoordinates(uid);
 
             if (mapPos.MapId != args.MapId)
                 continue;

--- a/Content.Client/MapText/MapTextSystem.cs
+++ b/Content.Client/MapText/MapTextSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.MapText;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
@@ -14,7 +15,7 @@ public sealed partial class MapTextSystem : SharedMapTextSystem
 {
     [Dependency] private IConfigurationManager _configManager = default!;
     [Dependency] private IUserInterfaceManager _uiManager = default!;
-    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private TransformSystem _transform = default!;
     [Dependency] private IResourceCache _resourceCache = default!;
     [Dependency] private IOverlayManager _overlayManager = default!;
 

--- a/Content.Client/Mining/MiningOverlay.cs
+++ b/Content.Client/Mining/MiningOverlay.cs
@@ -72,7 +72,7 @@ public sealed partial class MiningOverlay : Overlay
             var gridRot = xform.GridUid == null ? 0 : _xformQuery.CompOrNull(xform.GridUid.Value)?.LocalRotation ?? 0;
             var rotationMatrix = Matrix3Helpers.CreateRotation(gridRot);
 
-            var worldMatrix = Matrix3Helpers.CreateTranslation(_xform.GetWorldPosition(xform));
+            var worldMatrix = Matrix3Helpers.CreateTranslation(_xform.GetRenderWorldPosition((ore, xform)));
             var scaledWorld = Matrix3x2.Multiply(scaleMatrix, worldMatrix);
             var matty = Matrix3x2.Multiply(rotationMatrix, scaledWorld);
             handle.SetTransform(matty);

--- a/Content.Client/MouseRotator/MouseRotatorSystem.cs
+++ b/Content.Client/MouseRotator/MouseRotatorSystem.cs
@@ -1,7 +1,9 @@
 ﻿using Content.Shared.MouseRotator;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
+using Robust.Client.Timing;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
 
@@ -12,32 +14,126 @@ public sealed partial class MouseRotatorSystem : SharedMouseRotatorSystem
 {
     [Dependency] private IInputManager _input = default!;
     [Dependency] private IPlayerManager _player = default!;
-    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IClientGameTiming _timing = default!;
     [Dependency] private IEyeManager _eye = default!;
-    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private TransformSystem _transform = default!;
+
+    private EntityUid _renderRotationOverride;
+    private Angle _renderRotation;
+    private Angle _simulationRotationAtOverride;
+    private GameTick _renderRotationInactiveTick;
+    private bool _renderRotationInactive;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        UpdatesAfter.Add(typeof(EyeSystem));
+    }
+
+    public override void Shutdown()
+    {
+        ClearRenderRotationOverride();
+        base.Shutdown();
+    }
 
     public override void Update(float frameTime)
     {
+        var player = _player.LocalEntity;
+        var inactive = _renderRotationInactive && _timing.LastRealTick < _renderRotationInactiveTick;
+        MouseRotatorComponent? rotator = null;
+        TransformComponent? xform = null;
+        var snapRotation = false;
+        var oldWorldRotation = Angle.Zero;
+
+        if (player != null && TryComp(player, out rotator))
+        {
+            xform = Transform(player.Value);
+            snapRotation = rotator.Simple4DirMode;
+            if (snapRotation)
+                oldWorldRotation = _transform.GetWorldRotation(xform);
+        }
+
+        if (!inactive &&
+            _timing.IsFirstTimePredicted &&
+            _input.MouseScreenPosition.IsValid &&
+            player != null &&
+            rotator != null &&
+            xform != null)
+        {
+            UpdateMouseRotation(player.Value, rotator, xform);
+        }
+
         base.Update(frameTime);
 
-        if (!_timing.IsFirstTimePredicted || !_input.MouseScreenPosition.IsValid)
-            return;
+        if (!inactive &&
+            snapRotation &&
+            player != null &&
+            !oldWorldRotation.EqualsApprox(_transform.GetWorldRotation(player.Value)))
+        {
+            _transform.SnapRenderRotation(player.Value);
+        }
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        base.FrameUpdate(frameTime);
 
         var player = _player.LocalEntity;
+        if (player == null)
+        {
+            ClearRenderRotationOverride();
+            return;
+        }
 
-        if (player == null || !TryComp<MouseRotatorComponent>(player, out var rotator))
+        if (_renderRotationOverride.IsValid() && _renderRotationOverride != player.Value)
+            ClearRenderRotationOverride();
+
+        if (!TryComp(player, out MouseRotatorComponent? rotator))
+        {
+            if (_renderRotationOverride == player.Value && !_renderRotationInactive)
+            {
+                _renderRotationInactive = true;
+                _renderRotationInactiveTick = _timing.CurTick;
+            }
+
+            UpdateInactiveRenderRotationOverride(player.Value);
+            return;
+        }
+
+        if (_renderRotationInactive)
+        {
+            if (_timing.LastRealTick < _renderRotationInactiveTick)
+                return;
+
+            _renderRotationInactive = false;
+        }
+
+        if (!rotator.Simple4DirMode)
+        {
+            ClearRenderRotationOverride();
+            return;
+        }
+
+        if (!_input.MouseScreenPosition.IsValid)
             return;
 
         var xform = Transform(player.Value);
-
-        // Get mouse loc and convert to angle based on player location
-        var coords = _input.MouseScreenPosition;
-        var mapPos = _eye.PixelToMap(coords);
-
-        if (mapPos.MapId == MapId.Nullspace)
+        if (!TryGetMouseAngle(player.Value, xform, out var angle))
             return;
 
-        var angle = (mapPos.Position - _transform.GetMapCoordinates(player.Value, xform: xform).Position).ToWorldAngle();
+        var eyeRotation = _eye.CurrentEye.Rotation;
+        var rotation = GetCardinalRotation(angle, eyeRotation);
+
+        _transform.SetRenderRotationOverride(player.Value, rotation);
+        _renderRotationOverride = player.Value;
+        _renderRotation = rotation;
+        _simulationRotationAtOverride = _transform.GetWorldRotation(player.Value);
+    }
+
+    private void UpdateMouseRotation(EntityUid player, MouseRotatorComponent rotator, TransformComponent xform)
+    {
+        if (!TryGetMouseAngle(player, xform, out var angle))
+            return;
 
         var curRot = _transform.GetWorldRotation(xform);
 
@@ -50,11 +146,7 @@ public sealed partial class MouseRotatorSystem : SharedMouseRotatorSystem
             if (angleDir == (curRot + eyeRot).GetCardinalDir())
                 return;
 
-            var rotation = angleDir.ToAngle() - eyeRot; // convert back to world frame
-            if (rotation >= Math.PI) // convert to [-PI, +PI)
-                rotation -= 2 * Math.PI;
-            else if (rotation < -Math.PI)
-                rotation += 2 * Math.PI;
+            var rotation = GetCardinalRotation(angle, eyeRot);
             RaisePredictiveEvent(new RequestMouseRotatorRotationEvent
             {
                 Rotation = rotation,
@@ -81,5 +173,57 @@ public sealed partial class MouseRotatorSystem : SharedMouseRotatorSystem
             Rotation = angle,
             User = GetNetEntity(player)
         });
+    }
+
+    private bool TryGetMouseAngle(EntityUid player, TransformComponent xform, out Angle angle)
+    {
+        var mapPos = _eye.PixelToMap(_input.MouseScreenPosition);
+        var playerPos = _transform.GetRenderMapCoordinates((player, xform));
+
+        if (mapPos.MapId == MapId.Nullspace || mapPos.MapId != playerPos.MapId)
+        {
+            angle = default;
+            return false;
+        }
+
+        angle = (mapPos.Position - playerPos.Position).ToWorldAngle();
+        return true;
+    }
+
+    private static Angle GetCardinalRotation(Angle angle, Angle eyeRotation)
+    {
+        var rotation = (angle + eyeRotation).GetCardinalDir().ToAngle() - eyeRotation;
+        if (rotation >= Math.PI)
+            rotation -= 2 * Math.PI;
+        else if (rotation < -Math.PI)
+            rotation += 2 * Math.PI;
+
+        return rotation;
+    }
+
+    private void ClearRenderRotationOverride()
+    {
+        if (!_renderRotationOverride.IsValid())
+            return;
+
+        _transform.ClearRenderRotationOverride(_renderRotationOverride);
+        _renderRotationOverride = EntityUid.Invalid;
+        _renderRotationInactive = false;
+    }
+
+    private void UpdateInactiveRenderRotationOverride(EntityUid player)
+    {
+        if (_renderRotationOverride != player)
+            return;
+
+        if (_renderRotationInactive && _timing.LastRealTick < _renderRotationInactiveTick)
+            return;
+
+        var simulationRotation = _transform.GetWorldRotation(player);
+        if (simulationRotation.EqualsApprox(_renderRotation) ||
+            !simulationRotation.EqualsApprox(_simulationRotationAtOverride))
+        {
+            ClearRenderRotationOverride();
+        }
     }
 }

--- a/Content.Client/NetworkConfigurator/NetworkConfiguratorLinkOverlay.cs
+++ b/Content.Client/NetworkConfigurator/NetworkConfiguratorLinkOverlay.cs
@@ -1,5 +1,6 @@
 using Content.Client.NetworkConfigurator.Systems;
 using Content.Shared.DeviceNetwork.Components;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
@@ -12,7 +13,7 @@ public sealed partial class NetworkConfiguratorLinkOverlay : Overlay
     [Dependency] private IEntityManager _entityManager = default!;
     [Dependency] private IRobustRandom _random = default!;
     private readonly DeviceListSystem _deviceListSystem;
-    private readonly SharedTransformSystem _transformSystem;
+    private readonly TransformSystem _transformSystem;
 
     public Dictionary<EntityUid, Color> Colors = new();
     public EntityUid? Action;
@@ -24,7 +25,7 @@ public sealed partial class NetworkConfiguratorLinkOverlay : Overlay
         IoCManager.InjectDependencies(this);
 
         _deviceListSystem = _entityManager.System<DeviceListSystem>();
-        _transformSystem = _entityManager.System<SharedTransformSystem>();
+        _transformSystem = _entityManager.System<TransformSystem>();
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -68,7 +69,10 @@ public sealed partial class NetworkConfiguratorLinkOverlay : Overlay
                     continue;
                 }
 
-                args.WorldHandle.DrawLine(_transformSystem.GetWorldPosition(sourceTransform), _transformSystem.GetWorldPosition(linkTransform), Colors[uid]);
+                args.WorldHandle.DrawLine(
+                    _transformSystem.GetRenderWorldPosition((uid, sourceTransform)),
+                    _transformSystem.GetRenderWorldPosition((device, linkTransform)),
+                    Colors[uid]);
             }
         }
     }

--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -25,7 +25,7 @@ public sealed class EntityHealthBarOverlay : Overlay
     private readonly IEntityManager _entManager;
     private readonly IPrototypeManager _prototype;
 
-    private readonly SharedTransformSystem _transform;
+    private readonly TransformSystem _transform;
     private readonly MobStateSystem _mobStateSystem;
     private readonly MobThresholdSystem _mobThresholdSystem;
     private readonly StatusIconSystem _statusIconSystem;
@@ -42,7 +42,7 @@ public sealed class EntityHealthBarOverlay : Overlay
     {
         _entManager = entManager;
         _prototype = prototype;
-        _transform = _entManager.System<SharedTransformSystem>();
+        _transform = _entManager.System<TransformSystem>();
         _mobStateSystem = _entManager.System<MobStateSystem>();
         _mobThresholdSystem = _entManager.System<MobThresholdSystem>();
         _statusIconSystem = _entManager.System<StatusIconSystem>();
@@ -87,7 +87,7 @@ public sealed class EntityHealthBarOverlay : Overlay
             // we use the status icon component bounds if specified otherwise use sprite
             var bounds = _entManager.GetComponentOrNull<StatusIconComponent>(uid)?.Bounds ?? _spriteSystem.GetLocalBounds(
                 (uid, sprite));
-            var worldPos = _transform.GetWorldPosition(xform, xformQuery);
+            var worldPos = _transform.GetRenderWorldPosition((uid, xform));
 
             if (!bounds.Translated(worldPos).Intersects(args.WorldAABB))
                 continue;
@@ -96,7 +96,7 @@ public sealed class EntityHealthBarOverlay : Overlay
             if (CalcProgress(uid, mobStateComponent, damageableComponent, mobThresholdsComponent) is not { } deathProgress)
                 continue;
 
-            var worldPosition = _transform.GetWorldPosition(xform);
+            var worldPosition = worldPos;
             var worldMatrix = Matrix3Helpers.CreateTranslation(worldPosition);
 
             var scaledWorld = Matrix3x2.Multiply(scaleMatrix, worldMatrix);

--- a/Content.Client/Overlays/ScreechShockWaveOverlay.cs
+++ b/Content.Client/Overlays/ScreechShockWaveOverlay.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Shared.Screech;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
@@ -13,7 +14,7 @@ public sealed partial class ScreechShockWaveOverlay : Overlay
     [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IGameTiming _timing = default!;
 
-    private SharedTransformSystem? _xformSystem;
+    private TransformSystem? _xformSystem;
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
     public override bool RequestScreenTexture => true;
     private readonly ShaderInstance _shader;
@@ -79,7 +80,7 @@ public sealed partial class ScreechShockWaveOverlay : Overlay
                 continue;
 
             // shorthand
-            var mapPos = _xformSystem.GetWorldPosition(xform);
+            var mapPos = _xformSystem.GetRenderWorldPosition((entityUid, xform));
             var tempCoords = args.Viewport.WorldToLocal(mapPos);
 
             // normalized coords, 0 - 1 plane. This is pure hell, we subtract 1 because fragment calculates from the bottom and local goes from the top of the viewport

--- a/Content.Client/Physics/Controllers/MoverController.cs
+++ b/Content.Client/Physics/Controllers/MoverController.cs
@@ -18,6 +18,7 @@ public sealed partial class MoverController : SharedMoverController
     [Dependency] private IPlayerManager _playerManager = default!;
     [Dependency] private AlertsSystem _alerts = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
+    [Dependency] private Robust.Client.GameObjects.TransformSystem _renderTransforms = default!;
 
     public override void Initialize()
     {
@@ -26,6 +27,7 @@ public sealed partial class MoverController : SharedMoverController
         SubscribeLocalEvent<RelayInputMoverComponent, LocalPlayerDetachedEvent>(OnRelayPlayerDetached);
         SubscribeLocalEvent<InputMoverComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<InputMoverComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
+        SubscribeLocalEvent<InputMoverComponent, MoveEvent>(OnMoverTransformMoved);
 
         SubscribeLocalEvent<InputMoverComponent, UpdateIsPredictedEvent>(OnUpdatePredicted);
         SubscribeLocalEvent<MovementRelayTargetComponent, UpdateIsPredictedEvent>(OnUpdateRelayTargetPredicted);
@@ -83,6 +85,12 @@ public sealed partial class MoverController : SharedMoverController
     private void OnPlayerDetached(Entity<InputMoverComponent> entity, ref LocalPlayerDetachedEvent args)
     {
         SetMoveInput(entity, MoveButtons.None);
+    }
+
+    private void OnMoverTransformMoved(Entity<InputMoverComponent> entity, ref MoveEvent args)
+    {
+        if (!args.OldRotation.EqualsApprox(args.NewRotation))
+            _renderTransforms.SnapRenderRotation(entity);
     }
 
     public override void UpdateBeforeSolve(bool prediction, float frameTime)

--- a/Content.Client/Physics/Controllers/MoverController.cs
+++ b/Content.Client/Physics/Controllers/MoverController.cs
@@ -2,6 +2,7 @@ using Content.Shared.Alert;
 using Content.Shared.CCVar;
 using Content.Shared.Friction;
 using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Systems;
 using Robust.Client.GameObjects;
@@ -28,7 +29,7 @@ public sealed partial class MoverController : SharedMoverController
         SubscribeLocalEvent<RelayInputMoverComponent, LocalPlayerDetachedEvent>(OnRelayPlayerDetached);
         SubscribeLocalEvent<InputMoverComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<InputMoverComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
-        SubscribeLocalEvent<InputMoverComponent, MoveEvent>(OnMoverTransformMoved);
+        SubscribeLocalEvent<InputMoverComponent, MoveInputEvent>(OnMoverMoveInput);
 
         SubscribeLocalEvent<InputMoverComponent, UpdateIsPredictedEvent>(OnUpdatePredicted);
         SubscribeLocalEvent<MovementRelayTargetComponent, UpdateIsPredictedEvent>(OnUpdateRelayTargetPredicted);
@@ -88,10 +89,9 @@ public sealed partial class MoverController : SharedMoverController
         SetMoveInput(entity, MoveButtons.None);
     }
 
-    private void OnMoverTransformMoved(Entity<InputMoverComponent> entity, ref MoveEvent args)
+    private void OnMoverMoveInput(Entity<InputMoverComponent> entity, ref MoveInputEvent args)
     {
-        if (!args.OldRotation.EqualsApprox(args.NewRotation))
-            _transform.SnapRenderRotation(entity);
+        _transform.SnapRenderRotation(entity);
     }
 
     public override void UpdateBeforeSolve(bool prediction, float frameTime)

--- a/Content.Client/Physics/Controllers/MoverController.cs
+++ b/Content.Client/Physics/Controllers/MoverController.cs
@@ -34,6 +34,7 @@ public sealed partial class MoverController : SharedMoverController
         SubscribeLocalEvent<InputMoverComponent, UpdateIsPredictedEvent>(OnUpdatePredicted);
         SubscribeLocalEvent<MovementRelayTargetComponent, UpdateIsPredictedEvent>(OnUpdateRelayTargetPredicted);
         SubscribeLocalEvent<PullableComponent, UpdateIsPredictedEvent>(OnUpdatePullablePredicted);
+        SubscribeLocalEvent<RelayInputMoverComponent, GetPredictionReconciliationTargetEvent>(OnGetReconciliationTarget);
     }
 
     private void OnUpdatePredicted(Entity<InputMoverComponent> entity, ref UpdateIsPredictedEvent args)
@@ -61,6 +62,13 @@ public sealed partial class MoverController : SharedMoverController
 
         // TODO recursive pulling checks?
         // What if the entity is being pulled by a vehicle controlled by the player?
+    }
+
+    private void OnGetReconciliationTarget(
+        Entity<RelayInputMoverComponent> entity,
+        ref GetPredictionReconciliationTargetEvent args)
+    {
+        args.Target = GetEffectiveMover((entity.Owner, entity.Comp));
     }
 
     private void OnRelayPlayerAttached(Entity<RelayInputMoverComponent> entity, ref LocalPlayerAttachedEvent args)

--- a/Content.Client/Physics/Controllers/MoverController.cs
+++ b/Content.Client/Physics/Controllers/MoverController.cs
@@ -4,6 +4,7 @@ using Content.Shared.Friction;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Systems;
+using Robust.Client.GameObjects;
 using Robust.Client.Physics;
 using Robust.Client.Player;
 using Robust.Shared.Configuration;
@@ -18,7 +19,7 @@ public sealed partial class MoverController : SharedMoverController
     [Dependency] private IPlayerManager _playerManager = default!;
     [Dependency] private AlertsSystem _alerts = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
-    [Dependency] private Robust.Client.GameObjects.TransformSystem _renderTransforms = default!;
+    [Dependency] private TransformSystem _transform = default!;
 
     public override void Initialize()
     {
@@ -90,7 +91,7 @@ public sealed partial class MoverController : SharedMoverController
     private void OnMoverTransformMoved(Entity<InputMoverComponent> entity, ref MoveEvent args)
     {
         if (!args.OldRotation.EqualsApprox(args.NewRotation))
-            _renderTransforms.SnapRenderRotation(entity);
+            _transform.SnapRenderRotation(entity);
     }
 
     public override void UpdateBeforeSolve(bool prediction, float frameTime)

--- a/Content.Client/Radiation/Overlays/RadiationPulseOverlay.cs
+++ b/Content.Client/Radiation/Overlays/RadiationPulseOverlay.cs
@@ -98,7 +98,7 @@ namespace Content.Client.Radiation.Overlays
                             (
                                 _baseShader.Duplicate(),
                                 new RadiationShaderInstance(
-                                    _transform.GetMapCoordinates(pulseEntity),
+                                    _transform.GetRenderMapCoordinates(pulseEntity),
                                     pulse.VisualRange,
                                     pulse.StartTime,
                                     pulse.VisualDuration
@@ -116,7 +116,7 @@ namespace Content.Client.Radiation.Overlays
                     _entityManager.TryGetComponent(pulseEntity, out RadiationPulseComponent? pulse))
                 {
                     var shaderInstance = _pulses[pulseEntity];
-                    shaderInstance.instance.CurrentMapCoords = _transform.GetMapCoordinates(pulseEntity);
+                    shaderInstance.instance.CurrentMapCoords = _transform.GetRenderMapCoordinates(pulseEntity);
                     shaderInstance.instance.Range = pulse.VisualRange;
                 }
                 else

--- a/Content.Client/Singularity/SingularityOverlay.cs
+++ b/Content.Client/Singularity/SingularityOverlay.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Shared.CCVar;
 using Content.Shared.Singularity.Components;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Configuration;
@@ -16,7 +17,7 @@ namespace Content.Client.Singularity
         [Dependency] private IEntityManager _entMan = default!;
         [Dependency] private IPrototypeManager _prototypeManager = default!;
         [Dependency] private IConfigurationManager _configManager = default!;
-        private SharedTransformSystem? _xformSystem = null;
+        private TransformSystem? _xformSystem = null;
 
         /// <summary>
         ///     Maximum number of distortions that can be shown on screen at a time.
@@ -65,7 +66,7 @@ namespace Content.Client.Singularity
                 if (xform.MapID != args.MapId)
                     continue;
 
-                var mapPos = _xformSystem.GetWorldPosition(uid);
+                var mapPos = _xformSystem.GetRenderWorldPosition((uid, xform));
 
                 // is the distortion in range?
                 if ((mapPos - args.WorldAABB.ClosestPoint(mapPos)).LengthSquared() > MaxDistance * MaxDistance)

--- a/Content.Client/StatusIcon/StatusIconOverlay.cs
+++ b/Content.Client/StatusIcon/StatusIconOverlay.cs
@@ -40,7 +40,6 @@ public sealed partial class StatusIconOverlay : Overlay
 
         var eyeRot = args.Viewport.Eye?.Rotation ?? default;
 
-        var xformQuery = _entity.GetEntityQuery<TransformComponent>();
         var scaleMatrix = Matrix3Helpers.CreateScale(new Vector2(1, 1));
         var rotationMatrix = Matrix3Helpers.CreateRotation(-eyeRot);
 
@@ -52,7 +51,7 @@ public sealed partial class StatusIconOverlay : Overlay
 
             var bounds = comp.Bounds ?? _sprite.GetLocalBounds((uid, sprite));
 
-            var worldPos = _transform.GetWorldPosition(xform, xformQuery);
+            var worldPos = _transform.GetRenderWorldPosition((uid, xform));
 
             if (!bounds.Translated(worldPos).Intersects(args.WorldAABB))
                 continue;

--- a/Content.Client/Wall/WallMountVisibilityOverlay.cs
+++ b/Content.Client/Wall/WallMountVisibilityOverlay.cs
@@ -148,7 +148,7 @@ public sealed partial class WallMountVisibilityOverlay : Overlay
 
             viewportState.SeenThisFrame.Add(uid);
 
-            var targetAlpha = ComputeTargetAlpha(wallmount, xform, eye, matrix);
+            var targetAlpha = ComputeTargetAlpha(uid, wallmount, xform, eye, matrix);
             UpdateFadeState(uid, originalAlpha, targetAlpha, fadeStep, viewportState);
         }
     }
@@ -156,7 +156,7 @@ public sealed partial class WallMountVisibilityOverlay : Overlay
     /// <summary>
     /// Returns 1 if the entity is within its facing arc relative to the eye, 0 otherwise.
     /// </summary>
-    private float ComputeTargetAlpha(WallMountComponent wallmount, TransformComponent xform, IEye eye, Matrix3x2 matrix)
+    private float ComputeTargetAlpha(EntityUid uid, WallMountComponent wallmount, TransformComponent xform, IEye eye, Matrix3x2 matrix)
     {
         if (!wallmount.DirectionalVisibility || wallmount.Arc >= Math.Tau)
             return 1f;
@@ -168,7 +168,7 @@ public sealed partial class WallMountVisibilityOverlay : Overlay
         if (!_visibility.IsTileBlocked((gridUid, grid), tile))
             return 1f;
 
-        var (pos, rot) = _xform.GetWorldPositionRotation(xform);
+        var (pos, rot) = _xform.GetRenderWorldPositionRotation((uid, xform));
         var facingAngle = rot + eye.Rotation + wallmount.Direction;
 
         var entityScreenPos = Vector2.Transform(pos, matrix);

--- a/Content.Client/Weapons/Misc/TetherGunOverlay.cs
+++ b/Content.Client/Weapons/Misc/TetherGunOverlay.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Weapons.Misc;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
 
@@ -22,7 +23,7 @@ public sealed class TetherGunOverlay : Overlay
         var tetherQuery = _entManager.GetEntityQuery<TetherGunComponent>();
         var forceQuery = _entManager.GetEntityQuery<ForceGunComponent>();
         var worldHandle = args.WorldHandle;
-        var xformSystem = _entManager.System<SharedTransformSystem>();
+        var xformSystem = _entManager.System<TransformSystem>();
 
         while (query.MoveNext(out var uid, out var tethered))
         {
@@ -37,8 +38,8 @@ public sealed class TetherGunOverlay : Overlay
             if (xform.MapID != gunXform.MapID)
                 continue;
 
-            var worldPos = xformSystem.GetWorldPosition(xform, xformQuery);
-            var gunWorldPos = xformSystem.GetWorldPosition(gunXform, xformQuery);
+            var worldPos = xformSystem.GetRenderWorldPosition((uid, xform));
+            var gunWorldPos = xformSystem.GetRenderWorldPosition((gun, gunXform));
             var diff = worldPos - gunWorldPos;
             var angle = diff.ToWorldAngle();
             var length = diff.Length() / 2f;

--- a/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
+++ b/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
@@ -6,6 +6,7 @@ using Content.Shared.Buckle.Components;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Standing;
+using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 
 namespace Content.IntegrationTests.Tests.Buckle
@@ -227,6 +228,60 @@ namespace Content.IntegrationTests.Tests.Buckle
                     Assert.That(buckle.Buckled, Is.False);
                     Assert.That(buckle.BuckledTo, Is.Null);
                     Assert.That(strap.BuckledEntities, Is.Empty);
+                });
+            });
+        }
+
+        [Test]
+        public async Task BuckleAndUnbuckleSnapClientRenderPoseTest()
+        {
+            var map = await Pair.CreateTestMap();
+            EntityUid human = default;
+            EntityUid chair = default;
+            NetEntity netHuman = default;
+            NetEntity netChair = default;
+
+            await Server.WaitAssertion(() =>
+            {
+                human = SEntMan.SpawnEntity(BuckleDummyId, map.GridCoords);
+                chair = SEntMan.SpawnEntity(StrapDummyId, map.GridCoords);
+                netHuman = SEntMan.GetNetEntity(human);
+                netChair = SEntMan.GetNetEntity(chair);
+            });
+
+            await Pair.RunTicksSync(5);
+
+            await Client.WaitAssertion(() =>
+            {
+                var clientHuman = CEntMan.GetEntity(netHuman);
+                var clientChair = CEntMan.GetEntity(netChair);
+                var buckle = CEntMan.GetComponent<BuckleComponent>(clientHuman);
+                var buckleSystem = CEntMan.System<SharedBuckleSystem>();
+                var transformSystem = CEntMan.System<TransformSystem>();
+                var xform = CEntMan.GetComponent<TransformComponent>(clientHuman);
+
+                using (CGameTiming.StartStateApplicationArea())
+                    transformSystem.SetLocalPosition(clientHuman, new Vector2(0.5f, 0f), xform);
+
+                Assert.That(transformSystem.TryGetRenderPoseDebugData(clientHuman, out _), Is.True);
+                Assert.That(buckleSystem.TryBuckle(clientHuman, clientHuman, clientChair, buckle, popup: false), Is.True);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(transformSystem.TryGetRenderPoseDebugData(clientHuman, out _), Is.False);
+                    Assert.That(transformSystem.GetRenderWorldPosition(clientHuman),
+                        Is.EqualTo(transformSystem.GetWorldPosition(clientHuman)));
+                });
+
+                using (CGameTiming.StartStateApplicationArea())
+                    transformSystem.SetLocalPosition(clientHuman, new Vector2(0.25f, 0f), xform);
+
+                Assert.That(transformSystem.TryGetRenderPoseDebugData(clientHuman, out _), Is.True);
+                buckleSystem.Unbuckle(clientHuman, clientHuman);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(transformSystem.TryGetRenderPoseDebugData(clientHuman, out _), Is.False);
+                    Assert.That(transformSystem.GetRenderWorldPosition(clientHuman),
+                        Is.EqualTo(transformSystem.GetWorldPosition(clientHuman)));
                 });
             });
         }

--- a/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
+++ b/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
@@ -233,7 +233,7 @@ namespace Content.IntegrationTests.Tests.Buckle
         }
 
         [Test]
-        public async Task BuckleAndUnbuckleSnapClientRenderPoseTest()
+        public async Task BuckleAndUnbuckleSnapClientRenderTransformTest()
         {
             var map = await Pair.CreateTestMap();
             EntityUid human = default;
@@ -273,7 +273,7 @@ namespace Content.IntegrationTests.Tests.Buckle
                     if (!applied)
                         return;
 
-                    Assert.That(transformSystem.TryGetRenderPoseDebugData(clientHuman, out _), Is.False);
+                    Assert.That(transformSystem.TryGetRenderTransformDebugData(clientHuman, out _), Is.False);
                     Assert.That(transformSystem.GetRenderWorldPosition(clientHuman),
                         Is.EqualTo(transformSystem.GetWorldPosition(clientHuman)));
                 });
@@ -297,7 +297,7 @@ namespace Content.IntegrationTests.Tests.Buckle
                     if (!applied)
                         return;
 
-                    Assert.That(transformSystem.TryGetRenderPoseDebugData(clientHuman, out _), Is.False);
+                    Assert.That(transformSystem.TryGetRenderTransformDebugData(clientHuman, out _), Is.False);
                     Assert.That(transformSystem.GetRenderWorldPosition(clientHuman),
                         Is.EqualTo(transformSystem.GetWorldPosition(clientHuman)));
                 });

--- a/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
+++ b/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
@@ -251,39 +251,59 @@ namespace Content.IntegrationTests.Tests.Buckle
 
             await Pair.RunTicksSync(5);
 
-            await Client.WaitAssertion(() =>
+            await Server.WaitAssertion(() =>
             {
-                var clientHuman = CEntMan.GetEntity(netHuman);
-                var clientChair = CEntMan.GetEntity(netChair);
-                var buckle = CEntMan.GetComponent<BuckleComponent>(clientHuman);
-                var buckleSystem = CEntMan.System<SharedBuckleSystem>();
-                var transformSystem = CEntMan.System<TransformSystem>();
-                var xform = CEntMan.GetComponent<TransformComponent>(clientHuman);
-
-                using (CGameTiming.StartStateApplicationArea())
-                    transformSystem.SetLocalPosition(clientHuman, new Vector2(0.5f, 0f), xform);
-
-                Assert.That(transformSystem.TryGetRenderPoseDebugData(clientHuman, out _), Is.True);
-                Assert.That(buckleSystem.TryBuckle(clientHuman, clientHuman, clientChair, buckle, popup: false), Is.True);
-                Assert.Multiple(() =>
-                {
-                    Assert.That(transformSystem.TryGetRenderPoseDebugData(clientHuman, out _), Is.False);
-                    Assert.That(transformSystem.GetRenderWorldPosition(clientHuman),
-                        Is.EqualTo(transformSystem.GetWorldPosition(clientHuman)));
-                });
-
-                using (CGameTiming.StartStateApplicationArea())
-                    transformSystem.SetLocalPosition(clientHuman, new Vector2(0.25f, 0f), xform);
-
-                Assert.That(transformSystem.TryGetRenderPoseDebugData(clientHuman, out _), Is.True);
-                buckleSystem.Unbuckle(clientHuman, clientHuman);
-                Assert.Multiple(() =>
-                {
-                    Assert.That(transformSystem.TryGetRenderPoseDebugData(clientHuman, out _), Is.False);
-                    Assert.That(transformSystem.GetRenderWorldPosition(clientHuman),
-                        Is.EqualTo(transformSystem.GetWorldPosition(clientHuman)));
-                });
+                var buckle = SEntMan.GetComponent<BuckleComponent>(human);
+                Assert.That(SEntMan.System<SharedBuckleSystem>()
+                    .TryBuckle(human, human, chair, buckle, popup: false), Is.True);
             });
+
+            var applied = false;
+            for (var i = 0; i < 5 && !applied; i++)
+            {
+                await Pair.RunTicksSync(1);
+                await Client.WaitAssertion(() =>
+                {
+                    var clientHuman = CEntMan.GetEntity(netHuman);
+                    var clientChair = CEntMan.GetEntity(netChair);
+                    var buckle = CEntMan.GetComponent<BuckleComponent>(clientHuman);
+                    var transformSystem = CEntMan.System<TransformSystem>();
+                    var xform = CEntMan.GetComponent<TransformComponent>(clientHuman);
+                    applied = buckle.Buckled && xform.ParentUid == clientChair;
+                    if (!applied)
+                        return;
+
+                    Assert.That(transformSystem.TryGetRenderPoseDebugData(clientHuman, out _), Is.False);
+                    Assert.That(transformSystem.GetRenderWorldPosition(clientHuman),
+                        Is.EqualTo(transformSystem.GetWorldPosition(clientHuman)));
+                });
+            }
+
+            Assert.That(applied, Is.True, "the authoritative buckle state was not applied!!!");
+
+            await Server.WaitAssertion(() =>
+                SEntMan.System<SharedBuckleSystem>().Unbuckle(human, human));
+
+            applied = false;
+            for (var i = 0; i < 5 && !applied; i++)
+            {
+                await Pair.RunTicksSync(1);
+                await Client.WaitAssertion(() =>
+                {
+                    var clientHuman = CEntMan.GetEntity(netHuman);
+                    var buckle = CEntMan.GetComponent<BuckleComponent>(clientHuman);
+                    var transformSystem = CEntMan.System<TransformSystem>();
+                    applied = !buckle.Buckled;
+                    if (!applied)
+                        return;
+
+                    Assert.That(transformSystem.TryGetRenderPoseDebugData(clientHuman, out _), Is.False);
+                    Assert.That(transformSystem.GetRenderWorldPosition(clientHuman),
+                        Is.EqualTo(transformSystem.GetWorldPosition(clientHuman)));
+                });
+            }
+
+            Assert.That(applied, Is.True, "the authoritative unbuckle state was not applied");
         }
 
         [Test]

--- a/Content.IntegrationTests/Tests/Movement/MovementRenderTest.cs
+++ b/Content.IntegrationTests/Tests/Movement/MovementRenderTest.cs
@@ -37,7 +37,7 @@ public sealed class MovementRenderTest : MovementTest
             var sourceWorldPosition = transforms.GetWorldPosition(CPlayer);
             var targetPosition = sourcePosition + Vector2.UnitX;
             var targetRotation = xform.LocalRotation + Angle.FromDegrees(90);
-            transforms.ResetRenderPoses();
+            transforms.ResetRenderTransforms();
 
             using (CGameTiming.StartStateApplicationArea())
                 transforms.SetLocalPositionRotation(CPlayer, targetPosition, targetRotation, xform);
@@ -53,7 +53,7 @@ public sealed class MovementRenderTest : MovementTest
                 Assert.That(transforms.GetRenderWorldPosition(CPlayer), Is.EqualTo(sourceWorldPosition));
                 Assert.That(transforms.GetRenderWorldRotation(CPlayer).EqualsApprox(
                     transforms.GetWorldRotation(CPlayer)), Is.True);
-                Assert.That(transforms.TryGetRenderPoseDebugData(CPlayer, out _), Is.True);
+                Assert.That(transforms.TryGetRenderTransformDebugData(CPlayer, out _), Is.True);
             });
         });
     }
@@ -64,7 +64,7 @@ public sealed class MovementRenderTest : MovementTest
         await OverrideCVar(Side.Client, CVars.NetPredictTickBias, 12);
         await RunTicks(5);
 
-        await Client.WaitPost(() => CEntMan.System<TransformSystem>().ResetRenderPoses());
+        await Client.WaitPost(() => CEntMan.System<TransformSystem>().ResetRenderTransforms());
         await SetMovementKey(DirectionFlag.East, BoundKeyState.Down);
 
         var captures = new List<RotationCapture>();
@@ -112,7 +112,7 @@ public sealed class MovementRenderTest : MovementTest
         await Client.WaitPost(() =>
         {
             var transforms = CEntMan.System<TransformSystem>();
-            transforms.ResetRenderPoses();
+            transforms.ResetRenderTransforms();
             initialRotation = transforms.GetWorldRotation(CPlayer);
             var xform = CEntMan.GetComponent<TransformComponent>(CPlayer);
             target = CEntMan.GetNetCoordinates(xform.Coordinates.Offset(new Vector2(2f, 1f)));
@@ -168,7 +168,7 @@ public sealed class MovementRenderTest : MovementTest
 
                         var transforms = CEntMan.System<TransformSystem>();
                         var simulation = transforms.GetWorldRotation(CPlayer);
-                        var hasDebugData = transforms.TryGetRenderPoseDebugData(CPlayer, out var debugData);
+                        var hasDebugData = transforms.TryGetRenderTransformDebugData(CPlayer, out var debugData);
                         Assert.That(transforms.GetRenderWorldRotation(CPlayer).EqualsApprox(simulation), Is.True,
                             $"tick {tick}, frame {frame}, clicked {clickedRotation}, simulation {simulation}, data {debugData}");
                         if (hasDebugData)
@@ -205,7 +205,7 @@ public sealed class MovementRenderTest : MovementTest
         await Client.WaitPost(() =>
         {
             var transforms = CEntMan.System<TransformSystem>();
-            transforms.ResetRenderPoses();
+            transforms.ResetRenderTransforms();
             var coordinates = CEntMan.GetComponent<TransformComponent>(CPlayer).Coordinates;
             targets[0] = CEntMan.GetNetCoordinates(coordinates.Offset(Vector2.UnitX * 2f));
             targets[1] = CEntMan.GetNetCoordinates(coordinates.Offset(-Vector2.UnitX * 2f));
@@ -402,7 +402,7 @@ public sealed class MovementRenderTest : MovementTest
                         Assert.That(transforms.GetRenderWorldRotation(CPlayer).EqualsApprox(displayedRotation), Is.True,
                             $"displayed cursor tick {tick}, frame {frame}");
 
-                        if (transforms.TryGetRenderPoseDebugData(CPlayer, out var data))
+                        if (transforms.TryGetRenderTransformDebugData(CPlayer, out var data))
                         {
                             Assert.That(data.Type, Is.Not.EqualTo(RenderInterpolationType.PredictionCorrection),
                                 $"correction type tick {tick}, frame {frame}: {data}");
@@ -481,7 +481,7 @@ public sealed class MovementRenderTest : MovementTest
                 var renderedPosition = transforms.GetRenderWorldPosition(CPlayer);
                 var sourcePosition = simulationPosition;
                 var targetPosition = simulationPosition;
-                if (transforms.TryGetRenderPoseDebugData(CPlayer, out var data))
+                if (transforms.TryGetRenderTransformDebugData(CPlayer, out var data))
                 {
                     type = data.Type;
                     alpha = data.Alpha;

--- a/Content.IntegrationTests/Tests/Movement/MovementRenderTest.cs
+++ b/Content.IntegrationTests/Tests/Movement/MovementRenderTest.cs
@@ -1,7 +1,23 @@
+using System.Collections.Generic;
 using System.Numerics;
+using System.Reflection;
+using Content.Shared.Actions.Components;
+using Content.Shared.CombatMode;
+using Content.IntegrationTests.Fixtures.Attributes;
+using Content.Shared.MouseRotator;
+using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Events;
 using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Input;
+using Robust.Client.Timing;
+using Robust.Shared;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Input;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Map;
 using Robust.Shared.Maths;
+using Robust.Shared.Timing;
 
 namespace Content.IntegrationTests.Tests.Movement;
 
@@ -26,6 +42,10 @@ public sealed class MovementRenderTest : MovementTest
             using (CGameTiming.StartStateApplicationArea())
                 transforms.SetLocalPositionRotation(CPlayer, targetPosition, targetRotation, xform);
 
+            var inputMover = CEntMan.GetComponent<InputMoverComponent>(CPlayer);
+            var moveInput = new MoveInputEvent((CPlayer, inputMover), inputMover.HeldMoveButtons);
+            CEntMan.EventBus.RaiseLocalEvent(CPlayer, ref moveInput);
+
             Assert.Multiple(() =>
             {
                 Assert.That(xform.LocalPosition, Is.EqualTo(targetPosition));
@@ -36,5 +56,539 @@ public sealed class MovementRenderTest : MovementTest
                 Assert.That(transforms.TryGetRenderPoseDebugData(CPlayer, out _), Is.True);
             });
         });
+    }
+
+    [Test]
+    public async Task OrdinaryHeldMovementStaysCorrectionFreeTest()
+    {
+        await OverrideCVar(Side.Client, CVars.NetPredictTickBias, 12);
+        await RunTicks(5);
+
+        await Client.WaitPost(() => CEntMan.System<TransformSystem>().ResetRenderPoses());
+        await SetMovementKey(DirectionFlag.East, BoundKeyState.Down);
+
+        var captures = new List<RotationCapture>();
+        for (var tick = 0; tick < 6; tick++)
+        {
+            await Client.WaitRunTicks(1);
+            for (var frame = 1; frame <= 3; frame++)
+            {
+                var capture = await CaptureRotation(tick, frame);
+                captures.Add(capture);
+                AssertOrdinaryMovement(capture, captures);
+            }
+        }
+
+        for (var tick = 6; tick < 30; tick++)
+        {
+            await Server.WaitRunTicks(1);
+            var afterState = await CaptureRotation(tick, 0);
+            captures.Add(afterState);
+            AssertOrdinaryMovement(afterState, captures);
+
+            await Client.WaitRunTicks(1);
+            for (var frame = 1; frame <= 3; frame++)
+            {
+                var capture = await CaptureRotation(tick, frame);
+                captures.Add(capture);
+                AssertOrdinaryMovement(capture, captures);
+            }
+        }
+
+        await SetMovementKey(DirectionFlag.East, BoundKeyState.Up);
+        await RunTicks(3);
+    }
+
+    [Test]
+    public async Task ClickToFaceSnapsRenderRotationTest()
+    {
+        await OverrideCVar(Side.Client, CVars.NetPredictTickBias, 8);
+        await RunTicks(5);
+
+        NetCoordinates target = default;
+        var initialRotation = Angle.Zero;
+        var clickedRotation = Angle.Zero;
+        var authoritativeRotation = Angle.Zero;
+        await Client.WaitPost(() =>
+        {
+            var transforms = CEntMan.System<TransformSystem>();
+            transforms.ResetRenderPoses();
+            initialRotation = transforms.GetWorldRotation(CPlayer);
+            var xform = CEntMan.GetComponent<TransformComponent>(CPlayer);
+            target = CEntMan.GetNetCoordinates(xform.Coordinates.Offset(new Vector2(2f, 1f)));
+        });
+
+        await SetKey(EngineKeyFunctions.Use, BoundKeyState.Down, target);
+        await Client.WaitAssertion(() =>
+        {
+            var timing = Client.ResolveDependency<IClientGameTiming>();
+            timing.InSimulation = false;
+            try
+            {
+                timing.TickRemainder = timing.TickPeriod / 4;
+                CEntMan.FrameUpdate(1f / 60f);
+
+                var transforms = CEntMan.System<TransformSystem>();
+                var simulation = transforms.GetWorldRotation(CPlayer);
+                Assert.That(simulation.EqualsApprox(initialRotation), Is.False);
+                Assert.That(transforms.GetRenderWorldRotation(CPlayer).EqualsApprox(simulation), Is.True);
+                clickedRotation = simulation;
+            }
+            finally
+            {
+                timing.InSimulation = true;
+            }
+        });
+
+        await Server.WaitPost(() =>
+        {
+            // Replay the click against an already-correct authoritative rotation.
+            var xform = SEntMan.GetComponent<TransformComponent>(SPlayer);
+            var targetPosition = Transform.ToMapCoordinates(ToServer(target)).Position;
+            var position = Transform.GetWorldPosition(SPlayer) + new Vector2(0f, 0.75f);
+            Transform.SetWorldPosition((SPlayer, xform), position);
+            authoritativeRotation = Angle.FromWorldVec(targetPosition - position);
+            Transform.SetWorldRotation(SPlayer, authoritativeRotation);
+        });
+
+        for (var tick = 0; tick < 12; tick++)
+        {
+            await Server.WaitRunTicks(1);
+            await Client.WaitRunTicks(1);
+            await Client.WaitAssertion(() =>
+            {
+                var timing = Client.ResolveDependency<IClientGameTiming>();
+                timing.InSimulation = false;
+                try
+                {
+                    for (var frame = 1; frame <= 3; frame++)
+                    {
+                        timing.TickRemainder = timing.TickPeriod * frame / 4;
+                        CEntMan.FrameUpdate(1f / 144f);
+
+                        var transforms = CEntMan.System<TransformSystem>();
+                        var simulation = transforms.GetWorldRotation(CPlayer);
+                        var hasDebugData = transforms.TryGetRenderPoseDebugData(CPlayer, out var debugData);
+                        Assert.That(transforms.GetRenderWorldRotation(CPlayer).EqualsApprox(simulation), Is.True,
+                            $"tick {tick}, frame {frame}, clicked {clickedRotation}, simulation {simulation}, data {debugData}");
+                        if (hasDebugData)
+                        {
+                            Assert.That(Math.Abs(debugData.CorrectionRotation.Theta), Is.LessThan(0.0001),
+                                $"tick {tick}, frame {frame}");
+                        }
+                    }
+                }
+                finally
+                {
+                    timing.InSimulation = true;
+                }
+            });
+        }
+
+        await Client.WaitAssertion(() =>
+        {
+            var transforms = CEntMan.System<TransformSystem>();
+            Assert.That(transforms.GetWorldRotation(CPlayer).EqualsApprox(authoritativeRotation), Is.True);
+        });
+
+        await SetKey(EngineKeyFunctions.Use, BoundKeyState.Up, target);
+        await RunTicks(1);
+    }
+
+    [Test]
+    public async Task RapidClickFacingStaysOnLatestRotationTest()
+    {
+        await OverrideCVar(Side.Client, CVars.NetPredictTickBias, 12);
+        await RunTicks(5);
+
+        var targets = new NetCoordinates[2];
+        await Client.WaitPost(() =>
+        {
+            var transforms = CEntMan.System<TransformSystem>();
+            transforms.ResetRenderPoses();
+            var coordinates = CEntMan.GetComponent<TransformComponent>(CPlayer).Coordinates;
+            targets[0] = CEntMan.GetNetCoordinates(coordinates.Offset(Vector2.UnitX * 2f));
+            targets[1] = CEntMan.GetNetCoordinates(coordinates.Offset(-Vector2.UnitX * 2f));
+        });
+
+        var captures = new List<RotationCapture>();
+        var targetIndex = 0;
+        var finalRotation = Angle.Zero;
+        await SetKey(EngineKeyFunctions.Use, BoundKeyState.Down, targets[targetIndex]);
+        await SetKey(EngineKeyFunctions.Use, BoundKeyState.Up, targets[targetIndex]);
+
+        const int changes = 6;
+        for (var change = 0; change < changes; change++)
+        {
+            targetIndex ^= 1;
+            await SetKey(EngineKeyFunctions.Use, BoundKeyState.Down, targets[targetIndex]);
+            await SetKey(EngineKeyFunctions.Use, BoundKeyState.Up, targets[targetIndex]);
+
+            var expected = Angle.Zero;
+            await Client.WaitPost(() =>
+                expected = CEntMan.System<TransformSystem>().GetWorldRotation(CPlayer));
+            finalRotation = expected;
+
+            var immediate = await CaptureRotation(change, 0);
+            captures.Add(immediate);
+            AssertRotationSnapped(expected, immediate, captures);
+
+            await Client.WaitRunTicks(1);
+            for (var frame = 1; frame <= 3; frame++)
+            {
+                var capture = await CaptureRotation(change, frame);
+                captures.Add(capture);
+                AssertRotationSnapped(expected, capture, captures);
+            }
+        }
+
+        for (var settle = 0; settle < 16; settle++)
+        {
+            await Server.WaitRunTicks(1);
+            await Client.WaitRunTicks(1);
+            for (var frame = 1; frame <= 3; frame++)
+            {
+                var capture = await CaptureRotation(changes + settle, frame);
+                captures.Add(capture);
+                AssertRotationSnapped(finalRotation, capture, captures);
+            }
+        }
+    }
+
+    [Test]
+    public async Task CombatModeExitKeepsDisplayedRotationTest()
+    {
+        await OverrideCVar(Side.Client, CVars.NetPredictTickBias, 12);
+        await SetCombatMode(true);
+        await RunTicks(5);
+
+        var captures = new List<RotationCapture>();
+        const int changes = 12;
+        for (var change = 0; change < changes; change++)
+        {
+            var direction = (change & 1) == 0 ? Vector2.UnitX : -Vector2.UnitX;
+            await Client.WaitPost(() => SetMouseDirection(direction));
+            await Client.WaitRunTicks(1);
+
+            var capture = await CaptureRotation(change, 0);
+            captures.Add(capture);
+        }
+
+        var displayedRotation = captures[^1].Rendered;
+        await Client.WaitPost(() =>
+        {
+            var combat = CEntMan.GetComponent<CombatModeComponent>(CPlayer);
+            Assert.That(combat.IsInCombatMode, Is.True);
+            Assert.That(combat.CombatToggleActionEntity, Is.Not.Null);
+            var action = combat.CombatToggleActionEntity!.Value;
+            var actionComponent = CEntMan.GetComponent<ActionComponent>(action);
+            CEntMan.System<Content.Client.Actions.ActionsSystem>().TriggerAction((action, actionComponent));
+
+            Assert.That(combat.IsInCombatMode, Is.False);
+            Assert.That(CEntMan.HasComponent<MouseRotatorComponent>(CPlayer), Is.False);
+        });
+
+        for (var settle = 0; settle < 20; settle++)
+        {
+            var beforeState = await CaptureRotation(changes + settle, 0);
+            captures.Add(beforeState);
+            AssertRotationSnapped(displayedRotation, beforeState, captures);
+
+            await Server.WaitRunTicks(1);
+            var afterState = await CaptureRotation(changes + settle, 1);
+            captures.Add(afterState);
+            AssertRotationSnapped(displayedRotation, afterState, captures);
+
+            await Client.WaitRunTicks(1);
+            for (var frame = 2; frame <= 4; frame++)
+            {
+                var capture = await CaptureRotation(changes + settle, frame);
+                captures.Add(capture);
+                AssertRotationSnapped(displayedRotation, capture, captures);
+            }
+        }
+    }
+
+    [Test]
+    public async Task CombatFacingSurvivesTransientInvalidMousePositionTest()
+    {
+        await SetCombatMode(true);
+        await RunTicks(5);
+
+        await Client.WaitAssertion(() =>
+        {
+            var transforms = CEntMan.System<TransformSystem>();
+            var eye = Client.ResolveDependency<IEyeManager>();
+            var player = transforms.GetRenderMapCoordinates(CPlayer);
+            SetMouseScreenPosition(eye.MapToScreen(new MapCoordinates(player.Position - Vector2.UnitX, player.MapId)));
+
+            var timing = Client.ResolveDependency<IClientGameTiming>();
+            timing.InSimulation = false;
+            try
+            {
+                CEntMan.FrameUpdate(1f / 144f);
+                var displayedRotation = transforms.GetRenderWorldRotation(CPlayer);
+                Assert.That(displayedRotation.EqualsApprox(transforms.GetWorldRotation(CPlayer)), Is.False);
+
+                SetMouseScreenPosition(ScreenCoordinates.Invalid);
+                CEntMan.FrameUpdate(1f / 144f);
+                Assert.That(transforms.GetRenderWorldRotation(CPlayer).EqualsApprox(displayedRotation), Is.True);
+            }
+            finally
+            {
+                timing.InSimulation = true;
+            }
+        });
+
+        await SetCombatMode(false);
+    }
+
+    [Test]
+    public async Task CombatMouseRotationSnapsWithoutPredictionCorrectionTest()
+    {
+        await OverrideCVar(Side.Client, CVars.NetPredictTickBias, 8);
+        await SetCombatMode(true);
+        await RunTicks(5);
+        await Client.WaitAssertion(() =>
+            Assert.That(CEntMan.HasComponent<MouseRotatorComponent>(CPlayer), Is.True));
+        await SetMovementKey(DirectionFlag.East, BoundKeyState.Down);
+
+        for (var batch = 0; batch < 8; batch++)
+        {
+            await Server.WaitRunTicks(8);
+
+            for (var batchTick = 0; batchTick < 8; batchTick++)
+            {
+                var tick = batch * 8 + batchTick;
+                var theta = tick * MathF.Tau / 32f;
+                var direction = new Vector2(MathF.Cos(theta), MathF.Sin(theta));
+                var targetRotation = Angle.Zero;
+                await Client.WaitPost(() =>
+                {
+                    var transforms = CEntMan.System<TransformSystem>();
+                    var eye = Client.ResolveDependency<IEyeManager>();
+                    var player = transforms.GetRenderMapCoordinates(CPlayer);
+                    var mouse = eye.MapToScreen(new MapCoordinates(player.Position + direction * 0.25f, player.MapId));
+                    var mappedMouse = eye.PixelToMap(mouse);
+                    Assert.That(mappedMouse.MapId, Is.EqualTo(player.MapId));
+                    Assert.That((mappedMouse.Position - player.Position - direction * 0.25f).LengthSquared(), Is.LessThan(0.000001f));
+                    var eyeRotation = eye.CurrentEye.Rotation;
+                    targetRotation = ((mappedMouse.Position - player.Position).ToWorldAngle() + eyeRotation)
+                        .GetCardinalDir()
+                        .ToAngle() - eyeRotation;
+                    SetMouseScreenPosition(mouse);
+                });
+
+                await Client.WaitRunTicks(1);
+
+                for (var frame = 1; frame <= 3; frame++)
+                {
+                    await Client.WaitAssertion(() =>
+                    {
+                        var timing = Client.ResolveDependency<IClientGameTiming>();
+                        timing.TickRemainder = TimeSpan.FromTicks(timing.TickPeriod.Ticks * frame / 4);
+                        CEntMan.FrameUpdate(1f / 144f);
+
+                        var transforms = CEntMan.System<TransformSystem>();
+                        var eye = Client.ResolveDependency<IEyeManager>();
+                        var mappedMouse = eye.PixelToMap(InputManager.MouseScreenPosition);
+                        var renderPosition = transforms.GetRenderMapCoordinates(CPlayer);
+                        var eyeRotation = eye.CurrentEye.Rotation;
+                        var displayedRotation = ((mappedMouse.Position - renderPosition.Position).ToWorldAngle() + eyeRotation)
+                            .GetCardinalDir()
+                            .ToAngle() - eyeRotation;
+                        Assert.That(transforms.GetWorldRotation(CPlayer).EqualsApprox(targetRotation), Is.True,
+                            $"simulation tick {tick}, frame {frame}");
+                        Assert.That(transforms.GetRenderWorldRotation(CPlayer).EqualsApprox(displayedRotation), Is.True,
+                            $"displayed cursor tick {tick}, frame {frame}");
+
+                        if (transforms.TryGetRenderPoseDebugData(CPlayer, out var data))
+                        {
+                            Assert.That(data.Type, Is.Not.EqualTo(RenderInterpolationType.PredictionCorrection),
+                                $"correction type tick {tick}, frame {frame}: {data}");
+                            Assert.That(data.CorrectionTranslation.LengthSquared(), Is.LessThan(0.0000001f),
+                                $"translation tick {tick}, frame {frame}: {data}");
+                            Assert.That(Math.Abs(data.CorrectionRotation.Theta), Is.LessThan(0.0001),
+                                $"rotation tick {tick}, frame {frame}: {data}");
+                        }
+                    });
+                }
+            }
+        }
+
+        await SetMovementKey(DirectionFlag.East, BoundKeyState.Up);
+        await RunTicks(3);
+        await Client.WaitAssertion(() =>
+        {
+            SetMouseScreenPosition(ScreenCoordinates.Invalid);
+            CEntMan.FrameUpdate(1f / 144f);
+            var transforms = CEntMan.System<TransformSystem>();
+            Assert.That(transforms.GetRenderWorldRotation(CPlayer).EqualsApprox(
+                transforms.GetWorldRotation(CPlayer)), Is.True);
+        });
+    }
+
+    private void SetMouseScreenPosition(ScreenCoordinates position)
+    {
+        var mousePosition = FindField(InputManager.GetType(), "_mouseScreenPosition");
+        Assert.That(mousePosition, Is.Not.Null);
+        mousePosition!.SetValue(InputManager, position);
+    }
+
+    private void SetMouseDirection(Vector2 direction)
+    {
+        var transforms = CEntMan.System<TransformSystem>();
+        var eye = Client.ResolveDependency<IEyeManager>();
+        var player = transforms.GetRenderMapCoordinates(CPlayer);
+        SetMouseScreenPosition(eye.MapToScreen(new MapCoordinates(player.Position + direction, player.MapId)));
+    }
+
+    private static FieldInfo FindField(Type type, string name)
+    {
+        while (type != null)
+        {
+            if (type.GetField(name, BindingFlags.Instance | BindingFlags.NonPublic) is { } field)
+                return field;
+
+            type = type.BaseType;
+        }
+
+        return null;
+    }
+
+    private async Task<RotationCapture> CaptureRotation(int step, int frame)
+    {
+        var capture = default(RotationCapture);
+        await Client.WaitPost(() =>
+        {
+            var timing = Client.ResolveDependency<IClientGameTiming>();
+            timing.InSimulation = false;
+            try
+            {
+                timing.TickRemainder = timing.TickPeriod * frame / 4;
+                CEntMan.FrameUpdate(1f / 144f);
+
+                var transforms = CEntMan.System<TransformSystem>();
+                var simulation = transforms.GetWorldRotation(CPlayer);
+                var rendered = transforms.GetRenderWorldRotation(CPlayer);
+                RenderInterpolationType? type = null;
+                var alpha = 1f;
+                var correction = Angle.Zero;
+                var correctionTranslation = Vector2.Zero;
+                var source = simulation;
+                var target = simulation;
+                var simulationPosition = transforms.GetWorldPosition(CPlayer);
+                var renderedPosition = transforms.GetRenderWorldPosition(CPlayer);
+                var sourcePosition = simulationPosition;
+                var targetPosition = simulationPosition;
+                if (transforms.TryGetRenderPoseDebugData(CPlayer, out var data))
+                {
+                    type = data.Type;
+                    alpha = data.Alpha;
+                    correction = data.CorrectionRotation;
+                    correctionTranslation = data.CorrectionTranslation;
+                    source = data.Source.Rotation;
+                    target = data.Target.Rotation;
+                    sourcePosition = data.Source.Position;
+                    targetPosition = data.Target.Position;
+                }
+
+                capture = new RotationCapture(
+                    step,
+                    frame,
+                    timing.CurTick,
+                    timing.TickPhase,
+                    simulation,
+                    rendered,
+                    type,
+                    alpha,
+                    correction,
+                    source,
+                    target,
+                    simulationPosition,
+                    renderedPosition,
+                    correctionTranslation,
+                    sourcePosition,
+                    targetPosition);
+            }
+            finally
+            {
+                timing.InSimulation = true;
+            }
+        });
+        return capture;
+    }
+
+    private static void AssertRotationSnapped(
+        Angle expected,
+        RotationCapture capture,
+        List<RotationCapture> captures)
+    {
+        var error = Math.Abs(Angle.ShortestDistance(expected, capture.Rendered).Degrees);
+        if (error < 0.001)
+            return;
+
+        foreach (var row in captures)
+            TestContext.Out.WriteLine(row);
+
+        Assert.Fail($"Rendered rotation error {error} degrees: {capture}");
+    }
+
+    private static void AssertOrdinaryMovement(RotationCapture capture, List<RotationCapture> captures)
+    {
+        var rotationError = Math.Abs(Angle.ShortestDistance(capture.Simulation, capture.Rendered).Degrees);
+        var translationCorrection = capture.CorrectionTranslation.LengthSquared();
+        var rotationCorrection = Math.Abs(capture.Correction.Degrees);
+        var movedBackwards = captures.Count > 1 &&
+                             capture.RenderedPosition.X + 0.0001f < captures[^2].RenderedPosition.X;
+
+        if (rotationError < 0.001 &&
+            translationCorrection < 0.0000001f &&
+            rotationCorrection < 0.001 &&
+            !movedBackwards)
+        {
+            return;
+        }
+
+        foreach (var row in captures)
+            TestContext.Out.WriteLine(row);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rotationError, Is.LessThan(0.001), $"rendered rotation diverged: {capture}");
+            Assert.That(translationCorrection, Is.LessThan(0.0000001f), $"translation correction appeared: {capture}");
+            Assert.That(rotationCorrection, Is.LessThan(0.001), $"rotation correction appeared: {capture}");
+            Assert.That(movedBackwards, Is.False, $"rendered movement reversed: {capture}");
+        });
+    }
+
+    private readonly record struct RotationCapture(
+        int Step,
+        int Frame,
+        GameTick Tick,
+        float Phase,
+        Angle Simulation,
+        Angle Rendered,
+        RenderInterpolationType? Type,
+        float Alpha,
+        Angle Correction,
+        Angle Source,
+        Angle Target,
+        Vector2 SimulationPosition,
+        Vector2 RenderedPosition,
+        Vector2 CorrectionTranslation,
+        Vector2 SourcePosition,
+        Vector2 TargetPosition)
+    {
+        public override string ToString()
+        {
+            return $"step={Step},frame={Frame},tick={Tick.Value},phase={Phase:R}," +
+                   $"simulation={Simulation.Degrees:R},rendered={Rendered.Degrees:R}," +
+                   $"type={Type?.ToString() ?? "None"},alpha={Alpha:R},correction={Correction.Degrees:R}," +
+                   $"source={Source.Degrees:R},target={Target.Degrees:R}," +
+                   $"simulationPosition={SimulationPosition},renderedPosition={RenderedPosition}," +
+                   $"correctionTranslation={CorrectionTranslation},sourcePosition={SourcePosition}," +
+                   $"targetPosition={TargetPosition}";
+        }
     }
 }

--- a/Content.IntegrationTests/Tests/Movement/MovementRenderTest.cs
+++ b/Content.IntegrationTests/Tests/Movement/MovementRenderTest.cs
@@ -1,0 +1,40 @@
+using System.Numerics;
+using Robust.Client.GameObjects;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+
+namespace Content.IntegrationTests.Tests.Movement;
+
+public sealed class MovementRenderTest : MovementTest
+{
+    protected override int Tiles => 0;
+    protected override bool AddWalls => false;
+
+    [Test]
+    public async Task InputMoverRotationSnapsWithoutSnappingPositionTest()
+    {
+        await Client.WaitAssertion(() =>
+        {
+            var transforms = CEntMan.System<TransformSystem>();
+            var xform = CEntMan.GetComponent<TransformComponent>(CPlayer);
+            var sourcePosition = xform.LocalPosition;
+            var sourceWorldPosition = transforms.GetWorldPosition(CPlayer);
+            var targetPosition = sourcePosition + Vector2.UnitX;
+            var targetRotation = xform.LocalRotation + Angle.FromDegrees(90);
+            transforms.ResetRenderPoses();
+
+            using (CGameTiming.StartStateApplicationArea())
+                transforms.SetLocalPositionRotation(CPlayer, targetPosition, targetRotation, xform);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(xform.LocalPosition, Is.EqualTo(targetPosition));
+                Assert.That(xform.LocalRotation.EqualsApprox(targetRotation), Is.True);
+                Assert.That(transforms.GetRenderWorldPosition(CPlayer), Is.EqualTo(sourceWorldPosition));
+                Assert.That(transforms.GetRenderWorldRotation(CPlayer).EqualsApprox(
+                    transforms.GetWorldRotation(CPlayer)), Is.True);
+                Assert.That(transforms.TryGetRenderPoseDebugData(CPlayer, out _), Is.True);
+            });
+        });
+    }
+}

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -101,6 +101,14 @@ public abstract partial class SharedBuckleSystem
     private void OnParentChanged(Entity<BuckleComponent> ent, ref EntParentChangedMessage args)
     {
         BuckleTransformCheck(ent, args.Transform);
+        AfterBuckleParentChanged(ent, ref args);
+    }
+
+    /// <summary>
+    /// Allows sided buckle systems to handle completed parent changes.
+    /// </summary>
+    protected virtual void AfterBuckleParentChanged(Entity<BuckleComponent> ent, ref EntParentChangedMessage args)
+    {
     }
 
     private void OnInserted(Entity<BuckleComponent> ent, ref EntGotInsertedIntoContainerMessage args)
@@ -466,7 +474,6 @@ public abstract partial class SharedBuckleSystem
         if (buckleXform.ParentUid == strap.Owner && !Terminating(oldBuckledXform.ParentUid))
         {
             _transform.PlaceNextTo((buckle, buckleXform), (strap.Owner, oldBuckledXform));
-            buckleXform.ActivelyLerping = false;
 
             var oldBuckledToWorldRot = _transform.GetWorldRotation(strap);
             _transform.SetWorldRotationNoLerp((buckle, buckleXform), oldBuckledToWorldRot);

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Numerics;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.CCVar;
@@ -587,11 +588,14 @@ namespace Content.Shared.Interaction
             // Only rotate to face if they're not moving.
             if (!HasComp<NoRotateOnInteractComponent>(user) && (!TryComp(user, out InputMoverComponent? mover) || (mover.HeldMoveButtons & MoveButtons.AnyDirection) == 0x0))
             {
-                _rotateToFaceSystem.TryFaceCoordinates(user, _transform.ToMapCoordinates(coordinates).Position);
+                TryFaceInteraction(user, _transform.ToMapCoordinates(coordinates).Position);
             }
 
             return true;
         }
+
+        protected virtual bool TryFaceInteraction(EntityUid user, Vector2 coordinates)
+            => _rotateToFaceSystem.TryFaceCoordinates(user, coordinates);
 
         /// <summary>
         ///     Traces a ray from coords to otherCoords and returns the length


### PR DESCRIPTION
- Fix mob movement incorrectly causing rotation lerps (maybe I was the only one to notice it idk).
- Update API calls to use the new render-specific methods so they don't look stuttery.

BC on engine for downstreams on client code to use the render-specific methods as transformcomp no longer reflects the actual render transform.

Requires https://github.com/space-wizards/RobustToolbox/pull/7067

## Changelog
:cl:
- fix: Fix mobs not instantly changing direction when moving.