### PR TITLE
Add configurable solid material fires

### DIFF
--- a/Content.Client/Atmos/EntitySystems/FireVisualizerSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/FireVisualizerSystem.cs
@@ -20,7 +20,7 @@ public sealed partial class FireVisualizerSystem : VisualizerSystem<FireVisualsC
     {
         base.Initialize();
 
-        SubscribeLocalEvent<FireVisualsComponent, ComponentInit>(OnComponentInit);
+        SubscribeLocalEvent<FireVisualsComponent, ComponentStartup>(OnComponentStartup);
         SubscribeLocalEvent<FireVisualsComponent, ComponentShutdown>(OnShutdown);
     }
 
@@ -41,7 +41,8 @@ public sealed partial class FireVisualizerSystem : VisualizerSystem<FireVisualsC
         }
     }
 
-    private void OnComponentInit(EntityUid uid, FireVisualsComponent component, ComponentInit args)
+    // An entity entering PVS can already be burning. Its child light must wait until initialization finishes.
+    private void OnComponentStartup(EntityUid uid, FireVisualsComponent component, ComponentStartup args)
     {
         if (!TryComp<SpriteComponent>(uid, out var sprite) || !TryComp(uid, out AppearanceComponent? appearance))
             return;

--- a/Content.IntegrationTests/Tests/Atmos/SolidFuelTest.cs
+++ b/Content.IntegrationTests/Tests/Atmos/SolidFuelTest.cs
@@ -1,0 +1,464 @@
+using System.Collections.Generic;
+using Content.Server.Atmos.Components;
+using Content.Server.Atmos.EntitySystems;
+using Content.Server.Chemistry.TileReactions;
+using Content.Shared.Atmos;
+using Content.Shared.Atmos.Components;
+using Content.Shared.CCVar;
+using Content.Shared.Chemistry;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Chemistry.Reaction;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.IgnitionSource;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Interaction;
+using Content.Shared.Maps;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Smoking;
+using Content.Shared.Damage;
+using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.Configuration;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Utility;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Atmos;
+
+[TestFixture]
+[TestOf(typeof(SolidFuelSystem))]
+public sealed class SolidFuelTest : AtmosTest
+{
+    protected override ResPath? TestMapPath => new("Maps/Test/Atmospherics/DeltaPressure/deltapressuretest.yml");
+    private SolidFuelSystem _fuel = default!;
+    private FlammableSystem _fire = default!;
+    private SharedSolutionContainerSystem _solutions = default!;
+    private IConfigurationManager _config = default!;
+
+    private static readonly ProtoId<ReagentPrototype> Water = "Water";
+
+    [SetUp]
+    public override async Task Setup()
+    {
+        await base.Setup();
+        await Server.WaitPost(() =>
+        {
+            _fuel = SEntMan.System<SolidFuelSystem>();
+            _fire = SEntMan.System<FlammableSystem>();
+            _solutions = SEntMan.System<SharedSolutionContainerSystem>();
+            _config = Server.ResolveDependency<IConfigurationManager>();
+        });
+    }
+
+    private EntityUid SpawnFuel(string prototype)
+    {
+        var uid = SEntMan.SpawnEntity(prototype, new EntityCoordinates(RelevantAtmos.Owner, 0.5f, 0.5f));
+        var air = SAtmos.GetContainingMixture(uid);
+        Assert.That(air, Is.Not.Null);
+        air!.SetMoles(Gas.Oxygen, 20f);
+        air.SetMoles(Gas.Nitrogen, 80f);
+        return uid;
+    }
+
+    private EntityUid Cigarette()
+    {
+        var uid = SpawnFuel("Cigarette");
+        SEntMan.GetComponent<SmokableComponent>(uid).State = SmokableState.Lit;
+        return uid;
+    }
+
+    [TestCase("TowelColorWhite", 90)]
+    [TestCase("MaterialCloth1", 90)]
+    [TestCase("Carpet", 240)]
+    [TestCase("MaterialWoodPlank1", 300)]
+    [TestCase("ClothingUniformJumpsuitColorGrey", 90)]
+    [TestCase("CarpetChapel", 240)]
+    [TestCase("CarpetCard", 240)]
+    [TestCase("WoodenBench", 300)]
+    [TestCase("TableCarpet", 300)]
+    [TestCase("TableFancyBlack", 300)]
+    [TestCase("TableCounterWood", 300)]
+    [TestCase("CounterWoodFrame", 300)]
+    public async Task CigaretteIgnitesAfterMaterialDelay(string prototype, int seconds)
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var uid = SpawnFuel(prototype);
+            Cigarette();
+            for (var i = 0; i < seconds - 1; i++)
+                _fuel.Update(1f);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).OnFire, Is.False);
+            _fuel.Update(1f);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).OnFire, Is.True);
+        });
+    }
+
+    [TestCase("CounterMetalFrame")]
+    [TestCase("TableFrame")]
+    public async Task MetalFramesDoNotInheritSolidFuel(string prototype)
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var uid = SpawnFuel(prototype);
+            Cigarette();
+            for (var i = 0; i < 310; i++)
+                _fuel.Update(1f);
+            Assert.That(SEntMan.HasComponent<SolidFuelComponent>(uid), Is.False);
+            Assert.That(SEntMan.TryGetComponent<FlammableComponent>(uid, out var fire) && fire.OnFire, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task BurningAppearanceReachesClientAndClearsAfterExtinguishing()
+    {
+        EntityUid target = default;
+        NetEntity netTarget = default;
+        await Server.WaitAssertion(() =>
+        {
+            target = SpawnFuel("CarpetChapel");
+            netTarget = SEntMan.GetNetEntity(target);
+            _fire.Ignite(target, target);
+        });
+        await Pair.RunSeconds(1);
+        await Client.WaitAssertion(() =>
+        {
+            var uid = CEntMan.GetEntity(netTarget);
+            var appearance = CEntMan.System<SharedAppearanceSystem>();
+            Assert.That(appearance.TryGetData<bool>(uid, FireVisuals.OnFire, out var burning), Is.True);
+            Assert.That(burning, Is.True);
+        });
+        await Server.WaitAssertion(() => _fire.Extinguish(target));
+        await Pair.RunSeconds(1);
+        await Client.WaitAssertion(() =>
+        {
+            var uid = CEntMan.GetEntity(netTarget);
+            var appearance = CEntMan.System<SharedAppearanceSystem>();
+            Assert.That(appearance.TryGetData<bool>(uid, FireVisuals.OnFire, out var burning), Is.True);
+            Assert.That(burning, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task RemovingSourceCoolsMaterial()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var uid = SpawnFuel("TowelColorWhite");
+            var source = Cigarette();
+            for (var i = 0; i < 60; i++)
+                _fuel.Update(1f);
+            SEntMan.DeleteEntity(source);
+            for (var i = 0; i < 40; i++)
+                _fuel.Update(1f);
+            Assert.That(SEntMan.GetComponent<SolidFuelComponent>(uid).Exposure, Is.Zero);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).OnFire, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task OxygenRequiredAndLossExtinguishes()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var uid = SpawnFuel("TowelColorWhite");
+            var source = Cigarette();
+            var air = SAtmos.GetContainingMixture(uid)!;
+            air.SetMoles(Gas.Oxygen, 0);
+            for (var i = 0; i < 100; i++)
+                _fuel.Update(1f);
+            _fire.Ignite(uid, source);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).OnFire, Is.False);
+            Assert.That(SEntMan.GetComponent<SolidFuelComponent>(uid).Exposure, Is.Zero);
+            air.SetMoles(Gas.Oxygen, 20);
+            _fire.Ignite(uid, source);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).OnFire, Is.True);
+            air.SetMoles(Gas.Oxygen, 0);
+            _fuel.Update(1f);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).OnFire, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task ExtinguisherReactionStopsBurningAndBlocksRelighting()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var uid = SpawnFuel("TowelColorWhite");
+            var source = Cigarette();
+            _fire.Ignite(uid, source);
+            SEntMan.System<ReactiveSystem>().DoEntityReaction(uid, new Solution("Water", 5), ReactionMethod.Touch);
+            var fire = SEntMan.GetComponent<FlammableComponent>(uid);
+            Assert.That(fire.OnFire, Is.False);
+            Assert.That(fire.FireStacks, Is.Negative);
+            _fire.Ignite(uid, source);
+            _fuel.Update(1f);
+            Assert.That(fire.OnFire, Is.False);
+            Assert.That(SEntMan.GetComponent<SolidFuelComponent>(uid).Exposure, Is.Zero);
+        });
+    }
+
+    [Test]
+    public async Task AbsorbedWaterPreventsIgnition()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var uid = SpawnFuel("TowelColorWhite");
+            Cigarette();
+            Assert.That(_solutions.TryGetSolution(uid, "absorbed", out var solution, out _), Is.True);
+            _solutions.AddSolution(solution!.Value, new Solution("Water", 5));
+            for (var i = 0; i < 100; i++)
+                _fuel.Update(1f);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).OnFire, Is.False);
+            Assert.That(SEntMan.GetComponent<SolidFuelComponent>(uid).Exposure, Is.Zero);
+        });
+    }
+
+    [Test]
+    public async Task EmergencyToggleExtinguishesExistingFire()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var uid = SpawnFuel("TowelColorWhite");
+            var source = Cigarette();
+            _fire.Ignite(uid, source);
+            try
+            {
+                _config.SetCVar(CCVars.SolidFuelEnabled, false);
+                _fuel.Update(1f);
+                Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).OnFire, Is.False);
+                _fire.Ignite(uid, source);
+                Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).OnFire, Is.False);
+            }
+            finally
+            {
+                _config.SetCVar(CCVars.SolidFuelEnabled, true);
+            }
+        });
+    }
+
+    [TestCase("Lighter", 9)]
+    [TestCase("Torch", 3)]
+    public async Task StrongerSourcesIgniteFaster(string prototype, int seconds)
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var uid = SpawnFuel("TowelColorWhite");
+            var source = SpawnFuel(prototype);
+            SEntMan.System<SharedIgnitionSourceSystem>().SetIgnited(source);
+            for (var i = 0; i < seconds - 1; i++)
+                _fuel.Update(1f);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).OnFire, Is.False);
+            _fuel.Update(1f);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).OnFire, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task BurnoutLeavesAsh()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var uid = SpawnFuel("TowelColorWhite");
+            var source = Cigarette();
+            _fire.Ignite(uid, source);
+            for (var i = 0; i < 59; i++)
+                _fuel.Update(1f);
+            Assert.That(SEntMan.IsQueuedForDeletion(uid), Is.False);
+            _fuel.Update(1f);
+            Assert.That(SEntMan.IsQueuedForDeletion(uid), Is.True);
+            Assert.That(CountAsh(), Is.GreaterThan(0));
+        });
+    }
+
+    private int CountAsh()
+    {
+        var count = 0;
+        var query = SEntMan.EntityQueryEnumerator<MetaDataComponent>();
+        while (query.MoveNext(out var meta))
+        {
+            if (meta.EntityPrototype?.ID == "Ash")
+                count++;
+        }
+        return count;
+    }
+
+    [Test]
+    public async Task SprayTileReactionExtinguishesNonCollidingCarpet()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var uid = SpawnFuel("Carpet");
+            var source = Cigarette();
+            _fire.Ignite(uid, source);
+            var tile = SEntMan.System<TurfSystem>().GetTileRef(SEntMan.GetComponent<TransformComponent>(uid).Coordinates)!.Value;
+            new ExtinguishTileReaction().TileReact(tile, Server.ResolveDependency<IPrototypeManager>().Index(Water), 5, SEntMan, null);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).OnFire, Is.False);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).FireStacks, Is.Negative);
+            _fuel.Update(1f);
+            Assert.That(SEntMan.GetComponent<SolidFuelComponent>(uid).Exposure, Is.Zero);
+        });
+    }
+
+    [TestCase("FloorWood", 300, 120)]
+    [TestCase("FloorArcadeBlue", 240, 90)]
+    [TestCase("FloorArcadeRed", 240, 90)]
+    [TestCase("FloorBoxing", 240, 90)]
+    [TestCase("FloorGym", 240, 90)]
+    public async Task FloorBurnsToUnderlyingTileAndAsh(string prototype, int ignitionTime, int burnTime)
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var source = Cigarette();
+            var maps = SEntMan.System<SharedMapSystem>();
+            var wood = Server.ResolveDependency<IPrototypeManager>().Index<ContentTileDefinition>(prototype);
+            var underlying = Server.ResolveDependency<IPrototypeManager>().Index(wood.BaseTurf!.Value);
+            maps.SetTile(MapData.Grid, Vector2i.Zero, new Tile(wood.TileId));
+            for (var i = 0; i < ignitionTime; i++)
+                _fuel.Update(1f);
+            EntityUid? floor = null;
+            var query = SEntMan.EntityQueryEnumerator<SolidFuelComponent, FlammableComponent>();
+            while (query.MoveNext(out var uid, out var fuel, out var fire))
+            {
+                if (fuel.TileType == wood.ID && fire.OnFire)
+                    floor = uid;
+            }
+            Assert.That(floor, Is.Not.Null);
+            for (var i = 0; i < burnTime; i++)
+                _fuel.Update(1f);
+            var tile = SEntMan.System<TurfSystem>().GetTileRef(SEntMan.GetComponent<TransformComponent>(source).Coordinates)!.Value;
+            Assert.That(tile.Tile.TypeId, Is.EqualTo(underlying.TileId));
+            Assert.That(CountAsh(), Is.GreaterThan(0));
+        });
+    }
+
+    [Test]
+    public async Task ContainedCigaretteDoesNotHeatNearbyObjects()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var uid = SpawnFuel("TowelColorWhite");
+            var source = Cigarette();
+            var box = SpawnFuel("BoxCardboard");
+            var containers = SEntMan.System<SharedContainerSystem>();
+            var container = containers.EnsureContainer<Container>(box, "test-fuel-container");
+            Assert.That(containers.Insert(source, container), Is.True);
+            for (var i = 0; i < 100; i++)
+                _fuel.Update(1f);
+            Assert.That(SEntMan.GetComponent<SolidFuelComponent>(uid).Exposure, Is.Zero);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(uid).OnFire, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task SpreadToggleStopsPropagation()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var source = SpawnFuel("Carpet");
+            var target = SpawnFuel("TowelColorWhite");
+            _fire.Ignite(source, source);
+            try
+            {
+                _config.SetCVar(CCVars.SolidFuelSpread, false);
+                for (var i = 0; i < 10; i++)
+                    _fuel.Update(1f);
+                Assert.That(SEntMan.GetComponent<SolidFuelComponent>(target).Exposure, Is.Zero);
+                _config.SetCVar(CCVars.SolidFuelSpread, true);
+                for (var i = 0; i < 5; i++)
+                    _fuel.Update(1f);
+                Assert.That(SEntMan.GetComponent<FlammableComponent>(target).OnFire, Is.True);
+            }
+            finally
+            {
+                _config.SetCVar(CCVars.SolidFuelSpread, true);
+            }
+        });
+    }
+
+    [Test]
+    public async Task HeldLighterRequiresSustainedInteraction()
+    {
+        EntityUid target = default;
+        await Server.WaitAssertion(() =>
+        {
+            target = SpawnFuel("TowelColorWhite");
+            var user = SpawnFuel("MobHuman");
+            var lighter = SpawnFuel("Lighter");
+            var hands = SEntMan.GetComponent<HandsComponent>(user);
+            Assert.That(SEntMan.System<SharedHandsSystem>().TryPickup(user, lighter, hands.ActiveHandId!), Is.True);
+            SEntMan.System<SharedIgnitionSourceSystem>().SetIgnited(lighter);
+            Assert.That(SEntMan.System<SharedInteractionSystem>().InteractUsing(user, lighter, target,
+                SEntMan.GetComponent<TransformComponent>(target).Coordinates), Is.True);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(target).OnFire, Is.False);
+        });
+        await Pair.RunSeconds(3);
+        await Server.WaitAssertion(() => Assert.That(SEntMan.GetComponent<FlammableComponent>(target).OnFire, Is.False));
+        await Pair.RunSeconds(12);
+        await Server.WaitAssertion(() => Assert.That(SEntMan.GetComponent<FlammableComponent>(target).OnFire, Is.True));
+    }
+
+    [Test]
+    public async Task IncendiaryMeleeCannotEraseWetness()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var target = SpawnFuel("TowelColorWhite");
+            var weapon = SpawnFuel("Lighter");
+            SEntMan.EnsureComponent<IgniteOnMeleeHitComponent>(weapon).FireStacks = 10;
+            SEntMan.System<ReactiveSystem>().DoEntityReaction(target, new Solution("Water", 5), ReactionMethod.Touch);
+            var hit = new MeleeHitEvent(new List<EntityUid> { target }, weapon, weapon, new DamageSpecifier(), null);
+            SEntMan.EventBus.RaiseLocalEvent(weapon, hit);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(target).FireStacks, Is.Positive);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(target).OnFire, Is.False);
+            Assert.That(SEntMan.GetComponent<SolidFuelComponent>(target).WetTime, Is.Positive);
+        });
+    }
+
+    [Test]
+    public async Task TileReactionDoesNotDoubleWetCollidableObjects()
+    {
+        await Server.WaitAssertion(() =>
+        {
+            var target = SpawnFuel("TowelColorWhite");
+            SEntMan.System<ReactiveSystem>().DoEntityReaction(target, new Solution("Water", 5), ReactionMethod.Touch);
+            var before = SEntMan.GetComponent<FlammableComponent>(target).FireStacks;
+            var wetBefore = SEntMan.GetComponent<SolidFuelComponent>(target).WetTime;
+            var tile = SEntMan.System<TurfSystem>().GetTileRef(SEntMan.GetComponent<TransformComponent>(target).Coordinates)!.Value;
+            new ExtinguishTileReaction().TileReact(tile, Server.ResolveDependency<IPrototypeManager>().Index(Water), 5, SEntMan, null);
+            Assert.That(SEntMan.GetComponent<FlammableComponent>(target).FireStacks, Is.EqualTo(before));
+            Assert.That(SEntMan.GetComponent<SolidFuelComponent>(target).WetTime, Is.EqualTo(wetBefore));
+        });
+    }
+
+    [TestCase("FloorWood")]
+    [TestCase("FloorWoodLarge")]
+    public async Task ExistingFloorFuelIsReused(string prototype)
+    {
+        await Server.WaitAssertion(() =>
+        {
+            Cigarette();
+            ProtoId<ContentTileDefinition> tileId = prototype;
+            var wood = Server.ResolveDependency<IPrototypeManager>().Index(tileId);
+            SEntMan.System<SharedMapSystem>().SetTile(MapData.Grid, Vector2i.Zero, new Tile(wood.TileId));
+            // Represents a serialized floor fire loaded before the first heat-source update.
+            var existing = SpawnFuel("SolidFuelFloorWood");
+            SEntMan.GetComponent<SolidFuelComponent>(existing).TileType = wood.ID;
+            SEntMan.GetComponent<SolidFuelComponent>(existing).Exposure = 20;
+            _fuel.Update(1f);
+            var count = 0;
+            var query = SEntMan.EntityQueryEnumerator<SolidFuelComponent>();
+            while (query.MoveNext(out var fuel))
+            {
+                if (fuel.TileType == wood.ID)
+                    count++;
+            }
+            Assert.That(count, Is.EqualTo(1));
+            // The system can have a partial second accumulated from normal map startup ticks.
+            Assert.That(SEntMan.GetComponent<SolidFuelComponent>(existing).Exposure, Is.InRange(21f, 22f));
+        });
+    }
+}

--- a/Content.Server/Atmos/Components/SolidFuelComponent.cs
+++ b/Content.Server/Atmos/Components/SolidFuelComponent.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Maps;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Atmos.Components;
+
+/// <summary>
+/// Material which accumulates heat from nearby ignition sources and is consumed while burning.
+/// Times are seconds; ignition time is measured against a smouldering cigarette (rate 1).
+/// </summary>
+[RegisterComponent]
+public sealed partial class SolidFuelComponent : Component
+{
+    /// <summary>Exposure required to ignite, in cigarette-equivalent seconds.</summary>
+    [DataField] public float IgnitionTime = 90f;
+    /// <summary>Seconds of burning before the material is consumed at the default fuel rate.</summary>
+    [DataField] public float BurnTime = 60f;
+    /// <summary>Exposure lost per second when no ignition source is heating the material.</summary>
+    [DataField] public float CoolingRate = 2f;
+    /// <summary>Entity spawned when the material is fully consumed.</summary>
+    [DataField] public EntProtoId AshPrototype = "Ash";
+
+    /// <summary>Accumulated heat exposure, in cigarette-equivalent seconds.</summary>
+    [DataField] public float Exposure;
+    /// <summary>Accumulated burning time, scaled by the fuel consumption multiplier.</summary>
+    [DataField] public float BurnedTime;
+
+    /// <summary>Seconds of wetness remaining, independent of stacks added by incendiary weapons.</summary>
+    [DataField] public float WetTime;
+
+    /// <summary>Original tile type for transient floor fuel entities; null for ordinary objects.</summary>
+    [DataField] public ProtoId<ContentTileDefinition>? TileType;
+}

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -150,6 +150,10 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void OnInteractUsing(EntityUid uid, FlammableComponent flammable, InteractUsingEvent args)
         {
+            // Solid materials require sustained contact, handled by SolidFuelSystem.
+            if (HasComp<SolidFuelComponent>(uid))
+                return;
+
             if (args.Handled)
                 return;
 
@@ -241,6 +245,9 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void OnTileFire(Entity<FlammableComponent> ent, ref TileFireEvent args)
         {
+            if (HasComp<SolidFuelComponent>(ent) && !EntityManager.System<SolidFuelSystem>().CanBurn((ent.Owner, ent.Comp)))
+                return;
+
             var tempDelta = args.Temperature - ent.Comp.MinIgnitionTemperature;
 
             _fireEvents.TryGetValue(ent, out var maxTemp);
@@ -295,6 +302,10 @@ namespace Content.Server.Atmos.EntitySystems
         {
             if (!Resolve(uid, ref flammable))
                 return;
+
+            if (ignite && HasComp<SolidFuelComponent>(uid) &&
+                !EntityManager.System<SolidFuelSystem>().CanBurn((uid, flammable)))
+                ignite = false;
 
             flammable.FireStacks = MathF.Min(MathF.Max(flammable.MinimumFireStacks, stacks), flammable.MaximumFireStacks);
 
@@ -357,6 +368,9 @@ namespace Content.Server.Atmos.EntitySystems
             if (!Resolve(uid, ref flammable))
                 return;
 
+            if (HasComp<SolidFuelComponent>(uid) && !EntityManager.System<SolidFuelSystem>().CanBurn((uid, flammable)))
+                return;
+
             if (flammable.AlwaysCombustible)
             {
                 flammable.FireStacks = Math.Max(flammable.FirestacksOnIgnite, flammable.FireStacks);
@@ -398,7 +412,6 @@ namespace Content.Server.Atmos.EntitySystems
                 flammable.FireStacks += component.FireStacks;
                 Ignite(uid, uid, flammable);
             }
-
 
         }
 
@@ -468,7 +481,9 @@ namespace Content.Server.Atmos.EntitySystems
                     var air = _atmosphereSystem.GetContainingMixture(uid);
 
                     // If we're in an oxygenless environment, put the fire out.
-                    if (air == null || air.GetMoles(Gas.Oxygen) < 1f)
+                    if (HasComp<SolidFuelComponent>(uid)
+                        ? !EntityManager.System<SolidFuelSystem>().HasOxygen(uid)
+                        : air == null || air.GetMoles(Gas.Oxygen) < 1f)
                     {
                         TryExtinguish((uid, flammable));
                         continue;

--- a/Content.Server/Atmos/EntitySystems/SolidFuelSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/SolidFuelSystem.cs
@@ -1,0 +1,389 @@
+using Content.Server.Atmos.Components;
+using Content.Shared.Atmos;
+using Content.Shared.Atmos.Components;
+using Content.Shared.CCVar;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.DoAfter;
+using Content.Shared.EntityEffects.Effects.Atmos;
+using Content.Shared.Fluids;
+using Content.Shared.Fluids.Components;
+using Content.Shared.IgnitionSource;
+using Content.Shared.Interaction;
+using Content.Shared.Inventory;
+using Content.Shared.Maps;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Smoking;
+using Robust.Shared.Containers;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Physics.Components;
+
+namespace Content.Server.Atmos.EntitySystems;
+
+/// <summary>Contact ignition and finite fuel for combustible objects.</summary>
+public sealed partial class SolidFuelSystem : EntitySystem
+{
+    [Dependency] private AtmosphereSystem _atmos = default!;
+    [Dependency] private FlammableSystem _flammable = default!;
+    [Dependency] private EntityLookupSystem _lookup = default!;
+    [Dependency] private SharedContainerSystem _containers = default!;
+    [Dependency] private SharedInteractionSystem _interaction = default!;
+    [Dependency] private SharedSolutionContainerSystem _solutions = default!;
+    [Dependency] private SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private IConfigurationManager _config = default!;
+    [Dependency] private IPrototypeManager _prototypes = default!;
+    [Dependency] private ITileDefinitionManager _tiles = default!;
+    [Dependency] private TurfSystem _turf = default!;
+    [Dependency] private TileSystem _tileSystem = default!;
+
+    public bool Enabled => _config.GetCVar(CCVars.SolidFuelEnabled);
+
+    private readonly HashSet<Entity<SolidFuelComponent>> _nearby = new();
+    private readonly HashSet<Entity<PuddleComponent>> _puddles = new();
+    private readonly Dictionary<EntityUid, (EntityUid Source, float Rate, EntityUid? User)> _exposures = new();
+    private float _elapsed;
+    private readonly HashSet<Entity<SolidFuelComponent>> _floorCandidates = new();
+    private readonly HashSet<EntityUid> _sources = new();
+    private static readonly Vector2i[] Neighbors = { new(1, 0), new(-1, 0), new(0, 1), new(0, -1) };
+
+    /// <summary>Spray tile reactions must also reach non-colliding carpet and floor fire entities.</summary>
+    public void ExtinguishTile(TileRef tile, float amount)
+    {
+        if (amount <= 0)
+            return;
+        var center = new EntityCoordinates(tile.GridUid,
+            new System.Numerics.Vector2(tile.GridIndices.X + 0.5f, tile.GridIndices.Y + 0.5f));
+        var targets = new HashSet<Entity<SolidFuelComponent>>();
+        _lookup.GetEntitiesInRange(center, 0.71f, targets, LookupFlags.Uncontained);
+        foreach (var target in targets)
+        {
+            // Collidable objects already receive the vapor's ordinary entity reaction.
+            if (TryComp<PhysicsComponent>(target, out var body) && body.CanCollide)
+                continue;
+            if (_turf.GetTileRef(Transform(target).Coordinates) is not { } other ||
+                other.GridUid != tile.GridUid || other.GridIndices != tile.GridIndices)
+                continue;
+            target.Comp.Exposure = 0;
+            var ev = new ExtinguishEvent { FireStacksAdjustment = -1.5f * amount };
+            RaiseLocalEvent(target, ref ev);
+        }
+    }
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        UpdatesBefore.Add(typeof(FlammableSystem));
+        SubscribeLocalEvent<SolidFuelComponent, InteractUsingEvent>(OnInteractUsing);
+        SubscribeLocalEvent<SolidFuelComponent, SolidFuelIgnitionDoAfterEvent>(OnIgnitionDoAfter);
+        SubscribeLocalEvent<SolidFuelComponent, DoAfterAttemptEvent<SolidFuelIgnitionDoAfterEvent>>(OnIgnitionAttempt);
+        SubscribeLocalEvent<SolidFuelComponent, ExtinguishedEvent>(OnExtinguished);
+        Subs.SubscribeWithRelay<SolidFuelComponent, ExtinguishEvent>(OnExtinguish);
+        SubscribeLocalEvent<SolidFuelComponent, ComponentShutdown>(OnShutdown);
+    }
+
+    private void OnExtinguished(Entity<SolidFuelComponent> ent, ref ExtinguishedEvent args)
+    {
+        ent.Comp.Exposure = 0;
+        _exposures.Remove(ent);
+    }
+
+    private void OnShutdown(Entity<SolidFuelComponent> ent, ref ComponentShutdown args)
+    {
+        _exposures.Remove(ent);
+    }
+
+    private void OnExtinguish(Entity<SolidFuelComponent> ent, ref ExtinguishEvent args)
+    {
+        ent.Comp.Exposure = 0;
+        _exposures.Remove(ent);
+        if (args.FireStacksAdjustment < 0)
+            ent.Comp.WetTime = Math.Clamp(ent.Comp.WetTime - args.FireStacksAdjustment, 0, 10);
+    }
+
+    /// <summary>Returns contact heating from a lit cigarette, burning entity, or active ignition source.</summary>
+    public float GetIgnitionRate(EntityUid source)
+    {
+        if (TryComp<SmokableComponent>(source, out var smoke))
+            return smoke.State == SmokableState.Lit ? MathF.Max(0, _config.GetCVar(CCVars.SolidFuelCigaretteRate)) : 0f;
+        if (TryComp<FlammableComponent>(source, out var fire) && fire.OnFire)
+            return MathF.Max(0, _config.GetCVar(CCVars.SolidFuelFireRate));
+        return TryComp<IgnitionSourceComponent>(source, out var ignition) && ignition.Ignited
+            ? ignition.ContactIgnitionRate : 0f;
+    }
+
+    /// <summary>Checks the enable switch, fire stacks, recent and current wetness, and available oxygen.</summary>
+    public bool CanBurn(Entity<FlammableComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return false;
+
+        return Enabled && ent.Comp.FireStacks >= 0 &&
+               (!TryComp<SolidFuelComponent>(ent, out var fuel) || fuel.WetTime <= 0) && !IsWet(ent) &&
+               HasOxygen(ent);
+    }
+
+    /// <summary>Checks local oxygen, falling back to adjacent tiles for airtight entities such as wooden walls.</summary>
+    public bool HasOxygen(EntityUid uid)
+    {
+        if (_atmos.GetContainingMixture(uid) is { } air && air.GetMoles(Gas.Oxygen) >= 1f)
+            return true;
+        // Solid wooden walls occupy an airtight tile, but their exposed faces can burn.
+        if (!HasComp<AirtightComponent>(uid) || _turf.GetTileRef(Transform(uid).Coordinates) is not { } tile)
+            return false;
+        foreach (var offset in Neighbors)
+        {
+            if (_atmos.GetTileMixture(tile.GridUid, Transform(uid).MapUid, tile.GridIndices + offset) is { } adjacent &&
+                adjacent.GetMoles(Gas.Oxygen) >= 1f)
+                return true;
+        }
+        return false;
+    }
+
+    private bool IsWet(EntityUid uid)
+    {
+        // Absorbed water does not produce negative fire stacks when a towel mops a puddle.
+        if (TryComp<AbsorbentComponent>(uid, out var absorbent) &&
+            HasWater(uid, absorbent.SolutionName))
+            return true;
+
+        if (_containers.IsEntityOrParentInContainer(uid))
+            return false;
+
+        _puddles.Clear();
+        _lookup.GetEntitiesInRange(Transform(uid).Coordinates, 0.5f, _puddles);
+        foreach (var puddle in _puddles)
+        {
+            if (HasWater(puddle.Owner, puddle.Comp.SolutionName))
+                return true;
+        }
+        return false;
+    }
+
+    private bool HasWater(EntityUid uid, string solutionName)
+    {
+        if (!_solutions.TryGetSolution(uid, solutionName, out _, out var solution))
+            return false;
+
+        // Respect reagent definitions, including water, drinks and extinguishing chemicals.
+        foreach (var (reagent, quantity) in solution.Contents)
+        {
+            if (quantity <= 0 || !_prototypes.TryIndex<ReagentPrototype>(reagent.Prototype, out var proto) ||
+                proto.ReactiveEffects == null || !proto.ReactiveEffects.TryGetValue("Extinguish", out var reaction))
+                continue;
+            foreach (var effect in reaction.Effects)
+            {
+                if (effect is Extinguish)
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private void OnInteractUsing(Entity<SolidFuelComponent> ent, ref InteractUsingEvent args)
+    {
+        if (args.Handled || GetIgnitionRate(args.Used) <= 0 ||
+            !TryComp<FlammableComponent>(ent, out var fire) || fire.OnFire || !CanBurn((ent, fire)))
+            return;
+
+        args.Handled = true;
+        _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, 1f,
+            new SolidFuelIgnitionDoAfterEvent(), ent, target: ent, used: args.Used)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+            NeedHand = true,
+            BreakOnHandChange = true,
+            AttemptFrequency = AttemptFrequency.EveryTick,
+        });
+    }
+
+    private void OnIgnitionAttempt(Entity<SolidFuelComponent> ent,
+        ref DoAfterAttemptEvent<SolidFuelIgnitionDoAfterEvent> args)
+    {
+        if (args.DoAfter.Args.Used is not { } source || GetIgnitionRate(source) <= 0 ||
+            !TryComp<FlammableComponent>(ent, out var fire) || fire.OnFire || !CanBurn((ent, fire)))
+            args.Cancel();
+    }
+
+    private void OnIgnitionDoAfter(Entity<SolidFuelComponent> ent, ref SolidFuelIgnitionDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled || args.Used is not { } source ||
+            !TryComp<FlammableComponent>(ent, out var fire) || fire.OnFire || !CanBurn((ent, fire)))
+            return;
+
+        var rate = GetIgnitionRate(source);
+        if (rate <= 0)
+            return;
+
+        Expose(ent, source, rate, args.User);
+        args.Handled = true;
+        args.Repeat = true;
+    }
+
+    private void Expose(EntityUid target, EntityUid source, float rate, EntityUid? user = null)
+    {
+        // Multiple sources use the strongest contact, rather than multiplying the update frequency.
+        if (!_exposures.TryGetValue(target, out var old) || rate > old.Rate)
+            _exposures[target] = (source, rate, user);
+    }
+
+    private void HeatNearby(EntityUid source)
+    {
+        var rate = GetIgnitionRate(source);
+        if (rate <= 0 || _containers.IsEntityOrParentInContainer(source))
+            return;
+
+        var burning = TryComp<FlammableComponent>(source, out var fire) && fire.OnFire;
+        if (burning && HasComp<SolidFuelComponent>(source) && !CanBurn((source, fire!)))
+            return;
+        if (burning && !_config.GetCVar(CCVars.SolidFuelSpread))
+            return;
+        var range = Math.Clamp(_config.GetCVar(burning ? CCVars.SolidFuelSpreadRange : CCVars.SolidFuelContactRange), 0f, 3f);
+        if (range <= 0)
+            return;
+
+        HeatFloor(source, rate, range);
+
+        _nearby.Clear();
+        _lookup.GetEntitiesInRange(Transform(source).Coordinates, range, _nearby, LookupFlags.Uncontained);
+        foreach (var target in _nearby)
+        {
+            if (source != target.Owner &&
+                _interaction.InRangeUnobstructed(source, target.Owner, range: range))
+                Expose(target, source, rate);
+        }
+    }
+
+    private void HeatFloor(EntityUid source, float rate, float range)
+    {
+        var coords = Transform(source).Coordinates;
+        var radius = (int) MathF.Ceiling(range);
+        for (var x = -radius; x <= radius; x++)
+        for (var y = -radius; y <= radius; y++)
+        {
+            if (x * x + y * y > range * range)
+                continue;
+            var tile = _turf.GetTileRef(coords.Offset(new System.Numerics.Vector2(x, y)));
+            if (tile is not { } floor ||
+                ((ContentTileDefinition) _tiles[floor.Tile.TypeId]).SolidFuelEntity is not { } prototype)
+                continue;
+            var center = new EntityCoordinates(floor.GridUid,
+                new System.Numerics.Vector2(floor.GridIndices.X + 0.5f, floor.GridIndices.Y + 0.5f));
+            // Query actual entities so map loading and grid splitting cannot leave a stale cache.
+            EntityUid? existing = null;
+            _floorCandidates.Clear();
+            _lookup.GetEntitiesInRange(center, 0.1f, _floorCandidates, LookupFlags.Uncontained);
+            foreach (var candidate in _floorCandidates)
+            {
+                if (candidate.Comp.TileType != null && !TerminatingOrDeleted(candidate) &&
+                    !EntityManager.IsQueuedForDeletion(candidate))
+                {
+                    existing = candidate.Owner;
+                    break;
+                }
+            }
+            var fuel = existing ?? Spawn(prototype, center);
+            if (existing == null)
+                Comp<SolidFuelComponent>(fuel).TileType = ((ContentTileDefinition) _tiles[floor.Tile.TypeId]).ID;
+            if (fuel != source && _interaction.InRangeUnobstructed(source, fuel, range: range + 0.71f))
+                Expose(fuel, source, rate);
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        _elapsed += frameTime;
+        if (_elapsed < 1f)
+            return;
+        var elapsed = _elapsed;
+        _elapsed = 0;
+
+        if (!Enabled)
+        {
+            var disabled = EntityQueryEnumerator<SolidFuelComponent, FlammableComponent>();
+            while (disabled.MoveNext(out var uid, out var fuel, out var fire))
+            {
+                fuel.Exposure = 0;
+                _flammable.TryExtinguish((uid, fire));
+                if (fuel.TileType != null)
+                    QueueDel(uid);
+            }
+            _exposures.Clear();
+            return;
+        }
+
+        _sources.Clear();
+        var sources = EntityQueryEnumerator<IgnitionSourceComponent>();
+        while (sources.MoveNext(out var uid, out _))
+            _sources.Add(uid);
+        var cigarettes = EntityQueryEnumerator<SmokableComponent>();
+        while (cigarettes.MoveNext(out var uid, out _))
+            _sources.Add(uid);
+        var fires = EntityQueryEnumerator<FlammableComponent>();
+        while (fires.MoveNext(out var uid, out var fire))
+        {
+            if (fire.OnFire)
+                _sources.Add(uid);
+        }
+        foreach (var source in _sources)
+            HeatNearby(source);
+
+        var fuels = EntityQueryEnumerator<SolidFuelComponent, FlammableComponent>();
+        while (fuels.MoveNext(out var uid, out var fuel, out var fire))
+        {
+            fuel.WetTime = MathF.Max(0, fuel.WetTime - elapsed);
+            if (fuel.TileType is { } tileType &&
+                (_turf.GetTileRef(Transform(uid).Coordinates) is not { } tile ||
+                 ((ContentTileDefinition) _tiles[tile.Tile.TypeId]).ID != tileType.Id))
+            {
+                QueueDel(uid);
+                continue;
+            }
+            // Cold objects do not need atmosphere or puddle lookups.
+            if (!fire.OnFire && fuel.Exposure <= 0 && !_exposures.ContainsKey(uid))
+            {
+                if (fuel.TileType != null && fuel.BurnedTime <= 0 && fuel.WetTime <= 0)
+                    QueueDel(uid);
+                continue;
+            }
+            if (!CanBurn((uid, fire)))
+            {
+                fuel.Exposure = 0;
+                _flammable.TryExtinguish((uid, fire));
+                if (fuel.TileType != null && fuel.BurnedTime <= 0 && fuel.WetTime <= 0)
+                    QueueDel(uid);
+                continue;
+            }
+
+            if (fire.OnFire)
+            {
+                fuel.Exposure = 0;
+                fuel.BurnedTime += elapsed * MathF.Max(0, _config.GetCVar(CCVars.SolidFuelBurnMultiplier));
+                if (fuel.BurnedTime >= fuel.BurnTime)
+                {
+                    if (fuel.TileType != null && _turf.GetTileRef(Transform(uid).Coordinates) is { } floor)
+                        _tileSystem.DeconstructTile(floor, spawnItem: false);
+                    SpawnNextToOrDrop(fuel.AshPrototype, uid);
+                    QueueDel(uid);
+                }
+                continue;
+            }
+
+            if (_exposures.TryGetValue(uid, out var exposure) && !Deleted(exposure.Source) &&
+                GetIgnitionRate(exposure.Source) > 0)
+            {
+                fuel.Exposure += exposure.Rate * elapsed * MathF.Max(0, _config.GetCVar(CCVars.SolidFuelIgnitionMultiplier));
+                if (fuel.Exposure >= fuel.IgnitionTime)
+                    _flammable.Ignite(uid, exposure.Source, fire, exposure.User);
+            }
+            else
+                fuel.Exposure = MathF.Max(0, fuel.Exposure - fuel.CoolingRate * elapsed);
+
+            if (fuel.TileType != null && fuel.Exposure <= 0 && fuel.BurnedTime <= 0 && fuel.WetTime <= 0 && !fire.OnFire)
+                QueueDel(uid);
+        }
+        _exposures.Clear();
+    }
+}

--- a/Content.Server/Chemistry/TileReactions/ExtinguishTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/ExtinguishTileReaction.cs
@@ -25,6 +25,9 @@ namespace Content.Server.Chemistry.TileReactions
 
             var atmosphereSystem = entityManager.System<AtmosphereSystem>();
 
+            // Carpet and floor fires may have no colliding fixture or atmospheric hotspot.
+            entityManager.System<SolidFuelSystem>().ExtinguishTile(tile, reactVolume.Float());
+
             var environment = atmosphereSystem.GetTileMixture(tile.GridUid, null, tile.GridIndices, true);
 
             if (environment == null || !atmosphereSystem.IsHotspotActive(tile.GridUid, tile.GridIndices))

--- a/Content.Shared/Atmos/SolidFuelIgnitionDoAfterEvent.cs
+++ b/Content.Shared/Atmos/SolidFuelIgnitionDoAfterEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Atmos;
+
+[Serializable, NetSerializable]
+public sealed partial class SolidFuelIgnitionDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/CCVar/CCVars.SolidFuel.cs
+++ b/Content.Shared/CCVar/CCVars.SolidFuel.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    public static readonly CVarDef<bool> SolidFuelEnabled =
+        CVarDef.Create("fire.solid_fuel_enabled", true, CVar.SERVERONLY);
+    public static readonly CVarDef<float> SolidFuelIgnitionMultiplier =
+        CVarDef.Create("fire.solid_fuel_ignition_multiplier", 1f, CVar.SERVERONLY);
+    public static readonly CVarDef<float> SolidFuelBurnMultiplier =
+        CVarDef.Create("fire.solid_fuel_burn_multiplier", 1f, CVar.SERVERONLY);
+    public static readonly CVarDef<bool> SolidFuelSpread =
+        CVarDef.Create("fire.solid_fuel_spread", true, CVar.SERVERONLY);
+    public static readonly CVarDef<float> SolidFuelContactRange =
+        CVarDef.Create("fire.solid_fuel_contact_range", 0.6f, CVar.SERVERONLY);
+    public static readonly CVarDef<float> SolidFuelSpreadRange =
+        CVarDef.Create("fire.solid_fuel_spread_range", 1.1f, CVar.SERVERONLY);
+    public static readonly CVarDef<float> SolidFuelFireRate =
+        CVarDef.Create("fire.solid_fuel_fire_rate", 20f, CVar.SERVERONLY);
+    public static readonly CVarDef<float> SolidFuelCigaretteRate =
+        CVarDef.Create("fire.solid_fuel_cigarette_rate", 1f, CVar.SERVERONLY);
+}

--- a/Content.Shared/IgnitionSource/IgnitionSourceComponent.cs
+++ b/Content.Shared/IgnitionSource/IgnitionSourceComponent.cs
@@ -19,4 +19,8 @@ public sealed partial class IgnitionSourceComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public float Temperature = 700f;
+
+    /// <summary>Contact heating relative to a cigarette. Independent of atmos hotspot temperature.</summary>
+    [DataField, AutoNetworkedField]
+    public float ContactIgnitionRate = 10f;
 }

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -28,6 +28,9 @@ public sealed partial class ContentTileDefinition : IPrototype, IInheritingProto
 
     public ushort TileId { get; private set; }
 
+    /// <summary>Transient fuel entity used when this floor is exposed to a heat source.</summary>
+    [DataField] public EntProtoId? SolidFuelEntity { get; private set; }
+
     [DataField]
     public string Name { get; private set; } = "";
     [DataField] public ResPath? Sprite { get; private set; }

--- a/Documentation/solid-fuel.md
+++ b/Documentation/solid-fuel.md
@@ -1,0 +1,88 @@
+# Solid material fires
+
+Hot items gradually ignite nearby exposed solid fuel. Holding a hot item and using it on fuel starts a repeating interaction; movement, damage, changing hands, extinguishing the tool, wetting the target, or losing oxygen interrupts it. Items inside inventories and containers do not passively ignite things outside them.
+
+## Starting balance
+
+| Material | Cigarette | Lighter | Torch | Burnout after ignition |
+| --- | ---: | ---: | ---: | ---: |
+| Towels, cloth, cloth uniforms, cardboard | 90 s | 9 s | 3 s | 60 s |
+| Carpet items, placed carpets, carpet tiles | 240 s | 24 s | 8 s | 90 s |
+| Wood planks, wooden furniture, walls and floors | 300 s | 30 s | 10 s | 120 s |
+
+Times assume uninterrupted dry contact, sufficient oxygen, and default settings. The server samples passive contact approximately once per second. Manual use also advances in one-second interactions. The strongest source applies; piling up cigarettes does not multiply the heating rate. Removing a source cools accumulated exposure at two cigarette-equivalent seconds per second.
+
+Burning entities spread heat at rate 20: a nearby towel therefore takes about five seconds to catch. Burnout destroys the fuel entity and creates one Ash entity, without running normal damage-based material recovery. A material stack is one fuel entity. Floors expose the previous floor layer using normal tile history, without producing a reusable floor tile. Extinguishing pauses fuel consumption; already burned time is retained.
+
+Coverage is explicit through prototype inheritance. It includes cloth uniforms, all towel variants, cloth/cardboard/wood material stacks, carpet items and placed carpets, wooden chairs/tables/walls, wooden floor items, and wood/carpet floor tile definitions. Other objects can opt in using the profiles below; hard armor and unrelated objects are not automatically classified by their names.
+
+## Live server controls
+
+These are server CVars and can be changed without rebuilding. For example:
+
+```text
+cvar fire.solid_fuel_enabled false
+cvar fire.solid_fuel_spread false
+cvar fire.solid_fuel_ignition_multiplier 0.5
+```
+
+The first command prevents new solid fuel fires, cancels ignition interactions, clears pending heating, and extinguishes existing solid fuel fires on the next one-second update. Existing atmospheric gas fire and mob fire systems retain their normal behavior. Re-enabling starts contact heating from zero.
+
+| CVar | Default | Purpose |
+| --- | ---: | --- |
+| `fire.solid_fuel_enabled` | `true` | Emergency switch for this system |
+| `fire.solid_fuel_spread` | `true` | Allow burning entities to passively heat nearby solid fuel |
+| `fire.solid_fuel_ignition_multiplier` | `1` | Contact heating multiplier; 0.5 doubles ignition time, 0 stops contact heating |
+| `fire.solid_fuel_burn_multiplier` | `1` | Fuel consumption multiplier; 0.5 doubles burnout time, 0 freezes consumption |
+| `fire.solid_fuel_contact_range` | `0.6` | Passive range of hot tools and cigarettes, in tiles |
+| `fire.solid_fuel_spread_range` | `1.1` | Passive range of burning entities, in tiles |
+| `fire.solid_fuel_fire_rate` | `20` | Heating rate of burning entities |
+| `fire.solid_fuel_cigarette_rate` | `1` | Heating rate of lit smokables |
+
+Ranges are clamped to 0–3 tiles; zero disables that passive range. Wall obstruction checks still apply. A floor directly under a source counts as contact across its surface. Rate multipliers are clamped to non-negative values. These controls apply to the new contact system; pre-existing gas-fire, chemical and weapon ignition retain their normal routes, with wetness/oxygen/enabled checks for solid fuel.
+
+Persistent server configuration example:
+
+```toml
+[fire]
+solid_fuel_enabled = true
+solid_fuel_spread = false
+solid_fuel_ignition_multiplier = 0.5
+solid_fuel_burn_multiplier = 1.0
+```
+
+## Per-material and per-source tuning
+
+`Resources/Prototypes/Entities/Objects/Misc/solid_fuel.yml` defines three reusable parent profiles: `BaseSolidFuel`, `BaseWoodFuel`, and `BaseCarpetFuel`. Change their values to rebalance all inheriting objects, or override one object's component:
+
+```yaml
+- type: SolidFuel
+  ignitionTime: 180 # cigarette-equivalent seconds
+  burnTime: 120     # seconds actually spent burning
+  coolingRate: 3    # exposure lost each second without contact
+  ashPrototype: Ash
+```
+
+Keep ignition and burn times positive and cooling rates non-negative. The profile also supplies `Flammable`, `Reactive`, appearance and fire visuals. Avoid adding ordinary damage-based salvage triggers to burnout.
+
+Each `IgnitionSource` has `contactIgnitionRate`, default 10. Torches explicitly use 30. This is separate from its atmospheric hotspot temperature, so balancing carpet ignition need not change gas reactions. Lit smokables use the cigarette CVar; extinguished and spent smokables contribute no heat. Burning entities use the fire-rate CVar.
+
+Tile prototypes opt in with `solidFuelEntity: SolidFuelFloorWood` or `SolidFuelFloorCarpet`. The system creates temporary floor fuel only when a heat source reaches a combustible tile, and removes it if that tile is replaced. It does not create fuel entities for every floor on the map. Floor fuel stores the tile prototype ID, and existing entities are located directly instead of using a runtime-only cache, so loaded fires keep their accumulated burn progress.
+
+## Extinguishing and wetness
+
+Water and fire extinguishers use the existing `Extinguish` reagent reaction. Tile spray reactions also reach non-colliding carpets and floor fires even without an atmospheric hotspot. Negative fire stacks block ignition and dry using the existing flammable-system rules. Solid fuel also retains a serialized wetness timer so incendiary weapons cannot erase recent wetness by adding positive stacks. The timer adds one second per negative stack applied, capped at ten seconds, matching the normal stack limit. Collidable objects receive the existing entity reaction; the additional tile reaction is limited to non-colliding fuel. Extinguishing clears accumulated heat.
+
+Absorbed extinguishing liquids in towels and extinguishing puddles under objects also block ignition. Reagents are recognized through their extinguishing effect definitions, rather than a hard-coded list of water item names. An absorbed solution stays wet until removed; this feature does not add a separate towel evaporation model.
+
+Starting and sustaining fire requires the existing one-mole oxygen minimum. Airtight wooden walls use oxygen at their exposed neighboring faces. Losing oxygen extinguishes the fire. No separate gas combustion chemistry or smoke-generation model is added.
+
+## Validation
+
+Run the targeted integration tests with:
+
+```text
+dotnet test Content.IntegrationTests --no-build --filter "FullyQualifiedName~SolidFuelTest"
+```
+
+Before deploying on a populated server, playtest a dropped cigarette on a towel and carpet, a held lighter, water spray on a burning carpet, oxygen removal, adjacent carpet spread, and the emergency switch. The automated tests verify behavior; the starting values still need gameplay balance feedback.

--- a/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: [UnsensoredClothingUniformBase, ClothingHeadBase, ClothingBeltBase]
+  parent: [UnsensoredClothingUniformBase, ClothingHeadBase, ClothingBeltBase, BaseSolidFuel]
   id: BaseTowel
   name: base towel
   description: If you want to survive out here, you gotta know where your towel is.

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: [SolutionFood, SolutionToolNormal, Clothing, BaseSlicingRefinable]
+  parent: [SolutionFood, SolutionToolNormal, Clothing, BaseSlicingRefinable, BaseSolidFuel]
   id: UnsensoredClothingUniformBase
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: MaterialBase
+  parent: [MaterialBase, BaseSolidFuel]
   id: MaterialCardboard
   name: cardboard
   suffix: Full
@@ -55,7 +55,7 @@
     count: 1
 
 - type: entity
-  parent: [MaterialBase, FoodBase]
+  parent: [MaterialBase, FoodBase, BaseSolidFuel]
   id: MaterialCloth
   name: cloth
   suffix: Full
@@ -194,7 +194,7 @@
     count: 1
 
 - type: entity
-  parent: MaterialBase
+  parent: [MaterialBase, BaseWoodFuel]
   id: MaterialWoodPlank
   name: wood
   suffix: Full

--- a/Resources/Prototypes/Entities/Objects/Misc/carpets.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/carpets.yml
@@ -1,7 +1,7 @@
 # TODO once tiles can be smoothed and carpets ported over to that, add them to the FloorTile outputs
 - type: entity
   name: carpet
-  parent: FloorTileItemBase
+  parent: [FloorTileItemBase, BaseCarpetFuel]
   id: FloorCarpetItemRed
   suffix: Red
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/solid_fuel.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/solid_fuel.yml
@@ -1,0 +1,61 @@
+# Shared balance profiles. Ignition time is in cigarette-equivalent seconds.
+- type: entity
+  id: BaseSolidFuel
+  abstract: true
+  components:
+  - type: SolidFuel
+    ignitionTime: 90
+    burnTime: 60
+    coolingRate: 2
+  - type: Flammable
+    alwaysCombustible: true
+    fireSpread: false # SolidFuelSystem handles gradual spread.
+    firestackFade: 0
+    damage: {} # Burnout consumes the object, without triggering salvage drops.
+  - type: Appearance
+  - type: FireVisuals
+    sprite: Effects/fire.rsi
+    normalState: fire
+  - type: Reactive
+    groups:
+      Flammable: [Touch]
+      Extinguish: [Touch]
+
+- type: entity
+  id: BaseWoodFuel
+  parent: BaseSolidFuel
+  abstract: true
+  components:
+  - type: SolidFuel
+    ignitionTime: 300
+    burnTime: 120
+
+- type: entity
+  id: BaseCarpetFuel
+  parent: BaseSolidFuel
+  abstract: true
+  components:
+  - type: SolidFuel
+    ignitionTime: 240
+    burnTime: 90
+
+# Invisible until ignited. Created only for floor tiles currently exposed to heat.
+- type: entity
+  id: SolidFuelFloorWood
+  parent: BaseWoodFuel
+  name: burning wooden floor
+  categories: [HideSpawnMenu]
+  components:
+  - type: Sprite
+    noRot: true
+  - type: Transform
+    anchored: true
+
+- type: entity
+  id: SolidFuelFloorCarpet
+  parent: SolidFuelFloorWood
+  name: burning carpet floor
+  components:
+  - type: SolidFuel
+    ignitionTime: 240
+    burnTime: 90

--- a/Resources/Prototypes/Entities/Objects/Misc/torch.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/torch.yml
@@ -44,6 +44,7 @@
       energy: 5.0
       netsync: false
     - type: IgnitionSource
+      contactIgnitionRate: 30
       temperature: 400
       ignited: false
     - type: LightBehaviour

--- a/Resources/Prototypes/Entities/Objects/Tiles/astro.yml
+++ b/Resources/Prototypes/Entities/Objects/Tiles/astro.yml
@@ -189,7 +189,7 @@
 
 - type: entity
   name: large wood floor
-  parent: FloorTileItemBase
+  parent: [FloorTileItemBase, BaseWoodFuel]
   id: FloorTileItemWoodLarge
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Tiles/tiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Tiles/tiles.yml
@@ -439,7 +439,7 @@
 
 - type: entity
   name: wood floor
-  parent: FloorTileItemBase
+  parent: [FloorTileItemBase, BaseWoodFuel]
   id: FloorTileItemWood
   components:
   - type: Sprite
@@ -842,7 +842,7 @@
 
 - type: entity
   name: wood pattern floor
-  parent: FloorTileItemBase
+  parent: [FloorTileItemBase, BaseWoodFuel]
   id: FloorTileItemWoodPattern
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
@@ -50,7 +50,7 @@
     node: TableFrame
 
 - type: entity
-  parent: [ BaseStructure, StructureHealthFurnitureWeak ]
+  parent: [BaseStructure, StructureHealthFurnitureWeak, BaseWoodFuel]
   id: CounterWoodFrame
   name: wooden counter frame
   description: Pieces of wood that make the frame of a table.
@@ -411,7 +411,7 @@
     node: TableBrass
 
 - type: entity
-  parent: [ TableBase, StructureHealthFurniture ]
+  parent: [TableBase, StructureHealthFurniture, BaseWoodFuel]
   id: TableWood
   name: wood table
   description: Do not apply fire to this. Rumour says it burns easily.
@@ -443,7 +443,7 @@
       collection: FootstepWood
 
 - type: entity
-  parent: [ TableBase, StructureHealthFurnitureWeak ]
+  parent: [TableBase, StructureHealthFurnitureWeak, BaseWoodFuel]
   id: TableCarpet
   name: gambling table
   description: Play em' cowboy.
@@ -572,7 +572,7 @@
 
 - type: entity
   abstract: true
-  parent: [ TableBase, StructureHealthFurnitureWeak ]
+  parent: [TableBase, StructureHealthFurnitureWeak, BaseWoodFuel]
   id: TableFancyBase
   name: fancy table
   description: Expensive and rich.
@@ -840,7 +840,7 @@
 #region Counters
 
 - type: entity
-  parent: [ CounterBase, StructureHealthFurniture ]
+  parent: [CounterBase, StructureHealthFurniture, BaseWoodFuel]
   id: TableCounterWood
   name: wood counter
   description: Do not apply fire to this. Rumour says it burns easily.

--- a/Resources/Prototypes/Entities/Structures/Furniture/carpets.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/carpets.yml
@@ -1,7 +1,7 @@
 # TODO move all of this to tiles once tile smoothing is supported
 - type: entity
   abstract: true
-  parent: [ BaseStructure, StructureHealthFurnitureWeak ]
+  parent: [BaseStructure, StructureHealthFurnitureWeak, BaseCarpetFuel]
   id: CarpetBase
   name: carpet
   description: "Fancy walking surface."
@@ -220,7 +220,7 @@
 
 # TODO nuke this once tiles support rotating sprites
 - type: entity
-  parent: BaseStructure
+  parent: [BaseStructure, BaseCarpetFuel]
   id: CarpetChapel
   name: "chapel's carpet"
   components:
@@ -251,7 +251,7 @@
 #cardpet
 
 - type: entity
-  parent: [ BaseStructure, StructureHealthFurnitureWeak ]
+  parent: [BaseStructure, StructureHealthFurnitureWeak, BaseCarpetFuel]
   id: CarpetCard
   name: cardboard "carpet"
   description: "Even lino is better."

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -245,7 +245,7 @@
     thresholds: *ThresholdsFurnitureNormalSteel
 
 - type: entity
-  parent: [ UnanchoredChairBase, StructureHealthFurniture ]
+  parent: [UnanchoredChairBase, StructureHealthFurniture, BaseWoodFuel]
   id: ChairWood
   name: wooden chair
   components:
@@ -449,7 +449,7 @@
           MaterialCardboard: *Min0Max1
 
 - type: entity
-  parent: [ ChairBase, StructureHealthFurniture ]
+  parent: [ChairBase, StructureHealthFurniture, BaseWoodFuel]
   id: WoodenBench
   name: wooden bench
   description: Did you get a splinter? Well, at least it’s eco friendly.

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -875,7 +875,7 @@
     resistance: 6
 
 - type: entity
-  parent: [ BaseWall, StructureHealthBarrierStrong ]
+  parent: [BaseWall, StructureHealthBarrierStrong, BaseWoodFuel]
   id: WallWood
   name: wood wall
   description: The traditional greytide defense.

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -39,6 +39,7 @@
 
 - type: tile
   id: FloorWood
+  solidFuelEntity: SolidFuelFloorWood
   parent: BaseStationTile
   name: tiles-wood
   sprite: /Textures/Tiles/Wood/wood.png
@@ -143,6 +144,7 @@
 # Carpets (non smoothing)
 - type: tile
   id: FloorArcadeBlue
+  solidFuelEntity: SolidFuelFloorCarpet
   parent: BaseStationTile
   name: tiles-blue-arcade-floor
   sprite: /Textures/Tiles/arcadeblue.png
@@ -155,6 +157,7 @@
 
 - type: tile
   id: FloorArcadeRed
+  solidFuelEntity: SolidFuelFloorCarpet
   parent: BaseStationTile
   name: tiles-red-arcade-floor
   sprite: /Textures/Tiles/arcadered.png
@@ -167,6 +170,7 @@
 
 - type: tile
   id: FloorCarpetClown
+  solidFuelEntity: SolidFuelFloorCarpet
   parent: BaseStationTile
   name: tiles-clown-carpet-floor
   sprite: /Textures/Tiles/carpetclown.png
@@ -179,6 +183,7 @@
 
 - type: tile
   id: FloorCarpetOffice
+  solidFuelEntity: SolidFuelFloorCarpet
   parent: BaseStationTile
   name: tiles-office-carpet-floor
   sprite: /Textures/Tiles/carpetoffice.png
@@ -191,6 +196,7 @@
 
 - type: tile
   id: FloorBoxing
+  solidFuelEntity: SolidFuelFloorCarpet
   parent: BaseStationTile
   name: tiles-boxing-ring-floor
   sprite: /Textures/Tiles/boxing.png
@@ -200,6 +206,7 @@
 
 - type: tile
   id: FloorGym
+  solidFuelEntity: SolidFuelFloorCarpet
   parent: BaseStationTile
   name: tiles-gym-floor
   sprite: /Textures/Tiles/gym.png
@@ -278,6 +285,7 @@
 
 - type: tile
   id: FloorWoodTile
+  solidFuelEntity: SolidFuelFloorWood
   parent: BaseStationTile
   name: tiles-wood2
   sprite: /Textures/Tiles/Wood/wood-tile.png
@@ -289,6 +297,7 @@
 
 - type: tile
   id: FloorBrokenWood
+  solidFuelEntity: SolidFuelFloorWood
   parent: BaseStationTile
   name: tiles-wood3
   sprite: /Textures/Tiles/Wood/wood-broken.png
@@ -301,6 +310,7 @@
 
 - type: tile
   id: FloorWoodLarge
+  solidFuelEntity: SolidFuelFloorWood
   parent: BaseStationTile
   name: tiles-wood-large
   sprite: /Textures/Tiles/Wood/wood-large.png


### PR DESCRIPTION
## About the PR

Add configurable solid-material fires to Wizden. Sustained contact with hot items ignites dry towels, cloth uniforms, cloth/cardboard/wood stacks, carpets, wooden furniture, walls, and floors. Burning materials consume finite fuel and leave ash. Burning floors expose the underlying floor layer without dropping a reusable tile.

Prepared with Codex assistance.

Draft: automated integration checks pass, but Wizden visual playtesting and media are pending. Station-scale performance and multiplayer balance remain unvalidated.

## Why / Balance

Common combustible materials should have consistent interactions with hot tools and suppression. Slow contact ignition gives players time to notice an unattended cigarette; sustained lighter/torch use provides deliberate ignition. Oxygen, wetness, obstruction, and finite fuel limit propagation.

At default settings, cigarettes ignite cloth in 90 seconds, carpet in 240 seconds, and wood in 300 seconds. Lighters are ten times faster; torches are thirty times faster. Burnout takes 60/90/120 seconds respectively. Inventories and containers block passive heating, and multiple sources use the strongest contact instead of multiplying heat. These starting values need gameplay feedback.

## Technical details

- Adapt `SolidFuelSystem` and its component to upstream atmosphere namespaces, upstream `CCVars`, and current `TryExtinguish` APIs. Preserve existing furniture health inheritance and metal-frame behavior.
- Sample contact once per second, reuse source/lookup collections, and skip oxygen/puddle lookups for cold, unexposed fuel. Lookup radii are capped at three tiles. Floor fuel is created on demand, and live entity lookup reuses existing floor fires.
- Retain wetness independently of fire stacks so incendiary hits cannot erase recent suppression. The extra tile suppression route handles noncolliding fuel without double-applying to collidable entities.
- Preserve existing gas/mob fire routes; add solid-fuel enable, oxygen, and wetness checks. Airtight wooden walls can use adjacent oxygen.
- Initialize client fire visuals on component startup so burning entities can create their light after initialization.
- Add YAML fuel profiles, server tuning controls, documentation, and integration regressions. No engine dependency changes.

## Test plan

Based on Wizden master `f5149c4cad5b6ef3a376717c21b7a855182ced3e`.

- Integration project builds with zero errors against Wizden's pinned RobustToolbox `edf061e7450a4074f173e3000bf1552b6f54082f`.
- All 40 selected tests pass using the normal NUnit test adapter: solid-fuel regressions and existing fire-spreading tests. No test-runner or dependency overrides are included.
- `git diff --check` passes.

Reproduce automated checks:

```sh
dotnet test Content.IntegrationTests/Content.IntegrationTests.csproj --filter "FullyQualifiedName~SolidFuelTest|FullyQualifiedName~FireSpreading"
```

Pending manual checks in a local Sandbox round:

1. Drop a lit cigarette on a dry towel; confirm delayed ignition, visible flames, then ash. Repeat with carpet and wood.
2. Use a held lit lighter on a towel; verify progress and interruption by movement or hand changes. Holding a lighter without using it must not heat the floor.
3. Spray burning carpets, floors, and collidable objects with water/extinguisher. Confirm suppression and that recent wetness blocks immediate incendiary relighting.
4. Check wooden floor burnout exposes the actual previous layer, oxygen removal stops burning, and obstruction/container boundaries prevent passive ignition.
5. Toggle `fire.solid_fuel_spread` and `fire.solid_fuel_enabled`; check propagation and emergency extinguishing.
6. Measure tick time with many simultaneous sources/fires and test multiplayer/PVS transitions.

## Media

Pending the author's visual playtest and screenshots.

## Requirements

- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). (Read; in-game testing/media requirements remain pending.)
- [ ] I have tested this pull request and written instructions on how to test it. (Automated tests pass; manual verification pending.)
- [ ] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

No existing public API signatures or prototype IDs are removed or renamed. Adds `SolidFuel`, fuel parent prototypes, `IgnitionSource.contactIgnitionRate`, tile `solidFuelEntity`, and `fire.solid_fuel_*` CVars. Opted-in materials now use contact ignition and finite burnout; forks inheriting these prototypes should review the new behavior and overrides. Existing metal-frame prototypes remain noncombustible.

## Changelog

:cl:
- add: Hot items gradually ignite dry cloth, carpets, and wood, consuming them into ash. Water and fire extinguishers suppress these fires.
