### PR TITLE
Fix melee destruction on overlapping static entities

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -31,6 +31,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
     [Dependency] private MapSystem _map = default!;
     [Dependency] private SpriteSystem _sprite = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
+    [Dependency] private EntityQuery<SpriteComponent> _spriteQuery = default!;
 
     private const string MeleeLungeKey = "melee-lunge";
 
@@ -148,6 +149,39 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         // Light attack
         if (useDown == BoundKeyState.Down)
             ClientLightAttack(entity, mousePos, coordinates, weaponUid, weapon);
+    }
+
+    /// <summary>
+    /// Orders entities on top of each other in a similar way clicking on them does, so a wide swing hits
+    /// the right entity. See GameplayStateBase.ClickableEntityComparer.
+    /// </summary>
+    protected override bool IsDrawnAbove(EntityUid uid, EntityUid other)
+    {
+        if (!_spriteQuery.TryComp(uid, out var sprite) || !_spriteQuery.TryComp(other, out var otherSprite))
+            return false;
+
+        if (sprite.DrawDepth != otherSprite.DrawDepth)
+            return sprite.DrawDepth > otherSprite.DrawDepth;
+
+        if (sprite.RenderOrder != otherSprite.RenderOrder)
+            return sprite.RenderOrder > otherSprite.RenderOrder;
+
+        var eyeRotation = _eyeManager.CurrentEye.Rotation;
+        var bottom = GetSortBottom(uid, sprite, eyeRotation);
+        var otherBottom = GetSortBottom(other, otherSprite, eyeRotation);
+
+        if (!bottom.Equals(otherBottom))
+            return bottom < otherBottom;
+
+        return uid.CompareTo(other) > 0;
+    }
+
+    private float GetSortBottom(EntityUid uid, SpriteComponent sprite, Angle eyeRotation)
+    {
+        var (spritePos, spriteRot) = TransformSystem.GetWorldPositionRotation(uid);
+        var bounds = _sprite.CalculateBounds((uid, sprite), spritePos, spriteRot, eyeRotation);
+
+        return Matrix3Helpers.CreateRotation(eyeRotation).TransformBox(bounds).Bottom;
     }
 
     protected override bool InRange(EntityUid user, EntityUid target, float range, ICommonSession? session)

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -58,6 +58,7 @@ namespace Content.Shared.Interaction
         [Dependency] private ISharedChatManager _chat = default!;
         [Dependency] private ActionBlockerSystem _actionBlockerSystem = default!;
         [Dependency] private EntityLookupSystem _lookup = default!;
+        [Dependency] private FixtureSystem _fixtures = default!;
         [Dependency] private SharedHandsSystem _hands = default!;
         [Dependency] private InventorySystem _inventory = default!;
         [Dependency] private PullingSystem _pullSystem = default!;
@@ -935,11 +936,8 @@ namespace Content.Shared.Interaction
                 if (!fixture.Hard)
                     continue;
 
-                for (var i = 0; i < fixture.Shape.ChildCount; i++)
-                {
-                    if (fixture.Shape.ComputeAABB(transform, i).Contains(coords.Position))
-                        return true;
-                }
+                if (_fixtures.TestPoint(fixture.Shape, transform, coords.Position))
+                    return true;
             }
 
             return false;

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -24,6 +24,7 @@ using Content.Shared.Players.RateLimiting;
 using Content.Shared.Popups;
 using Content.Shared.Storage;
 using Content.Shared.Strip;
+using Content.Shared.SubFloor;
 using Content.Shared.Tag;
 using Content.Shared.Timing.Components;
 using Content.Shared.Timing.Systems;
@@ -62,7 +63,6 @@ namespace Content.Shared.Interaction
         [Dependency] private PullingSystem _pullSystem = default!;
         [Dependency] private RotateToFaceSystem _rotateToFaceSystem = default!;
         [Dependency] private SharedContainerSystem _containerSystem = default!;
-        [Dependency] private SharedMapSystem _map = default!;
         [Dependency] private SharedPhysicsSystem _broadphase = default!;
         [Dependency] private SharedTransformSystem _transform = default!;
         [Dependency] private SharedVerbSystem _verbSystem = default!;
@@ -81,6 +81,7 @@ namespace Content.Shared.Interaction
         [Dependency] private EntityQuery<InteractionRelayComponent> _relayQuery = default!;
         [Dependency] private EntityQuery<CombatModeComponent> _combatQuery = default!;
         [Dependency] private EntityQuery<WallMountComponent> _wallMountQuery = default!;
+        [Dependency] private EntityQuery<SubFloorHideComponent> _subFloorQuery = default!;
         [Dependency] private EntityQuery<UseDelayComponent> _delayQuery = default!;
         [Dependency] private EntityQuery<ActivatableUIComponent> _uiQuery = default!;
 
@@ -859,6 +860,7 @@ namespace Content.Shared.Interaction
         /// </summary>
         /// <example>
         /// if the target entity is a wallmount we ignore all other entities on the tile.
+        /// Entities covering the target are ignored.
         /// </example>
         private Ignored GetPredicate(
             MapCoordinates originCoords,
@@ -869,6 +871,7 @@ namespace Content.Shared.Interaction
             Ignored? predicate = null)
         {
             HashSet<EntityUid> ignored = new();
+            var ignoreCovering = true;
 
             if (_itemQuery.HasComp(target) && _physicsQuery.TryComp(target, out var physics) && physics.CanCollide)
             {
@@ -893,22 +896,53 @@ namespace Content.Shared.Interaction
             {
                 // wall-mount exemptions may be restricted to a specific angle range.da
 
-                bool ignoreAnchored;
-                if (wallMount.Arc >= Math.Tau)
-                    ignoreAnchored = true;
-                else
+                if (wallMount.Arc < Math.Tau)
                 {
                     var angle = Angle.FromWorldVec(originCoords.Position - targetCoords.Position);
                     var angleDelta = (wallMount.Direction + targetRotation - angle).Reduced().FlipPositive();
-                    ignoreAnchored = angleDelta < wallMount.Arc / 2 || Math.Tau - angleDelta < wallMount.Arc / 2;
+                    ignoreCovering = angleDelta < wallMount.Arc / 2 || Math.Tau - angleDelta < wallMount.Arc / 2;
                 }
-
-                if (ignoreAnchored && _map.TryFindGridAt(targetCoords, out var gridUid, out var grid))
-                    ignored.UnionWith(_map.GetAnchoredEntities((gridUid, grid), targetCoords));
             }
 
-            Ignored combinedPredicate = e => e == target || (predicate?.Invoke(e) ?? false) || ignored.Contains(e);
-            return combinedPredicate;
+            // Ignore subfloor if covered.
+            if (_subFloorQuery.TryComp(target, out var subFloor) && subFloor.BlockInteractions)
+                ignoreCovering = false;
+
+            return e =>
+            {
+                if (e == target || (predicate?.Invoke(e) ?? false) || ignored.Contains(e))
+                    return true;
+
+                if (!ignoreCovering)
+                    return false;
+
+                return CoversPoint(e, targetCoords);
+            };
+        }
+
+        /// <summary>
+        /// Checks if another entity's hard fixtures cover the given coordinates.
+        /// </summary>
+        public bool CoversPoint(EntityUid uid, MapCoordinates coords)
+        {
+            if (!_fixtureQuery.TryComp(uid, out var fixtures) || fixtures.FixtureCount == 0)
+                return false;
+
+            var transform = _broadphase.GetPhysicsTransform(uid);
+
+            foreach (var fixture in fixtures.Fixtures.Values)
+            {
+                if (!fixture.Hard)
+                    continue;
+
+                for (var i = 0; i < fixture.Shape.ChildCount; i++)
+                {
+                    if (fixture.Shape.ComputeAABB(transform, i).Contains(coords.Position))
+                        return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -812,17 +812,13 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
                 // Check static objects that can overlap.
                 if (IsStatic(hitEntity))
                 {
-                    var hitCoords = TransformSystem.GetMapCoordinates(hitEntity);
-
-                    foreach (var r in res)
+                    for (var j = 1; j < res.Count; j++)
                     {
-                        // If overlapping with an other static, pick the one drawn on top.
-                        if (IsStatic(r.HitEntity) &&
-                            Interaction.CoversPoint(r.HitEntity, hitCoords) &&
-                            IsDrawnAbove(r.HitEntity, hitEntity))
-                        {
-                            hitEntity = r.HitEntity;
-                        }
+                        if (res[j].Distance - res[0].Distance > 0.1f)
+                            break;
+
+                        if (IsStatic(res[j].HitEntity) && IsDrawnAbove(res[j].HitEntity, hitEntity))
+                            hitEntity = res[j].HitEntity;
                     }
                 }
 

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -37,6 +37,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -70,6 +71,7 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
     [Dependency] private SharedEntityEffectsSystem _effects = default!;
 
     [Dependency] private EntityQuery<DamageableComponent> _damageQuery = default!;
+    [Dependency] private EntityQuery<PhysicsComponent> _physicsQuery = default!;
 
     private const int AttackMask = (int) (CollisionGroup.MobMask | CollisionGroup.Opaque);
 
@@ -783,6 +785,7 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
     protected HashSet<EntityUid> ArcRayCast(Vector2 position, Angle angle, Angle arcWidth, float range, MapId mapId, EntityUid ignore)
     {
         // TODO: This is pretty sucky.
+        // TODO: Only ever called in Client, move to client?
         var widthRad = arcWidth;
         var increments = 1 + 35 * (int) Math.Ceiling(widthRad / (2 * Math.PI));
         var increment = widthRad / increments;
@@ -804,17 +807,43 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
 
             if (res.Count != 0)
             {
-                // If there's exact distance overlap, we simply have to deal with all overlapping objects to avoid selecting randomly.
-                var resChecked = res.Where(x => x.Distance.Equals(res[0].Distance));
-                foreach (var r in resChecked)
+                var hitEntity = res[0].HitEntity;
+
+                // Check static objects that can overlap.
+                if (IsStatic(hitEntity))
                 {
-                    if (Interaction.InRangeUnobstructed(ignore, r.HitEntity, range + 0.1f, overlapCheck: false))
-                        resSet.Add(r.HitEntity);
+                    var hitCoords = TransformSystem.GetMapCoordinates(hitEntity);
+
+                    foreach (var r in res)
+                    {
+                        // If overlapping with an other static, pick the one drawn on top.
+                        if (IsStatic(r.HitEntity) &&
+                            Interaction.CoversPoint(r.HitEntity, hitCoords) &&
+                            IsDrawnAbove(r.HitEntity, hitEntity))
+                        {
+                            hitEntity = r.HitEntity;
+                        }
+                    }
                 }
+
+                // Normal hit detection.
+                if (Interaction.InRangeUnobstructed(ignore, hitEntity, range + 0.1f, overlapCheck: false))
+                    resSet.Add(hitEntity);
             }
         }
 
         return resSet;
+    }
+
+    private bool IsStatic(EntityUid uid)
+    {
+        return _physicsQuery.TryComp(uid, out var body) && body.BodyType == BodyType.Static;
+    }
+
+    protected virtual bool IsDrawnAbove(EntityUid uid, EntityUid other)
+    {
+        // Only matters for client.
+        return false;
     }
 
     protected virtual bool ArcRaySuccessful(EntityUid targetUid,

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -129,8 +129,6 @@
     enabled: false
   - type: Occluder
     enabled: false
-  - type: WallMount
-    arc: 360
   - type: StaticPrice
     price: 200
   - type: AccessReader

--- a/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
@@ -15,8 +15,6 @@
     soundGroups:
       Brute:
         collection: GlassSmack
-  - type: WallMount
-    arc: 360 # interact despite grilles
   - type: Tag
     tags:
       - ForceFixRotations

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -17,8 +17,6 @@
     soundGroups:
       Brute:
         collection: GlassSmack
-  - type: WallMount
-    arc: 360 # interact despite grilles
   - type: Tag
     tags:
     - ForceFixRotations
@@ -142,8 +140,6 @@
     snap:
     - Window
   components:
-  - type: WallMount
-    arc: 360 # interact despite grilles
   - type: Tag
     tags:
     - Window


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed overlapping static entities becoming invulnerable to melee attacks, such as:
* Shutters on top of a window
* Two rock tiles spawned on top of each other.
  * Commonly spawned by asteroids or rock anomalies
  * The common ingame workaround for players for this is to use a ranged weapon like PKA to get rid of them (no longer required, pickaxe will actually work now)

## Why / Balance
Shutters on windows are no longer invulnerable to melee attacks, which is technically a minor balance change.

## Technical details
`InRangeUnobstructed()` casts a ray to the target and returns false for every entity it hits. An entity occupying the exact same bounding box as the target is also hit by it, so two entities of the same size on top of each other blocked each other, making both of them invulnerable to melee attacks.

`ArcRayCast()` now checks which entity is drawn on top when a ray hits a static body and selects that entity to hit, which is what the player would expect would happen. Still uses the same old `InRangeUnobstructed()` if there are no overlapping static entities.

`GetPredicate()` now checks hard physics fixtures if they actually contain the target's position on entities like grills, windows, shutters, airlocks, etc. Other entities such as edge firelocks, windoors, directional windows, etc. still block because their fixtures don't overlap the target fully like fullsize entities. Because of the new rule in `GetPredicate()` I also had to add a SubFloor entity guard here, to prevent players from being able to cut wires or unwrench pipes inside of walls using the right click menu.

In yaml people previously used a bandaid fix for this issue by adding `Wallmount arc: 360` to some prototypes, which obviously weren't wallmounts such as windows and firelocks, but that's obviously not the right way to go about this, so they have been removed.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Shutters:
1. Build a grille, a window and shutters on top of each other.
2. Start hitting it with a melee weapon: The shutter now breaks first, then the window, then the grille (previously invulnerable).

Rocks:
1. Infect yourself with a rock anomaly.
2. Activate it.
3. Spawn an rock on top of the spawning rocks during the animation to create stacked rocks.
4. Hit it with a melee weapon and you should now be able to destroy both (previously invulnerable).

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/266762c4-e2ba-46c6-9ff1-f547009159aa



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None, unless someone turned this into a feature and relied on the fact stacked static entities are invulnerable to melee for whatever reason.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
<!--
:cl:
- add: Crowbars now randomly spawn in maintenance lockers.
- remove: Crowbars no longer spawn in maintenance crates.
- tweak: Crowbar spawn rates have been increased for tool lockers.
- fix: Crowbars no longer accidentally spawn in microwaves.
-->
:cl: SuperDicq
- fix: Static entities on top of each other are no longer invulnerable to melee attacks.