### PR TITLE
Nyctalon duration per u increased, drinking doesn't flash 

### DIFF
--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -670,4 +670,4 @@
       - !type:HealthChange
         damage:
           types:
-           Radiation: 0.25
+           Radiation: 0.5

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -661,7 +661,7 @@
   color: "#1A0A2E"
   metabolisms:
     Bloodstream:
-      metabolismRate: 0.5
+      metabolismRate: 0.2
       effects:
       - !type:ModifyStatusEffect
         effectProto: StatusEffectNightVision
@@ -670,4 +670,4 @@
       - !type:HealthChange
         damage:
           types:
-           Radiation: 0.5
+           Radiation: 0.25


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Nyctalon metab rate reduced to 0.2 to make it digestible without flashing

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fixes https://forum.spacestation14.com/t/nyctalon-nightvision-is-flashing/28593/3, flashing lights are bad! 

Effectiveness per u is upped by a significant amount, rads per sec is retained so 5u=12.5 rads up from 5u=5rads
Duration/dmg of night vision is unchanged 

## Technical details
<!-- Summary of code changes for easier review. -->
yaml 2 lines this time

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
1. make nyctalon
2. drink it
3. confirm no flashing
4. inject nyctalon, confirm no flashing 

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->

:cl:
- tweak: Nyctalon effectiveness per unit increased, is now drinkable (without flashing)

