### PR TITLE
Allow bullets to pass by open lockers, gas canisters

### DIFF
--- a/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
+++ b/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
@@ -45,7 +45,10 @@ public sealed partial class RequireProjectileTargetSystem : EntitySystem
         }
     }
 
-    private void SetActive(Entity<RequireProjectileTargetComponent> ent, bool value)
+    /// <summary>
+    /// Sets whether <see cref="RequireProjectileTargetComponent"/> is active and will require aiming at to be hit.
+    /// </summary>
+    public void SetActive(Entity<RequireProjectileTargetComponent> ent, bool value)
     {
         if (ent.Comp.Active == value)
             return;

--- a/Content.Shared/Storage/Components/EntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/EntityStorageComponent.cs
@@ -63,6 +63,12 @@ public sealed partial class EntityStorageComponent : Component, IGasMixtureHolde
     public bool IsCollidableWhenOpen;
 
     /// <summary>
+    /// Whether or not the entity blocks bullets when open.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool BlocksProjectilesWhenOpen;
+
+    /// <summary>
     /// If true, it opens the storage when the entity inside of it moves
     /// If false, it prevents the storage from opening when the entity inside of it moves.
     /// This is for objects that you want the player to move while inside, like large cardboard boxes, without opening the storage.

--- a/Content.Shared/Storage/Components/EntityStorageComponent.cs
+++ b/Content.Shared/Storage/Components/EntityStorageComponent.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Shared.Atmos;
+using Content.Shared.Damage.Components;
 using Content.Shared.Physics;
 using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
@@ -63,10 +64,10 @@ public sealed partial class EntityStorageComponent : Component, IGasMixtureHolde
     public bool IsCollidableWhenOpen;
 
     /// <summary>
-    /// Whether or not the entity blocks bullets when open.
+    /// When true, the storage will toggle <see cref="RequireProjectileTargetComponent"/> to match the open status.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public bool BlocksProjectilesWhenOpen;
+    public bool ToggleRequireProjectileTargetWhenOpen;
 
     /// <summary>
     /// If true, it opens the storage when the entity inside of it moves

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -499,7 +499,7 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
             }
         }
 
-        if (!component.BlocksProjectilesWhenOpen)
+        if (component.ToggleRequireProjectileTargetWhenOpen)
         {
             var requireTargetComp = EnsureComp<RequireProjectileTargetComponent>(uid);
             _requireProjectileTarget.SetActive((uid, requireTargetComp), component.Open);

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -1,6 +1,8 @@
 using System.Linq;
 using System.Numerics;
 using Content.Shared.ActionBlocker;
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Systems;
 using Content.Shared.Destructible;
 using Content.Shared.Explosion;
 using Content.Shared.Foldable;
@@ -30,6 +32,7 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private INetManager _net = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
+    [Dependency] private RequireProjectileTargetSystem _requireProjectileTarget = default!;
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedContainerSystem _container = default!;
@@ -494,6 +497,12 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
                     manager: fixtures);
                 component.RemovedMasks = 0;
             }
+        }
+
+        if (!component.BlocksProjectilesWhenOpen)
+        {
+            var requireTargetComp = EnsureComp<RequireProjectileTargetComponent>(uid);
+            _requireProjectileTarget.SetActive((uid, requireTargetComp), component.Open);
         }
 
         _appearance.SetData(uid, StorageVisuals.Open, component.Open);

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -89,7 +89,7 @@
           bounds: "-0.25,-0.25,0.25,0.25"
         density: 190
         mask:
-        - SmallMobMask
+        - MachineMask
         layer:
         - MachineLayer
   - type: AtmosDevice
@@ -136,6 +136,7 @@
     - GasCanisters
   - type: Paintable
     group: Canisters
+  - type: RequireProjectileTarget
 
 - type: entity
   parent: GasCanister
@@ -664,6 +665,7 @@
         Plasteel: 200
     - type: StaticPrice
       price: 125
+    - type: RequireProjectileTarget
 
 - type: entity
   parent: GasCanisterBrokenBase

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -49,6 +49,8 @@
     containers:
       entity_storage: !type:Container
       paper_label: !type:ContainerSlot
+  - type: RequireProjectileTarget
+    active: false
   - type: Weldable
   - type: PlaceableSurface
     placeCentered: true
@@ -133,6 +135,7 @@
       map: ["enum.WeldableLayers.BaseWelded"]
   - type: EntityStorage
     isCollidableWhenOpen: true
+    blocksProjectilesWhenOpen: true
     enteringOffset: 0, -0.6
     enteringRange: 0.03
     closeSound:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -45,6 +45,7 @@
         layer:
         - MachineLayer
   - type: EntityStorage
+    toggleRequireProjectileTargetWhenOpen: true
   - type: ContainerContainer
     containers:
       entity_storage: !type:Container
@@ -135,7 +136,6 @@
       map: ["enum.WeldableLayers.BaseWelded"]
   - type: EntityStorage
     isCollidableWhenOpen: true
-    blocksProjectilesWhenOpen: true
     enteringOffset: 0, -0.6
     enteringRange: 0.03
     closeSound:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR makes bullets pass by open lockers, as well as canisters (and broken canisters). They require targetting to be hit.

If a locker is closed, bullets collide again. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

It's a bit odd that you can run past a locker but someone shooting bullets after you end up hitting the locker instead. There are also instances where you end up having difficulty hitting someone walking in or around lockers, which can be frustrating to deal with.

Additionally, canisters are used very frequently by various players and mobs to act as a bullet shield. Not only does a gas canister seem like it should be large enough to block bullets, it has also led to some cheese strategies for e.g. dragons creating nests of gas canisters to prevent being shot while flying over them. 

## Technical details
<!-- Summary of code changes for easier review. -->

`ToggleRequireProjectileTargetWhenOpen` is a new datafield for `EntityStorageComponent` that, when true, ensures and toggles `RequireProjectileTargetComponent`. `SetActive` was previously private but made public to allow this toggle.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

1. Spawn in a locker
2. pew pew it
3. open it
4. pew pew past it

Fire over and at some gas canisters too.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/2dcab27e-efcd-4b31-a371-6141273b70d2

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->

:cl:
- tweak: Projectiles no longer collide with open lockers or gas canisters.
