### PR TITLE
Resolving #45897 (preventing unintended door unwelding) by decoupling weld status from DoorState (`DoorState.Welded` is gone, use `WeldableComponent` instead))

### DIFF
--- a/Content.Client/Doors/AirlockSystem.cs
+++ b/Content.Client/Doors/AirlockSystem.cs
@@ -96,7 +96,7 @@ public sealed partial class AirlockSystem : SharedAirlockSystem
         if (hasPower)
         {
             _appearanceSystem.TryGetData<bool>(uid, DoorVisuals.BoltLights, out var boltedVisible, args.Component);
-            showBolted = boltedVisible && (state == DoorState.Closed || state == DoorState.Welded);
+            showBolted = boltedVisible && state == DoorState.Closed;
 
             _appearanceSystem.TryGetData<bool>(uid, DoorVisuals.EmergencyLights, out var emergencyVisible, args.Component);
             showEmergency = emergencyVisible;

--- a/Content.Server/Construction/Conditions/DoorWelded.cs
+++ b/Content.Server/Construction/Conditions/DoorWelded.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Construction;
 using Content.Shared.Doors.Components;
 using Content.Shared.Examine;
+using Content.Shared.Tools.Components;
 using JetBrains.Annotations;
 
 namespace Content.Server.Construction.Conditions
@@ -14,10 +15,10 @@ namespace Content.Server.Construction.Conditions
 
         public bool Condition(EntityUid uid, IEntityManager entityManager)
         {
-            if (!entityManager.TryGetComponent(uid, out DoorComponent? doorComponent))
+            if (!(entityManager.TryGetComponent(uid, out DoorComponent? doorComponent) && entityManager.TryGetComponent(uid, out WeldableComponent? weldComp)))
                 return false;
 
-            return doorComponent.State == DoorState.Welded;
+            return weldComp.IsWelded;
         }
 
         public bool DoExamine(ExaminedEvent args)
@@ -26,9 +27,9 @@ namespace Content.Server.Construction.Conditions
 
             var entMan = IoCManager.Resolve<IEntityManager>();
 
-            if (!entMan.TryGetComponent(entity, out DoorComponent? door)) return false;
+            if (!entMan.TryGetComponent(entity, out WeldableComponent? weld)) return false;
 
-            var isWelded = door.State == DoorState.Welded;
+            var isWelded = weld.IsWelded;
             if (isWelded != Welded)
             {
                 if (Welded)

--- a/Content.Server/Doors/Systems/FirelockSystem.cs
+++ b/Content.Server/Doors/Systems/FirelockSystem.cs
@@ -67,7 +67,6 @@ namespace Content.Server.Doors.Systems
 
                 // only bother to check pressure on doors that are some variation of closed.
                 if (door.State != DoorState.Closed
-                    && door.State != DoorState.Welded
                     && door.State != DoorState.Denying)
                 {
                     continue;

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -329,7 +329,6 @@ public enum DoorState : byte
     Closing,
     Open,
     Opening,
-    Welded,
     Denying,
     Emagging
 }

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -48,6 +48,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
     [Dependency] protected SharedPopupSystem Popup = default!;
     [Dependency] private SharedMapSystem _mapSystem = default!;
     [Dependency] private SharedPowerReceiverSystem _powerReceiver = default!;
+    [Dependency] private WeldableSystem _weldSystem = default!;
 
     public static readonly ProtoId<TagPrototype> DoorBumpTag = "DoorBumpOpener";
 
@@ -74,7 +75,6 @@ public abstract partial class SharedDoorSystem : EntitySystem
         SubscribeLocalEvent<DoorComponent, BeforePryEvent>(OnBeforePry);
         SubscribeLocalEvent<DoorComponent, PriedEvent>(OnAfterPry);
         SubscribeLocalEvent<DoorComponent, WeldableAttemptEvent>(OnWeldAttempt);
-        SubscribeLocalEvent<DoorComponent, WeldableChangedEvent>(OnWeldChanged);
         SubscribeLocalEvent<DoorComponent, GetPryTimeModifierEvent>(OnPryTimeModifier);
         SubscribeLocalEvent<DoorComponent, GotEmaggedEvent>(OnEmagged);
     }
@@ -160,6 +160,11 @@ public abstract partial class SharedDoorSystem : EntitySystem
         switch (state)
         {
             case DoorState.Opening:
+                if (_weldSystem.IsWelded(uid))
+                {
+                    state = DoorState.Closed;
+                    goto case DoorState.Closed;
+                }
                 _activeDoors.Add((uid, door));
                 door.NextStateChange = GameTiming.CurTime + door.OpenTimeOne;
                 break;
@@ -180,6 +185,8 @@ public abstract partial class SharedDoorSystem : EntitySystem
                 break;
 
             case DoorState.Open:
+                if (_weldSystem.IsWelded(uid))
+                    return false;
                 door.Partial = false;
                 if (door.NextStateChange == null)
                     _activeDoors.Remove((uid, door));
@@ -219,7 +226,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
     private void OnBeforePry(EntityUid uid, DoorComponent door, ref BeforePryEvent args)
     {
-        if (door.State == DoorState.Welded || !door.CanPry)
+        if (!door.CanPry || _weldSystem.IsWelded(uid))
             args.Cancelled = true;
     }
 
@@ -247,18 +254,10 @@ public abstract partial class SharedDoorSystem : EntitySystem
             args.Cancel();
             return;
         }
-        if (component.State != DoorState.Closed && component.State != DoorState.Welded)
+        if (component.State == DoorState.Open || component.State == DoorState.Opening || component.State == DoorState.Closing)
         {
             args.Cancel();
         }
-    }
-
-    private void OnWeldChanged(EntityUid uid, DoorComponent component, ref WeldableChangedEvent args)
-    {
-        if (component.State == DoorState.Closed)
-            SetState(uid, DoorState.Welded, component);
-        else if (component.State == DoorState.Welded)
-            SetState(uid, DoorState.Closed, component);
     }
 
     /// <summary>
@@ -329,9 +328,6 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (!Resolve(uid, ref door))
             return false;
 
-        if (door.State == DoorState.Welded)
-            return false;
-
         if (Paused(uid))
             return false;
 
@@ -346,6 +342,9 @@ public abstract partial class SharedDoorSystem : EntitySystem
                 Deny(uid, door, user, predicted: true);
             return false;
         }
+
+        if (_weldSystem.IsWelded(uid))
+            return false;
 
         return true;
     }
@@ -441,7 +440,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
         // since both closing/closed and welded are door states, we need to prevent 'closing'
         // a welded door or else there will be weird state bugs
-        if (door.State is DoorState.Welded or DoorState.Closed)
+        if (door.State is DoorState.Closed || _weldSystem.IsWelded(uid))
             return false;
 
         if (Paused(uid))
@@ -863,11 +862,6 @@ public abstract partial class SharedDoorSystem : EntitySystem
                     // The door failed to close (blocked?). Try again in one second.
                     door.NextStateChange = time + TimeSpan.FromSeconds(1);
                 }
-                break;
-
-            case DoorState.Welded:
-                // A welded door? This should never have been active in the first place.
-                Log.Error($"Welded door was in the list of active doors. Door: {ToPrettyString(ent)}");
                 break;
         }
     }

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -122,7 +122,6 @@ public abstract partial class SharedFirelockSystem : EntitySystem
 
         // only bother to check pressure on doors that are some variation of closed.
         if (door.State != DoorState.Closed
-            && door.State != DoorState.Welded
             && door.State != DoorState.Denying)
         {
             _appearance.SetData(uid, DoorVisuals.ClosedLights, false, appearance);

--- a/Resources/Maps/Salvage/asteroid-base.yml
+++ b/Resources/Maps/Salvage/asteroid-base.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 289.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/22/2026 14:45:39
+  time: 09/07/2026 17:40:39
   entityCount: 366
 maps: []
 grids:
@@ -241,7 +241,9 @@ entities:
       parent: 407
       pos: -9.5,-6.5
     - type: Door
-      state: Welded
+      state: Closed
+    - type: Weldable
+      isWelded: True
     - type: Physics
       canCollide: False
     - type: Airtight


### PR DESCRIPTION
resolves #45897

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
* Removes `Welded` state from `DoorState`, relies on `WeldableComponent` to keep track of whether or not a door is welded.
* Somewhat in response to #45897, somewhat neater implementation than #45905
* If a door is welded, attempts to open that door will fail.
  * Trying to open with access - door will stay closed.
  * Doorjacking - will remove accesses but bolt door closed.
  * Greytide virus - door will be bolted closed.
* It's now possible for a welded door to enter the `denied` state.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
* `DoorState.Welded` is somewhat redundant given the presence of `WeldableComponent` on doors.
  * `DoorComponent` now won't keep track of whether or not the door is welded, it will defer to `WeldableComponent` instead.
* Behaviour when doorjacking
  * Currently sticks to default behaviour, but with the slight caveat of the opening of welded doors being outright prevented.
  * Behaviour could be altered (such as not bolting the door if it was welded when it was doorjacked) if that would be preferable.

## Technical details
<!-- Summary of code changes for easier review. -->
* DoorComponent.cs
  * Removed `DoorState.Welded`
* SharedDoorSystem.cs etc
  * Anything which used to explicitly check if the door was welded via `door.State == DoorState.Welded` will now check `WeldableSystem.IsWelded(uid)`
  * Welded doors will not be openable.
    * Cannot enter `DoorState.Opening` or `DoorState.Open` if it's been welded.
  * Cannot weld a door unless it is in a 'closed' state (`DoorState.Closed`, `DoorState.Denying`, `DoorState.Emagging`)
    * yes, `DoorState.Emagging` *is* a closed state - it's the prelude to `DoorState.Opening`->`DoorState.Open`, but, in that state (of the doorjacking tool hacking into and jacking the door), the door hasn't _yet_ been opened.
* `Maps/Salvage/asteroid-base.yml`
  * there was an airlock with `DoorState.Welded`, performed the migration described in the breaking changes section.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. weld unbolted door
2. take note of accesses
3. doorjack it (access breaker etc)
4. door should still be welded shut, but bolted, and access restrictions should be removed.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<details><summary>Welded doors will now flash 'access denied' lights when someone without access bumps into them</summary>

https://github.com/user-attachments/assets/c9eb25f2-ce04-4d9a-80a0-537dfec3d782

</details>
<details><summary>Doorjacking will not unweld a welded door</summary>

https://github.com/user-attachments/assets/8f85d5f7-1122-4ed0-ba68-e1ecaad88e76

</details>

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
* `DoorState` (in `DoorComponent.cs`)
  * `DoorState.Welded` has been removed.
    * Welding has been completely decoupled from the `DoorState` system.
  * `SharedDoorSystem` etc will now rely on the presence of a `WeldableComponent` on the door in order to work out if the door has been welded or not.
  * Welded doors should not open.

* Mapping:

```yaml
- type: Door
  state: Welded
```

should be replaced with

```yaml
- type: Door
  state: Closed
- type: Weldable
  isWelded: True
```

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
<!--
:cl:
- add: Crowbars now randomly spawn in maintenance lockers.
- remove: Crowbars no longer spawn in maintenance crates.
- tweak: Crowbar spawn rates have been increased for tool lockers.
- fix: Crowbars no longer accidentally spawn in microwaves.
-->
:cl:
- fix: Welded doors will no longer get unwelded when doorjacked or hit by the greytide virus.
- fix: Welded doors will flash 'access denied' lights if bumped into by someone without access.