### PR TITLE
Fix vehicle camera tracking while driving

### DIFF
--- a/Content.Shared/Vehicle/Systems/VehicleSystem.cs
+++ b/Content.Shared/Vehicle/Systems/VehicleSystem.cs
@@ -192,7 +192,7 @@ public sealed partial class VehicleSystem : EntitySystem
         if (entity.Comp.Operator is not { } currentOperator)
             return false;
 
-        ClearEyeTarget(currentOperator, entity.Owner);
+        ClearEyeTarget(currentOperator);
         if (_operatorQuery.TryComp(currentOperator, out var currentOperatorComponent))
         {
             var exitEvent = new OnVehicleExitedEvent(entity, currentOperator);
@@ -255,7 +255,7 @@ public sealed partial class VehicleSystem : EntitySystem
         if (_vehicleQuery.TryComp(vehicleUid, out var vehicle))
             return TryRemoveOperator((vehicleUid.Value, vehicle));
 
-        ClearEyeTarget(operatorEntity.Owner, vehicleUid.Value);
+        ClearEyeTarget(operatorEntity.Owner);
         UnblockHands(vehicleUid.Value, operatorEntity.Owner);
         ClearOperatorRelays(operatorEntity.Owner, vehicleUid.Value);
         operatorEntity.Comp.Vehicle = null;
@@ -263,9 +263,9 @@ public sealed partial class VehicleSystem : EntitySystem
         return true;
     }
 
-    private void ClearEyeTarget(EntityUid operatorUid, EntityUid vehicleUid)
+    private void ClearEyeTarget(EntityUid operatorUid)
     {
-        if (TryComp<EyeComponent>(operatorUid, out var eye) && eye.Target == vehicleUid)
+        if (TryComp<EyeComponent>(operatorUid, out var eye))
             _eye.SetTarget(operatorUid, null, eye);
     }
 

--- a/Content.Shared/Vehicle/Systems/VehicleSystem.cs
+++ b/Content.Shared/Vehicle/Systems/VehicleSystem.cs
@@ -31,6 +31,7 @@ public sealed partial class VehicleSystem : EntitySystem
     [Dependency] private SharedContainerSystem _container = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private SharedEyeSystem _eye = default!;
     [Dependency] private EntityWhitelistSystem _entityWhitelist = default!;
     [Dependency] private SharedHandsSystem _hands = default!;
     [Dependency] private SharedMoverController _mover = default!;
@@ -166,6 +167,7 @@ public sealed partial class VehicleSystem : EntitySystem
         Dirty(operatorUid, vehicleOperator);
 
         _mover.SetRelay(operatorUid, entity);
+        _eye.SetTarget(operatorUid, entity.Owner);
 
         var enterEvent = new OnVehicleEnteredEvent(entity, operatorUid);
         RaiseLocalEvent(operatorUid, ref enterEvent);
@@ -190,6 +192,7 @@ public sealed partial class VehicleSystem : EntitySystem
         if (entity.Comp.Operator is not { } currentOperator)
             return false;
 
+        ClearEyeTarget(currentOperator, entity.Owner);
         _operatorQuery.TryComp(currentOperator, out var currentOperatorComponent);
 
         if (currentOperatorComponent != null)
@@ -254,11 +257,18 @@ public sealed partial class VehicleSystem : EntitySystem
         if (_vehicleQuery.TryComp(vehicleUid, out var vehicle))
             return TryRemoveOperator((vehicleUid.Value, vehicle));
 
+        ClearEyeTarget(operatorEntity.Owner, vehicleUid.Value);
         UnblockHands(vehicleUid.Value, operatorEntity.Owner);
         ClearOperatorRelays(operatorEntity.Owner, vehicleUid.Value);
         operatorEntity.Comp.Vehicle = null;
         RemCompDeferred<VehicleOperatorComponent>(operatorEntity.Owner);
         return true;
+    }
+
+    private void ClearEyeTarget(EntityUid operatorUid, EntityUid vehicleUid)
+    {
+        if (TryComp<EyeComponent>(operatorUid, out var eye) && eye.Target == vehicleUid)
+            _eye.SetTarget(operatorUid, null, eye);
     }
 
     /// <summary>

--- a/Content.Shared/Vehicle/Systems/VehicleSystem.cs
+++ b/Content.Shared/Vehicle/Systems/VehicleSystem.cs
@@ -193,9 +193,7 @@ public sealed partial class VehicleSystem : EntitySystem
             return false;
 
         ClearEyeTarget(currentOperator, entity.Owner);
-        _operatorQuery.TryComp(currentOperator, out var currentOperatorComponent);
-
-        if (currentOperatorComponent != null)
+        if (_operatorQuery.TryComp(currentOperator, out var currentOperatorComponent))
         {
             var exitEvent = new OnVehicleExitedEvent(entity, currentOperator);
             RaiseLocalEvent(currentOperator, ref exitEvent);
@@ -214,7 +212,7 @@ public sealed partial class VehicleSystem : EntitySystem
         var setEvent = new VehicleOperatorSetEvent(null, currentOperator);
         RaiseLocalEvent(entity, ref setEvent);
 
-        Dirty(entity);
+        DirtyFields(entity.Owner, entity.Comp, null, nameof(VehicleComponent.Operator));
         return true;
     }
 


### PR DESCRIPTION
## About the PR
Makes the player's eye follow the vehicle while operating it, instead of following the buckle offset

Partially addresses #45920

## Why / Balance
Prevents jerky camera movement and motion sickness when driving vehicles

## Technical details
Sets the operator's eye target to the vehicle on entry and safely clears it on exit

Also includes minor cleanup:
- Uses field-specific dirtying for `VehicleComponent.Operator`
- Simplifies the operator component lookup

## Test plan
- Entered and exited a vehicle
- Verified that the camera follows the vehicle while driving and returns to the player afterward

## Media
Not required?

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None

## Changelog
:cl:
- fix: Vehicle cameras now follow the vehicle smoothly while driving.