### PR TITLE
Rename AsimovCircuitBoard to CrewsimovCircuitBoard

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
@@ -23,7 +23,7 @@
     laws: NTDefault
 
 - type: entity
-  id: AsimovCircuitBoard
+  id: CrewsimovCircuitBoard
   parent: BaseSiliconLawboard
   name: law board (Crewsimov)
   description: An electronics board containing the Crewsimov lawset.

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1132,3 +1132,6 @@ JanitorServiceLight: null
 
 #2026-08-31
 DrinkWaterJug: JugWater
+
+#2026-09-05
+AsimovCircuitBoard: CrewsimovCircuitBoard


### PR DESCRIPTION
## About the PR
Renames the Crewsimov law board prototype from `AsimovCircuitBoard` to `CrewsimovCircuitBoard`. Its name, description and lawset already said Crewsimov; only the ID did not.

## Why / Balance
Fixes #45825. The mismatch is confusing and blocks downstreams that want an actual Asimov board. No gameplay effect.

## Technical details
One ID change in `law_boards.yml` plus a `migration.yml` entry. The ten station maps that place the board are left alone and migrate on load, like previous renames.

## Test plan
YAML linter passes locally. In game, load Box or Bagel and confirm the Crewsimov board is still placed and the server log has no unknown-prototype error.

## Media
Nothing visual changed.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
Prototype `AsimovCircuitBoard` renamed to `CrewsimovCircuitBoard`; the migration entry covers maps, direct references need the new name.

## Changelog
No player-facing change, so no :cl: entry.
