### PR TITLE
Allow secondary/tertiary config atmos entities to be copied in the map editor

### DIFF
--- a/Content.Client/Sandbox/Components/SandboxCopyableComponent.cs
+++ b/Content.Client/Sandbox/Components/SandboxCopyableComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Client.Sandbox.Components;
+
+/// <summary>
+/// A marker component for entities that can be copied in sandbox mode.
+/// </summary>
+/// <remarks>
+/// This is useful for entities with HideSpawnMenu set to true that should still be copied.
+/// (e.g. alternative pipe layouts). Will not work on abstract prototypes.
+/// </remarks>
+[RegisterComponent]
+public sealed partial class SandboxCopyableComponent : Component;

--- a/Content.Client/Sandbox/SandboxSystem.cs
+++ b/Content.Client/Sandbox/SandboxSystem.cs
@@ -1,5 +1,6 @@
 using Content.Client.Administration.Managers;
 using Content.Client.Movement.Systems;
+using Content.Client.Sandbox.Components;
 using Content.Shared.Sandbox;
 using Robust.Client.Console;
 using Robust.Client.Placement;
@@ -17,6 +18,8 @@ namespace Content.Client.Sandbox
         [Dependency] private ContentEyeSystem _contentEye = default!;
         [Dependency] private SharedTransformSystem _transform = default!;
         [Dependency] private SharedMapSystem _mapSystem = default!;
+
+        [Dependency] private EntityQuery<SandboxCopyableComponent> _sandboxCopyableQuery;
 
         private bool _sandboxEnabled;
         public bool SandboxAllowed { get; private set; }
@@ -97,7 +100,12 @@ namespace Content.Client.Sandbox
                 && TryComp(uid, out MetaDataComponent? comp)
                 && !comp.EntityDeleted)
             {
-                if (comp.EntityPrototype == null || comp.EntityPrototype.HideSpawnMenu || comp.EntityPrototype.Abstract)
+                // Unconditional failures.
+                if (comp.EntityPrototype == null || comp.EntityPrototype.Abstract)
+                    return false;
+
+                // Skippable failures.
+                if (comp.EntityPrototype.HideSpawnMenu && !_sandboxCopyableQuery.HasComp(uid))
                     return false;
 
                 if (_placement.Eraser)

--- a/Content.Server/Entry/IgnoredComponents.cs
+++ b/Content.Server/Entry/IgnoredComponents.cs
@@ -22,7 +22,8 @@ namespace Content.Server.Entry
             "OptionsVisualizer",
             "AnomalyScannerScreen",
             "MultipartMachineGhost",
-            "DirectionalArrowIndicator"
+            "DirectionalArrowIndicator",
+            "SandboxCopyable"
         };
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -27,6 +27,7 @@
       Primary: Structures/Piping/Atmospherics/pump.rsi
       Secondary: Structures/Piping/Atmospherics/pump_alt1.rsi
       Tertiary: Structures/Piping/Atmospherics/pump_alt2.rsi
+  - type: SandboxCopyable
 
 - type: entity
   parent: GasBinaryBase
@@ -559,7 +560,7 @@
       shader: unshaded
   - type: AtmosPipeLayers
     pipeLayer: !type:CreateVariants
-      values: [ 0, 1, 2 ] 
+      values: [ 0, 1, 2 ]
     spriteLayersRsiPaths:
       enum.PipeVisualLayers.Pipe:
         Primary: Structures/Piping/Atmospherics/pipe.rsi

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/gas_pipe_sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/gas_pipe_sensor.yml
@@ -11,7 +11,7 @@
   components:
   - type: Sprite
     sprite: !type:CreateVariants
-       values: 
+       values:
        - Structures/Piping/Atmospherics/gas_pipe_sensor.rsi
        - Structures/Piping/Atmospherics/gas_pipe_sensor_alt1.rsi
        - Structures/Piping/Atmospherics/gas_pipe_sensor_alt2.rsi

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -74,6 +74,7 @@
         Primary: Structures/Piping/Atmospherics/pipe.rsi
         Secondary: Structures/Piping/Atmospherics/pipe_alt1.rsi
         Tertiary: Structures/Piping/Atmospherics/pipe_alt2.rsi
+  - type: SandboxCopyable
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -26,6 +26,7 @@
           !type:PipeNode
           nodeGroupID: Pipe
           pipeDirection: South
+    - type: SandboxCopyable
 
 - type: entity
   parent: GasTrinaryBase

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -19,6 +19,7 @@
           nodeGroupID: Pipe
           pipeDirection: South
     - type: CollideOnAnchor
+    - type: SandboxCopyable
 
 - type: entity
   parent: [GasUnaryBase, AirSensorBase]
@@ -300,7 +301,7 @@
   name: freezer
   description: Cools gas in connected pipes.
   categories: !type:CreateVariants
-    sequences: [ [ ], [ HideSpawnMenu ], [ HideSpawnMenu ] ]  
+    sequences: [ [ ], [ HideSpawnMenu ], [ HideSpawnMenu ] ]
   placement:
     mode: AlignAtmosPipeLayers
   components:
@@ -313,7 +314,7 @@
         - state: freezerPanelOpen
           map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
         - sprite: !type:CreateVariants
-            values: 
+            values:
             - Structures/Piping/Atmospherics/thermomachine.rsi
             - Structures/Piping/Atmospherics/thermomachine_alt1.rsi
             - Structures/Piping/Atmospherics/thermomachine_alt2.rsi
@@ -322,7 +323,7 @@
           renderingStrategy: Default
     - type: AtmosPipeLayers
       pipeLayer: !type:CreateVariants
-        values: [ 0, 1, 2 ] 
+        values: [ 0, 1, 2 ]
       spriteLayersRsiPaths:
         enum.PipeVisualLayers.Pipe:
           Primary: Structures/Piping/Atmospherics/thermomachine.rsi
@@ -378,7 +379,7 @@
         - state: heaterPanelOpen
           map: ["enum.WiresVisualLayers.MaintenancePanel"]
         - sprite: !type:CreateVariants
-            values: 
+            values:
             - Structures/Piping/Atmospherics/thermomachine.rsi
             - Structures/Piping/Atmospherics/thermomachine_alt1.rsi
             - Structures/Piping/Atmospherics/thermomachine_alt2.rsi
@@ -387,7 +388,7 @@
           renderingStrategy: Default
     - type: AtmosPipeLayers
       pipeLayer: !type:CreateVariants
-        values: [ 0, 1, 2 ] 
+        values: [ 0, 1, 2 ]
       spriteLayersRsiPaths:
         enum.PipeVisualLayers.Pipe:
           Primary: Structures/Piping/Atmospherics/thermomachine.rsi
@@ -551,4 +552,3 @@
   - type: GuideHelp
     guides:
     - GasCondensing
-


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Adds a client-side component, `SandboxCopyableComponent`, for entities with the HideSpawnMenu category that should still be copied in the map editor.

Adds this to the atmos pipe, unary, binary and trinary bases so atmos devices can be copied.

## Why / Balance

Minor quality of life improvement for mappers.

Resolves https://github.com/space-wizards/space-station-14/issues/45947

## Technical details

Previously, any entity prototype with HideSpawnMenu set was hidden.  This is useful for a lot of prototypes, but in some cases (atmos device variants) it's used to declutter the spawn menu rather than prevent them from being spawned in the first place.

By adding this component, which only exists on the client, you can copy an entity marked HideSpawnMenu with the EditorCopyObject key (P by default).

## Test plan

1. Spawn some atmos devices.  Reconfigure them into a non-primary setting.
2. Copy them with P, place them, confirm that they maintain their setting.
3. Spawn `CornPlants`.  Try to copy the corn with P.  It shouldn't work (HideSpawnMenu true, but no SandboxCopyableComponent).

## Media

A simple use case of the PR: copying three lines of pipes.  The P key is used to select each of the configurations of pipes - first the primary (which works as it did before), then the other two marked HideSpawnMenu - these can not currently be copied on master.

https://github.com/user-attachments/assets/1ba23273-db14-4e43-8954-13891d4b33ab

This test example is a bit contrived, but if you wanted to copy a pump or some more infrequently used entity that's marked HideSpawnMenu, this saves you from having to look it up.  Minor gains, but gains nonetheless.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
Small, probably not.