### PR TITLE
Predict SpriteMovement visuals

### DIFF
--- a/Content.Client/Movement/Systems/ClientSpriteMovementSystem.cs
+++ b/Content.Client/Movement/Systems/ClientSpriteMovementSystem.cs
@@ -1,24 +1,36 @@
 using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Robust.Client.GameObjects;
 
 namespace Content.Client.Movement.Systems;
 
 /// <summary>
-/// Controls the switching of motion and standing still animation
+/// Controls the switching of motion and standing still animation.
 /// </summary>
 public sealed partial class ClientSpriteMovementSystem : SharedSpriteMovementSystem
 {
     [Dependency] private SpriteSystem _sprite = default!;
     [Dependency] private EntityQuery<SpriteComponent> _spriteQuery;
 
+    protected override void OnSpriteMoveInput(Entity<SpriteMovementComponent> ent, ref SpriteMoveEvent args)
+    {
+        base.OnSpriteMoveInput(ent, ref args);
+        UpdateSprite(ent, args.IsMoving);
+    }
+
     [SubscribeLocalEvent]
     private void OnAfterAutoHandleState(Entity<SpriteMovementComponent> ent, ref AfterAutoHandleStateEvent args)
+    {
+        UpdateSprite(ent, ent.Comp.IsMoving);
+    }
+
+    private void UpdateSprite(Entity<SpriteMovementComponent> ent, bool isMoving)
     {
         if (!_spriteQuery.TryGetComponent(ent, out var sprite))
             return;
 
-        if (ent.Comp.IsMoving)
+        if (isMoving)
         {
             foreach (var (layer, state) in ent.Comp.MovementLayers)
             {

--- a/Content.Client/Movement/Systems/ClientSpriteMovementSystem.cs
+++ b/Content.Client/Movement/Systems/ClientSpriteMovementSystem.cs
@@ -10,15 +10,9 @@ namespace Content.Client.Movement.Systems;
 public sealed partial class ClientSpriteMovementSystem : SharedSpriteMovementSystem
 {
     [Dependency] private SpriteSystem _sprite = default!;
-    [Dependency] private EntityQuery<SpriteComponent> _spriteQuery = default!;
+    [Dependency] private EntityQuery<SpriteComponent> _spriteQuery;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<SpriteMovementComponent, AfterAutoHandleStateEvent>(OnAfterAutoHandleState);
-    }
-
+    [SubscribeLocalEvent]
     private void OnAfterAutoHandleState(Entity<SpriteMovementComponent> ent, ref AfterAutoHandleStateEvent args)
     {
         if (!_spriteQuery.TryGetComponent(ent, out var sprite))

--- a/Content.Shared/Movement/Systems/SharedSpriteMovementSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedSpriteMovementSystem.cs
@@ -3,15 +3,9 @@ using Content.Shared.Movement.Events;
 
 namespace Content.Shared.Movement.Systems;
 
-public abstract class SharedSpriteMovementSystem : EntitySystem
+public abstract partial class SharedSpriteMovementSystem : EntitySystem
 {
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<SpriteMovementComponent, SpriteMoveEvent>(OnSpriteMoveInput);
-    }
-
+    [SubscribeLocalEvent]
     private void OnSpriteMoveInput(Entity<SpriteMovementComponent> ent, ref SpriteMoveEvent args)
     {
         if (ent.Comp.IsMoving == args.IsMoving)

--- a/Content.Shared/Movement/Systems/SharedSpriteMovementSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedSpriteMovementSystem.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Movement.Systems;
 public abstract partial class SharedSpriteMovementSystem : EntitySystem
 {
     [SubscribeLocalEvent]
-    private void OnSpriteMoveInput(Entity<SpriteMovementComponent> ent, ref SpriteMoveEvent args)
+    protected virtual void OnSpriteMoveInput(Entity<SpriteMovementComponent> ent, ref SpriteMoveEvent args)
     {
         if (ent.Comp.IsMoving == args.IsMoving)
             return;


### PR DESCRIPTION
## About the PR
Predicts `SpriteMovement `visual state changes on the client

Related to #45920

## Why / Balance
Movement animations previously waited for networked component state before updating, which made them visibly delayed

## Technical details
`ClientSpriteMovementSystem` now updates movement layers directly from `SpriteMoveEvent`, while network state handling remains as reconciliation

## Test plan
- Tested movement animations on entities using `SpriteMovement`

## Media
Not required

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

## Changelog
No player-facing changes