### PR TITLE
Bugfix: Surveillance camera heartbeat fixes

### DIFF
--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
@@ -213,7 +213,7 @@ public sealed partial class SurveillanceCameraMonitorSystem : EntitySystem
             return;
         }
 
-        var payload = new SurveillanceCameraHeartbeatPayload();
+        var payload = new SurveillanceCameraHeartbeatRequestPayload();
         _deviceNetworkRouter.SendPacketRouted(uid, ref payload, subnetAddress, monitor.ActiveCameraAddress, ProtoMan.Index(activeSubnet).Frequency);
 
         monitor.LastHeartbeatSent = 0;
@@ -367,6 +367,10 @@ public sealed partial class SurveillanceCameraMonitorSystem : EntitySystem
 
         monitor.ActiveCamera = camera;
 
+        // Reset the heartbeat timers for the new device.
+        monitor.LastHeartbeat = 0;
+        monitor.LastHeartbeatSent = 0;
+
         AddComp<ActiveSurveillanceCameraMonitorComponent>(uid);
 
         UpdateUserInterface(uid, monitor);
@@ -384,6 +388,10 @@ public sealed partial class SurveillanceCameraMonitorSystem : EntitySystem
         _surveillanceCameras.SwitchActiveViewers(monitor.ActiveCamera.Value, camera, monitor.Viewers, uid);
 
         monitor.ActiveCamera = camera;
+
+        // Reset the heartbeat timers for the new device.
+        monitor.LastHeartbeat = 0;
+        monitor.LastHeartbeatSent = 0;
 
         UpdateUserInterface(uid, monitor);
     }

--- a/Resources/Prototypes/Entities/Structures/Machines/surveillance_camera_routers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/surveillance_camera_routers.yml
@@ -190,6 +190,8 @@
     receiveFrequencyId: SurveillanceCamera
     transmitFrequencyId: SurveillanceCamera
     prefix: device-address-prefix-camera-router-wireless
+  - type: DeviceNetworkRouter
+  - type: SurveillanceCameraRouter
   - type: WirelessNetworkConnection
     range: 200
   - type: DeviceNetworkRequiresPower

--- a/Resources/Prototypes/Entities/Structures/Machines/surveillance_camera_routers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/surveillance_camera_routers.yml
@@ -190,11 +190,11 @@
     receiveFrequencyId: SurveillanceCamera
     transmitFrequencyId: SurveillanceCamera
     prefix: device-address-prefix-camera-router-wireless
-  - type: DeviceNetworkRouter
-  - type: SurveillanceCameraRouter
   - type: WirelessNetworkConnection
     range: 200
   - type: DeviceNetworkRequiresPower
+  - type: DeviceNetworkRouter
+  - type: SurveillanceCameraRouter
   - type: UserInterface
     interfaces:
       enum.SurveillanceCameraSetupUiKey.Router:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Two small bugfixes.

1. Setting a new camera resets the heartbeat timer (new camera, old data doesn't matter)
2. Uses the HeartbeatRequest payload when requesting a heartbeat vs. the Heartbeat payload (this is for the response).

## Why / Balance

Bugfixes for https://discord.com/channels/310555209753690112/1444093242986467419

1. Long standing bug, I think.  Switching cameras continues to tick up the timer.
2. Curse of Roudenn: AFAICT, regression from #44346 - introduced a new message type but didn't swap over to it.  No cameras currently handle the heartbeat messages being sent off.

## Technical details

Setting a new camera resets the heartbeat timers to 0 - this currently only happens on receiving a new heartbeat response.  If your timer ever reaches 300 seconds, you're screwed, since you disable the camera before you can even receive a response.

On master, this is really easy to reproduce: check the VV window for the SurveillanceCameraMonitorComponent, check the LastHeartbeat and LastHeartbeatSent time.  Currently, nothing handles the heartbeat message, so the timer keeps increasing to 300 s, at which point the console is effectively bricked.

## Test plan

1. Open a surveillance console.  Open VV for the console, open the SurveillanceCameraMonitorComponent.
2. Choose a camera, wait 30 seconds.  Both heartbeat timers should reset to 0 (implying a sent request and received response).
3. Swap to a new camera.  The timers should reset to 0.

For bonus points: build master, and wait 300 seconds on one camera.  You should disconnect and the console will be unusable in its current state (the bug report is in this state, though it shouldn't be easy without the device rework bug, so :shrug:)

## Media

Current behaviour on master: timer doesn't reset when changing devices, no heartbeat handling.

https://github.com/user-attachments/assets/93687181-b8b7-417e-9ddc-7f470ce6c7aa

Fixed behaviour on PR: timer resets when changing devices, heartbeat messages are received properly and returned.

https://github.com/user-attachments/assets/1a46f18a-fa3a-43ab-bcd6-d009bd725c3d

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
:cl:
- fix: Camera monitors should no longer spontaneously become unusable.
- fix: Wireless and xenoborg cameras should work again.