### PR TITLE
Stop spent casings cycling the chamber

### DIFF
--- a/Content.IntegrationTests/Tests/Weapons/WeaponTests.cs
+++ b/Content.IntegrationTests/Tests/Weapons/WeaponTests.cs
@@ -14,6 +14,7 @@ public sealed class WeaponTests : InteractionTest
     protected override string PlayerPrototype => "MobHuman"; // The default test mob only has one hand
     private static readonly EntProtoId MobHuman = "MobHuman";
     private static readonly EntProtoId SniperMosin = "WeaponSniperMosin";
+    private static readonly EntProtoId PistolMk58 = "WeaponPistolMk58";
 
     [Test]
     public async Task GunRequiresWieldTest()
@@ -62,5 +63,49 @@ public sealed class WeaponTests : InteractionTest
         Assert.That(damageSystem.GetTotalDamage(ToServer(urist)),
             Is.GreaterThan(FixedPoint2.Zero),
             "Mosin was fired but urist sustained no damage!");
+    }
+
+    [Test]
+    public async Task SpentCartridgeDoesNotCycleTest()
+    {
+        var gunSystem = SEntMan.System<SharedGunSystem>();
+
+        await AddAtmosphere(); // prevent the Urist from suffocating
+
+        var urist = await SpawnTarget(MobHuman);
+
+        var pistolNet = await PlaceInHands(PistolMk58);
+        var pistolEnt = ToServer(pistolNet);
+
+        await Pair.RunSeconds(2f); // Guns have a cooldown when picking them up.
+
+        await UseInHand(); // Rack the pistol to chamber a round.
+
+        var chambered = gunSystem.GetChamberEntity(pistolEnt);
+        Assert.That(chambered, Is.Not.Null, "Pistol has nothing chambered after racking!");
+
+        var cartridge = SEntMan.GetComponent<CartridgeAmmoComponent>(chambered.Value);
+        await Server.WaitPost(() =>
+        {
+            cartridge.Spent = true;
+            SEntMan.Dirty(chambered.Value, cartridge);
+        });
+
+        var startAmmo = gunSystem.GetAmmoCount(pistolEnt);
+
+        await AttemptShoot(urist);
+
+        Assert.That(gunSystem.GetChamberEntity(pistolEnt),
+            Is.EqualTo(chambered),
+            "Spent cartridge was cycled out of the chamber!");
+        Assert.That(gunSystem.GetAmmoCount(pistolEnt),
+            Is.EqualTo(startAmmo),
+            "Spent cartridge pulled a fresh round from the magazine!");
+
+        await UseInHand(); // Racking should still clear the dud.
+
+        Assert.That(gunSystem.GetChamberEntity(pistolEnt),
+            Is.Not.EqualTo(chambered),
+            "Racking did not eject the spent cartridge!");
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -363,8 +363,12 @@ public abstract partial class SharedGunSystem
 
         EntityUid? chamberEnt;
 
+        // A spent casing has no propellant left to work the action, so it can't cycle a fresh round in.
+        var chamberSpent = TryComp<CartridgeAmmoComponent>(GetChamberEntity(uid), out var chamberCartridge) &&
+                           chamberCartridge.Spent;
+
         // Normal behaviour for guns.
-        if (component.AutoCycle)
+        if (component.AutoCycle && !chamberSpent)
         {
             if (TryTakeChamberEntity(uid, out chamberEnt))
             {
@@ -416,7 +420,8 @@ public abstract partial class SharedGunSystem
 
             FinaliseMagazineTakeAmmo(uid, component, ammoEv.Count, ammoEv.Capacity, args.User, appearance);
         }
-        // If gun doesn't autocycle (e.g. bolt-action weapons) then we leave the chambered entity in there but still return it.
+        // If the gun doesn't autocycle (e.g. bolt-action weapons), or the chambered round is a dud, then we leave the
+        // chambered entity in there but still return it so it has to be cleared by hand.
         else if (Containers.TryGetContainer(uid, ChamberSlot, out var container) &&
                  container is ContainerSlot { ContainedEntity: not null } slot)
         {


### PR DESCRIPTION
## About the PR
Spent casings no longer work the action on chamber-and-magazine guns. Fire a dud and it stays in the chamber until you rack it out.

## Why / Balance
Closes #45777. You can currently fill a magazine with spent brass and a semi-auto will chamber and click its way through the lot. Empty brass has no propellant left in it, so there is nothing to cycle the action with. Bolt-action and pump guns are unaffected, they never auto-cycled anyway.

## Technical details
`OnChamberMagazineTakeAmmo` took the chambered round out and pulled a replacement from the magazine whenever `AutoCycle` was set. It now checks whether the chambered cartridge is spent, and if it is, falls through to the branch non-cycling guns already use: the casing stays put and is still handed to the shooting code, which plays the empty click. Racking is untouched.

## Test plan
Added `SpentCartridgeDoesNotCycleTest` to `Content.IntegrationTests/Tests/Weapons/WeaponTests.cs`. It racks an Mk58, marks the chambered round spent, fires, and checks the chamber and ammo count are unchanged, then racks again and checks the casing was ejected.

```
dotnet test Content.IntegrationTests -c Release --filter FullyQualifiedName~SpentCartridgeDoesNotCycleTest
```

It fails without the fix, because the chamber entity changes, and passes with it.

In game: empty an Mk58 into a wall, pick the casings up and load them back into the magazine, then rack and hold fire. Before this PR the gun cycles through every casing. Now the first dud stays chambered and has to be racked out.

## Media
No media needed, this is a small fix with no new visuals.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

:cl:
- fix: Spent casings no longer cycle through the chamber of automatic and semi-automatic guns. A dud has to be racked out by hand.
