### PR TITLE
Make stun batons not drop when slipping/stunned

### DIFF
--- a/Content.Shared/Hands/Components/PreventForcedThrowComponent.cs
+++ b/Content.Shared/Hands/Components/PreventForcedThrowComponent.cs
@@ -1,0 +1,9 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.Hands.Components;
+
+/// <summary>
+/// An item with this component will not be involuntarily dropped, e.g. from slips/stuns.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class PreventForcedThrowComponent : Component;

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Hands.Components;
+using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 
 namespace Content.Shared.Hands.EntitySystems;
@@ -41,5 +42,11 @@ public abstract partial class SharedHandsSystem
             args.SpeedModifier = 0f;
         else
             args.SpeedModifier *= (float)freeHands / totalHands;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnAttemptedItemDrop(Entity<PreventForcedThrowComponent> ent, ref FellDownThrowAttemptEvent args)
+    {
+        args.Cancelled = true;
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -2,7 +2,7 @@
   name: stun baton
   parent: [BaseItem, BaseSecurityContraband]
   id: Stunbaton
-  description: A stun baton for incapacitating people with. Actively harming with this is considered bad tone.
+  description: A stun baton for incapacitating people with. Has advanced wrist strap technology to prevent cadets accidentally dropping it.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Melee/stunbaton.rsi
@@ -100,6 +100,7 @@
   - type: Tag
     tags:
     - Stunbaton
+  - type: PreventForcedThrow
 
 - type: entity
   name: truncheon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

<img width="400" height="154" alt="image" src="https://github.com/user-attachments/assets/0eebf8ea-6801-45bd-9e18-11e235d554e5" />

Stun batons no longer drop from the player's hand unless explicitly dropped/stripped.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

With the experimental changes to disabler, Security are going to be a lot more susceptible to slipping for basic arrests. Slipping is already quite strong and funny but seeing as stun batons are the only non-lethal method for an officer to detain someone, slips are now even more beneficial. 

I don't want to change how slips work at their core, so this should be a sufficient evening of the balance. I am also not interested in making it work *only* on slips because that's needlessly specific for a single mob state (and doesn't even make sense for how wrist straps work anyways). 

Also the stun baton already has a strap in the sprite so, easy to rationalize. If you're wondering why I am not having any qualifier for the effect to take place, it's because the stun baton should be easy to use and adding complexity to the "turn on" functionality isn't desirable. 

No, we're not adding it to the truncheon just because it also has a strap in its sprite. 

## Technical details
<!-- Summary of code changes for easier review. -->

Simple component, there was already an event for forced throws so it just cancels it.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Hold stun baton
2. Slip
3. Stun baton still there

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/52d0baf0-3a77-4eb1-af38-b76ff0980f2d

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->

:cl:
- tweak: Stun batons are no longer dropped when slipped/stunned.