### PR TITLE
Gave monkeys kobolds & scurrets pockets

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
@@ -37,6 +37,28 @@
     strippingWindowPos: 2,4
     dependsOn: jumpsuit
     displayName: ID
+  - name: pocket1
+    slotTexture: pocket
+    fullTextureName: template_small
+    slotFlags: POCKET
+    slotGroup: MainHotbar
+    stripTime: 3
+    uiWindowPos: 0,3
+    strippingWindowPos: 0,4
+    dependsOn: jumpsuit
+    displayName: Pocket 1
+    stripHidden: true
+  - name: pocket2
+    slotTexture: pocket
+    fullTextureName: template_small
+    slotFlags: POCKET
+    slotGroup: MainHotbar
+    stripTime: 3
+    uiWindowPos: 2,3
+    strippingWindowPos: 1,4
+    dependsOn: jumpsuit
+    displayName: Pocket 2
+    stripHidden: true
   - name: suitstorage
     slotTexture: suit_storage
     slotFlags:   SUITSTORAGE

--- a/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/scurret_inventory_template.yml
@@ -48,6 +48,28 @@
     uiWindowPos: 2,1
     strippingWindowPos: 2,4
     displayName: ID
+  - name: pocket1
+    slotTexture: pocket
+    fullTextureName: template_small
+    slotFlags: POCKET
+    slotGroup: MainHotbar
+    stripTime: 3
+    uiWindowPos: 0,3
+    strippingWindowPos: 0,4
+    dependsOn: jumpsuit
+    displayName: Pocket 1
+    stripHidden: true
+  - name: pocket2
+    slotTexture: pocket
+    fullTextureName: template_small
+    slotFlags: POCKET
+    slotGroup: MainHotbar
+    stripTime: 3
+    uiWindowPos: 2,3
+    strippingWindowPos: 1,4
+    dependsOn: jumpsuit
+    displayName: Pocket 2
+    stripHidden: true
   - name: suitstorage
     slotTexture: suit_storage
     slotFlags:   SUITSTORAGE


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I gave monkeys, kobolds & scurrets the ability to have & utilise the incredible invention known as; Pockets, in the same manner any roundstart species can.

## Why / Balance
For monkeys/kobolds:
It doesn't make very much sense thematically or balance wise to restrict their access to pockets, as they already lack a bag, glove, and boot slot, which leaves them with their only storage solution being bags or toolboxes they drag or hold at all times. If that storage is stolen whilst they drag it, they lose _everything_ they had; this change, however, lets them store up to two small objects in a more secure spot, like everyone else already can; the pockets shouldn't just unexpectedly vanish for monkeys & kobolds.

> An example scenario before this proposed change: a Reinforcement Kobold (Nukie variant) has put their bag down momentarily to interact with something (or is slipped), and someone else rushes in and picks their bag up; this Kobold now no longer has their weapons, tools, or other various vital supplies and is entirely defenseless.  **_However_**, in a scenario after this proposed change, this Kobold loses most of their belongings, however they keep the viper & whatever else they already had in their pockets, and can now attempt to gun down the person who nabbed their bag.


For Scurrets:
To bring the expectations of pocket behaviour in-line with main species, as they too can wear clothes that have pockets for everyone else, yet don't for them.

## Technical details
Added twenty lines of standard pocket code taken from the human_inventory_template code unto both the monkey_inventory_template.yml & the scrurret_inventory_template.yml 

## Test plan
- 1. Load in
- 2. Spawn a Monkey, Kobold, & Scurret
- 3. Control them & put clothes on
- 4. Try put something small (such as a screwdriver) in their pockets
- 5. Success!

## Media
pun-pun
<img width="741" height="721" alt="punpunpockets" src="https://github.com/user-attachments/assets/5351c01f-787e-4e25-ad97-c86c1a88fdfe" />
reinforcement kobold
<img width="629" height="727" alt="koboldpockets" src="https://github.com/user-attachments/assets/1d44162a-4585-433e-a767-a78927dd0a9f" />
scurret
<img width="597" height="701" alt="scurretpockets" src="https://github.com/user-attachments/assets/8f691877-5f2d-4b85-a2cf-d6eaf3083d62" />

The UI looks a little funky but that really is just how it looks on everyone else minus the slots these guys are missing; I _can_ adjust it if necessary though (I will have to figure out how that works, but that's a-ok)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

## Changelog
:cl:
- add: Monkeys Kobolds & Scurrets now have standard pockets.
