### PR TITLE
LitOnPowered & AmbientOnPowered update on init

### DIFF
--- a/Content.Server/Audio/AmbientSoundSystem.cs
+++ b/Content.Server/Audio/AmbientSoundSystem.cs
@@ -8,11 +8,19 @@ namespace Content.Server.Audio;
 
 public sealed partial class AmbientSoundSystem : SharedAmbientSoundSystem
 {
+    [Dependency] private PowerReceiverSystem _powerReceiver = default!;
+
     public override void Initialize()
     {
         base.Initialize();
+        SubscribeLocalEvent<AmbientOnPoweredComponent, MapInitEvent>(HandleMapInit);
         SubscribeLocalEvent<AmbientOnPoweredComponent, PowerChangedEvent>(HandlePowerChange);
         SubscribeLocalEvent<AmbientOnPoweredComponent, PowerNetBatterySupplyEvent>(HandlePowerSupply);
+    }
+
+    private void HandleMapInit(EntityUid uid, AmbientOnPoweredComponent component, MapInitEvent args)
+    {
+        SetAmbience(uid, _powerReceiver.IsPowered(uid));
     }
 
     private void HandlePowerSupply(EntityUid uid, AmbientOnPoweredComponent component, ref PowerNetBatterySupplyEvent args)

--- a/Content.Server/Light/EntitySystems/LitOnPoweredSystem.cs
+++ b/Content.Server/Light/EntitySystems/LitOnPoweredSystem.cs
@@ -1,5 +1,4 @@
 using Content.Server.Light.Components;
-using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.Power;
 
@@ -8,27 +7,36 @@ namespace Content.Server.Light.EntitySystems
     public sealed partial class LitOnPoweredSystem : EntitySystem
     {
         [Dependency] private SharedPointLightSystem _lights = default!;
+        [Dependency] private PowerReceiverSystem _powerReceiver = default!;
 
         public override void Initialize()
         {
             base.Initialize();
+            SubscribeLocalEvent<LitOnPoweredComponent, MapInitEvent>(OnMapInit);
             SubscribeLocalEvent<LitOnPoweredComponent, PowerChangedEvent>(OnPowerChanged);
             SubscribeLocalEvent<LitOnPoweredComponent, PowerNetBatterySupplyEvent>(OnPowerSupply);
         }
 
+        private void OnMapInit(EntityUid uid, LitOnPoweredComponent component, MapInitEvent args)
+        {
+            SetLit(uid, _powerReceiver.IsPowered(uid));
+        }
+
         private void OnPowerChanged(EntityUid uid, LitOnPoweredComponent component, ref PowerChangedEvent args)
         {
-            if (_lights.TryGetLight(uid, out var light))
-            {
-                _lights.SetEnabled(uid, args.Powered, light);
-            }
+            SetLit(uid, args.Powered);
         }
 
         private void OnPowerSupply(EntityUid uid, LitOnPoweredComponent component, ref PowerNetBatterySupplyEvent args)
         {
+            SetLit(uid, args.Supply);
+        }
+
+        private void SetLit(EntityUid uid, bool lit)
+        {
             if (_lights.TryGetLight(uid, out var light))
             {
-                _lights.SetEnabled(uid, args.Supply, light);
+                _lights.SetEnabled(uid, lit, light);
             }
         }
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
A minor fix. The LitOnPowered and AmbientOnPowered components now also update their state during initialization. This prevents situations where a device that has been powered off continues to light up and play sounds from the very start, until the first power update.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
