### PR TITLE
remove StatusEffectRelayedEvent

### DIFF
--- a/Content.Client/Drowsiness/DrowsinessSystem.cs
+++ b/Content.Client/Drowsiness/DrowsinessSystem.cs
@@ -18,21 +18,17 @@ public sealed partial class DrowsinessSystem : SharedDrowsinessSystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<DrowsinessStatusEffectComponent, StatusEffectAppliedEvent>(OnDrowsinessApply);
-        SubscribeLocalEvent<DrowsinessStatusEffectComponent, StatusEffectRemovedEvent>(OnDrowsinessShutdown);
-
-        SubscribeLocalEvent<DrowsinessStatusEffectComponent, StatusEffectRelayedEvent<LocalPlayerAttachedEvent>>(OnStatusEffectPlayerAttached);
-        SubscribeLocalEvent<DrowsinessStatusEffectComponent, StatusEffectRelayedEvent<LocalPlayerDetachedEvent>>(OnStatusEffectPlayerDetached);
-
         _overlay = new();
     }
 
+    [SubscribeLocalEvent]
     private void OnDrowsinessApply(Entity<DrowsinessStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
     {
         if (_player.LocalEntity == args.Target)
             _overlayMan.AddOverlay(_overlay);
     }
 
+    [SubscribeLocalEvent]
     private void OnDrowsinessShutdown(Entity<DrowsinessStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
     {
         if (_player.LocalEntity != args.Target)
@@ -45,12 +41,14 @@ public sealed partial class DrowsinessSystem : SharedDrowsinessSystem
         }
     }
 
-    private void OnStatusEffectPlayerAttached(Entity<DrowsinessStatusEffectComponent> ent, ref StatusEffectRelayedEvent<LocalPlayerAttachedEvent> args)
+    [SubscribeLocalEvent]
+    private void OnStatusEffectPlayerAttached(Entity<DrowsinessStatusEffectComponent> ent, ref LocalPlayerAttachedEvent args)
     {
         _overlayMan.AddOverlay(_overlay);
     }
 
-    private void OnStatusEffectPlayerDetached(Entity<DrowsinessStatusEffectComponent> ent, ref StatusEffectRelayedEvent<LocalPlayerDetachedEvent> args)
+    [SubscribeLocalEvent]
+    private void OnStatusEffectPlayerDetached(Entity<DrowsinessStatusEffectComponent> ent, ref LocalPlayerDetachedEvent args)
     {
         if (_player.LocalEntity is null)
             return;

--- a/Content.Client/Drugs/DrugOverlaySystem.cs
+++ b/Content.Client/Drugs/DrugOverlaySystem.cs
@@ -22,15 +22,10 @@ public sealed partial class DrugOverlaySystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<SeeingRainbowsStatusEffectComponent, StatusEffectAppliedEvent>(OnApplied);
-        SubscribeLocalEvent<SeeingRainbowsStatusEffectComponent, StatusEffectRemovedEvent>(OnRemoved);
-
-        SubscribeLocalEvent<SeeingRainbowsStatusEffectComponent, StatusEffectRelayedEvent<LocalPlayerAttachedEvent>>(OnPlayerAttached);
-        SubscribeLocalEvent<SeeingRainbowsStatusEffectComponent, StatusEffectRelayedEvent<LocalPlayerDetachedEvent>>(OnPlayerDetached);
-
         _overlay = new();
     }
 
+    [SubscribeLocalEvent]
     private void OnRemoved(Entity<SeeingRainbowsStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
     {
         if (_player.LocalEntity != args.Target)
@@ -41,6 +36,7 @@ public sealed partial class DrugOverlaySystem : EntitySystem
         _overlayMan.RemoveOverlay(_overlay);
     }
 
+    [SubscribeLocalEvent]
     private void OnApplied(Entity<SeeingRainbowsStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
     {
         if (_player.LocalEntity != args.Target)
@@ -50,12 +46,14 @@ public sealed partial class DrugOverlaySystem : EntitySystem
         _overlayMan.AddOverlay(_overlay);
     }
 
-    private void OnPlayerAttached(Entity<SeeingRainbowsStatusEffectComponent> ent, ref StatusEffectRelayedEvent<LocalPlayerAttachedEvent> args)
+    [SubscribeLocalEvent]
+    private void OnPlayerAttached(Entity<SeeingRainbowsStatusEffectComponent> ent, ref LocalPlayerAttachedEvent args)
     {
         _overlayMan.AddOverlay(_overlay);
     }
 
-    private void OnPlayerDetached(Entity<SeeingRainbowsStatusEffectComponent> ent, ref StatusEffectRelayedEvent<LocalPlayerDetachedEvent> args)
+    [SubscribeLocalEvent]
+    private void OnPlayerDetached(Entity<SeeingRainbowsStatusEffectComponent> ent, ref LocalPlayerDetachedEvent args)
     {
         _overlay.Intoxication = 0;
         _overlay.TimeTicker = 0;

--- a/Content.Client/Drunk/DrunkSystem.cs
+++ b/Content.Client/Drunk/DrunkSystem.cs
@@ -19,15 +19,10 @@ public sealed partial class DrunkSystem : SharedDrunkSystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<DrunkStatusEffectComponent, StatusEffectAppliedEvent>(OnStatusApplied);
-        SubscribeLocalEvent<DrunkStatusEffectComponent, StatusEffectRemovedEvent>(OnStatusRemoved);
-
-        SubscribeLocalEvent<DrunkStatusEffectComponent, StatusEffectRelayedEvent<LocalPlayerAttachedEvent>>(OnPlayerAttached);
-        SubscribeLocalEvent<DrunkStatusEffectComponent, StatusEffectRelayedEvent<LocalPlayerDetachedEvent>>(OnPlayerDetached);
-
         _overlay = new();
     }
 
+    [SubscribeLocalEvent]
     private void OnStatusApplied(Entity<DrunkStatusEffectComponent> entity, ref StatusEffectAppliedEvent args)
     {
         if (!_overlayMan.HasOverlay<DrunkOverlay>())
@@ -37,6 +32,7 @@ public sealed partial class DrunkSystem : SharedDrunkSystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnStatusRemoved(Entity<DrunkStatusEffectComponent> entity, ref StatusEffectRemovedEvent args)
     {
         if (Status.HasEffectComp<DrunkStatusEffectComponent>(args.Target))
@@ -49,13 +45,14 @@ public sealed partial class DrunkSystem : SharedDrunkSystem
         _overlayMan.RemoveOverlay(_overlay);
     }
 
-    private void OnPlayerAttached(Entity<DrunkStatusEffectComponent> entity, ref StatusEffectRelayedEvent<LocalPlayerAttachedEvent> args)
+    [SubscribeLocalEvent]
+    private void OnPlayerAttached(Entity<DrunkStatusEffectComponent> entity, ref LocalPlayerAttachedEvent args)
     {
         _overlayMan.AddOverlay(_overlay);
-
     }
 
-    private void OnPlayerDetached(Entity<DrunkStatusEffectComponent> entity, ref StatusEffectRelayedEvent<LocalPlayerDetachedEvent> args)
+    [SubscribeLocalEvent]
+    private void OnPlayerDetached(Entity<DrunkStatusEffectComponent> entity, ref LocalPlayerDetachedEvent args)
     {
         _overlay.CurrentBoozePower = 0;
         _overlayMan.RemoveOverlay(_overlay);

--- a/Content.Client/Flash/FlashSystem.cs
+++ b/Content.Client/Flash/FlashSystem.cs
@@ -46,16 +46,16 @@ public sealed partial class FlashSystem : SharedFlashSystem
     }
 
     [SubscribeLocalEvent]
-    private void OnPlayerAttached(Entity<FlashedStatusEffectComponent> ent, ref StatusEffectRelayedEvent<LocalPlayerAttachedEvent> args)
+    private void OnPlayerAttached(Entity<FlashedStatusEffectComponent> ent, ref LocalPlayerAttachedEvent args)
     {
         _overlay.RequestScreenTexture = true;
         _overlayMan.AddOverlay(_overlay);
     }
 
     [SubscribeLocalEvent]
-    private void OnPlayerDetached(Entity<FlashedStatusEffectComponent> ent, ref StatusEffectRelayedEvent<LocalPlayerDetachedEvent> args)
+    private void OnPlayerDetached(Entity<FlashedStatusEffectComponent> ent, ref LocalPlayerDetachedEvent args)
     {
-        if (_player.LocalEntity is null || _statusEffects.HasEffectComp<FlashedStatusEffectComponent>(_player.LocalEntity.Value))
+        if (_player.LocalEntity is not { } mob || _statusEffects.HasEffectComp<FlashedStatusEffectComponent>(mob))
             return;
 
         _overlay.ScreenshotTexture = null;

--- a/Content.Server/Atmos/EntitySystems/PressureImmunityStatusEffectSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/PressureImmunityStatusEffectSystem.cs
@@ -27,8 +27,8 @@ public sealed partial class PressureImmunityStatusEffectSystem : EntitySystem
     }
 
     [SubscribeLocalEvent]
-    private void OnRefreshPressureImmunity(Entity<PressureImmunityStatusEffectComponent> ent, ref StatusEffectRelayedEvent<RefreshPressureImmunityEvent> args)
+    private void OnRefreshPressureImmunity(Entity<PressureImmunityStatusEffectComponent> ent, ref RefreshPressureImmunityEvent args)
     {
-        args.Args = args.Args with { IsImmune = true };
+        args.IsImmune = true;
     }
 }

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -42,6 +42,7 @@ public sealed partial class SleepingSystem : EntitySystem
     [Dependency] private SharedEmitSoundSystem _emitSound = default!;
     [Dependency] private StatusEffectsSystem _statusEffect = default!;
     [Dependency] private SharedStunSystem _stun = default!;
+    [Dependency] private EntityQuery<SleepingComponent> _query = default!;
 
     public static readonly EntProtoId SleepActionId = "ActionSleep";
     public static readonly EntProtoId WakeActionId = "ActionWake";
@@ -74,8 +75,6 @@ public sealed partial class SleepingSystem : EntitySystem
         SubscribeLocalEvent<SleepingComponent, StunEndAttemptEvent>(OnStunEndAttempt);
         SubscribeLocalEvent<SleepingComponent, StandUpAttemptEvent>(OnStandUpAttempt);
 
-        SubscribeLocalEvent<ForcedSleepingStatusEffectComponent, StatusEffectRelayedEvent<MobStateChangedEvent>>(OnStatusMobStateChanged);
-        SubscribeLocalEvent<ForcedSleepingStatusEffectComponent, StatusEffectAppliedEvent>(OnStatusEffectApplied);
         SubscribeLocalEvent<SleepingComponent, UnbuckleAttemptEvent>(OnUnbuckleAttempt);
         SubscribeLocalEvent<SleepingComponent, EmoteAttemptEvent>(OnEmoteAttempt);
 
@@ -284,14 +283,16 @@ public sealed partial class SleepingSystem : EntitySystem
             RemCompDeferred<SleepingComponent>(ent);
     }
 
-    private void OnStatusMobStateChanged(Entity<ForcedSleepingStatusEffectComponent> ent, ref StatusEffectRelayedEvent<MobStateChangedEvent> args)
+    [SubscribeLocalEvent]
+    private void OnStatusMobStateChanged(Entity<ForcedSleepingStatusEffectComponent> ent, ref MobStateChangedEvent args)
     {
-        if (args.Args.NewMobState == MobState.Dead || HasComp<SleepingComponent>(args.Args.Target))
+        if (args.NewMobState == MobState.Dead || _query.HasComp(args.Target))
             return;
 
-        TrySleeping(args.Args.Target);
+        TrySleeping(args.Target);
     }
 
+    [SubscribeLocalEvent]
     private void OnStatusEffectApplied(Entity<ForcedSleepingStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
     {
         // Applying state check needed so we don't add SleepingComp during

--- a/Content.Shared/Clumsy/ClumsyStatusEffectSystem.cs
+++ b/Content.Shared/Clumsy/ClumsyStatusEffectSystem.cs
@@ -38,144 +38,145 @@ public sealed partial class ClumsyStatusEffectSystem : EntitySystem
 
     /// <summary> Clumsy people are bad at baseball! </summary>
     [SubscribeLocalEvent]
-    private void OnCatchAttemptEvent(Entity<ClumsyCatchStatusEffectComponent> status, ref StatusEffectRelayedEvent<CatchAttemptEvent> args)
+    private void OnCatchAttemptEvent(Entity<ClumsyCatchStatusEffectComponent> status, ref CatchAttemptEvent args)
     {
-        if (args.Args.Cancelled
-            || !SharedRandomExtensions.PredictedProb(_timing, status.Comp.ClumsyChance, GetNetEntity(status), GetNetEntity(args.AppliedTo)))
+        var user = args.User;
+        if (args.Cancelled
+            || !SharedRandomExtensions.PredictedProb(_timing, status.Comp.ClumsyChance, GetNetEntity(status), GetNetEntity(user)))
             return;
 
-        // Song and dance :o|
-        var ev = args.Args;
-        ev.Cancelled = true;
-        args.Args = ev;
+        args.Cancelled = true;
 
         if (status.Comp.FailDamage != null)
-            _damageable.ChangeDamage(args.AppliedTo, status.Comp.FailDamage, origin: args.Args.Item);
+            _damageable.ChangeDamage(user, status.Comp.FailDamage, origin: args.Item);
 
-        var identity = Identity.Entity(args.AppliedTo, EntityManager);
+        var identity = Identity.Entity(user, EntityManager);
 
         var selfMessage = status.Comp.SelfFailedMessage == null
             ? null
-            : Loc.GetString(status.Comp.SelfFailedMessage, ("item", args.Args.Item));
+            : Loc.GetString(status.Comp.SelfFailedMessage, ("item", args.Item));
         var othersMessage = status.Comp.OtherFailedMessage == null
             ? null
-            : Loc.GetString(status.Comp.OtherFailedMessage, ("item", args.Args.Item), ("catcher", identity));
+            : Loc.GetString(status.Comp.OtherFailedMessage, ("item", args.Item), ("catcher", identity));
 
-        _popup.PopupEntity(selfMessage, othersMessage, args.AppliedTo, args.AppliedTo);
+        _popup.PopupEntity(selfMessage, othersMessage, user, user);
 
         // _audio.PlayPredicted doesn't play nice with collision events so we need PlayPvs
         // exit early for clients so the sound doesn't play twice
         if (_net.IsClient)
             return;
 
-        _audio.PlayPvs(status.Comp.ClumsySound, args.AppliedTo);
+        _audio.PlayPvs(status.Comp.ClumsySound, user);
     }
 
     /// <summary> Clumsy people shock themselves with defibrillators! </summary>
     [SubscribeLocalEvent]
-    private void OnBeforeDefibrillatorZapsEvent(Entity<ClumsyDefibStatusEffectComponent> status, ref StatusEffectRelayedEvent<SelfBeforeDefibrillatorZapsEvent> args)
+    private void OnBeforeDefibrillatorZapsEvent(Entity<ClumsyDefibStatusEffectComponent> status, ref SelfBeforeDefibrillatorZapsEvent args)
     {
-        if (!SharedRandomExtensions.PredictedProb(_timing, status.Comp.ClumsyChance, GetNetEntity(status), GetNetEntity(args.AppliedTo)))
+        var user = args.EntityUsingDefib;
+        if (!SharedRandomExtensions.PredictedProb(_timing, status.Comp.ClumsyChance, GetNetEntity(status), GetNetEntity(user)))
             return;
 
-        var ev = args.Args;
-        ev.DefibTarget = ev.EntityUsingDefib;
+        args.DefibTarget = args.EntityUsingDefib;
 
         if (status.Comp.FailedMessage != null)
-            _popup.PopupEntity(Loc.GetString(status.Comp.FailedMessage), args.AppliedTo, args.AppliedTo);
+            _popup.PopupEntity(Loc.GetString(status.Comp.FailedMessage), user, user);
 
-        _audio.PlayPredicted(status.Comp.ClumsySound, args.AppliedTo, args.AppliedTo);
+        _audio.PlayPredicted(status.Comp.ClumsySound, user, user);
     }
 
     /// <summary> Clumsy people can't be trusted with guns! </summary>
     [SubscribeLocalEvent]
-    private void OnBeforeGunShotEvent(Entity<ClumsyGunStatusEffectComponent> status, ref StatusEffectRelayedEvent<SelfBeforeGunShotEvent> args)
+    private void OnBeforeGunShotEvent(Entity<ClumsyGunStatusEffectComponent> status, ref SelfBeforeGunShotEvent args)
     {
-        if (args.Args.Cancelled
-            || args.Args.Gun.Comp.ClumsyProof
-            || !SharedRandomExtensions.PredictedProb(_timing, status.Comp.ClumsyChance, GetNetEntity(status), GetNetEntity(args.AppliedTo)))
+        var user = args.Shooter;
+        if (args.Cancelled
+            || args.Gun.Comp.ClumsyProof
+            || !SharedRandomExtensions.PredictedProb(_timing, status.Comp.ClumsyChance, GetNetEntity(status), GetNetEntity(user)))
             return;
 
-        args.Args.Cancel();
+        args.Cancel();
 
         if (status.Comp.FailDamage != null)
-            _damageable.ChangeDamage(args.AppliedTo, status.Comp.FailDamage, origin: args.Args.Gun);
+            _damageable.ChangeDamage(user, status.Comp.FailDamage, origin: args.Gun);
 
-        _stun.TryUpdateParalyzeDuration(args.AppliedTo, status.Comp.StunDuration);
+        _stun.TryUpdateParalyzeDuration(user, status.Comp.StunDuration);
 
         if (status.Comp.FailedMessage != null)
-            _popup.PopupEntity(Loc.GetString(status.Comp.FailedMessage, ("gun", args.Args.Gun)), args.AppliedTo, args.AppliedTo);
+            _popup.PopupEntity(Loc.GetString(status.Comp.FailedMessage, ("gun", args.Gun)), user, user);
 
         // SelfBeforeGunShotEvent is raised on server so _audio.PlayPredicted fails to play locally
         if (_net.IsClient)
             return;
 
         // Apply salt to the wound ("Honk!") (No idea what this comment means) :o)
-        _audio.PlayPvs(status.Comp.GunShootFailSound, args.Args.Gun);
-        _audio.PlayPvs(status.Comp.ClumsySound, args.AppliedTo);
+        _audio.PlayPvs(status.Comp.GunShootFailSound, args.Gun);
+        _audio.PlayPvs(status.Comp.ClumsySound, user);
     }
 
     /// <summary> Clumsy people sometimes inject themselves! </summary>
     [SubscribeLocalEvent]
-    private void OnBeforeInjectEvent(Entity<ClumsyInjectorStatusEffectComponent> status, ref StatusEffectRelayedEvent<SelfBeforeInjectEvent> args)
+    private void OnBeforeInjectEvent(Entity<ClumsyInjectorStatusEffectComponent> status, ref SelfBeforeInjectEvent args)
     {
-        if (!SharedRandomExtensions.PredictedProb(_timing, status.Comp.ClumsyChance, GetNetEntity(status), GetNetEntity(args.AppliedTo)))
+        var user = args.EntityUsingInjector;
+        if (!SharedRandomExtensions.PredictedProb(_timing, status.Comp.ClumsyChance, GetNetEntity(status), GetNetEntity(user)))
             return;
 
-        var ev = args.Args;
+        var ev = args;
         ev.TargetGettingInjected = ev.EntityUsingInjector;
 
         if (status.Comp.FailedMessage != null)
             ev.OverrideMessage = Loc.GetString(status.Comp.FailedMessage);
 
-        _audio.PlayPredicted(status.Comp.ClumsySound, args.AppliedTo, args.AppliedTo);
+        _audio.PlayPredicted(status.Comp.ClumsySound, user, user);
     }
 
     /// <summary> Clumsy people have a blood feud with tables! </summary>
     [SubscribeLocalEvent]
-    private void OnBeforeClimbEvent(Entity<ClumsyVaultStatusEffectComponent> status, ref StatusEffectRelayedEvent<SelfBeforeClimbEvent> args)
+    private void OnBeforeClimbEvent(Entity<ClumsyVaultStatusEffectComponent> status, ref SelfBeforeClimbEvent args)
     {
-        if (args.Args.Cancelled
-            || !_cfg.GetCVar(CCVars.GameTableBonk)
-            || !SharedRandomExtensions.PredictedProb(_timing, status.Comp.ClumsyChance, GetNetEntity(status), GetNetEntity(args.AppliedTo)))
+        var target = args.GettingPutOnTable;
+        var user = args.PuttingOnTable;
+        if (args.Cancelled ||
+            !_cfg.GetCVar(CCVars.GameTableBonk) ||
+            !SharedRandomExtensions.PredictedProb(_timing, status.Comp.ClumsyChance, GetNetEntity(status), GetNetEntity(target)))
             return;
 
-        args.Args.Cancel();
+        args.Cancel();
 
-        _climb.Bonk(args.Args.BeingClimbedOn.Owner, args.Args.GettingPutOnTable);
+        _climb.Bonk(args.BeingClimbedOn.Owner, target);
 
-        var putOnTable = Identity.Entity(args.Args.GettingPutOnTable, EntityManager);
-        var puttingOnTable = Identity.Entity(args.Args.PuttingOnTable, EntityManager);
+        var putOnTable = Identity.Entity(target, EntityManager);
+        var puttingOnTable = Identity.Entity(user, EntityManager);
 
-        if (args.Args.PuttingOnTable == args.Args.GettingPutOnTable)
+        if (target == user)
         {
             // You are slamming yourself onto the table.
 
             var selfMessage = status.Comp.SelfFailedMessage == null
                 ? null
-                : Loc.GetString(status.Comp.SelfFailedMessage, ("bonkable", args.Args.BeingClimbedOn));
+                : Loc.GetString(status.Comp.SelfFailedMessage, ("bonkable", args.BeingClimbedOn));
             var othersMessage = status.Comp.OtherFailedMessage == null
                 ? null
-                : Loc.GetString(status.Comp.OtherFailedMessage, ("victim", putOnTable), ("bonkable", args.Args.BeingClimbedOn));
+                : Loc.GetString(status.Comp.OtherFailedMessage, ("victim", putOnTable), ("bonkable", args.BeingClimbedOn));
 
-            _popup.PopupEntity(selfMessage, othersMessage, args.AppliedTo, args.AppliedTo);
+            _popup.PopupEntity(selfMessage, othersMessage, user, user);
         }
         else
         {
             // Someone else slammed you onto the table.
-            // This is only run in server so you need to use popup entity.
 
             var message = status.Comp.ForcedMessage == null
                 ? null
                 : Loc.GetString(status.Comp.ForcedMessage,
                     ("bonker", puttingOnTable),
                     ("victim", putOnTable),
-                    ("bonkable", args.Args.BeingClimbedOn));
+                    ("bonkable", args.BeingClimbedOn));
 
-            _popup.PopupEntity(message, args.AppliedTo);
+            _popup.PopupEntity(message, target);
         }
 
-        _audio.PlayPredicted(status.Comp.ClumsySound, args.Args.GettingPutOnTable, args.Args.GettingPutOnTable);
+        _audio.PlayPredicted(status.Comp.ClumsySound, target, user);
     }
 
     #endregion

--- a/Content.Shared/Damage/Systems/DamageModifierStatusEffect.cs
+++ b/Content.Shared/Damage/Systems/DamageModifierStatusEffect.cs
@@ -1,19 +1,13 @@
-﻿using Content.Shared.Damage.Components;
-using Content.Shared.StatusEffectNew;
+using Content.Shared.Damage.Components;
 
 namespace Content.Shared.Damage.Systems;
 
+// TODO: can probably kill this, ArmorComponent exists
 public sealed partial class DamageModifierStatusEffectSystem : EntitySystem
 {
-    public override void Initialize()
+    [SubscribeLocalEvent]
+    private void OnDamageModifyStatus(Entity<DamageModifierStatusEffectComponent> status, ref DamageModifyEvent args)
     {
-        base.Initialize();
-
-        SubscribeLocalEvent<DamageModifierStatusEffectComponent, StatusEffectRelayedEvent<DamageModifyEvent>>(OnDamageModifyStatus);
-    }
-
-    private void OnDamageModifyStatus(Entity<DamageModifierStatusEffectComponent> status, ref StatusEffectRelayedEvent<DamageModifyEvent> args)
-    {
-        args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage, status.Comp.Modifiers);
+        args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage, status.Comp.Modifiers);
     }
 }

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.Modifier.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.Modifier.cs
@@ -6,28 +6,22 @@ namespace Content.Shared.Damage.Systems;
 
 public partial class SharedStaminaSystem
 {
-    private void InitializeModifier()
-    {
-        SubscribeLocalEvent<StaminaModifierStatusEffectComponent, StatusEffectAppliedEvent>(OnEffectApplied);
-        SubscribeLocalEvent<StaminaModifierStatusEffectComponent, StatusEffectRemovedEvent>(OnEffectRemoved);
-        SubscribeLocalEvent<StaminaModifierStatusEffectComponent, StatusEffectRelayedEvent<RefreshStaminaCritThresholdEvent>>(OnRefreshCritThreshold);
-    }
-
+    [SubscribeLocalEvent]
     private void OnEffectApplied(Entity<StaminaModifierStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
     {
         RefreshStaminaCritThreshold(args.Target);
     }
 
+    [SubscribeLocalEvent]
     private void OnEffectRemoved(Entity<StaminaModifierStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
     {
         RefreshStaminaCritThreshold(args.Target);
     }
 
-    private void OnRefreshCritThreshold(Entity<StaminaModifierStatusEffectComponent> ent, ref StatusEffectRelayedEvent<RefreshStaminaCritThresholdEvent> args)
+    [SubscribeLocalEvent]
+    private void OnRefreshCritThreshold(Entity<StaminaModifierStatusEffectComponent> ent, ref RefreshStaminaCritThresholdEvent args)
     {
-        var evArgs = args.Args;
-        evArgs.Modifier = Math.Max(ent.Comp.Modifier, evArgs.Modifier); // We only pick the highest value, to avoid stacking different status effects.
-        args.Args = evArgs;
+        args.Modifier = Math.Max(ent.Comp.Modifier, args.Modifier); // We only pick the highest value, to avoid stacking different status effects.
     }
 
     public void RefreshStaminaCritThreshold(Entity<StaminaComponent?> entity)

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
@@ -65,7 +65,6 @@ public abstract partial class SharedStaminaSystem : EntitySystem
     {
         base.Initialize();
 
-        InitializeModifier();
         InitializeResistance();
 
         Subs.CVar(_config, CCVars.PlaytestStaminaDamageModifier, value => UniversalStaminaDamageModifier = value, true);

--- a/Content.Shared/Damage/Systems/SlowOnDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/SlowOnDamageSystem.cs
@@ -24,10 +24,6 @@ public sealed partial class SlowOnDamageSystem : EntitySystem
         SubscribeLocalEvent<ClothingSlowOnDamageModifierComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<ClothingSlowOnDamageModifierComponent, ClothingGotEquippedEvent>(OnGotEquipped);
         SubscribeLocalEvent<ClothingSlowOnDamageModifierComponent, ClothingGotUnequippedEvent>(OnGotUnequipped);
-
-        SubscribeLocalEvent<IgnoreSlowOnDamageComponent, StatusEffectAppliedEvent>(OnIgnoreApplied);
-        SubscribeLocalEvent<IgnoreSlowOnDamageComponent, StatusEffectRemovedEvent>(OnIgnoreRemoved);
-        SubscribeLocalEvent<IgnoreSlowOnDamageComponent, StatusEffectRelayedEvent<ModifySlowOnDamageSpeedEvent>>(OnIgnoreModifySpeed);
     }
 
     private void OnRefreshMovespeed(EntityUid uid, SlowOnDamageComponent component, RefreshMovementSpeedModifiersEvent args)
@@ -55,7 +51,8 @@ public sealed partial class SlowOnDamageSystem : EntitySystem
 
             var ev = new ModifySlowOnDamageSpeedEvent(speed);
             RaiseLocalEvent(uid, ref ev);
-            args.ModifySpeed(ev.Speed, ev.Speed);
+            if (!ev.Cancelled)
+                args.ModifySpeed(ev.Speed, ev.Speed);
         }
     }
 
@@ -93,24 +90,27 @@ public sealed partial class SlowOnDamageSystem : EntitySystem
         _movementSpeedModifierSystem.RefreshMovementSpeedModifiers(args.Wearer);
     }
 
+    [SubscribeLocalEvent]
     private void OnIgnoreApplied(Entity<IgnoreSlowOnDamageComponent> ent, ref StatusEffectAppliedEvent args)
     {
         _movementSpeedModifierSystem.RefreshMovementSpeedModifiers(args.Target);
     }
 
+    [SubscribeLocalEvent]
     private void OnIgnoreRemoved(Entity<IgnoreSlowOnDamageComponent> ent, ref StatusEffectRemovedEvent args)
     {
         _movementSpeedModifierSystem.RefreshMovementSpeedModifiers(args.Target);
     }
 
-    private void OnIgnoreModifySpeed(Entity<IgnoreSlowOnDamageComponent> ent, ref StatusEffectRelayedEvent<ModifySlowOnDamageSpeedEvent> args)
+    [SubscribeLocalEvent]
+    private void OnIgnoreModifySpeed(Entity<IgnoreSlowOnDamageComponent> ent, ref ModifySlowOnDamageSpeedEvent args)
     {
-        args.Args = args.Args with { Speed = 1f };
+        args.Cancelled = true;
     }
 }
 
 [ByRefEvent]
-public record struct ModifySlowOnDamageSpeedEvent(float Speed) : IInventoryRelayEvent
+public record struct ModifySlowOnDamageSpeedEvent(float Speed, bool Cancelled = false) : IInventoryRelayEvent
 {
     public SlotFlags TargetSlots => SlotFlags.WITHOUT_POCKET;
 }

--- a/Content.Shared/Eye/Blinding/Systems/BlindnessSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlindnessSystem.cs
@@ -11,37 +11,27 @@ public sealed partial class BlindnessSystem : EntitySystem
 
     [Dependency] private BlindableSystem _blindableSystem = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<BlindnessStatusEffectComponent, StatusEffectAppliedEvent>(OnApplied);
-        SubscribeLocalEvent<BlindnessStatusEffectComponent, StatusEffectRemovedEvent>(OnRemoved);
-        SubscribeLocalEvent<BlindnessStatusEffectComponent, StatusEffectRelayedEvent<CanSeeAttemptEvent>>(OnBlindTrySee);
-        SubscribeLocalEvent<BlindnessStatusEffectComponent, StatusEffectRelayedEvent<FlashAttemptEvent>>(OnFlashAttempt);
-    }
-
+    [SubscribeLocalEvent]
     private void OnApplied(Entity<BlindnessStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
     {
         _blindableSystem.UpdateIsBlind(args.Target);
     }
 
+    [SubscribeLocalEvent]
     private void OnRemoved(Entity<BlindnessStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
     {
         _blindableSystem.UpdateIsBlind(args.Target);
     }
 
-    private void OnBlindTrySee(Entity<BlindnessStatusEffectComponent> ent, ref StatusEffectRelayedEvent<CanSeeAttemptEvent> args)
+    [SubscribeLocalEvent]
+    private void OnBlindTrySee(Entity<BlindnessStatusEffectComponent> ent, ref CanSeeAttemptEvent args)
     {
-        var ev = args.Args;
-        ev.Cancel();
-        args.Args = ev;
+        args.Cancel();
     }
 
-    private void OnFlashAttempt(Entity<BlindnessStatusEffectComponent> ent, ref StatusEffectRelayedEvent<FlashAttemptEvent> args)
+    [SubscribeLocalEvent]
+    private void OnFlashAttempt(Entity<BlindnessStatusEffectComponent> ent, ref FlashAttemptEvent args)
     {
-        var ev = args.Args;
-        ev.Cancelled = true;
-        args.Args = ev;
+        args.Cancelled = true;
     }
 }

--- a/Content.Shared/Item/ForcedItemStatusEffectSystem.cs
+++ b/Content.Shared/Item/ForcedItemStatusEffectSystem.cs
@@ -129,7 +129,7 @@ public sealed partial class ForcedItemStatusEffectSystem : EntitySystem
     }
 
     [SubscribeLocalEvent]
-    private void OnGotHandcuffed(Entity<ForcedItemStatusEffectComponent> entity, ref StatusEffectRelayedEvent<TargetHandcuffedEvent> args)
+    private void OnGotHandcuffed(Entity<ForcedItemStatusEffectComponent> entity, ref TargetHandcuffedEvent args)
     {
         if (!entity.Comp.RemoveWhenCuffed)
             return;
@@ -137,7 +137,7 @@ public sealed partial class ForcedItemStatusEffectSystem : EntitySystem
         if (!TryComp<StatusEffectComponent>(entity, out var status) || status.AppliedTo == null)
             return;
 
-        if (MetaData(entity).EntityPrototype?.ID is not { } entProto)
+        if (Prototype(entity)?.ID is not { } entProto)
             return;
 
         _status.TryRemoveStatusEffect(status.AppliedTo.Value, entProto);

--- a/Content.Shared/Movement/Systems/MovementModStatusSystem.cs
+++ b/Content.Shared/Movement/Systems/MovementModStatusSystem.cs
@@ -28,58 +28,47 @@ public sealed partial class MovementModStatusSystem : EntitySystem
     [Dependency] private MovementSpeedModifierSystem _movementSpeedModifier = default!;
     [Dependency] private StatusEffectsSystem _status = default!;
 
-    public override void Initialize()
-    {
-        SubscribeLocalEvent<MovementModStatusEffectComponent, StatusEffectAppliedEvent>(OnMovementModApplied);
-        SubscribeLocalEvent<MovementModStatusEffectComponent, StatusEffectRemovedEvent>(OnMovementModRemoved);
-        SubscribeLocalEvent<MovementModStatusEffectComponent, StatusEffectRelayedEvent<RefreshMovementSpeedModifiersEvent>>(OnRefreshRelay);
-        SubscribeLocalEvent<FrictionStatusEffectComponent, StatusEffectAppliedEvent>(OnFrictionStatusEffectApplied);
-        SubscribeLocalEvent<FrictionStatusEffectComponent, StatusEffectRemovedEvent>(OnFrictionStatusEffectRemoved);
-        SubscribeLocalEvent<FrictionStatusEffectComponent, StatusEffectRelayedEvent<RefreshFrictionModifiersEvent>>(OnRefreshFrictionStatus);
-        SubscribeLocalEvent<FrictionStatusEffectComponent, StatusEffectRelayedEvent<TileFrictionEvent>>(OnRefreshTileFrictionStatus);
-    }
-
+    [SubscribeLocalEvent]
     private void OnMovementModApplied(Entity<MovementModStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
     {
         _movementSpeedModifier.RefreshMovementSpeedModifiers(args.Target);
     }
 
+    [SubscribeLocalEvent]
     private void OnMovementModRemoved(Entity<MovementModStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
     {
         TryUpdateMovementStatus(args.Target, (ent, ent), 1f);
     }
 
+    [SubscribeLocalEvent]
     private void OnFrictionStatusEffectApplied(Entity<FrictionStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
     {
         _movementSpeedModifier.RefreshFrictionModifiers(args.Target);
     }
 
+    [SubscribeLocalEvent]
     private void OnFrictionStatusEffectRemoved(Entity<FrictionStatusEffectComponent> entity, ref StatusEffectRemovedEvent args)
     {
         TrySetFrictionStatus(entity!, 1f, args.Target);
     }
 
-    private void OnRefreshRelay(
-        Entity<MovementModStatusEffectComponent> entity,
-        ref StatusEffectRelayedEvent<RefreshMovementSpeedModifiersEvent> args
-    )
+    [SubscribeLocalEvent]
+    private void OnRefreshSpeed(Entity<MovementModStatusEffectComponent> entity, ref RefreshMovementSpeedModifiersEvent args)
     {
-        args.Args.ModifySpeed(entity.Comp.WalkSpeedModifier, entity.Comp.SprintSpeedModifier);
+        args.ModifySpeed(entity.Comp.WalkSpeedModifier, entity.Comp.SprintSpeedModifier);
     }
 
-    private void OnRefreshFrictionStatus(Entity<FrictionStatusEffectComponent> ent, ref StatusEffectRelayedEvent<RefreshFrictionModifiersEvent> args)
+    [SubscribeLocalEvent]
+    private void OnRefreshFrictionStatus(Entity<FrictionStatusEffectComponent> ent, ref RefreshFrictionModifiersEvent args)
     {
-        var ev = args.Args;
-        ev.ModifyFriction(ent.Comp.FrictionModifier);
-        ev.ModifyAcceleration(ent.Comp.AccelerationModifier);
-        args.Args = ev;
+        args.ModifyFriction(ent.Comp.FrictionModifier);
+        args.ModifyAcceleration(ent.Comp.AccelerationModifier);
     }
 
-    private void OnRefreshTileFrictionStatus(Entity<FrictionStatusEffectComponent> ent, ref StatusEffectRelayedEvent<TileFrictionEvent> args)
+    [SubscribeLocalEvent]
+    private void OnRefreshTileFrictionStatus(Entity<FrictionStatusEffectComponent> ent, ref TileFrictionEvent args)
     {
-        var ev = args.Args;
-        ev.Modifier *= ent.Comp.FrictionModifier;
-        args.Args = ev;
+        args.Modifier *= ent.Comp.FrictionModifier;
     }
 
     /// <summary>

--- a/Content.Shared/NightVision/SharedNightVisionSystem.cs
+++ b/Content.Shared/NightVision/SharedNightVisionSystem.cs
@@ -25,12 +25,12 @@ public abstract partial class SharedNightVisionSystem : EntitySystem
     }
 
     [SubscribeLocalEvent]
-    private void OnRefreshStatusEffect(Entity<NightVisionComponent> ent, ref StatusEffectRelayedEvent<RefreshNightVisionEvent> args)
+    private void OnRefreshStatusEffect(Entity<NightVisionComponent> ent, ref RefreshNightVisionEvent args)
     {
         if (!ent.Comp.Enabled)
             return;
 
-        args.Args.Entities.Add(ent);
+        args.Entities.Add(ent);
     }
 
     [SubscribeLocalEvent]

--- a/Content.Shared/NightVision/SharedNightVisionSystem.cs
+++ b/Content.Shared/NightVision/SharedNightVisionSystem.cs
@@ -25,15 +25,6 @@ public abstract partial class SharedNightVisionSystem : EntitySystem
     }
 
     [SubscribeLocalEvent]
-    private void OnRefreshStatusEffect(Entity<NightVisionComponent> ent, ref RefreshNightVisionEvent args)
-    {
-        if (!ent.Comp.Enabled)
-            return;
-
-        args.Entities.Add(ent);
-    }
-
-    [SubscribeLocalEvent]
     private void OnRemove(Entity<NightVisionComponent> ent, ref ComponentShutdown args)
     {
         if (ent.Comp.RelayOverlay)
@@ -63,13 +54,13 @@ public abstract partial class SharedNightVisionSystem : EntitySystem
     }
 
     [SubscribeLocalEvent]
-    protected virtual void OnRefreshEquipmentHud(Entity<NightVisionComponent> ent, ref InventoryRelayedEvent<RefreshNightVisionEvent> args)
+    private void OnRefreshEquipmentHud(Entity<NightVisionComponent> ent, ref InventoryRelayedEvent<RefreshNightVisionEvent> args)
     {
         OnRefreshComponentHud(ent, ref args.Args);
     }
 
     [SubscribeLocalEvent]
-    protected virtual void OnRefreshComponentHud(Entity<NightVisionComponent> ent, ref RefreshNightVisionEvent args)
+    private void OnRefreshComponentHud(Entity<NightVisionComponent> ent, ref RefreshNightVisionEvent args)
     {
         if (!ent.Comp.Enabled)
             return;

--- a/Content.Shared/Speech/EntitySystems/RelayAccentSystem.cs
+++ b/Content.Shared/Speech/EntitySystems/RelayAccentSystem.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Inventory;
 using Content.Shared.Speech.Components;
-using Content.Shared.StatusEffectNew;
 
 namespace Content.Shared.Speech.EntitySystems;
 
@@ -34,7 +33,6 @@ public abstract class RelayAccentSystem<T> : EntitySystem where T : BaseAccentCo
     {
         SubscribeLocalEvent<T, AccentGetEvent>(OnAccent, before: AccentBefore, after: AccentAfter);
         SubscribeLocalEvent<T, InventoryRelayedEvent<AccentGetEvent>>(OnInventoryRelayAccent, before: RelayAccentBefore, after: RelayAccentAfter);
-        SubscribeLocalEvent<T, StatusEffectRelayedEvent<AccentGetEvent>>(OnStatusEffectRelayAccent, before: RelayAccentBefore, after: RelayAccentAfter);
     }
 
     protected virtual void OnInventoryRelayAccent(Entity<T> ent, ref InventoryRelayedEvent<AccentGetEvent> args)
@@ -43,13 +41,6 @@ public abstract class RelayAccentSystem<T> : EntitySystem where T : BaseAccentCo
             return;
 
         OnAccent(ent, ref args.Args);
-    }
-
-    protected virtual void OnStatusEffectRelayAccent(Entity<T> ent, ref StatusEffectRelayedEvent<AccentGetEvent> args)
-    {
-        var ev = args.Args;
-        OnAccent(ent, ref ev);
-        args.Args = ev;
     }
 
     protected virtual void OnAccent(Entity<T> ent, ref AccentGetEvent args)

--- a/Content.Shared/Speech/Muting/MutedStatusEffectSystem.cs
+++ b/Content.Shared/Speech/Muting/MutedStatusEffectSystem.cs
@@ -1,7 +1,6 @@
 using Content.Shared.Chat;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Popups;
-using Content.Shared.StatusEffectNew;
 
 namespace Content.Shared.Speech.Muting;
 
@@ -12,44 +11,38 @@ public sealed partial class MutedStatusEffectSystem : EntitySystem
 {
     [Dependency] private SharedPopupSystem _popup = default!;
 
-    /// <inheritdoc />
-    public override void Initialize()
+    [SubscribeLocalEvent]
+    private void OnEmote(Entity<MutedStatusEffectComponent> ent, ref EmoteEvent args)
     {
-        SubscribeLocalEvent<MutedStatusEffectComponent, StatusEffectRelayedEvent<SpeakAttemptEvent>>(OnSpeakAttempt);
-        SubscribeLocalEvent<MutedStatusEffectComponent, StatusEffectRelayedEvent<EmoteEvent>>(OnEmote);
-        SubscribeLocalEvent<MutedStatusEffectComponent, StatusEffectRelayedEvent<EmoteActionEvent>>(OnEmoteAction);
-    }
-
-    private void OnEmote(Entity<MutedStatusEffectComponent> ent, ref StatusEffectRelayedEvent<EmoteEvent> args)
-    {
-        if (args.Args.Handled)
+        if (args.Handled)
             return;
 
         // Still leaves the text so it looks like they are pantomiming a laugh.
-        if (args.Args.Emote.Category.HasFlag(EmoteCategory.Vocal))
+        if (args.Emote.Category.HasFlag(EmoteCategory.Vocal))
         {
-            args.Args = args.Args with { Handled = true };
+            args.Handled = true;
         }
     }
 
-    private void OnEmoteAction(Entity<MutedStatusEffectComponent> ent, ref StatusEffectRelayedEvent<EmoteActionEvent> args)
+    [SubscribeLocalEvent]
+    private void OnEmoteAction(Entity<MutedStatusEffectComponent> ent, ref EmoteActionEvent args)
     {
-        if (args.Args.Handled)
+        if (args.Handled)
             return;
 
-        _popup.PopupEntity(Loc.GetString(ent.Comp.ActionPopup), args.AppliedTo, args.AppliedTo);
-        args.Args.Handled = true;
+        var user = args.Performer;
+        _popup.PopupEntity(Loc.GetString(ent.Comp.ActionPopup), user, user);
+        args.Handled = true;
     }
 
-    private void OnSpeakAttempt(Entity<MutedStatusEffectComponent> ent, ref StatusEffectRelayedEvent<SpeakAttemptEvent> args)
+    [SubscribeLocalEvent]
+    private void OnSpeakAttempt(Entity<MutedStatusEffectComponent> ent, ref SpeakAttemptEvent args)
     {
-        if (args.Args.Cancelled)
+        if (args.Cancelled)
             return;
 
-        var target = args.Args.Uid;
-
+        var target = args.Uid;
         _popup.PopupEntity(Loc.GetString(ent.Comp.SpeakPopup), target, target);
-
-        args.Args.Cancel();
+        args.Cancel();
     }
 }

--- a/Content.Shared/StatusEffectNew/ExaminableStatusEffectSystem.cs
+++ b/Content.Shared/StatusEffectNew/ExaminableStatusEffectSystem.cs
@@ -10,11 +10,11 @@ namespace Content.Shared.StatusEffectNew;
 public sealed partial class ExaminableStatusEffectSystem : EntitySystem
 {
     [SubscribeLocalEvent]
-    private void OnExaminedEvent(Entity<ExaminableStatusEffectComponent> ent, ref StatusEffectRelayedEvent<ExaminedEvent> args)
+    private void OnExaminedEvent(Entity<ExaminableStatusEffectComponent> ent, ref ExaminedEvent args)
     {
-        using (args.Args.PushGroup(nameof(ExaminableStatusEffectSystem)))
+        using (args.PushGroup(nameof(ExaminableStatusEffectSystem)))
         {
-            args.Args.PushMarkup(Loc.GetString(ent.Comp.MessageId, ("target", Identity.Entity(args.AppliedTo, EntityManager))));
+            args.PushMarkup(Loc.GetString(ent.Comp.MessageId, ("target", Identity.Entity(args.Examined, EntityManager))));
         }
     }
 }

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -88,20 +88,15 @@ public sealed partial class StatusEffectsSystem
 
     public void RelayEvent<T>(Entity<StatusEffectContainerComponent> statusEffect, ref T args) where T : struct
     {
-        if(statusEffect.Comp.ActiveStatusEffects?.ContainedEntities is not {} originalCollection || originalCollection.Count == 0)
+        if (statusEffect.Comp.ActiveStatusEffects?.ContainedEntities is not {} originalCollection || originalCollection.Count == 0)
             return;
-
-        // this copies the by-ref event if it is a struct
-        var ev = new StatusEffectRelayedEvent<T>(args, statusEffect);
 
         // Prevent a collection modified enumeration error by copying the list in case a status adds another status
         var list = new ValueList<EntityUid>(originalCollection);
         foreach (var activeEffect in list)
         {
-            RaiseLocalEvent(activeEffect, ref ev);
+            RaiseLocalEvent(activeEffect, ref args);
         }
-        // and now we copy it back
-        args = ev.Args;
     }
 
     public void RelayEvent<T>(Entity<StatusEffectContainerComponent> statusEffect, T args) where T : class
@@ -109,20 +104,11 @@ public sealed partial class StatusEffectsSystem
         if (statusEffect.Comp.ActiveStatusEffects?.ContainedEntities is not { } originalCollection || originalCollection.Count == 0)
             return;
 
-        // this copies the by-ref event if it is a struct
-        var ev = new StatusEffectRelayedEvent<T>(args, statusEffect);
-
         // Prevent a collection modified enumeration error by copying the list in case a status adds another status
         var list = new ValueList<EntityUid>(originalCollection);
         foreach (var activeEffect in list)
         {
-            RaiseLocalEvent(activeEffect, ref ev);
+            RaiseLocalEvent(activeEffect, args);
         }
     }
 }
-
-/// <summary>
-/// Event wrapper for relayed events.
-/// </summary>
-[ByRefEvent]
-public record struct StatusEffectRelayedEvent<TEvent>(TEvent Args, EntityUid AppliedTo);

--- a/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
@@ -31,8 +31,6 @@ public sealed partial class StatusEffectsSystem : EntitySystem
         SubscribeLocalEvent<StatusEffectContainerComponent, ComponentShutdown>(OnStatusContainerShutdown);
         SubscribeLocalEvent<StatusEffectContainerComponent, EntInsertedIntoContainerMessage>(OnEntityInserted);
         SubscribeLocalEvent<StatusEffectContainerComponent, EntRemovedFromContainerMessage>(OnEntityRemoved);
-
-        SubscribeLocalEvent<RejuvenateRemovedStatusEffectComponent, StatusEffectRelayedEvent<RejuvenateEvent>>(OnRejuvenate);
     }
 
     public override void Update(float frameTime)
@@ -113,8 +111,8 @@ public sealed partial class StatusEffectsSystem : EntitySystem
         Dirty(args.Entity, statusComp);
     }
 
-    private void OnRejuvenate(Entity<RejuvenateRemovedStatusEffectComponent> ent,
-        ref StatusEffectRelayedEvent<RejuvenateEvent> args)
+    [SubscribeLocalEvent]
+    private void OnRejuvenate(Entity<RejuvenateRemovedStatusEffectComponent> ent, ref RejuvenateEvent args)
     {
         PredictedQueueDel(ent.Owner);
     }

--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -60,14 +60,6 @@ public abstract partial class SharedStunSystem : EntitySystem
         SubscribeLocalEvent<StunnedComponent, IsUnequippingAttemptEvent>(OnUnequipAttempt);
         SubscribeLocalEvent<MobStateComponent, MobStateChangedEvent>(OnMobStateChanged);
 
-        // New Status Effect subscriptions
-        SubscribeLocalEvent<StunnedStatusEffectComponent, StatusEffectAppliedEvent>(OnStunStatusApplied);
-        SubscribeLocalEvent<StunnedStatusEffectComponent, StatusEffectRemovedEvent>(OnStunStatusRemoved);
-        SubscribeLocalEvent<StunnedStatusEffectComponent, StatusEffectRelayedEvent<StunEndAttemptEvent>>(OnStunEndAttempt);
-
-        SubscribeLocalEvent<KnockdownStatusEffectComponent, StatusEffectAppliedEvent>(OnKnockdownStatusApplied);
-        SubscribeLocalEvent<KnockdownStatusEffectComponent, StatusEffectRelayedEvent<StandUpAttemptEvent>>(OnStandUpAttempt);
-
         // Stun Appearance Data
         InitializeKnockdown();
         InitializeAppearance();
@@ -333,6 +325,7 @@ public abstract partial class SharedStunSystem : EntitySystem
         return !ev.Cancelled && RemComp<StunnedComponent>(entity);
     }
 
+    [SubscribeLocalEvent]
     private void OnStunStatusApplied(Entity<StunnedStatusEffectComponent> entity, ref StatusEffectAppliedEvent args)
     {
         if (GameTiming.ApplyingState)
@@ -341,21 +334,19 @@ public abstract partial class SharedStunSystem : EntitySystem
         EnsureComp<StunnedComponent>(args.Target);
     }
 
+    [SubscribeLocalEvent]
     private void OnStunStatusRemoved(Entity<StunnedStatusEffectComponent> entity, ref StatusEffectRemovedEvent args)
     {
         TryUnstun(args.Target);
     }
 
-    private void OnStunEndAttempt(Entity<StunnedStatusEffectComponent> entity, ref StatusEffectRelayedEvent<StunEndAttemptEvent> args)
+    [SubscribeLocalEvent]
+    private void OnStunEndAttempt(Entity<StunnedStatusEffectComponent> entity, ref StunEndAttemptEvent args)
     {
-        if (args.Args.Cancelled)
-            return;
-
-        var ev = args.Args;
-        ev.Cancelled = true;
-        args.Args = ev;
+        args.Cancelled = true;
     }
 
+    [SubscribeLocalEvent]
     private void OnKnockdownStatusApplied(Entity<KnockdownStatusEffectComponent> entity, ref StatusEffectAppliedEvent args)
     {
         if (GameTiming.ApplyingState)
@@ -368,14 +359,10 @@ public abstract partial class SharedStunSystem : EntitySystem
             Knockdown(args.Target, null, true, true, drop: entity.Comp.Drop);
     }
 
-    private void OnStandUpAttempt(Entity<KnockdownStatusEffectComponent> entity, ref StatusEffectRelayedEvent<StandUpAttemptEvent> args)
+    [SubscribeLocalEvent]
+    private void OnStandUpAttempt(Entity<KnockdownStatusEffectComponent> entity, ref StandUpAttemptEvent args)
     {
-        if (args.Args.Cancelled)
-            return;
-
-        var ev = args.Args;
-        ev.Cancelled = true;
-        args.Args = ev;
+        args.Cancelled = true;
     }
 
     #region Attempt Event Handling

--- a/Content.Shared/Throwing/CatchAttemptEvent.cs
+++ b/Content.Shared/Throwing/CatchAttemptEvent.cs
@@ -4,4 +4,4 @@ namespace Content.Shared.Throwing;
 /// Raised on someone when they try to catch an item.
 /// </summary>
 [ByRefEvent]
-public record struct CatchAttemptEvent(EntityUid Item, float CatchChance, bool Cancelled = false);
+public record struct CatchAttemptEvent(EntityUid User, EntityUid Item, float CatchChance, bool Cancelled = false);

--- a/Content.Shared/Throwing/CatchableSystem.cs
+++ b/Content.Shared/Throwing/CatchableSystem.cs
@@ -46,7 +46,7 @@ public sealed partial class CatchableSystem : EntitySystem
         if (!_whitelist.IsWhitelistPassOrNull(ent.Comp.CatcherWhitelist, args.Target))
             return;
 
-        var attemptEv = new CatchAttemptEvent(ent.Owner, ent.Comp.CatchChance);
+        var attemptEv = new CatchAttemptEvent(args.Target, ent.Owner, ent.Comp.CatchChance);
         RaiseLocalEvent(args.Target, ref attemptEv);
 
         if (attemptEv.Cancelled)

--- a/Content.Shared/Traits/Assorted/HemophiliaSystem.cs
+++ b/Content.Shared/Traits/Assorted/HemophiliaSystem.cs
@@ -1,20 +1,13 @@
-﻿using Content.Shared.Body.Events;
-using Content.Shared.StatusEffectNew;
+using Content.Shared.Body.Events;
 
 namespace Content.Shared.Traits.Assorted;
 
 public sealed partial class HemophiliaSystem : EntitySystem
 {
-    public override void Initialize()
+    [SubscribeLocalEvent]
+    private void OnBleedModifier(Entity<HemophiliaStatusEffectComponent> ent, ref BleedModifierEvent args)
     {
-        SubscribeLocalEvent<HemophiliaStatusEffectComponent, StatusEffectRelayedEvent<BleedModifierEvent>>(OnBleedModifier);
-    }
-
-    private void OnBleedModifier(Entity<HemophiliaStatusEffectComponent> ent, ref StatusEffectRelayedEvent<BleedModifierEvent> args)
-    {
-        var ev = args.Args;
-        ev.BleedReductionAmount *= ent.Comp.BleedReductionMultiplier;
-        ev.BleedAmount *= ent.Comp.BleedAmountMultiplier;
-        args.Args = ev;
+        args.BleedReductionAmount *= ent.Comp.BleedReductionMultiplier;
+        args.BleedAmount *= ent.Comp.BleedAmountMultiplier;
     }
 }

--- a/Content.Shared/Traits/Assorted/PainNumbnessSystem.cs
+++ b/Content.Shared/Traits/Assorted/PainNumbnessSystem.cs
@@ -8,41 +8,37 @@ namespace Content.Shared.Traits.Assorted;
 
 public sealed partial class PainNumbnessSystem : EntitySystem
 {
-    [Dependency] private MobThresholdSystem _mobThresholdSystem = default!;
+    [Dependency] private MobThresholdSystem _threshold = default!;
 
-    public override void Initialize()
-    {
-        SubscribeLocalEvent<PainNumbnessStatusEffectComponent, StatusEffectAppliedEvent>(OnEffectApplied);
-        SubscribeLocalEvent<PainNumbnessStatusEffectComponent, StatusEffectRemovedEvent>(OnEffectRemoved);
-        SubscribeLocalEvent<PainNumbnessStatusEffectComponent, StatusEffectRelayedEvent<BeforeForceSayEvent>>(OnChangeForceSay);
-        SubscribeLocalEvent<PainNumbnessStatusEffectComponent, StatusEffectRelayedEvent<BeforeAlertSeverityCheckEvent>>(OnAlertSeverityCheck);
-    }
-
+    [SubscribeLocalEvent]
     private void OnEffectApplied(Entity<PainNumbnessStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
     {
         if (!HasComp<MobThresholdsComponent>(args.Target))
             return;
 
-        _mobThresholdSystem.VerifyThresholds(args.Target);
+        _threshold.VerifyThresholds(args.Target);
     }
 
+    [SubscribeLocalEvent]
     private void OnEffectRemoved(Entity<PainNumbnessStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
     {
         if (!HasComp<MobThresholdsComponent>(args.Target))
             return;
 
-        _mobThresholdSystem.VerifyThresholds(args.Target);
+        _threshold.VerifyThresholds(args.Target);
     }
 
-    private void OnChangeForceSay(Entity<PainNumbnessStatusEffectComponent> ent, ref StatusEffectRelayedEvent<BeforeForceSayEvent> args)
+    [SubscribeLocalEvent]
+    private void OnChangeForceSay(Entity<PainNumbnessStatusEffectComponent> ent, ref BeforeForceSayEvent args)
     {
-        if (ent.Comp.ForceSayNumbDataset != null)
-            args.Args.Prefix = ent.Comp.ForceSayNumbDataset.Value;
+        if (ent.Comp.ForceSayNumbDataset is { } dataset)
+            args.Prefix = dataset;
     }
 
-    private void OnAlertSeverityCheck(Entity<PainNumbnessStatusEffectComponent> ent, ref StatusEffectRelayedEvent<BeforeAlertSeverityCheckEvent> args)
+    [SubscribeLocalEvent]
+    private void OnAlertSeverityCheck(Entity<PainNumbnessStatusEffectComponent> ent, ref BeforeAlertSeverityCheckEvent args)
     {
-        if (args.Args.CurrentAlert == "HumanHealth")
-            args.Args.CancelUpdate = true;
+        if (args.CurrentAlert == "HumanHealth")
+            args.CancelUpdate = true;
     }
 }


### PR DESCRIPTION
## About the PR
title

there are no cases where a status effect entity is used besides status effects, and if you are insane you can just check `if (ent.Owner != args.User)` or whatever if you want to use events on the effects themselves and behave differently from the relay.

## Why / Balance
- its so bad and bug bait with struct events which should always be used
- false sense of security, just using the StatusEffectRelay type has no guarantee it's actually relayed so you get no benefit
- literally no reason to exist. if you want the entity it's applied to, store it on the event which makes it more robust for everything else too

if you gave a status effect ArmorComponent which would you want more: 
- it protects the status effect from damage, but the status effect can't even take damage anyway
- it protects the effect target automatically just werks

## Technical details
- killed it lol
- no more `ev = args.Args; args.Args = ev;` slop
- `IgnoreSlowOnDamageComponent` now cancels the event instead of relying on no other system changing speed from 1f
- added User to catching event

## Test plan
Content.IntegrationTests

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
Removed `StatusEffectRelayedEvent`, events are raised on the status effects directly now.
If you relied on `AppliedTo` to get the original target of your event, add it to the event instead.

## Changelog