### PR TITLE
Cleanup tesla coil & grounding rod

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -1,15 +1,9 @@
 - type: entity
-  parent: BaseStructureHealth
+  parent: [BaseStructure, BaseStructureHealth]
   id: TeslaCoil
   name: tesla coil
   description: A machine that converts lightning strikes into an electric current.
-  placement:
-    mode: SnapgridCenter
   components:
-  - type: Transform
-    anchored: true
-  - type: Physics
-    bodyType: Static
   - type: Fixtures
     fixtures:
       fix1:
@@ -23,14 +17,13 @@
         - MachineLayer
   - type: Sprite
     sprite: Structures/Power/Generation/Tesla/coil.rsi
-    snapCardinals: true
     noRot: true
     layers:
-      - state: coil
-        map: ["enabled"]
-      - state: coilhit
-        visible: false
-        map: ["hit"]
+    - state: coil
+      map: ["enabled"]
+    - state: coilhit
+      visible: false
+      map: ["hit"]
   - type: Appearance
   - type: GenericVisualizer
     visuals:
@@ -82,9 +75,6 @@
     usesApcPower: false
     highVoltageNode: input
   - type: Anchorable
-  - type: Rotatable
-  - type: Pullable
-  - type: Clickable
   - type: InteractionOutline
   - type: ExaminableDamage
     messages: WindowMessages
@@ -117,17 +107,11 @@
     - SingularityTeslaEngine
 
 - type: entity
-  parent: BaseStructureHealth
+  parent: [BaseStructure, BaseStructureHealth]
   id: TeslaGroundingRod
   name: grounding rod
   description: A machine that keeps lightning from striking too far away.
-  placement:
-    mode: SnapgridCenter
   components:
-  - type: Transform
-    anchored: true
-  - type: Physics
-    bodyType: Static
   - type: Fixtures
     fixtures:
       fix1:
@@ -142,13 +126,12 @@
   - type: Sprite
     sprite: Structures/Power/Generation/Tesla/coil.rsi
     noRot: true
-    snapCardinals: true
     layers:
-      - state: grounding_rod
-        map: ["power"]
-      - state: grounding_rodhit
-        visible: false
-        map: ["hit"]
+    - state: grounding_rod
+      map: ["power"]
+    - state: grounding_rodhit
+      visible: false
+      map: ["hit"]
   - type: Appearance
   - type: GenericVisualizer
     visuals:
@@ -167,9 +150,6 @@
     lightningExplode: false
     damageFromLightning: 0
   - type: Anchorable
-  - type: Rotatable
-  - type: Pullable
-  - type: Clickable
   - type: InteractionOutline
   - type: ExaminableDamage
     messages: WindowMessages


### PR DESCRIPTION
## About the PR

Cleans up the tesla coil and grounding rod YAML entries.

## Why / Balance

Slightly better parenting.  We can remove a good few components off of them.

Resolves https://github.com/space-wizards/space-station-14/issues/45876

## Technical details

Transform, Physics, Pullable, Clickable components already all on BaseStructure.  Still need the entirety of Fixtures to redefine the density.

Removing `RotatableComponent`: these entities have no meaningful orientation, this does nothing.

`SpriteComponent.SnapCardinals` also isn't needed, they already have noRot set to true and have sprites with 1 direction.

## Test plan

Spawn both, play around with them - they should be draggable, outline on hover, and generally act as they did before.

Try to label them.  It works.

## Media

Simple execution of the test plan.  The brief fumble was trying to point at them, I don't know how I managed to flub it.

https://github.com/user-attachments/assets/d8e8042a-5c85-4d27-ab50-457efb6fb5f1

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
nah