### PR TITLE
fix: renamed SatiationPrecondition to BaseSatiationPrecondition

### DIFF
--- a/Resources/Prototypes/NPCs/nutrition.yml
+++ b/Resources/Prototypes/NPCs/nutrition.yml
@@ -5,7 +5,7 @@
     - tasks:
         - !type:HTNPrimitiveTask
           preconditions:
-            - !type:SatiationPrecondition
+            - !type:BaseSatiationPrecondition
               satiationType: Hunger
               below: Peckish
           operator: !type:UtilityOperator
@@ -36,7 +36,7 @@
     - tasks:
         - !type:HTNPrimitiveTask
           preconditions:
-            - !type:SatiationPrecondition
+            - !type:BaseSatiationPrecondition
               satiationType: Thirst
               below: Parched
           operator: !type:UtilityOperator


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
`SatiationPrecondition` type isn't defined anywhere, its actually using `BaseSatiationPrecondition` cause of partial type name match (see https://github.com/space-wizards/RobustToolbox/pull/7073 for more info)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

## Changelog
Doesn't need one i guess
