### PR TITLE
refactor: update changelog tool for publish-testing workflow, it should fix names in changelogs

### DIFF
--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Update changelog
       run: |
-        dotnet tool install --global SpaceWizards.ChangelogTool --version 1.0.7
+        dotnet tool install --global SpaceWizards.ChangelogTool --version 1.0.8
         ss14-changelog update -d Resources/Changelog
       env:
         REPO: ${{ github.repository }}


### PR DESCRIPTION
Example of changelog generated by tool
https://github.com/Fildrance/space-station-14/pull/20/changes

Fixes this

<img width="1000" height="328" alt="image" src="https://github.com/user-attachments/assets/ad6182ba-42e3-498b-8214-56cb6436d54c" />


and some other minor stuff that is not easily visible.