### PR TITLE
Paradox clones now see their age in briefing screen

### DIFF
--- a/Content.Server/Roles/ParadoxCloneRoleSystem.cs
+++ b/Content.Server/Roles/ParadoxCloneRoleSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Ghost.Components;
+using Content.Shared.Humanoid;
 using Content.Shared.Mind;
 using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Roles.Components;
@@ -15,6 +16,18 @@ public sealed partial class ParadoxCloneRoleSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<ParadoxCloneRoleComponent, MindRelayedEvent<RefreshNameModifiersEvent>>(OnRefreshNameModifiers);
+        SubscribeLocalEvent<ParadoxCloneRoleComponent, GetBriefingEvent>(OnGetBriefing);
+    }
+
+    /// <summary>
+    ///     Tells the clone their own exact age so others don't metagame the manifest.
+    /// </summary>
+    private void OnGetBriefing(Entity<ParadoxCloneRoleComponent> ent, ref GetBriefingEvent args)
+    {
+        if (!TryComp<HumanoidProfileComponent>(args.Mind.Comp.OwnedEntity, out var profile))
+            return;
+
+        args.Append(Loc.GetString("paradox-clone-role-briefing-age", ("age", profile.Age)));
     }
 
     private void OnRefreshNameModifiers(Entity<ParadoxCloneRoleComponent> ent, ref MindRelayedEvent<RefreshNameModifiersEvent> args)

--- a/Resources/Locale/en-US/paradox-clone/role.ftl
+++ b/Resources/Locale/en-US/paradox-clone/role.ftl
@@ -4,4 +4,6 @@ objective-issuer-paradox = [color=lightblue]Paradox[/color]
 
 paradox-clone-role-greeting = A freak space-time anomaly has teleported you into another reality! Now you have to find your counterpart and kill and replace them. Only one of you two can survive.
 
+paradox-clone-role-briefing-age = You are {$age} years old.
+
 paradox-clone-ghost-name-modifier = {$baseName} (clone)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Paradox clones now see their exact age in briefing screen.

## Why / Balance
Sec use the exact age as a measure to determine which one was the clone
Fixes #42734

## Media
<img width="800" height="1088" alt="image" src="https://github.com/user-attachments/assets/d059eaab-7261-4831-ac6e-3bebf75c1d80" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
- add: Paradox clones now see their age in briefing screen
