### PR TITLE
move xenoborg mindrole/briefing definitions from XenoborgComponent into XenoborgSystem (#45941)

### DIFF
--- a/Content.Server/Xenoborgs/XenoborgSystem.cs
+++ b/Content.Server/Xenoborgs/XenoborgSystem.cs
@@ -3,7 +3,6 @@ using Content.Server.GameTicking.Rules;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Silicons.Borgs;
 using Content.Shared.Destructible;
-using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Roles;
 using Content.Shared.Roles.Components;
@@ -11,6 +10,7 @@ using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared.Xenoborgs.Components;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Xenoborgs;
 
@@ -22,6 +22,18 @@ public sealed partial class XenoborgSystem : EntitySystem
     [Dependency] private XenoborgsRuleSystem _xenoborgsRule = default!;
 
     private static readonly Color XenoborgBriefingColor = Color.BlueViolet;
+    /// <summary>
+    /// The mindrole associated with the xenoborg
+    /// </summary>
+    private static readonly EntProtoId<MindRoleComponent> MindRoleXenoborg = "MindRoleXenoborg";
+    /// <summary>
+    /// The text that is sent when you become a xenoborg
+    /// </summary>
+    private static readonly LocId BriefingTextXenoborg = "xenoborgs-welcome";
+    /// <summary>
+    /// Briefing sound when you become a xenoborg
+    /// </summary>
+    private static readonly SoundSpecifier BriefingSoundXenoborg = new SoundPathSpecifier("/Audio/Ambience/Antag/xenoborg_start.ogg");
 
     public override void Initialize()
     {
@@ -82,15 +94,15 @@ public sealed partial class XenoborgSystem : EntitySystem
 
     private void OnXenoborgMindAdded(EntityUid ent, XenoborgComponent comp, MindAddedMessage args)
     {
-        _roles.MindAddRole(args.Mind, comp.MindRole, silent: true);
+        _roles.MindAddRole(args.Mind, MindRoleXenoborg, silent: true);
 
         if (!TryComp<ActorComponent>(ent, out var actorComp))
             return;
 
         _antag.SendBriefing(actorComp.PlayerSession,
-            Loc.GetString(comp.BriefingText),
+            Loc.GetString(BriefingTextXenoborg),
             XenoborgBriefingColor,
-            comp.BriefingSound
+            BriefingSoundXenoborg
         );
     }
 
@@ -98,6 +110,6 @@ public sealed partial class XenoborgSystem : EntitySystem
     {
         // We don't need to update the mind if the mind is being fully detached!
         if (args.TransferEntity != null)
-            _roles.MindRemoveRole(args.Mind.Owner, comp.MindRole);
+            _roles.MindRemoveRole(args.Mind.Owner, MindRoleXenoborg);
     }
 }

--- a/Content.Shared/Xenoborgs/Components/XenoborgComponent.cs
+++ b/Content.Shared/Xenoborgs/Components/XenoborgComponent.cs
@@ -1,7 +1,3 @@
-using Content.Shared.Roles.Components;
-using Robust.Shared.Audio;
-using Robust.Shared.Prototypes;
-
 namespace Content.Shared.Xenoborgs.Components;
 
 /// <summary>
@@ -10,23 +6,4 @@ namespace Content.Shared.Xenoborgs.Components;
 /// It's also used by the mothership core
 /// </summary>
 [RegisterComponent]
-public sealed partial class XenoborgComponent : Component
-{
-    /// <summary>
-    /// The mindrole associated with the xenoborg
-    /// </summary>
-    [DataField]
-    public EntProtoId<MindRoleComponent> MindRole = "MindRoleXenoborg";
-
-    /// <summary>
-    /// The text that is sent when you become a xenoborg
-    /// </summary>
-    [DataField]
-    public LocId BriefingText = "xenoborgs-welcome";
-
-    /// <summary>
-    /// Briefing sound when you become a xenoborg
-    /// </summary>
-    [DataField]
-    public SoundSpecifier BriefingSound = new SoundPathSpecifier("/Audio/Ambience/Antag/xenoborg_start.ogg");
-}
+public sealed partial class XenoborgComponent : Component;


### PR DESCRIPTION
Resolves #45941

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
* saw #45941
* moved the hardcoded mindrole/briefing info for the xenoborgs off the `XenoborgComponent` (where they are duplicated on every single xenoborg) into the `XenoborgSystem`
  * the other conversion antagonists (revs, zombies) seem to have their briefings/mindroles hardcoded into their conversion systems as well - doesn't seem possible to pass this in via an AntagSpecifier or something without a major overhaul of how the conversion system works. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
* I _think_ this is what was requested in #45941
  * I looked into adding the briefing data to the `Xenoborg` AntagSpecifier in `Resources/Prototypes/Roles/Antags/xenoborgs.yml`, and loading it in from one of those when needed - adds extra boilerplate, not sure if it would be desirable or not. this PR doesn't use that approach, for simplicity.

## Technical details
<!-- Summary of code changes for easier review. -->
* removed the public `MindRole`, `BriefingText`, `BriefingSound` fields from `XenoborgComponent.cs`
* moved them to private readonly fields in `Content.Server/Xenoborgs/XenoborgSystem.cs`

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
* automated tests should still pass
* xenoborgs still get the briefing when they spawn in/get converted

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
* `XenoborgComponent.cs`
  * removed all fields (`MindRole`, `BriefingText`, `BriefingSound`)
  * they're now declared in `Content.Server.Xenoborgs.XenoborgSystem`

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
<!--
:cl:
- add: Crowbars now randomly spawn in maintenance lockers.
- remove: Crowbars no longer spawn in maintenance crates.
- tweak: Crowbar spawn rates have been increased for tool lockers.
- fix: Crowbars no longer accidentally spawn in microwaves.
-->
