### PR TITLE
Resolving #45897 - keeping welded doors welded whilst being doorjacked via new `EmaggingWelded` door state (avoiding unintended unweld via `Emagging` state transition)

### DIFF
--- a/Content.Client/Doors/AirlockSystem.cs
+++ b/Content.Client/Doors/AirlockSystem.cs
@@ -96,7 +96,7 @@ public sealed partial class AirlockSystem : SharedAirlockSystem
         if (hasPower)
         {
             _appearanceSystem.TryGetData<bool>(uid, DoorVisuals.BoltLights, out var boltedVisible, args.Component);
-            showBolted = boltedVisible && (state == DoorState.Closed || state == DoorState.Welded);
+            showBolted = boltedVisible && (state is DoorState.Closed or DoorState.Welded or DoorState.EmaggingWelded);
 
             _appearanceSystem.TryGetData<bool>(uid, DoorVisuals.EmergencyLights, out var emergencyVisible, args.Component);
             showEmergency = emergencyVisible;

--- a/Content.Client/Doors/DoorSystem.cs
+++ b/Content.Client/Doors/DoorSystem.cs
@@ -118,7 +118,7 @@ public sealed partial class DoorSystem : SharedDoorSystem
 
         // We are checking beforehand since some doors may not have an emagging visual layer, and we don't want LayerSetVisible to throw an error.
         if (_sprite.TryGetLayer(entity.Owner, DoorVisualLayers.BaseEmagging, out var _, false))
-            _sprite.LayerSetVisible(entity.Owner, DoorVisualLayers.BaseEmagging, state == DoorState.Emagging);
+            _sprite.LayerSetVisible(entity.Owner, DoorVisualLayers.BaseEmagging, state is DoorState.Emagging or DoorState.EmaggingWelded);
 
         UpdateAppearanceForDoorState(entity, args.Sprite, state);
     }
@@ -192,7 +192,7 @@ public sealed partial class DoorSystem : SharedDoorSystem
                 _animationSystem.Play(entity, (Animation)entity.Comp.DenyingAnimation, DoorComponent.DenyKey);
 
                 return;
-            case DoorState.Emagging:
+            case DoorState.Emagging or DoorState.EmaggingWelded:
                 if (_animationSystem.HasRunningAnimation(entity, DoorComponent.EmagKey))
                     return;
 

--- a/Content.Server/Construction/Conditions/DoorWelded.cs
+++ b/Content.Server/Construction/Conditions/DoorWelded.cs
@@ -17,7 +17,7 @@ namespace Content.Server.Construction.Conditions
             if (!entityManager.TryGetComponent(uid, out DoorComponent? doorComponent))
                 return false;
 
-            return doorComponent.State == DoorState.Welded;
+            return doorComponent.State is DoorState.Welded or DoorState.EmaggingWelded;
         }
 
         public bool DoExamine(ExaminedEvent args)
@@ -28,7 +28,7 @@ namespace Content.Server.Construction.Conditions
 
             if (!entMan.TryGetComponent(entity, out DoorComponent? door)) return false;
 
-            var isWelded = door.State == DoorState.Welded;
+            var isWelded = door.State is DoorState.Welded or DoorState.EmaggingWelded;
             if (isWelded != Welded)
             {
                 if (Welded)

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -68,6 +68,7 @@ namespace Content.Server.Doors.Systems
                 // only bother to check pressure on doors that are some variation of closed.
                 if (door.State != DoorState.Closed
                     && door.State != DoorState.Welded
+                    && door.State != DoorState.EmaggingWelded
                     && door.State != DoorState.Denying)
                 {
                     continue;

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -331,7 +331,8 @@ public enum DoorState : byte
     Opening,
     Welded,
     Denying,
-    Emagging
+    Emagging,
+    EmaggingWelded
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -427,7 +427,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         {
             SetState(uid, DoorState.EmaggingWelded, door);
         }
-        else if (door.State is not DoorState.Emagging or DoorState.EmaggingWelded)
+        else if (door.State != DoorState.Emagging && door.State !=  DoorState.EmaggingWelded)
         {
             SetState(uid, DoorState.Emagging, door);
         }
@@ -876,7 +876,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
             case DoorState.EmaggingWelded:
                 // engage bolts, leave it welded
                 if (TryComp<DoorBoltComponent>(ent, out var doorBoltComponent))
-                    SetBoltsDown((ent, doorBoltComponent),true);
+                    SetBoltsDown((ent, doorBoltComponent),true, predicted:true);
                 SetState(ent, DoorState.Welded, door);
                 break;
 

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -126,11 +126,23 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (!airlock.Powered)
             return;
 
-        if (door.State != DoorState.Closed)
-            return;
-
-        if (!SetState(uid, DoorState.Emagging, door))
-            return;
+        switch (door.State)
+        {
+            case DoorState.Emagging or DoorState.EmaggingWelded:
+                return;
+            case DoorState.Welded:
+            {
+                if (!SetState(uid, DoorState.EmaggingWelded, door))
+                    return;
+                break;
+            }
+            default:
+            {
+                if (!SetState(uid, DoorState.Emagging, door))
+                    return;
+                break;
+            }
+        }
 
         args.Repeatable = true;
         args.Handled = true;
@@ -174,7 +186,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
                 door.NextStateChange = GameTiming.CurTime + door.DenyDuration;
                 break;
 
-            case DoorState.Emagging:
+            case DoorState.Emagging or DoorState.EmaggingWelded:
                 _activeDoors.Add((uid, door));
                 door.NextStateChange = GameTiming.CurTime + door.EmagDuration;
                 break;
@@ -219,7 +231,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
     private void OnBeforePry(EntityUid uid, DoorComponent door, ref BeforePryEvent args)
     {
-        if (door.State == DoorState.Welded || !door.CanPry)
+        if (door.State == DoorState.Welded || door.State == DoorState.EmaggingWelded || !door.CanPry)
             args.Cancelled = true;
     }
 
@@ -247,7 +259,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
             args.Cancel();
             return;
         }
-        if (component.State != DoorState.Closed && component.State != DoorState.Welded)
+        if (component.State != DoorState.Closed && component.State != DoorState.Welded && component.State != DoorState.EmaggingWelded)
         {
             args.Cancel();
         }
@@ -259,6 +271,8 @@ public abstract partial class SharedDoorSystem : EntitySystem
             SetState(uid, DoorState.Welded, component);
         else if (component.State == DoorState.Welded)
             SetState(uid, DoorState.Closed, component);
+        else if (component.State == DoorState.EmaggingWelded)
+            SetState(uid, DoorState.Emagging, component);
     }
 
     /// <summary>
@@ -329,7 +343,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (!Resolve(uid, ref door))
             return false;
 
-        if (door.State == DoorState.Welded)
+        if (door.State is DoorState.Welded or DoorState.EmaggingWelded)
             return false;
 
         if (Paused(uid))
@@ -409,7 +423,14 @@ public abstract partial class SharedDoorSystem : EntitySystem
             return false;
         }
 
-        SetState(uid, DoorState.Emagging, door);
+        if (door.State == DoorState.Welded)
+        {
+            SetState(uid, DoorState.EmaggingWelded, door);
+        }
+        else if (door.State is not DoorState.Emagging or DoorState.EmaggingWelded)
+        {
+            SetState(uid, DoorState.Emagging, door);
+        }
 
         return true;
     }
@@ -441,7 +462,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
         // since both closing/closed and welded are door states, we need to prevent 'closing'
         // a welded door or else there will be weird state bugs
-        if (door.State is DoorState.Welded or DoorState.Closed)
+        if (door.State is DoorState.Welded or DoorState.EmaggingWelded or DoorState.Closed)
             return false;
 
         if (Paused(uid))
@@ -850,6 +871,13 @@ public abstract partial class SharedDoorSystem : EntitySystem
             case DoorState.Denying:
                 // Finish denying entry and return to the closed state.
                 SetState(ent, DoorState.Closed, door);
+                break;
+
+            case DoorState.EmaggingWelded:
+                // engage bolts, leave it welded
+                if (TryComp<DoorBoltComponent>(ent, out var doorBoltComponent))
+                    SetBoltsDown((ent, doorBoltComponent),true);
+                SetState(ent, DoorState.Welded, door);
                 break;
 
             case DoorState.Emagging:

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -123,6 +123,7 @@ public abstract partial class SharedFirelockSystem : EntitySystem
         // only bother to check pressure on doors that are some variation of closed.
         if (door.State != DoorState.Closed
             && door.State != DoorState.Welded
+            && door.State != DoorState.EmaggingWelded
             && door.State != DoorState.Denying)
         {
             _appearance.SetData(uid, DoorVisuals.ClosedLights, false, appearance);


### PR DESCRIPTION
Resolves #45897

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
* Welded doors will no longer get unwelded whilst getting doorjacked.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
* Created in response to #45897 
* Would definitely weaken doorjacking tools (welding would effectively counter it, requiring one to unweld the door beforehand or unweld + unbolt after the fact), may not be desirable.
  * Could alter this PR to make welded doors _not_ get bolted in the doorjacking process, if that would be desirable behaviour.
  * Retained existing behaviour (still bolting doors) to err on the side of caution/fewer additional changes to the overall process.

## Technical details
<!-- Summary of code changes for easier review. -->
* Added new `EmaggingWelded` state to `DoorState` in `DoorComponent.cs`
  * Used like the `Emagging` state but for the case where the door has been welded shut
* Updated `SharedDoorSystem.cs` to update the door's state to `EmaggingWelded` if it got doorjacked whilst welded.
  * Also added behaviour for `EmaggingWelded` state to `SetState` and `NextState` methods
* Generally also checked for `EmaggingWelded` state in situations which check for `Welded` DoorState across the codebase.
  * FirelockSystem, AirlockSystem, and DoorWelded have been updated as necessary.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. weld unbolted door
2. take note of accesses
3. doorjack it (access breaker etc)
4. door should still be welded shut, but bolted, and access restrictions should be removed.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/14496b31-d6f6-4541-9aac-287d849931e8

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
* Adds a new `EmaggingWelded` state to `DoorState` (`Content.Shared/Doors/Components/DoorComponent.cs`)
  * Similar functionality to the `Emagging` state, but for the case where a door gets welded.
* If using `DoorState` in areas which differ from upstream
  * Areas of the codebase which check for `DoorState.Welded` may need to check for `DoorState.EmaggingWelded` as well.
  * Areas which check for `DoorState.Emagging` may need to check for `DoorState.EmaggingWelded` as well.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
<!--
:cl:
- add: Crowbars now randomly spawn in maintenance lockers.
- remove: Crowbars no longer spawn in maintenance crates.
- tweak: Crowbar spawn rates have been increased for tool lockers.
- fix: Crowbars no longer accidentally spawn in microwaves.
-->
:cl:
- fix: Welded doors will no longer get unwelded when doorjacked or hit by the greytide virus.