### PR TITLE
Fix camera rotation while movement is blocked

### DIFF
--- a/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Relay.cs
@@ -33,13 +33,6 @@ public abstract partial class SharedMoverController
 
     protected virtual void OnInputMoverCanMoveUpdated(Entity<InputMoverComponent> ent, ref CanMoveUpdatedEvent args)
     {
-        if (!args.CanMove)
-        {
-            // Remove from active mover query when entity cannot move
-            RemCompDeferred<ActiveInputMoverComponent>(ent);
-            return;
-        }
-
         UpdateMoverStatus((ent, ent.Comp));
     }
 


### PR DESCRIPTION
## About the PR
Fixes camera rotation desync while movement is blocked
Resolves #44136
Closes #44154
Closes #45563

The `ActiveInputMoverComponent` removal on `CanMove == false` was originally added by me as a performance optimization following review feedback. However, `HandleMobMovement` also updates non-physical mover state before checking `CanMove`, including camera rotation and relative movement state. Removing the active mover therefore skips required server-side state updates, not just physical movement processing

## Why / Balance
When `CanMove` became false, the server stopped processing the mover while the client continued updating camera rotation locally. Server state could then overwrite the predicted rotation, causing snapping and incorrect angles

## Technical details
Blocked movers now remain active for mover state updates. Physical movement is still prevented by the existing `CanMove` check in `HandleMobMovement`

## Test plan
Tested camera rotation while buckled
Tested movement remains blocked while CanMove is false
Tested movement resumes normally afterwards

## Media
Not required

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None?

## Changelog
:cl:
- fix: Fixed camera rotation desyncing while movement is blocked.