### PR TITLE
resolving #45940 by removing hat slot from xenoborgs

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseMob, StripableInventoryBase]
+  parent: BaseMob
   id: BaseBorgChassisNotIonStormable
   name: cyborg
   description: A man-machine hybrid that assists in station activity. They love being asked to state their laws over and over.
@@ -83,8 +83,6 @@
     stunTime: 5
   - type: SiliconLawProvider
     laws: Crewsimov
-  - type: Inventory
-    templateId: borg
   - type: Hands
     showInHands: false
     disableExplosionRecursion: true
@@ -314,8 +312,24 @@
     canCreateVacuum: false
 
 - type: entity
+  abstract: true
+  parent: StripableInventoryBase
+  id: BorgInventory
+  components:
+  - type: Inventory
+    templateId: borg
+
+- type: entity
+  abstract: true
+  parent: InventoryBase
+  id: UnstrippableBorgInventory
+  components:
+  - type: Inventory
+    templateId: xenoborg
+
+- type: entity
   id: BaseBorgChassisNT
-  parent: [BaseBorgChassis, BaseBorgTransponder]
+  parent: [BaseBorgChassis, BaseBorgTransponder, BorgInventory]
   abstract: true
   components:
   - type: RandomMetadata
@@ -339,7 +353,7 @@
 
 - type: entity
   id: BaseBorgChassisSyndicate
-  parent: BaseBorgChassis
+  parent: [BaseBorgChassis, BorgInventory]
   abstract: true
   components:
   - type: NpcFactionMember
@@ -377,7 +391,7 @@
 
 - type: entity
   id: BaseBorgChassisDerelict
-  parent: BaseBorgChassis
+  parent: [BaseBorgChassis, BorgInventory]
   abstract: true
   components:
   - type: NpcFactionMember
@@ -397,7 +411,7 @@
 
 - type: entity
   id: BaseBorgChassisSyndicateDerelict #For assault borg and maybe others in time
-  parent: BaseBorgChassis # We don't want them to see Nukies or have syndi comms, their database is out of date
+  parent: [BaseBorgChassis, BorgInventory] # We don't want them to see Nukies or have syndi comms, their database is out of date
   abstract: true
   components:
   - type: SiliconLawProvider
@@ -436,7 +450,7 @@
     bypassDelay: 15 # We don't want people to easily be able to remove syndieborg brains.
 
 - type: entity
-  parent: BaseBorgChassisNotIonStormable
+  parent: [BaseBorgChassisNotIonStormable, UnstrippableBorgInventory]
   id: BaseXenoborgChassis
   name: xenoborg
   description: A man-machine hybrid that aims to replicate itself. They love extracting brains to insert into fresh Xenoborg chassis to grow their army.
@@ -525,8 +539,6 @@
     bypassDelay: 15 # We don't want people to easily be able to remove xenoborg brains.
   - type: EmpResistance
     strengthMultiplier: 0
-  - type: Inventory
-    templateId: xenoborg
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -525,6 +525,8 @@
     bypassDelay: 15 # We don't want people to easily be able to remove xenoborg brains.
   - type: EmpResistance
     strengthMultiplier: 0
+  - type: Inventory
+    templateId: xenoborg
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/InventoryTemplates/borg.yml
+++ b/Resources/Prototypes/InventoryTemplates/borg.yml
@@ -42,3 +42,9 @@
     strippingWindowPos: 0,0
     displayName: Head
     offset: 0, 0.09375
+
+# xenoborgs (hatless)
+- type: inventoryTemplate
+  id: xenoborg
+  # in terms of inventory slots they have no inventory slots
+  slots: []


### PR DESCRIPTION
Resolves #45940

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
* removes the hat inventory slot from xenoborgs

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
* Requested in #45940
* one cannot wear a hat one one's head if one has no head to wear the hat on

## Technical details
<!-- Summary of code changes for easier review. -->
* created new `xenoborg` InventoryTemplate in `Resources/Prototypes/InventoryTemplates/borg.yml`
  * it has an empty array of inventory slots
* applied that inventory template to `BaseXenoborgChassis` in `Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml`
  * all xenoborgs inherit that base xenoborg chassis
  * overrides the base borg chassis inventory template
* note - this PR does not contain any C# changes, so, for the time being, xenoborgs will still have a 'strip' menu like other borgs. however, it will facilitate any refactors to outright remove the strip menu.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
* spawn in xenoborg
* attempt stripping them - observe the lack of slots for a hat
* control the xenoborg
* observe the lack of inventory slots for a hat

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="1280" height="752" alt="xenoborgs have no wearable slots" src="https://github.com/user-attachments/assets/0037da89-b8de-43eb-aa2b-3cd92478df42" />
behold the lack of inventory slots available on this xenoborg

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

* Added new type of `inventoryTemplate` for Xenoborgs (id is `xenoborg`).
  * it has no inventory slots (it is now impossible for them to wear hats).
  * this is applied to the `BaseXenoborgChassis` prototype in `Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml`, which all xenoborgs inherit from.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
<!--
:cl:
- add: Crowbars now randomly spawn in maintenance lockers.
- remove: Crowbars no longer spawn in maintenance crates.
- tweak: Crowbar spawn rates have been increased for tool lockers.
- fix: Crowbars no longer accidentally spawn in microwaves.
-->
:cl:
- remove: xenoborgs are now unable to wear hats.