### PR TITLE
change ultravasculine plasma required to catalyst 

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -332,6 +332,7 @@
       amount: 2
     Plasma:
       amount: 1
+      catalyst: true  
   products:
     Ultravasculine: 2
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed ultravasculine recipe to require 1 plasma as a catalyst instead of consuming it. 
## Why / Balance
Change made in response to new ambuzol (https://forum.spacestation14.com/t/new-ambu-is-way-too-hard/28364/22)
New ambu recipe is harder for new/amateur chemists. Adding a finite plasma requirement makes it even harder as a main bottleneck - if they aren't able to obtain plasma, they're fully stuck. This change makes it so the main difficulty for them is still step count
Brings role of plasma more in line with regular healing chems instead of epic RR phlog polytrinic 
Doesn't really affect experienced chemists who have been deconning their locker anyway - cure is still capped by romerodone / centrifuge speed, chem is still relatively simple to disable as II 
ultravasc is the best anti-tox chem but capped by blunt damage + higher carbon requirement than diphenhydramine/arithrazine, 20u OD makes it bad to killhypo, 0.5/u makes it slower than the acids as a foam killer, not much danger in letting it be easier 

## Technical details
one line yaml

## Test plan
1. make histamine
2. add 1 plasma
3. retain plasma stores, get ultravasculine 

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
:cl:
- tweak: Ultravasculine now requires plasma as a catalyst instead of being consumed.

