### PR TITLE
Bugfix: Direction in SandboxSystem copy is grid-local if possible.

### DIFF
--- a/Content.Client/Sandbox/SandboxSystem.cs
+++ b/Content.Client/Sandbox/SandboxSystem.cs
@@ -103,7 +103,14 @@ namespace Content.Client.Sandbox
                 if (_placement.Eraser)
                     _placement.ToggleEraser();
 
-                _placement.Direction = _transform.GetWorldRotation(uid).GetCardinalDir();
+                // Get the rotation of the object to copy relative to its grid (if it exists) or the map.
+                var xform = Transform(uid);
+                var targetRotation = _transform.GetWorldRotation(xform);
+                if (TryComp(xform.GridUid, out TransformComponent? gridXform))
+                {
+                    targetRotation -= gridXform.LocalRotation;
+                }
+                _placement.Direction = targetRotation.GetCardinalDir();
 
                 _placement.BeginPlacing(new()
                 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Fixes a bug from #34860 where the entity is rotated at odd angles relative to the grid when the grid itself is rotated.

## Why / Balance

We fixe boog.  Angle was relative to the map, regardless of whether or not it had a grid.  It _should_ be relative to the grid where possible (see comment: https://github.com/space-wizards/space-station-14/pull/34860#discussion_r3984885319)

## Technical details

Cache the transform component on the entity to copy, get its world rotation, then check for the grid and subtract its rotation (relative to the map - _should_ be equivalent to worldrotation, but I could swap it out if you really want).

## Test plan

1. Hop onto the debug shuttle.
2. Rotate to some jaunty angle (~100 degrees used in test media).
3. Copy entities, they should keep their relative rotation (lights are _offset_, but should be correctly rotated)

## Media

Fixed behaviour:

https://github.com/user-attachments/assets/144bae89-23ee-4e04-9ee2-a6640d26f728

Current behaviour on master:

https://github.com/user-attachments/assets/c0e07767-c336-4f0d-8917-1758e9ca39c8

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
<!--
:cl:
- add: Crowbars now randomly spawn in maintenance lockers.
- remove: Crowbars no longer spawn in maintenance crates.
- tweak: Crowbar spawn rates have been increased for tool lockers.
- fix: Crowbars no longer accidentally spawn in microwaves.
-->
not player facing