### PR TITLE
Nyctalon now drinkable without flashing screen

### DIFF
--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -661,7 +661,7 @@
   color: "#1A0A2E"
   metabolisms:
     Bloodstream:
-      metabolismRate: 0.5
+      metabolismRate: 0.2
       effects:
       - !type:ModifyStatusEffect
         effectProto: StatusEffectNightVision
@@ -670,4 +670,4 @@
       - !type:HealthChange
         damage:
           types:
-           Radiation: 0.5
+           Radiation: 0.25


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Nyctalon metab rate reduced to 0.2u/s 
Rads dealt per sec increased (from 10u=10 to 10u=12.5) 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://forum.spacestation14.com/t/nyctalon-nightvision-is-flashing/28593/4, Nyctalon is tactical enough of a chem to be often drank, flashing lights are very bad ! 

Anything below 0.2u/s 2s still results in flashing. NV duration from 5u is up a lot and damage from it has been upped to compensate. (maybe worth upping even more as 5u duration is now 25s from 10s... if theres another way to make it drink-safe please lmk) 
It's still better to inject it than drink it overall

## Technical details
<!-- Summary of code changes for easier review. -->
yaml 2 lines this time 
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. drink nyctalon
2. enjoy smooth night vision with no eye strain


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


## Changelog

:cl:
- tweak: Nyctalon can be drunk for half efficiency and no flashing. 

