### PR TITLE
Fixed non-en-US locales failing to compile, fixed unhelpful warnings from missing MAKEPLURAL and MANY functions

### DIFF
--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -40,6 +40,8 @@ namespace Content.Shared.Localizations
             _loc.AddFunction(culture, "NATURALPERCENT", FormatNaturalPercent);
             _loc.AddFunction(culture, "PLAYTIME", FormatPlaytime);
 
+            _loc.AddFunction(culture, "MAKEPLURAL", FormatMakePlural);
+            _loc.AddFunction(culture, "MANY", FormatMany);
 
             /*
              * The following language functions are specific to the english localization. When working on your own
@@ -48,6 +50,10 @@ namespace Content.Shared.Localizations
              */
             var cultureEn = new CultureInfo("en-US");
 
+            if (culture.Name != cultureEn.Name)
+            {
+                _loc.LoadCulture(cultureEn);
+            }
             _loc.AddFunction(cultureEn, "MAKEPLURAL", FormatMakePlural);
             _loc.AddFunction(cultureEn, "MANY", FormatMany);
         }


### PR DESCRIPTION
Fixed the server failing to compile with a culture other than en-US, silenced unhelpful warnings due to missing functions.

## About the PR
I've added a LoadCulture function call that explicitly loads the en-US fallback locale if it's not already loaded; it appears that before it relied entirely on the existing loaded culture being en-US, which would lead to a failure to compile the project.
I've added the registration of MAKEPLURAL and MANY functions with the localization system for the default (auto-initialized) culture, as otherwise the server would spam a bunch of unhelpful warnings about MANY() function being missing, despite the localization files it mentions not having a single call to those - probably something deeper in how it parses. I didn't investigate further.

## Why / Balance
This is probably a very silly oversight.
Having a functional localization system at the source, this repository, is going to go a long way in making other localization projects reliably and predictably maintainable.
Furthermore, there's a comment inviting one to just change a single string to change the entire project's localization, but unfortunately it just leads to failures to build.

## Technical details
If en-US culture isn't actually loaded, load it so it's visible to the localization system.
Register MANY and MAKEPLURAL formatting functions so they don't spawn irrelevant warnings - though this probably warrants a deeper investigation and a more comprehensive fix.

## Test plan
Before PR:
1. In Resources/Locale, copy and paste the en-US localization directory, rename it to a different language-REGION BCP 47 code - such as ja-JP. 
2. Change an easily verifiable string to make sure you're running the correct locale - Locale/ja-JP/examine/examine-system.ftl, examine-verb-name is a good candidate to change "Examine" to "Take a look".
3. In /Content.Shared/Localizations/ContentLocalizationManager.cs, change the string literal in `private const string Culture = "en-US";` to your new language-REGION code.
4. Try compiling and running the server. It will fail to build.
5. Apply the fix with the LoadCulture:
6. The server will compile, but will warn that it cannot find MANY() function for several of the locale files.
7. Apply the fix that registers MANY and MAKEPLURAL for the project-wide culture. By now the entire commit is applied:
8. The server builds and doesn't spam unhelpful warnings. 

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
As far as I'm aware, this shouldn't break anything. This patch works whether the locale is the default en-US, or something different (where it'd fail to build before).
However, I did mention that I silenced some warnings that made no sense - it probably warrants a deeper investigation eventually, into the core of the localization parsing system.

## Changelog
This only affects downstream localization developers and has no relevance for players. 
