### PR TITLE
Aloxadone and Oppo tweaks

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1314,12 +1314,14 @@
   metabolisms:
     Bloodstream:
       effects:
+        - !type:AdjustTemperature
+        amount: 80000
         - !type:ReduceRotting
           seconds: 20
           conditions:
           #Patient must be dead and in a cryo tube (or something cold)
           - !type:TemperatureCondition
-            max: 150.0
+            max: 273.15
           - !type:MobStateCondition
             mobstate: Dead
 
@@ -1357,12 +1359,14 @@
   metabolisms:
     Bloodstream:
       effects:
+      - !type:AdjustTemperature
+        amount: 80000 # parity with arcryox
       - !type:EvenHealthChange
         conditions:
         - !type:TemperatureCondition
-          max: 213.0
+          max: 273.15
         damage:
-          Burn: -4.5
+          Burn: -6
 
 - type: reagent
   id : Mannitol # currently this is just a way to create psicodine


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Alox + Oppo working conditions updated to be identical to Arcryox (threshold 0 °C/273.15K, adds 80J)
Aloxadone burn healing increased from 4.5 to 6/u 


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #45768

Aloxadone and Oppo still had previous cryo thresholds from temp change #42785 making it extremely hard to reach the temps required and/or dealing damage once there. Change makes it so it uses the same rules as Arcryox, a much more commonly used, significantly cheaper cryo chem.

Aloxadone buffed as since the introduction of Arc it's pretty much never made/used, hopefully the upped burn heal carves out a stronger niche over Arc given as it requires more work + needs botany cooperation. 


## Technical details
yaml

## Test plan
1. set up cryo
2. burn urist with fire 
3. put urist in cryo
4. push aloxa
5. confirm only starts working once below 0 degrees, healing 6/s
6. put freshly rotten urist inside cryo
7. push small amounts of oppo
8. confirm only unrotted once below 0 degrees 

## Media
old: 
<img width="480" height="200" alt="image" src="https://github.com/user-attachments/assets/e9763310-4fd5-4039-aac7-293e0389a330" />
<img width="480" height="280" alt="image" src="https://github.com/user-attachments/assets/d6c6ce78-3862-4316-9dbd-338bc2f55f38" />
new: 
<img width="480" height="350" alt="image" src="https://github.com/user-attachments/assets/0f2355c6-b72a-486e-aacc-ad9c9b2bad48" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


## Changelog
:cl:

- tweak: Aloxadone now heals 6 burn/s, up from 4.5/s
- fix: Aloxadone and Opporozidone now work at 273K (0 °C)
