### PR TITLE
Fix MysteryLighterBox EntitySpawnEntry prob param naming

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/smokables.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/smokables.yml
@@ -78,3 +78,53 @@
         - id: CigPackMixed
       - id: CigarGold
         weight: 0.10
+
+- type: entityTable
+  id: LighterTable
+  table: !type:GroupSelector
+    children:
+    - id: CybersunFlippo
+      orGroup: Lighterbox
+      weight: 0.15
+    - id: InterdyneFlippo
+      orGroup: Lighterbox
+      weight: 0.15
+    - id: NanotrasenFlippo
+      orGroup: Lighterbox
+      weight: 0.25
+    - id: WaffleCoFlippo
+      orGroup: Lighterbox
+      weight: 0.35
+    - id: HonkCoFlippo
+      orGroup: Lighterbox
+    - id: GorlexMatchbox
+      orGroup: Lighterbox
+      weight: 0.15
+    - id: DonkcoLighter
+      orGroup: Lighterbox
+      weight: 0.25
+    - id: SyndicateFlippo
+      orGroup: Lighterbox
+      weight: 0.15
+    - id: SpiderclanFlippo
+      orGroup: Lighterbox
+      weight: 0.15
+
+- type: entityTable
+  id: LighterSyndicateTable
+  table: !type:GroupSelector
+    children:
+    - id: CybersunFlippo
+      orGroup: Lighterbox
+    - id: InterdyneFlippo
+      orGroup: Lighterbox
+    - id: WaffleCoFlippo
+      orGroup: Lighterbox
+    - id: HonkCoFlippo
+      orGroup: Lighterbox
+    - id: GorlexMatchbox
+      orGroup: Lighterbox
+    - id: DonkcoLighter
+      orGroup: Lighterbox
+    - id: SyndicateFlippo
+      orGroup: Lighterbox

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/smokables.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/smokables.yml
@@ -84,47 +84,31 @@
   table: !type:GroupSelector
     children:
     - id: CybersunFlippo
-      orGroup: Lighterbox
-      weight: 0.15
+      weight: 3
     - id: InterdyneFlippo
-      orGroup: Lighterbox
-      weight: 0.15
+      weight: 3
     - id: NanotrasenFlippo
-      orGroup: Lighterbox
-      weight: 0.25
+      weight: 5
     - id: WaffleCoFlippo
-      orGroup: Lighterbox
-      weight: 0.35
+      weight: 7
     - id: HonkCoFlippo
-      orGroup: Lighterbox
     - id: GorlexMatchbox
-      orGroup: Lighterbox
-      weight: 0.15
+      weight: 3
     - id: DonkcoLighter
-      orGroup: Lighterbox
-      weight: 0.25
+      weight: 5
     - id: SyndicateFlippo
-      orGroup: Lighterbox
-      weight: 0.15
+      weight: 3
     - id: SpiderclanFlippo
-      orGroup: Lighterbox
-      weight: 0.15
+      weight: 3
 
 - type: entityTable
   id: LighterSyndicateTable
   table: !type:GroupSelector
     children:
     - id: CybersunFlippo
-      orGroup: Lighterbox
     - id: InterdyneFlippo
-      orGroup: Lighterbox
     - id: WaffleCoFlippo
-      orGroup: Lighterbox
     - id: HonkCoFlippo
-      orGroup: Lighterbox
     - id: GorlexMatchbox
-      orGroup: Lighterbox
     - id: DonkcoLighter
-      orGroup: Lighterbox
     - id: SyndicateFlippo
-      orGroup: Lighterbox

--- a/Resources/Prototypes/Entities/Objects/Fun/Figurines/figurine_boxes.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Figurines/figurine_boxes.yml
@@ -16,15 +16,14 @@
   - type: SpaceGarbage
 
 - type: entity
+  abstract: true
   parent: BaseItem
-  id: MysteryFigureBox
-  name: mystery spacemen minifigure box
-  description: A box containing a mystery minifigure. The side of the box depicts a few blacked-out 'rare' figures, including one with a large, non-humanoid shilouette.
+  id: BaseMysteryBox
   components:
   - type: Sprite
     sprite: Objects/Fun/figurines.rsi
     layers:
-      - state: fig_box
+    - state: fig_box
   - type: TriggerOnActivate
   - type: DeleteOnTrigger
   - type: EmitSoundOnTrigger
@@ -34,6 +33,14 @@
       path: /Audio/Effects/unwrap.ogg
   - type: SpawnEntityTableOnTrigger
     useMapCoords: true
+
+- type: entity
+  parent: BaseMysteryBox
+  id: MysteryFigureBox
+  name: mystery spacemen minifigure box
+  description: A box containing a mystery minifigure. The side of the box depicts a few blacked-out 'rare' figures, including one with a large, non-humanoid shilouette.
+  components:
+  - type: SpawnEntityTableOnTrigger
     table: !type:AllSelector
       children:
       - id: MysteryFigureBoxTrash
@@ -41,63 +48,27 @@
         tableId: AllFigurinesTable
 
 - type: entity
-  parent: BaseItem
+  parent: BaseMysteryBox
   id: MysteryLighterBox
   name: Novelty lighter mystery box
   suffix: Filled
   description: A box of discontinued promotional lighters, many of which have since been declared "contraband".
   components:
-  - type: Sprite
-    sprite: Objects/Fun/figurines.rsi
-    layers:
-    - state: fig_box
-  - type: SpawnItemsOnUse
-    items:
-    - id: MysteryFigureBoxTrash
-    - id: CybersunFlippo
-      orGroup: Lighterbox
-      prob: 0.15
-    - id: InterdyneFlippo
-      orGroup: Lighterbox
-      prob: 0.15
-    - id: NanotrasenFlippo
-      orGroup: Lighterbox
-      prob: 0.25
-    - id: WaffleCoFlippo
-      orGroup: Lighterbox
-      prob: 0.35
-    - id: HonkCoFlippo
-      orGroup: Lighterbox
-    - id: GorlexMatchbox
-      orGroup: Lighterbox
-      prob: 0.15
-    - id: DonkcoLighter
-      orGroup: Lighterbox
-      prob: 0.25
-    - id: SyndicateFlippo
-      orGroup: Lighterbox
-      prob: 0.15
-    - id: SpiderclanFlippo
-      orGroup: Lighterbox
-      prob: 0.15
+  - type: SpawnEntityTableOnTrigger
+    table: !type:AllSelector
+      children:
+      - id: MysteryFigureBoxTrash
+      - !type:NestedSelector
+        tableId: LighterTable
 
 - type: entity
   parent: MysteryLighterBox
   id: UplinkLighterBox
   suffix: Uplink
   components:
-  - type: SpawnItemsOnUse
-    items:
+  - type: SpawnEntityTableOnTrigger
+    table: !type:AllSelector
+      children:
       - id: MysteryFigureBoxTrash
-      - id: CybersunFlippo
-        orGroup: Lighterbox
-      - id: InterdyneFlippo
-        orGroup: Lighterbox
-      - id: WaffleCoFlippo
-        orGroup: Lighterbox
-      - id: GorlexMatchbox
-        orGroup: Lighterbox
-      - id: DonkcoLighter
-        orGroup: Lighterbox
-      - id: SyndicateFlippo
-        orGroup: Lighterbox
+      - !type:NestedSelector
+        tableId: LighterSyndicateTable

--- a/Resources/Prototypes/Entities/Objects/Fun/Figurines/figurine_boxes.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Figurines/figurine_boxes.yml
@@ -53,33 +53,33 @@
     - state: fig_box
   - type: SpawnItemsOnUse
     items:
-      - id: MysteryFigureBoxTrash
-      - id: CybersunFlippo
-        orGroup: Lighterbox
-        weight: 0.15
-      - id: InterdyneFlippo
-        orGroup: Lighterbox
-        weight: 0.15
-      - id: NanotrasenFlippo
-        orGroup: Lighterbox
-        weight: 0.25
-      - id: WaffleCoFlippo
-        orGroup: Lighterbox
-        weight: 0.35
-      - id: HonkCoFlippo
-        orGroup: Lighterbox
-      - id: GorlexMatchbox
-        orGroup: Lighterbox
-        weight: 0.15
-      - id: DonkcoLighter
-        orGroup: Lighterbox
-        weight: 0.25
-      - id: SyndicateFlippo
-        orGroup: Lighterbox
-        weight: 0.15
-      - id: SpiderclanFlippo
-        orGroup: Lighterbox
-        weight: 0.15
+    - id: MysteryFigureBoxTrash
+    - id: CybersunFlippo
+      orGroup: Lighterbox
+      prob: 0.15
+    - id: InterdyneFlippo
+      orGroup: Lighterbox
+      prob: 0.15
+    - id: NanotrasenFlippo
+      orGroup: Lighterbox
+      prob: 0.25
+    - id: WaffleCoFlippo
+      orGroup: Lighterbox
+      prob: 0.35
+    - id: HonkCoFlippo
+      orGroup: Lighterbox
+    - id: GorlexMatchbox
+      orGroup: Lighterbox
+      prob: 0.15
+    - id: DonkcoLighter
+      orGroup: Lighterbox
+      prob: 0.25
+    - id: SyndicateFlippo
+      orGroup: Lighterbox
+      prob: 0.15
+    - id: SpiderclanFlippo
+      orGroup: Lighterbox
+      prob: 0.15
 
 - type: entity
   parent: MysteryLighterBox


### PR DESCRIPTION
## About the PR
Replaces weight with prob in MysteryLighterBox prototype

## Why / Balance
See [EntitySpawnEntry params](https://github.com/space-wizards/space-station-14/blob/35b53903616ddd70cd9f240e61bd5817b07be791/Content.Shared/Storage/EntitySpawnEntry.cs#L25). Weight just doesn't exist.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.