### PR TITLE
Cleanup surveillance camera viewer lifecycle (bugfix for mothership core console)

### DIFF
--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared.DeviceNetwork;
 using Content.Shared.DeviceNetwork.Events;
 using Content.Shared.DeviceNetwork.Systems;
 using Content.Shared.Power;
-using Content.Shared.UserInterface;
 using Content.Shared.SurveillanceCamera;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
@@ -26,7 +25,6 @@ public sealed partial class SurveillanceCameraMonitorSystem : EntitySystem
         SubscribeLocalEvent<SurveillanceCameraMonitorComponent, PowerChangedEvent>(OnPowerChanged);
         SubscribeLocalEvent<SurveillanceCameraMonitorComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<SurveillanceCameraMonitorComponent, ComponentStartup>(OnComponentStartup);
-        SubscribeLocalEvent<SurveillanceCameraMonitorComponent, AfterActivatableUIOpenEvent>(OnToggleInterface);
         Subs.BuiEvents<SurveillanceCameraMonitorComponent>(SurveillanceCameraMonitorUiKey.Key, subs =>
         {
             subs.Event<SurveillanceCameraRefreshCamerasMessage>(OnRefreshCamerasMessage);
@@ -35,6 +33,7 @@ public sealed partial class SurveillanceCameraMonitorSystem : EntitySystem
             subs.Event<SurveillanceCameraMonitorSubnetRequestMessage>(OnSubnetRequest);
             subs.Event<SurveillanceCameraMonitorSwitchMessage>(OnSwitchMessage);
             subs.Event<BoundUIClosedEvent>(OnBoundUiClose);
+            subs.Event<BoundUIOpenedEvent>(OnBoundUiOpen);
         });
     }
 
@@ -183,17 +182,15 @@ public sealed partial class SurveillanceCameraMonitorSystem : EntitySystem
         RemoveActiveCamera(uid, component);
     }
 
-
-    private void OnToggleInterface(EntityUid uid, SurveillanceCameraMonitorComponent component,
-        AfterActivatableUIOpenEvent args)
-    {
-        AfterOpenUserInterface(uid, args.User, component);
-    }
-
     // This is to ensure that there's no delay in ensuring that a camera is deactivated.
     private void OnSurveillanceCameraDeactivate(EntityUid uid, SurveillanceCameraMonitorComponent monitor, SurveillanceCameraDeactivateEvent args)
     {
         DisconnectCamera(uid, false, monitor);
+    }
+
+    private void OnBoundUiOpen(EntityUid uid, SurveillanceCameraMonitorComponent component, BoundUIOpenedEvent args)
+    {
+        AddViewer(uid, args.Actor, component);
     }
 
     private void OnBoundUiClose(EntityUid uid, SurveillanceCameraMonitorComponent component, BoundUIClosedEvent args)

--- a/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
+++ b/Content.Server/SurveillanceCamera/Systems/SurveillanceCameraMonitorSystem.cs
@@ -6,7 +6,6 @@ using Content.Shared.DeviceNetwork.Systems;
 using Content.Shared.Power;
 using Content.Shared.SurveillanceCamera;
 using Robust.Server.GameObjects;
-using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.SurveillanceCamera;
@@ -432,19 +431,6 @@ public sealed partial class SurveillanceCameraMonitorSystem : EntitySystem
         _surveillanceCameras.RemoveActiveViewers(monitor.ActiveCamera.Value, monitor.Viewers, uid);
 
         UpdateUserInterface(uid, monitor);
-    }
-
-    // This is public primarily because it might be useful to have the ability to
-    // have this component added to any entity, and have them open the BUI (somehow).
-    public void AfterOpenUserInterface(EntityUid uid, EntityUid player, SurveillanceCameraMonitorComponent? monitor = null, ActorComponent? actor = null)
-    {
-        if (!Resolve(uid, ref monitor)
-            || !Resolve(player, ref actor))
-        {
-            return;
-        }
-
-        AddViewer(uid, player);
     }
 
     private void UpdateUserInterface(EntityUid uid, SurveillanceCameraMonitorComponent? monitor = null, EntityUid? player = null)


### PR DESCRIPTION

## About the PR

The function that currently adds a viewer to the console is triggered on an `AfterActivatableUIOpenEvent`, and closed on a `BoundUIClosedEvent`.  This moves the open to the `BoundUIOpenedEvent` to match the lifecycle.

The `AfterOpenUserInterface`, being unused now, has also been removed.  This hole in the lifecycle should not have been used - the lifecycle should be tied to the specific SurveillanceCameraMonitorBUI.

## Why / Balance

First reported here (AFAICT): https://discord.com/channels/310555209753690112/1546749787607539813

The mothership core is not an activatable UI.  No event was being triggered, so the player controlling the core was never registered to get the xenoborgs added to their PVS.

This also means that aghosts can now also theoretically work as a camera controller on the same principle without issue.

## Technical details

AddViewer is now being called directly on the `BoundUIOpenedEvent`, and we rely on the BUI itself to set up and teardown the camera lifecycle.

## Test plan

Requires #45921 to function properly (fix is for the wireless console router - sorry, but apply the patch [here](https://patch-diff.githubusercontent.com/raw/space-wizards/space-station-14/pull/45921.patch))

1. Spawn mothership core.
2. Spawn xenoborg camera router.
3. Move far away from the station, make a little patch of dirt, spawn a xenoborg on it.
4. Spawn a xenoborg in space a little bit away.
5. Return to the mothership core and take it over.
6. Open the camera monitor, refresh your subnets, pick Xenoborg.
7. The Xenoborgs should be visible on the menu by name.
8. Pick one.  The viewport should open for the xenoborg.
9. Pick the other.  The viewport should swap over to the other xenoborg.

## Media

The test plan roughly followed (steps 3-9):

https://github.com/user-attachments/assets/9f666bc7-1006-4682-87be-74fb32544231

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

`SurveillanceCameraMonitorSystem.AfterOpenUserInterface` has been removed.  Use the `SurveillanceCameraBoundUserInterface` instead, or change the access to `Add/RemoveViewer` if needed.

## Changelog
:cl:
- fix: The mothership core should now be able to view xenoborgs on its camera monitor normally.