### PR TITLE
Teleportation rework. Part 1:Introduction

### DIFF
--- a/Content.Server/Teleportation/HandTeleporterPortalComponent.cs
+++ b/Content.Server/Teleportation/HandTeleporterPortalComponent.cs
@@ -1,0 +1,15 @@
+namespace Content.Server.Teleportation;
+
+/// <summary>
+/// Marks a hand teleporter portal that closes when its supporting tile is removed,
+/// even if the device that created it no longer exists.
+/// </summary>
+[RegisterComponent]
+public sealed partial class HandTeleporterPortalComponent : Component
+{
+    /// <summary>
+    /// The creating device, used to clear its portal references when it still exists.
+    /// </summary>
+    [DataField]
+    public EntityUid Teleporter;
+}

--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -20,6 +20,7 @@ public sealed partial class HandTeleporterSystem : EntitySystem
     [Dependency] private AudioSystem _audio = default!;
     [Dependency] private SharedDoAfterSystem _doafter = default!;
     [Dependency] private PopupSystem _popup = default!;
+    [Dependency] private SharedPortalSystem _portal = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -122,9 +123,8 @@ public sealed partial class HandTeleporterSystem : EntitySystem
             if (xform.ParentUid != xform.GridUid)
                 return;
 
-            var timeout = EnsureComp<PortalTimeoutComponent>(user);
-            timeout.EnteredPortal = null;
             component.FirstPortal = Spawn(component.FirstPortalPrototype, Transform(user).Coordinates);
+            _portal.SetPortalTimeout(user, component.FirstPortal.Value);
             Dirty(uid, component);
 
             if (component.AllowPortalsOnDifferentMaps && TryComp<PortalComponent>(component.FirstPortal, out var portal))
@@ -145,9 +145,8 @@ public sealed partial class HandTeleporterSystem : EntitySystem
                 return;
             }
 
-            var timeout = EnsureComp<PortalTimeoutComponent>(user);
-            timeout.EnteredPortal = null;
             component.SecondPortal = Spawn(component.SecondPortalPrototype, Transform(user).Coordinates);
+            _portal.SetPortalTimeout(user, component.SecondPortal.Value);
             Dirty(uid, component);
 
             if (component.AllowPortalsOnDifferentMaps && TryComp<PortalComponent>(component.SecondPortal, out var portal))

--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -41,7 +41,10 @@ public sealed partial class HandTeleporterSystem : EntitySystem
 
     private void OnDoAfter(EntityUid uid, HandTeleporterComponent component, DoAfterEvent args)
     {
-        if (args.Cancelled || args.Handled)
+        if (args.Cancelled)
+            return;
+
+        if (args.Handled)
             return;
 
         HandlePortalUpdating(uid, component, args.Args.User);
@@ -66,23 +69,22 @@ public sealed partial class HandTeleporterSystem : EntitySystem
         {
             // handle removing portals immediately as opposed to a doafter
             HandlePortalUpdating(uid, component, args.User);
+            args.Handled = true;
+            return;
         }
-        else
+
+        var xform = Transform(args.User);
+        if (xform.ParentUid != xform.GridUid)
+            return;
+
+        var doafterArgs = new DoAfterArgs(EntityManager, args.User, component.PortalCreationDelay, new TeleporterDoAfterEvent(), uid, used: uid)
         {
-            var xform = Transform(args.User);
-            if (xform.ParentUid != xform.GridUid)
-                return;
+            BreakOnDamage = true,
+            BreakOnMove = true,
+            MovementThreshold = 0.5f,
+        };
 
-            var doafterArgs = new DoAfterArgs(EntityManager, args.User, component.PortalCreationDelay, new TeleporterDoAfterEvent(), uid, used: uid)
-            {
-                BreakOnDamage = true,
-                BreakOnMove = true,
-                MovementThreshold = 0.5f,
-            };
-
-            _doafter.TryStartDoAfter(doafterArgs);
-        }
-
+        _doafter.TryStartDoAfter(doafterArgs);
         args.Handled = true;
     }
 
@@ -93,7 +95,10 @@ public sealed partial class HandTeleporterSystem : EntitySystem
     private void CheckPortals(Entity<HandTeleporterComponent> entity)
     {
         // no need to check nothing if there aren't 2 portals
-        if (Deleted(entity.Comp.FirstPortal) || Deleted(entity.Comp.SecondPortal))
+        if (Deleted(entity.Comp.FirstPortal))
+            return;
+
+        if (Deleted(entity.Comp.SecondPortal))
             return;
 
         var portal1Xform = Transform(entity.Comp.FirstPortal!.Value);
@@ -102,7 +107,13 @@ public sealed partial class HandTeleporterSystem : EntitySystem
         var sameGrid = portal1Xform.GridUid == portal2Xform.GridUid;
         var sameMap = portal1Xform.MapID == portal2Xform.MapID;
 
-        if (!sameGrid && !entity.Comp.AllowPortalsOnDifferentGrids || !sameMap && !entity.Comp.AllowPortalsOnDifferentMaps)
+        if (!sameGrid && !entity.Comp.AllowPortalsOnDifferentGrids)
+        {
+            FizzlePortals(entity, null, false);
+            return;
+        }
+
+        if (!sameMap && !entity.Comp.AllowPortalsOnDifferentMaps)
             FizzlePortals(entity, null, false);
     }
 
@@ -116,50 +127,66 @@ public sealed partial class HandTeleporterSystem : EntitySystem
 
         var xform = Transform(user);
 
-        // Create the first portal.
         if (Deleted(component.FirstPortal) && Deleted(component.SecondPortal))
         {
-            // don't portal
-            if (xform.ParentUid != xform.GridUid)
-                return;
-
-            component.FirstPortal = Spawn(component.FirstPortalPrototype, Transform(user).Coordinates);
-            _portal.SetPortalTimeout(user, component.FirstPortal.Value);
-            Dirty(uid, component);
-
-            if (component.AllowPortalsOnDifferentMaps && TryComp<PortalComponent>(component.FirstPortal, out var portal))
-                portal.CanTeleportToOtherMaps = true;
-
-            _adminLogger.Add(LogType.EntitySpawn, LogImpact.High, $"{ToPrettyString(user):player} opened {ToPrettyString(component.FirstPortal.Value)} at {Transform(component.FirstPortal.Value).Coordinates} using {ToPrettyString(uid)}");
-            _audio.PlayPvs(component.NewPortalSound, uid);
+            CreateFirstPortal(uid, component, user, xform);
+            return;
         }
-        else if (Deleted(component.SecondPortal))
+
+        if (Deleted(component.SecondPortal))
         {
-            if (xform.ParentUid != xform.GridUid) // Still, don't portal.
-                return;
-
-            if (!component.AllowPortalsOnDifferentGrids && xform.ParentUid != Transform(component.FirstPortal!.Value).ParentUid)
-            {
-                // Whoops. Fizzle time. Crime time too because yippee I'm not refactoring this logic right now (I started to, I'm not going to.)
-                FizzlePortals((uid, component), user, true);
-                return;
-            }
-
-            component.SecondPortal = Spawn(component.SecondPortalPrototype, Transform(user).Coordinates);
-            _portal.SetPortalTimeout(user, component.SecondPortal.Value);
-            Dirty(uid, component);
-
-            if (component.AllowPortalsOnDifferentMaps && TryComp<PortalComponent>(component.SecondPortal, out var portal))
-                portal.CanTeleportToOtherMaps = true;
-
-            _adminLogger.Add(LogType.EntitySpawn, LogImpact.High, $"{ToPrettyString(user):player} opened {ToPrettyString(component.SecondPortal.Value)} at {Transform(component.SecondPortal.Value).Coordinates} linked to {ToPrettyString(component.FirstPortal!.Value)} using {ToPrettyString(uid)}");
-            _link.TryLink(component.FirstPortal!.Value, component.SecondPortal.Value, true);
-            _audio.PlayPvs(component.NewPortalSound, uid);
+            CreateSecondPortal(uid, component, user, xform);
+            return;
         }
-        else
+
+        FizzlePortals((uid, component), user, false);
+    }
+
+    private void CreateFirstPortal(EntityUid uid, HandTeleporterComponent component, EntityUid user, TransformComponent xform)
+    {
+        if (xform.ParentUid != xform.GridUid)
+            return;
+
+        component.FirstPortal = Spawn(component.FirstPortalPrototype, Transform(user).Coordinates);
+        _portal.SetPortalTimeout(user, component.FirstPortal.Value);
+        Dirty(uid, component);
+        ConfigurePortalMapTravel(component.FirstPortal, component);
+
+        _adminLogger.Add(LogType.EntitySpawn, LogImpact.High, $"{ToPrettyString(user):player} opened {ToPrettyString(component.FirstPortal.Value)} at {Transform(component.FirstPortal.Value).Coordinates} using {ToPrettyString(uid)}");
+        _audio.PlayPvs(component.NewPortalSound, uid);
+    }
+
+    private void CreateSecondPortal(EntityUid uid, HandTeleporterComponent component, EntityUid user, TransformComponent xform)
+    {
+        if (xform.ParentUid != xform.GridUid)
+            return;
+
+        if (!component.AllowPortalsOnDifferentGrids && xform.ParentUid != Transform(component.FirstPortal!.Value).ParentUid)
         {
-            FizzlePortals((uid, component), user, false);
+            // Whoops. Fizzle time. Crime time too because yippee I'm not refactoring this logic right now (I started to, I'm not going to.)
+            FizzlePortals((uid, component), user, true);
+            return;
         }
+
+        component.SecondPortal = Spawn(component.SecondPortalPrototype, Transform(user).Coordinates);
+        _portal.SetPortalTimeout(user, component.SecondPortal.Value);
+        Dirty(uid, component);
+        ConfigurePortalMapTravel(component.SecondPortal, component);
+
+        _adminLogger.Add(LogType.EntitySpawn, LogImpact.High, $"{ToPrettyString(user):player} opened {ToPrettyString(component.SecondPortal.Value)} at {Transform(component.SecondPortal.Value).Coordinates} linked to {ToPrettyString(component.FirstPortal!.Value)} using {ToPrettyString(uid)}");
+        _link.TryLink(component.FirstPortal!.Value, component.SecondPortal.Value, true);
+        _audio.PlayPvs(component.NewPortalSound, uid);
+    }
+
+    private void ConfigurePortalMapTravel(EntityUid? portal, HandTeleporterComponent component)
+    {
+        if (!component.AllowPortalsOnDifferentMaps)
+            return;
+
+        if (!TryComp<PortalComponent>(portal, out var portalComponent))
+            return;
+
+        portalComponent.CanTeleportToOtherMaps = true;
     }
 
     /// <summary>
@@ -170,19 +197,7 @@ public sealed partial class HandTeleporterSystem : EntitySystem
     /// <param name="instability">if it should send an "instability" popup to the user</param>
     private void FizzlePortals(Entity<HandTeleporterComponent> entity, EntityUid? user, bool instability)
     {
-        // Logging
-        var portalStrings = "";
-        portalStrings += ToPrettyString(entity.Comp.FirstPortal);
-        if (portalStrings != "")
-            portalStrings += " and ";
-        portalStrings += ToPrettyString(entity.Comp.SecondPortal);
-        if (portalStrings != "")
-        {
-            if (user != null)
-                _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{ToPrettyString(user):player} closed {portalStrings} with {ToPrettyString(entity)}");
-            else
-                _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{portalStrings} were closed");
-        }
+        LogPortalClosure(entity, user);
 
         // Clear both portals
         if (!Deleted(entity.Comp.FirstPortal))
@@ -195,7 +210,32 @@ public sealed partial class HandTeleporterSystem : EntitySystem
         Dirty(entity);
         _audio.PlayPvs(entity.Comp.ClearPortalsSound, entity);
 
-        if (instability && user != null)
-            _popup.PopupEntity(Loc.GetString("handheld-teleporter-instability-fizzle"), entity, user.Value, PopupType.MediumCaution);
+        if (!instability)
+            return;
+
+        if (user == null)
+            return;
+
+        _popup.PopupEntity(Loc.GetString("handheld-teleporter-instability-fizzle"), entity, user.Value, PopupType.MediumCaution);
+    }
+
+    private void LogPortalClosure(Entity<HandTeleporterComponent> entity, EntityUid? user)
+    {
+        var portalStrings = "";
+        portalStrings += ToPrettyString(entity.Comp.FirstPortal);
+        if (portalStrings != "")
+            portalStrings += " and ";
+        portalStrings += ToPrettyString(entity.Comp.SecondPortal);
+
+        if (portalStrings == "")
+            return;
+
+        if (user != null)
+        {
+            _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{ToPrettyString(user):player} closed {portalStrings} with {ToPrettyString(entity)}");
+            return;
+        }
+
+        _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{portalStrings} were closed");
     }
 }

--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -233,7 +233,8 @@ public sealed partial class HandTeleporterSystem : EntitySystem
     /// <param name="instability">if it should send an "instability" popup to the user</param>
     private void FizzlePortals(Entity<HandTeleporterComponent> entity, EntityUid? user, bool instability)
     {
-        LogPortalClosure(entity, user);
+        LogPortalClosure(entity.Comp.FirstPortal, entity, user);
+        LogPortalClosure(entity.Comp.SecondPortal, entity, user);
 
         // Clear both portals
         if (!Deleted(entity.Comp.FirstPortal))
@@ -255,23 +256,17 @@ public sealed partial class HandTeleporterSystem : EntitySystem
         _popup.PopupEntity(Loc.GetString("handheld-teleporter-instability-fizzle"), entity, user.Value, PopupType.MediumCaution);
     }
 
-    private void LogPortalClosure(Entity<HandTeleporterComponent> entity, EntityUid? user)
+    private void LogPortalClosure(EntityUid? portal, EntityUid teleporter, EntityUid? user)
     {
-        var portalStrings = "";
-        portalStrings += ToPrettyString(entity.Comp.FirstPortal);
-        if (portalStrings != "")
-            portalStrings += " and ";
-        portalStrings += ToPrettyString(entity.Comp.SecondPortal);
-
-        if (portalStrings == "")
+        if (Deleted(portal))
             return;
 
         if (user != null)
         {
-            _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{ToPrettyString(user):player} closed {portalStrings} with {ToPrettyString(entity)}");
+            _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{ToPrettyString(user):player} closed {ToPrettyString(portal)} with {ToPrettyString(teleporter)}");
             return;
         }
 
-        _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{portalStrings} were closed");
+        _adminLogger.Add(LogType.EntityDelete, LogImpact.High, $"{ToPrettyString(portal)} was closed by {ToPrettyString(teleporter)}");
     }
 }

--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Popups;
 using Content.Shared.DoAfter;
@@ -32,49 +31,36 @@ public sealed partial class HandTeleporterSystem : EntitySystem
         SubscribeLocalEvent<HandTeleporterComponent, UseInHandEvent>(OnUseInHand);
         SubscribeLocalEvent<HandTeleporterComponent, TeleporterDoAfterEvent>(OnDoAfter);
         SubscribeLocalEvent<GridSplitEvent>(OnGridSplit);
-        // Check the original grid coordinates before tile removal detaches the portals.
+        // Find supported portals before tile removal clears the grid's anchored entities.
         SubscribeLocalEvent<TileChangedEvent>(OnTileChanged, before: new[] { typeof(TransformSystem) });
     }
 
     private void OnTileChanged(ref TileChangedEvent args)
     {
-        if (!args.Changes.Any(change => change.NewTile == Tile.Empty))
-            return;
-
-        var query = EntityQueryEnumerator<HandTeleporterComponent>();
-        while (query.MoveNext(out var uid, out var teleporter))
-        {
-            if (IsPortalTileRemoved(teleporter.FirstPortal, args))
-            {
-                FizzlePortals((uid, teleporter), null, false);
-                continue;
-            }
-
-            if (IsPortalTileRemoved(teleporter.SecondPortal, args))
-                FizzlePortals((uid, teleporter), null, false);
-        }
-    }
-
-    private bool IsPortalTileRemoved(EntityUid? portal, TileChangedEvent args)
-    {
-        if (Deleted(portal))
-            return false;
-
-        var xform = Transform(portal.Value);
-        if (xform.GridUid != args.Entity.Owner)
-            return false;
-
-        var indices = _map.CoordinatesToTile(args.Entity, args.Entity.Comp, xform.Coordinates);
         foreach (var change in args.Changes)
         {
-            if (change.GridIndices != indices)
+            if (change.NewTile != Tile.Empty)
                 continue;
 
-            if (change.NewTile == Tile.Empty)
-                return true;
-        }
+            var anchored = _map.GetAnchoredEntities(args.Entity, args.Entity.Comp, change.GridIndices);
+            while (anchored.MoveNext(out var portal))
+            {
+                if (!TryComp<HandTeleporterPortalComponent>(portal, out var portalComponent))
+                    continue;
 
-        return false;
+                if (EntityManager.IsQueuedForDeletion(portal.Value))
+                    continue;
+
+                if (!TryComp<HandTeleporterComponent>(portalComponent.Teleporter, out var teleporter))
+                {
+                    // LinkedEntitySystem also removes the paired exit, even without the device.
+                    QueueDel(portal.Value);
+                    continue;
+                }
+
+                FizzlePortals((portalComponent.Teleporter, teleporter), null, false);
+            }
+        }
     }
 
     private void OnGridSplit(ref GridSplitEvent args)
@@ -196,6 +182,7 @@ public sealed partial class HandTeleporterSystem : EntitySystem
             return;
 
         component.FirstPortal = Spawn(component.FirstPortalPrototype, Transform(user).Coordinates);
+        EnsureComp<HandTeleporterPortalComponent>(component.FirstPortal.Value).Teleporter = uid;
         _portal.SetPortalTimeout(user, component.FirstPortal.Value);
         Dirty(uid, component);
         ConfigurePortalMapTravel(component.FirstPortal, component);
@@ -217,6 +204,7 @@ public sealed partial class HandTeleporterSystem : EntitySystem
         }
 
         component.SecondPortal = Spawn(component.SecondPortalPrototype, Transform(user).Coordinates);
+        EnsureComp<HandTeleporterPortalComponent>(component.SecondPortal.Value).Teleporter = uid;
         _portal.SetPortalTimeout(user, component.SecondPortal.Value);
         Dirty(uid, component);
         ConfigurePortalMapTravel(component.SecondPortal, component);

--- a/Content.Server/Teleportation/HandTeleporterSystem.cs
+++ b/Content.Server/Teleportation/HandTeleporterSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Popups;
 using Content.Shared.DoAfter;
@@ -7,6 +8,8 @@ using Content.Shared.Popups;
 using Content.Shared.Teleportation.Components;
 using Content.Shared.Teleportation.Systems;
 using Robust.Server.Audio;
+using Robust.Server.GameObjects;
+using Robust.Shared.Map;
 
 namespace Content.Server.Teleportation;
 
@@ -21,6 +24,7 @@ public sealed partial class HandTeleporterSystem : EntitySystem
     [Dependency] private SharedDoAfterSystem _doafter = default!;
     [Dependency] private PopupSystem _popup = default!;
     [Dependency] private SharedPortalSystem _portal = default!;
+    [Dependency] private SharedMapSystem _map = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -28,6 +32,49 @@ public sealed partial class HandTeleporterSystem : EntitySystem
         SubscribeLocalEvent<HandTeleporterComponent, UseInHandEvent>(OnUseInHand);
         SubscribeLocalEvent<HandTeleporterComponent, TeleporterDoAfterEvent>(OnDoAfter);
         SubscribeLocalEvent<GridSplitEvent>(OnGridSplit);
+        // Check the original grid coordinates before tile removal detaches the portals.
+        SubscribeLocalEvent<TileChangedEvent>(OnTileChanged, before: new[] { typeof(TransformSystem) });
+    }
+
+    private void OnTileChanged(ref TileChangedEvent args)
+    {
+        if (!args.Changes.Any(change => change.NewTile == Tile.Empty))
+            return;
+
+        var query = EntityQueryEnumerator<HandTeleporterComponent>();
+        while (query.MoveNext(out var uid, out var teleporter))
+        {
+            if (IsPortalTileRemoved(teleporter.FirstPortal, args))
+            {
+                FizzlePortals((uid, teleporter), null, false);
+                continue;
+            }
+
+            if (IsPortalTileRemoved(teleporter.SecondPortal, args))
+                FizzlePortals((uid, teleporter), null, false);
+        }
+    }
+
+    private bool IsPortalTileRemoved(EntityUid? portal, TileChangedEvent args)
+    {
+        if (Deleted(portal))
+            return false;
+
+        var xform = Transform(portal.Value);
+        if (xform.GridUid != args.Entity.Owner)
+            return false;
+
+        var indices = _map.CoordinatesToTile(args.Entity, args.Entity.Comp, xform.Coordinates);
+        foreach (var change in args.Changes)
+        {
+            if (change.GridIndices != indices)
+                continue;
+
+            if (change.NewTile == Tile.Empty)
+                return true;
+        }
+
+        return false;
     }
 
     private void OnGridSplit(ref GridSplitEvent args)
@@ -82,6 +129,7 @@ public sealed partial class HandTeleporterSystem : EntitySystem
             BreakOnDamage = true,
             BreakOnMove = true,
             MovementThreshold = 0.5f,
+            NeedHand = true,
         };
 
         _doafter.TryStartDoAfter(doafterArgs);

--- a/Content.Server/Teleportation/TeleportSoundSystem.cs
+++ b/Content.Server/Teleportation/TeleportSoundSystem.cs
@@ -1,0 +1,36 @@
+using Content.Shared.Teleportation;
+using Content.Shared.Teleportation.Components;
+using Robust.Shared.Audio.Systems;
+
+namespace Content.Server.Teleportation;
+
+public sealed partial class TeleportSoundSystem : EntitySystem
+{
+    [Dependency] private SharedAudioSystem _audio = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TeleportSoundComponent, BeforeTeleportEvent>(OnBeforeTeleport);
+        SubscribeLocalEvent<TeleportSoundComponent, TargetTeleportedEvent>(OnTargetTeleported);
+    }
+
+    private void OnBeforeTeleport(Entity<TeleportSoundComponent> ent, ref BeforeTeleportEvent args)
+    {
+        if (ent.Comp.DepartureSound is not { } sound)
+            return;
+
+        // Keep the sound at the departure location instead of letting it follow the teleported target.
+        _audio.PlayPvs(sound, Transform(args.Target).Coordinates);
+    }
+
+    private void OnTargetTeleported(Entity<TeleportSoundComponent> ent, ref TargetTeleportedEvent args)
+    {
+        if (ent.Comp.ArrivalSound is not { } sound)
+            return;
+
+        // Keep the sound at the arrival location if the target moves away after teleporting.
+        _audio.PlayPvs(sound, Transform(args.Target).Coordinates);
+    }
+}

--- a/Content.Server/Teleportation/TeleportSoundSystem.cs
+++ b/Content.Server/Teleportation/TeleportSoundSystem.cs
@@ -18,7 +18,8 @@ public sealed partial class TeleportSoundSystem : EntitySystem
 
     private void OnBeforeTeleport(Entity<TeleportSoundComponent> ent, ref BeforeTeleportEvent args)
     {
-        if (ent.Comp.DepartureSound is not { } sound)
+        var sound = ent.Comp.DepartureSound;
+        if (sound == null)
             return;
 
         // Keep the sound at the departure location instead of letting it follow the teleported target.
@@ -27,7 +28,8 @@ public sealed partial class TeleportSoundSystem : EntitySystem
 
     private void OnTargetTeleported(Entity<TeleportSoundComponent> ent, ref TargetTeleportedEvent args)
     {
-        if (ent.Comp.ArrivalSound is not { } sound)
+        var sound = ent.Comp.ArrivalSound;
+        if (sound == null)
             return;
 
         // Keep the sound at the arrival location if the target moves away after teleporting.

--- a/Content.Shared/Teleportation/Components/PortalComponent.cs
+++ b/Content.Shared/Teleportation/Components/PortalComponent.cs
@@ -1,5 +1,4 @@
-﻿using Robust.Shared.Audio;
-using Robust.Shared.GameStates;
+﻿using Robust.Shared.GameStates;
 
 namespace Content.Shared.Teleportation.Components;
 
@@ -11,22 +10,9 @@ namespace Content.Shared.Teleportation.Components;
 public sealed partial class PortalComponent : Component
 {
     /// <summary>
-    ///     Sound played on arriving to this portal, centered on the destination.
-    ///     The arrival sound of the entered portal will play if the destination is not a portal.
-    /// </summary>
-    [DataField("arrivalSound")]
-    public SoundSpecifier ArrivalSound = new SoundPathSpecifier("/Audio/Effects/teleport_arrival.ogg");
-
-    /// <summary>
-    ///     Sound played on departing from this portal, centered on the original portal.
-    /// </summary>
-    [DataField("departureSound")]
-    public SoundSpecifier DepartureSound = new SoundPathSpecifier("/Audio/Effects/teleport_departure.ogg");
-
-    /// <summary>
     ///     If no portals are linked, the subject will be teleported a random distance at maximum this far away.
     /// </summary>
-    [DataField("maxRandomRadius"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float MaxRandomRadius = 7.0f;
 
     /// <summary>
@@ -35,7 +21,7 @@ public sealed partial class PortalComponent : Component
     /// <remarks>
     ///     Shouldn't be able to teleport people to centcomm or the eshuttle from the station
     /// </remarks>
-    [DataField("canTeleportToOtherMaps"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public bool CanTeleportToOtherMaps = false;
 
     /// <summary>
@@ -45,12 +31,12 @@ public sealed partial class PortalComponent : Component
     /// <remarks>
     ///     Obviously this should strictly be larger than <see cref="MaxRandomRadius"/> (or null)
     /// </remarks>
-    [DataField("maxTeleportRadius"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float? MaxTeleportRadius;
 
     /// <summary>
     /// Should we teleport randomly if nothing is linked.
     /// </summary>
-    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField, AutoNetworkedField]
     public bool RandomTeleport = true;
 }

--- a/Content.Shared/Teleportation/Components/PortalComponent.cs
+++ b/Content.Shared/Teleportation/Components/PortalComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Teleportation.Components;
 
@@ -39,4 +40,18 @@ public sealed partial class PortalComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool RandomTeleport = true;
+
+    /// <summary>
+    /// Restricts explicit initiators when the portal has no linked destinations.
+    /// Null adds no restriction. Automatic activations without a user are unaffected.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityWhitelist? UnlinkedUserWhitelist;
+
+    /// <summary>
+    /// Blocks matching explicit initiators when the portal has no linked destinations.
+    /// Takes precedence over <see cref="UnlinkedUserWhitelist"/>. Automatic activations are unaffected.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityWhitelist? UnlinkedUserBlacklist;
 }

--- a/Content.Shared/Teleportation/Components/PortalComponent.cs
+++ b/Content.Shared/Teleportation/Components/PortalComponent.cs
@@ -3,8 +3,8 @@
 namespace Content.Shared.Teleportation.Components;
 
 /// <summary>
-///     Marks an entity as being a 'portal' which teleports entities sent through it to linked entities.
-///     Relies on <see cref="LinkedEntityComponent"/> being set up.
+/// Resolves teleport requests to destinations linked through <see cref="LinkedEntityComponent"/>.
+/// When no destinations are linked, can choose a random nearby destination if <see cref="RandomTeleport"/> is enabled.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class PortalComponent : Component

--- a/Content.Shared/Teleportation/Components/PortalTimeoutComponent.cs
+++ b/Content.Shared/Teleportation/Components/PortalTimeoutComponent.cs
@@ -5,12 +5,14 @@ namespace Content.Shared.Teleportation.Components;
 /// <summary>
 /// Blocks portal use until the target leaves the bounds of its exit trigger.
 /// Also protects the creator of a hand-teleporter portal until they step out.
+/// Attached to the target; no component means no portal exit block.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class PortalTimeoutComponent : Component
 {
     /// <summary>
     /// The portal whose trigger bounds must be left before another portal can be used.
+    /// For a hand teleporter, this is the portal just created beneath the user.
     /// </summary>
     [ViewVariables, DataField, AutoNetworkedField]
     public EntityUid ExitPortal;

--- a/Content.Shared/Teleportation/Components/PortalTimeoutComponent.cs
+++ b/Content.Shared/Teleportation/Components/PortalTimeoutComponent.cs
@@ -3,15 +3,15 @@
 namespace Content.Shared.Teleportation.Components;
 
 /// <summary>
-///     Attached to an entity after portal transit to mark that they should not immediately be portaled back
-///     at the end destination.
+/// Blocks portal use until the target leaves the bounds of its exit trigger.
+/// Also protects the creator of a hand-teleporter portal until they step out.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class PortalTimeoutComponent : Component
 {
     /// <summary>
-    ///     The portal that was entered. Null if coming from a hand teleporter, etc.
+    /// The portal whose trigger bounds must be left before another portal can be used.
     /// </summary>
     [ViewVariables, DataField, AutoNetworkedField]
-    public EntityUid? EnteredPortal;
+    public EntityUid ExitPortal;
 }

--- a/Content.Shared/Teleportation/Components/TeleportSoundComponent.cs
+++ b/Content.Shared/Teleportation/Components/TeleportSoundComponent.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.Audio;
+
+namespace Content.Shared.Teleportation.Components;
+
+/// <summary>
+/// Plays sounds at a target's departure and arrival locations during teleportation.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TeleportSoundComponent : Component
+{
+    /// <summary>
+    /// Sound played at the target's departure location.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? DepartureSound;
+
+    /// <summary>
+    /// Sound played at the target's arrival location.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? ArrivalSound;
+}

--- a/Content.Shared/Teleportation/Components/TeleportingComponent.cs
+++ b/Content.Shared/Teleportation/Components/TeleportingComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.Teleportation.Components;
+
+/// <summary>
+/// Marks a target while a teleport request and all of its effects are being processed.
+/// Prevents nested teleport requests for the same target.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TeleportingComponent : Component
+{
+}

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.Timeout.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.Timeout.cs
@@ -1,0 +1,72 @@
+using Content.Shared.Teleportation.Components;
+using Robust.Shared.Map;
+using Robust.Shared.Physics.Components;
+
+namespace Content.Shared.Teleportation.Systems;
+
+public abstract partial class SharedPortalSystem
+{
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<PortalTimeoutComponent>();
+        while (query.MoveNext(out var target, out var timeout))
+        {
+            // Remote targets are reconciled by the server; only predict our simulated bodies.
+            if (_net.IsClient && (!TryComp<PhysicsComponent>(target, out var body) || !body.Predict))
+                continue;
+
+            RefreshTimeout(target, timeout);
+        }
+    }
+
+    /// <summary>
+    /// Protects a target from portal use until it leaves the specified exit's trigger bounds.
+    /// Returns false when this exit cannot trigger for the target.
+    /// </summary>
+    public bool SetPortalTimeout(EntityUid target, EntityUid exit)
+    {
+        if (!HasComp<PortalComponent>(exit) || !_collisionTrigger.CanTrigger(exit, target))
+            return false;
+
+        var timeout = EnsureComp<PortalTimeoutComponent>(target);
+        timeout.ExitPortal = exit;
+        Dirty(target, timeout);
+        return true;
+    }
+
+    private bool IsTimeoutActive(EntityUid target, PortalTimeoutComponent timeout)
+    {
+        // An exit outside client visibility is not evidence that the server deleted it.
+        if (_net.IsClient && (!TryComp(timeout.ExitPortal, out TransformComponent? exitTransform) ||
+                              exitTransform.MapID == MapId.Nullspace))
+            return true;
+
+        return HasComp<PortalComponent>(timeout.ExitPortal) &&
+               _collisionTrigger.IsInsideTriggerBounds(timeout.ExitPortal, target);
+    }
+
+    private void RefreshTimeout(EntityUid target, PortalTimeoutComponent timeout)
+    {
+        // Movement can synchronously end the source contact before arrival is complete.
+        if (HasComp<TeleportingComponent>(target) || IsTimeoutActive(target, timeout))
+            return;
+
+        // Do not queue removal: another request may replace the timeout in the same tick.
+        RemComp<PortalTimeoutComponent>(target);
+    }
+
+    private void RestoreTimeout(EntityUid target, EntityUid? previousExit)
+    {
+        if (previousExit is not { } exit)
+        {
+            RemComp<PortalTimeoutComponent>(target);
+            return;
+        }
+
+        var timeout = EnsureComp<PortalTimeoutComponent>(target);
+        timeout.ExitPortal = exit;
+        Dirty(target, timeout);
+    }
+}

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.Timeout.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.Timeout.cs
@@ -25,7 +25,8 @@ public abstract partial class SharedPortalSystem
         if (!_net.IsClient)
             return true;
 
-        // Remote targets are reconciled by the server; only predict our simulated bodies.
+        // On clients, update timeouts only for bodies with physics prediction enabled.
+        // Other entities receive timeout changes from the server.
         if (!TryComp<PhysicsComponent>(target, out var body))
             return false;
 

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.Timeout.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.Timeout.cs
@@ -13,18 +13,23 @@ public abstract partial class SharedPortalSystem
         var query = EntityQueryEnumerator<PortalTimeoutComponent>();
         while (query.MoveNext(out var target, out var timeout))
         {
-            // Remote targets are reconciled by the server; only predict our simulated bodies.
-            if (_net.IsClient)
-            {
-                if (!TryComp<PhysicsComponent>(target, out var body))
-                    continue;
-
-                if (!body.Predict)
-                    continue;
-            }
+            if (!ShouldUpdateTimeout(target))
+                continue;
 
             RefreshTimeout(target, timeout);
         }
+    }
+
+    private bool ShouldUpdateTimeout(EntityUid target)
+    {
+        if (!_net.IsClient)
+            return true;
+
+        // Remote targets are reconciled by the server; only predict our simulated bodies.
+        if (!TryComp<PhysicsComponent>(target, out var body))
+            return false;
+
+        return body.Predict;
     }
 
     /// <summary>
@@ -48,19 +53,24 @@ public abstract partial class SharedPortalSystem
     private bool IsTimeoutActive(EntityUid target, PortalTimeoutComponent timeout)
     {
         // An exit outside client visibility is not evidence that the server deleted it.
-        if (_net.IsClient)
-        {
-            if (!TryComp(timeout.ExitPortal, out TransformComponent? exitTransform))
-                return true;
-
-            if (exitTransform.MapID == MapId.Nullspace)
-                return true;
-        }
+        if (IsExitUnavailableOnClient(timeout.ExitPortal))
+            return true;
 
         if (!HasComp<PortalComponent>(timeout.ExitPortal))
             return false;
 
         return _collisionTrigger.IsInsideTriggerBounds(timeout.ExitPortal, target);
+    }
+
+    private bool IsExitUnavailableOnClient(EntityUid exit)
+    {
+        if (!_net.IsClient)
+            return false;
+
+        if (!TryComp(exit, out TransformComponent? transform))
+            return true;
+
+        return transform.MapID == MapId.Nullspace;
     }
 
     private void RefreshTimeout(EntityUid target, PortalTimeoutComponent timeout)

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.Timeout.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.Timeout.cs
@@ -96,14 +96,14 @@ public abstract partial class SharedPortalSystem
         if (TerminatingOrDeleted(target))
             return;
 
-        if (previousExit is not { } exit)
+        if (previousExit == null)
         {
             RemComp<PortalTimeoutComponent>(target);
             return;
         }
 
         var timeout = EnsureComp<PortalTimeoutComponent>(target);
-        timeout.ExitPortal = exit;
+        timeout.ExitPortal = previousExit.Value;
         Dirty(target, timeout);
     }
 }

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.Timeout.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.Timeout.cs
@@ -14,8 +14,14 @@ public abstract partial class SharedPortalSystem
         while (query.MoveNext(out var target, out var timeout))
         {
             // Remote targets are reconciled by the server; only predict our simulated bodies.
-            if (_net.IsClient && (!TryComp<PhysicsComponent>(target, out var body) || !body.Predict))
-                continue;
+            if (_net.IsClient)
+            {
+                if (!TryComp<PhysicsComponent>(target, out var body))
+                    continue;
+
+                if (!body.Predict)
+                    continue;
+            }
 
             RefreshTimeout(target, timeout);
         }
@@ -27,7 +33,10 @@ public abstract partial class SharedPortalSystem
     /// </summary>
     public bool SetPortalTimeout(EntityUid target, EntityUid exit)
     {
-        if (!HasComp<PortalComponent>(exit) || !_collisionTrigger.CanTrigger(exit, target))
+        if (!HasComp<PortalComponent>(exit))
+            return false;
+
+        if (!_collisionTrigger.CanTrigger(exit, target))
             return false;
 
         var timeout = EnsureComp<PortalTimeoutComponent>(target);
@@ -39,26 +48,43 @@ public abstract partial class SharedPortalSystem
     private bool IsTimeoutActive(EntityUid target, PortalTimeoutComponent timeout)
     {
         // An exit outside client visibility is not evidence that the server deleted it.
-        if (_net.IsClient && (!TryComp(timeout.ExitPortal, out TransformComponent? exitTransform) ||
-                              exitTransform.MapID == MapId.Nullspace))
-            return true;
+        if (_net.IsClient)
+        {
+            if (!TryComp(timeout.ExitPortal, out TransformComponent? exitTransform))
+                return true;
 
-        return HasComp<PortalComponent>(timeout.ExitPortal) &&
-               _collisionTrigger.IsInsideTriggerBounds(timeout.ExitPortal, target);
+            if (exitTransform.MapID == MapId.Nullspace)
+                return true;
+        }
+
+        if (!HasComp<PortalComponent>(timeout.ExitPortal))
+            return false;
+
+        return _collisionTrigger.IsInsideTriggerBounds(timeout.ExitPortal, target);
     }
 
     private void RefreshTimeout(EntityUid target, PortalTimeoutComponent timeout)
     {
         // Movement can synchronously end the source contact before arrival is complete.
-        if (HasComp<TeleportingComponent>(target) || IsTimeoutActive(target, timeout))
+        if (HasComp<TeleportingComponent>(target))
+            return;
+
+        if (IsTimeoutActive(target, timeout))
             return;
 
         // Do not queue removal: another request may replace the timeout in the same tick.
         RemComp<PortalTimeoutComponent>(target);
     }
 
-    private void RestoreTimeout(EntityUid target, EntityUid? previousExit)
+    private void RestoreTimeoutAfterFailedTeleport(EntityUid target, EntityUid? previousExit, bool moved)
     {
+        // A failed post-move effect must not remove protection at the exit.
+        if (moved)
+            return;
+
+        if (TerminatingOrDeleted(target))
+            return;
+
         if (previousExit is not { } exit)
         {
             RemComp<PortalTimeoutComponent>(target);

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
@@ -1,7 +1,5 @@
 ﻿using System.Linq;
-using Content.Shared.Ghost.Components;
 using Content.Shared.Popups;
-using Content.Shared.Revenant.Components;
 using Content.Shared.Teleportation.Components;
 using Content.Shared.Teleportation.Triggers;
 using Robust.Shared.Map;
@@ -23,6 +21,7 @@ public abstract partial class SharedPortalSystem : EntitySystem
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedTeleportSystem _teleport = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private CollisionTeleportTriggerSystem _collisionTrigger = default!;
 
     private const int MaxRandomTeleportAttempts = 20;
 
@@ -37,30 +36,6 @@ public abstract partial class SharedPortalSystem : EntitySystem
 
     private void OnTeleportUseAttempt(Entity<PortalComponent> ent, ref TeleportUseAttemptEvent args)
     {
-        if (args.Mode == TeleportMode.Ghost)
-        {
-            if (!IsGhostTraversalTarget(args.Target))
-            {
-                args.Cancelled = true;
-                return;
-            }
-
-            if (!TryComp<LinkedEntityComponent>(ent, out var ghostLink))
-            {
-                args.Cancelled = true;
-                args.CancelReason ??= "portal-component-no-linked-entities";
-                return;
-            }
-
-            if (ghostLink.LinkedEntities.Count != 1)
-            {
-                args.Cancelled = true;
-                args.CancelReason ??= "portal-component-no-linked-entities";
-            }
-
-            return;
-        }
-
         if (HasComp<PortalTimeoutComponent>(args.Target))
         {
             args.Cancelled = true;
@@ -87,31 +62,9 @@ public abstract partial class SharedPortalSystem : EntitySystem
         if (args.Handled)
             return;
 
-        if (args.Mode == TeleportMode.Ghost)
-        {
-            if (IsGhostTraversalTarget(args.Target) && TryTeleportGhost(ent, args.Target))
-                args.Handled = true;
-
-            return;
-        }
-
         if (TryComp<LinkedEntityComponent>(ent, out var link) && link.LinkedEntities.Count != 0)
         {
-            if (_net.IsClient && !CanPredictTeleport((ent, link)))
-                return;
-
-            var destinationEntity = _random.Pick(link.LinkedEntities);
-            if (!Exists(destinationEntity))
-                return;
-
-            if (TerminatingOrDeleted(destinationEntity))
-                return;
-
-            var destination = Transform(destinationEntity).Coordinates;
-            if (!TryTeleport(ent, args.Target, destination, destinationEntity))
-                return;
-
-            args.Handled = true;
+            args.Handled = TryTeleportLinked(ent, link, args.Target);
             return;
         }
 
@@ -126,34 +79,17 @@ public abstract partial class SharedPortalSystem : EntitySystem
             args.Handled = true;
     }
 
-    private bool TryTeleportGhost(Entity<PortalComponent> ent, EntityUid target)
+    private bool TryTeleportLinked(Entity<PortalComponent> ent, LinkedEntityComponent link, EntityUid target)
     {
-        if (!TryComp<LinkedEntityComponent>(ent, out var link))
-            return false;
-
-        if (link.LinkedEntities.Count != 1)
-            return false;
-
         if (_net.IsClient && !CanPredictTeleport((ent, link)))
             return false;
 
-        var destinationEntity = link.LinkedEntities.First();
-        if (!Exists(destinationEntity))
-            return false;
-
-        if (TerminatingOrDeleted(destinationEntity))
+        var destinationEntity = _random.Pick(link.LinkedEntities);
+        if (!Exists(destinationEntity) || TerminatingOrDeleted(destinationEntity))
             return false;
 
         var destination = Transform(destinationEntity).Coordinates;
-        if (!TryValidateDestination(ent, destination, destinationEntity))
-            return false;
-
-        var source = Transform(target).Coordinates;
-        if (!_teleport.TryTeleportGhost(target, destination))
-            return false;
-
-        LogTeleport(ent, target, source, destination);
-        return true;
+        return TryTeleport(ent, target, destination, destinationEntity);
     }
 
     private bool TryTeleport(
@@ -165,26 +101,31 @@ public abstract partial class SharedPortalSystem : EntitySystem
         if (!TryValidateDestination(ent, destination, destinationEntity))
             return false;
 
-        var addedTimeout = false;
-        if (HasComp<PortalComponent>(destinationEntity))
-        {
-            addedTimeout = !HasComp<PortalTimeoutComponent>(target);
-            var timeout = EnsureComp<PortalTimeoutComponent>(target);
-            timeout.EnteredPortal = ent;
-            Dirty(target, timeout);
-        }
-
+        var addedTimeout = AddTimeout(ent, target, destinationEntity);
         var source = Transform(target).Coordinates;
-        if (!_teleport.TryTeleport(ent, target, destination))
+        if (_teleport.TryTeleport(ent, target, destination))
         {
-            if (addedTimeout)
-                RemComp<PortalTimeoutComponent>(target);
-
-            return false;
+            LogTeleport(ent, target, source, destination);
+            return true;
         }
 
-        LogTeleport(ent, target, source, destination);
-        return true;
+        if (addedTimeout)
+            RemComp<PortalTimeoutComponent>(target);
+
+        return false;
+    }
+
+    private bool AddTimeout(EntityUid portal, EntityUid target, EntityUid? destination)
+    {
+        // Only collision-triggered return trips need a timeout. Other targets may never raise an exit event.
+        if (destination is not { } exit || !HasComp<PortalComponent>(exit) || !_collisionTrigger.CanTrigger(exit, target))
+            return false;
+
+        var addedTimeout = !HasComp<PortalTimeoutComponent>(target);
+        var timeout = EnsureComp<PortalTimeoutComponent>(target);
+        timeout.EnteredPortal = portal;
+        Dirty(target, timeout);
+        return addedTimeout;
     }
 
     private bool TryValidateDestination(
@@ -261,13 +202,5 @@ public abstract partial class SharedPortalSystem : EntitySystem
             return false;
 
         return Transform(destination).MapID != MapId.Nullspace;
-    }
-
-    private bool IsGhostTraversalTarget(EntityUid target)
-    {
-        if (HasComp<GhostComponent>(target))
-            return true;
-
-        return HasComp<RevenantComponent>(target);
     }
 }

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
@@ -1,283 +1,273 @@
 ﻿using System.Linq;
-using Content.Shared.Movement.Pulling.Components;
-using Content.Shared.Movement.Pulling.Systems;
+using Content.Shared.Ghost.Components;
 using Content.Shared.Popups;
-using Content.Shared.Projectiles;
-using Content.Shared.Tag;
+using Content.Shared.Revenant.Components;
 using Content.Shared.Teleportation.Components;
-using Content.Shared.Weapons.Misc;
-using Content.Shared.Verbs;
-using Robust.Shared.Audio.Systems;
+using Content.Shared.Teleportation.Triggers;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
-using Robust.Shared.Physics.Dynamics;
-using Robust.Shared.Physics.Events;
-using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
-using Robust.Shared.Utility;
-using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Teleportation.Systems;
 
 /// <summary>
-/// This handles teleporting entities from a portal to a linked portal, or to a random nearby destination.
-/// Uses <see cref="LinkedEntitySystem"/> to get linked portals.
+/// Resolves linked or random portal destinations and delegates movement to <see cref="SharedTeleportSystem"/>.
 /// </summary>
 /// <seealso cref="PortalComponent"/>
 public abstract partial class SharedPortalSystem : EntitySystem
 {
-    [Dependency] private INetManager _netMan = default!;
+    [Dependency] private INetManager _net = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
-    [Dependency] private PullingSystem _pulling = default!;
-    [Dependency] private SharedAudioSystem _audio = default!;
-    [Dependency] private SharedJointSystem _joints = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private SharedTeleportSystem _teleport = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
-    [Dependency] private TagSystem _tag = default!;
-
-    private const string PortalFixture = "portalFixture";
-    private const string ProjectileFixture = "projectile";
-    private static readonly ProtoId<TagPrototype> ShowTraverseVerbTag = "AllowPortalTraversal";
-    private static readonly ProtoId<TagPrototype> PreventCollisionTag = "PreventPortalCollision";
 
     private const int MaxRandomTeleportAttempts = 20;
 
-    /// <inheritdoc/>
     public override void Initialize()
     {
-        SubscribeLocalEvent<PortalComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+        base.Initialize();
 
-        SubscribeLocalEvent<PortalComponent, StartCollideEvent>(OnCollide);
-        SubscribeLocalEvent<PortalComponent, EndCollideEvent>(OnEndCollide);
+        SubscribeLocalEvent<PortalComponent, TeleportUseAttemptEvent>(OnTeleportUseAttempt);
+        SubscribeLocalEvent<PortalComponent, TeleportRequestEvent>(OnTeleportRequest);
+        SubscribeLocalEvent<PortalComponent, TeleportTriggerExitedEvent>(OnTeleportTriggerExited);
     }
 
-    private void OnGetVerbs(Entity<PortalComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    private void OnTeleportUseAttempt(Entity<PortalComponent> ent, ref TeleportUseAttemptEvent args)
     {
-        // Traversal altverb for ghosts to use that bypasses normal functionality
-        if (!args.CanAccess || !_tag.HasTag(args.User, ShowTraverseVerbTag))
-            return;
-
-        // Don't use the verb with unlinked or with multi-output portals
-        // (this is only intended to be useful for ghosts to see where a linked portal leads)
-        var disabled = !TryComp<LinkedEntityComponent>(ent, out var link) || link.LinkedEntities.Count != 1;
-
-        var subject = args.User;
-        args.Verbs.Add(new AlternativeVerb
+        if (args.Mode == TeleportMode.Ghost)
         {
-            Priority = 11,
-            Act = () =>
+            if (!IsGhostTraversalTarget(args.Target))
             {
-                if (link == null || disabled)
-                    return;
+                args.Cancelled = true;
+                return;
+            }
 
-                // check prediction
-                if (_netMan.IsClient && !CanPredictTeleport((ent, link)))
-                    return;
+            if (!TryComp<LinkedEntityComponent>(ent, out var ghostLink))
+            {
+                args.Cancelled = true;
+                args.CancelReason ??= "portal-component-no-linked-entities";
+                return;
+            }
 
-                var destination = link.LinkedEntities.First();
+            if (ghostLink.LinkedEntities.Count != 1)
+            {
+                args.Cancelled = true;
+                args.CancelReason ??= "portal-component-no-linked-entities";
+            }
 
-                TeleportEntity(ent, subject, Transform(destination).Coordinates, destination, false);
-            },
-            Disabled = disabled,
-            Text = Loc.GetString("portal-component-ghost-traverse"),
-            Message = disabled
-                ? Loc.GetString("portal-component-no-linked-entities")
-                : Loc.GetString("portal-component-can-ghost-traverse"),
-            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/open.svg.192dpi.png"))
-        });
+            return;
+        }
+
+        if (HasComp<PortalTimeoutComponent>(args.Target))
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        if (ent.Comp.RandomTeleport)
+            return;
+
+        if (TryComp<LinkedEntityComponent>(ent, out var link) && link.LinkedEntities.Count != 0)
+            return;
+
+        args.Cancelled = true;
     }
 
-    private void OnCollide(Entity<PortalComponent> ent, ref StartCollideEvent args)
+    private void OnTeleportTriggerExited(Entity<PortalComponent> ent, ref TeleportTriggerExitedEvent args)
     {
-        if (!ShouldCollide(args.OurFixtureId, args.OtherFixtureId, args.OurFixture, args.OtherFixture))
+        if (TryComp<PortalTimeoutComponent>(args.Target, out var timeout) && timeout.EnteredPortal != ent)
+            RemCompDeferred<PortalTimeoutComponent>(args.Target);
+    }
+
+    private void OnTeleportRequest(Entity<PortalComponent> ent, ref TeleportRequestEvent args)
+    {
+        if (args.Handled)
             return;
 
-        var subject = args.OtherEntity;
-
-        if (_tag.HasTag(args.OtherEntity, PreventCollisionTag))
-            return;
-
-        // best not.
-        if (Transform(subject).Anchored)
-            return;
-
-        // break pulls before portal enter so we don't break shit
-        if (TryComp<PullableComponent>(subject, out var pullable) && pullable.BeingPulled)
+        if (args.Mode == TeleportMode.Ghost)
         {
-            _pulling.TryStopPull(subject, pullable);
-        }
+            if (IsGhostTraversalTarget(args.Target) && TryTeleportGhost(ent, args.Target))
+                args.Handled = true;
 
-        if (TryComp<PullerComponent>(subject, out var pullerComp)
-            && TryComp<PullableComponent>(pullerComp.Pulling, out var subjectPulling))
-        {
-            _pulling.TryStopPull(pullerComp.Pulling.Value, subjectPulling);
-        }
-
-        // also break grapple joints
-        _joints.RemoveJoint(subject, SharedGrapplingGunSystem.GrapplingJoint);
-
-        // if they came from another portal, just return and wait for them to exit the portal
-        if (HasComp<PortalTimeoutComponent>(subject))
-        {
             return;
         }
 
         if (TryComp<LinkedEntityComponent>(ent, out var link) && link.LinkedEntities.Count != 0)
         {
-            // check prediction
-            if (_netMan.IsClient && !CanPredictTeleport((ent, link)))
+            if (_net.IsClient && !CanPredictTeleport((ent, link)))
                 return;
 
-            // pick a target and teleport there
-            var target = _random.Pick(link.LinkedEntities);
+            var destinationEntity = _random.Pick(link.LinkedEntities);
+            if (!Exists(destinationEntity))
+                return;
 
-            if (HasComp<PortalComponent>(target))
-            {
-                // if target is a portal, signal that they shouldn't be immediately teleported back
-                var timeout = EnsureComp<PortalTimeoutComponent>(subject);
-                timeout.EnteredPortal = ent;
-                Dirty(subject, timeout);
-            }
+            if (TerminatingOrDeleted(destinationEntity))
+                return;
 
-            TeleportEntity(ent, subject, Transform(target).Coordinates, target);
+            var destination = Transform(destinationEntity).Coordinates;
+            if (!TryTeleport(ent, args.Target, destination, destinationEntity))
+                return;
+
+            args.Handled = true;
             return;
         }
 
-        if (_netMan.IsClient)
+        if (_net.IsClient)
             return;
 
-        // no linked entity--teleport randomly
-        if (ent.Comp.RandomTeleport)
-            TeleportRandomly(ent, subject);
-    }
-
-    private void OnEndCollide(Entity<PortalComponent> ent, ref EndCollideEvent args)
-    {
-        if (!ShouldCollide(args.OurFixtureId, args.OtherFixtureId, args.OurFixture, args.OtherFixture))
+        if (!ent.Comp.RandomTeleport)
             return;
 
-        var subject = args.OtherEntity;
-
-        // if they came from a different portal, remove the timeout
-        if (TryComp<PortalTimeoutComponent>(subject, out var timeout) && timeout.EnteredPortal != ent)
-        {
-            RemCompDeferred<PortalTimeoutComponent>(subject);
-        }
+        var randomDestination = FindRandomDestination(ent);
+        if (TryTeleport(ent, args.Target, randomDestination))
+            args.Handled = true;
     }
 
-    /// <summary>
-    /// Checks if the colliding fixtures are the ones we want.
-    /// </summary>
-    /// <returns>
-    /// False if our fixture is not a portal fixture.
-    /// False if other fixture is not hard, but makes an exception for projectiles.
-    /// </returns>
-    private bool ShouldCollide(string ourId, string otherId, Fixture our, Fixture other)
+    private bool TryTeleportGhost(Entity<PortalComponent> ent, EntityUid target)
     {
-        return ourId == PortalFixture && (other.Hard || otherId == ProjectileFixture);
-    }
-
-    /// <summary>
-    /// Checks if the client is able to predict the teleport.
-    /// Client can't predict outside 1-to-1 portal-to-portal interactions due to randomness involved.
-    /// </summary>
-    /// <returns>
-    /// False if the linked entity count isn't 1.
-    /// False if the linked entity doesn't exist on the client / is outside PVS.
-    /// </returns>
-    private bool CanPredictTeleport(Entity<LinkedEntityComponent> portal)
-    {
-        var first = portal.Comp.LinkedEntities.First();
-        var exists = Exists(first);
-
-        if (!exists ||
-            portal.Comp.LinkedEntities.Count != 1 || // 0 and >1 use RNG
-            exists && Transform(first).MapID == MapId.Nullspace) // The linked entity is most likely outside PVS
+        if (!TryComp<LinkedEntityComponent>(ent, out var link))
             return false;
 
+        if (link.LinkedEntities.Count != 1)
+            return false;
+
+        if (_net.IsClient && !CanPredictTeleport((ent, link)))
+            return false;
+
+        var destinationEntity = link.LinkedEntities.First();
+        if (!Exists(destinationEntity))
+            return false;
+
+        if (TerminatingOrDeleted(destinationEntity))
+            return false;
+
+        var destination = Transform(destinationEntity).Coordinates;
+        if (!TryValidateDestination(ent, destination, destinationEntity))
+            return false;
+
+        var source = Transform(target).Coordinates;
+        if (!_teleport.TryTeleportGhost(target, destination))
+            return false;
+
+        LogTeleport(ent, target, source, destination);
         return true;
     }
 
-    /// <summary>
-    /// Handles teleporting a subject from the portal entity to a coordinate.
-    /// Also deletes invalid portals.
-    /// </summary>
-    /// <param name="ent"> The portal being collided with. </param>
-    /// <param name="subject"> The entity getting teleported. </param>
-    /// <param name="target"> The location to teleport to. </param>
-    /// <param name="targetEntity"> The portal on the other side of the teleport. </param>
-    private void TeleportEntity(Entity<PortalComponent> ent, EntityUid subject, EntityCoordinates target, EntityUid? targetEntity = null, bool playSound = true)
+    private bool TryTeleport(
+        Entity<PortalComponent> ent,
+        EntityUid target,
+        EntityCoordinates destination,
+        EntityUid? destinationEntity = null)
     {
-        var ourCoords = Transform(ent).Coordinates;
-        var onSameMap = _transform.GetMapId(ourCoords) == _transform.GetMapId(target);
+        if (!TryValidateDestination(ent, destination, destinationEntity))
+            return false;
+
+        var addedTimeout = false;
+        if (HasComp<PortalComponent>(destinationEntity))
+        {
+            addedTimeout = !HasComp<PortalTimeoutComponent>(target);
+            var timeout = EnsureComp<PortalTimeoutComponent>(target);
+            timeout.EnteredPortal = ent;
+            Dirty(target, timeout);
+        }
+
+        var source = Transform(target).Coordinates;
+        if (!_teleport.TryTeleport(ent, target, destination))
+        {
+            if (addedTimeout)
+                RemComp<PortalTimeoutComponent>(target);
+
+            return false;
+        }
+
+        LogTeleport(ent, target, source, destination);
+        return true;
+    }
+
+    private bool TryValidateDestination(
+        Entity<PortalComponent> ent,
+        EntityCoordinates destination,
+        EntityUid? destinationEntity)
+    {
+        var source = Transform(ent).Coordinates;
+        var onSameMap = _transform.GetMapId(source) == _transform.GetMapId(destination);
+        var mapInvalid = !onSameMap && !ent.Comp.CanTeleportToOtherMaps;
         var distanceInvalid = ent.Comp.MaxTeleportRadius != null
-                              && ourCoords.TryDistance(EntityManager, target, out var distance)
+                              && source.TryDistance(EntityManager, destination, out var distance)
                               && distance > ent.Comp.MaxTeleportRadius;
 
-        // Early out if this is an invalid configuration
-        if (!onSameMap && !ent.Comp.CanTeleportToOtherMaps || distanceInvalid)
+        if (!mapInvalid && !distanceInvalid)
+            return true;
+
+        if (_net.IsClient)
+            return false;
+
+        _popup.PopupCoordinates(
+            Loc.GetString("portal-component-invalid-configuration-fizzle"),
+            source,
+            Filter.Pvs(source, entityMan: EntityManager),
+            true);
+
+        _popup.PopupCoordinates(
+            Loc.GetString("portal-component-invalid-configuration-fizzle"),
+            destination,
+            Filter.Pvs(destination, entityMan: EntityManager),
+            true);
+
+        QueueDel(ent);
+
+        if (destinationEntity != null)
+            QueueDel(destinationEntity.Value);
+
+        return false;
+    }
+
+    private EntityCoordinates FindRandomDestination(Entity<PortalComponent> ent)
+    {
+        var source = Transform(ent).Coordinates;
+        var destination = source.Offset(_random.NextVector2(ent.Comp.MaxRandomRadius));
+
+        for (var i = 0; i < MaxRandomTeleportAttempts; i++)
         {
-            if (_netMan.IsClient)
-                return;
-
-            _popup.PopupCoordinates(Loc.GetString("portal-component-invalid-configuration-fizzle"),
-                ourCoords, Filter.Pvs(ourCoords, entityMan: EntityManager), true);
-
-            _popup.PopupCoordinates(Loc.GetString("portal-component-invalid-configuration-fizzle"),
-                target, Filter.Pvs(target, entityMan: EntityManager), true);
-
-            QueueDel(ent);
-
-            if (targetEntity != null)
-                QueueDel(targetEntity.Value);
-
-            return;
+            destination = source.Offset(_random.NextVector2(ent.Comp.MaxRandomRadius));
+            if (!_lookup.AnyEntitiesIntersecting(_transform.ToMapCoordinates(destination), LookupFlags.Static))
+                break;
         }
 
-        var arrivalSound = CompOrNull<PortalComponent>(targetEntity)?.ArrivalSound ?? ent.Comp.ArrivalSound;
-        var departureSound = ent.Comp.DepartureSound;
-
-        LogTeleport(ent, subject, Transform(subject).Coordinates, target);
-
-        _transform.SetCoordinates(subject, target);
-
-        if (!playSound)
-            return;
-
-        _audio.PlayPredicted(departureSound, ent, subject);
-        _audio.PlayPredicted(arrivalSound, subject, subject);
+        return destination;
     }
 
     /// <summary>
-    /// Finds a random coordinate within the portal's radius and teleports the subject there.
-    /// Attempts to not put the subject inside a static entity (e.g. wall).
+    /// Logs a successful portal teleport on the server.
     /// </summary>
-    /// <param name="ent"> The portal being collided with. </param>
-    /// <param name="subject"> The entity getting teleported. </param>
-    private void TeleportRandomly(Entity<PortalComponent> ent, EntityUid subject)
+    protected virtual void LogTeleport(
+        EntityUid portal,
+        EntityUid target,
+        EntityCoordinates source,
+        EntityCoordinates destination)
     {
-        var xform = Transform(ent);
-        var coords = xform.Coordinates;
-        var newCoords = coords.Offset(_random.NextVector2(ent.Comp.MaxRandomRadius));
-        for (var i = 0; i < MaxRandomTeleportAttempts; i++)
-        {
-            var randVector = _random.NextVector2(ent.Comp.MaxRandomRadius);
-            newCoords = coords.Offset(randVector);
-            if (!_lookup.AnyEntitiesIntersecting(_transform.ToMapCoordinates(newCoords), LookupFlags.Static))
-            {
-                // newCoords is not a wall
-                break;
-            }
-            // after "MaxRandomTeleportAttempts" attempts, end up in the walls
-        }
-
-        TeleportEntity(ent, subject, newCoords);
     }
 
-    protected virtual void LogTeleport(EntityUid portal, EntityUid subject, EntityCoordinates source,
-        EntityCoordinates target)
+    private bool CanPredictTeleport(Entity<LinkedEntityComponent> portal)
     {
+        if (portal.Comp.LinkedEntities.Count != 1)
+            return false;
+
+        var destination = portal.Comp.LinkedEntities.First();
+        if (!Exists(destination))
+            return false;
+
+        return Transform(destination).MapID != MapId.Nullspace;
+    }
+
+    private bool IsGhostTraversalTarget(EntityUid target)
+    {
+        if (HasComp<GhostComponent>(target))
+            return true;
+
+        return HasComp<RevenantComponent>(target);
     }
 }

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
@@ -120,7 +120,7 @@ public abstract partial class SharedPortalSystem : EntitySystem
 
         var source = Transform(target).Coordinates;
         var previousExit = CompOrNull<PortalTimeoutComponent>(target)?.ExitPortal;
-        var timeoutSet = destinationEntity is { } exit && SetPortalTimeout(target, exit);
+        var timeoutSet = destinationEntity != null && SetPortalTimeout(target, destinationEntity.Value);
         var moved = false;
         try
         {

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
@@ -53,8 +53,13 @@ public abstract partial class SharedPortalSystem : EntitySystem
 
     private void OnTeleportTriggerExited(Entity<PortalComponent> ent, ref TeleportTriggerExitedEvent args)
     {
-        if (TryComp<PortalTimeoutComponent>(args.Target, out var timeout) && timeout.ExitPortal == ent.Owner)
-            RefreshTimeout(args.Target, timeout);
+        if (!TryComp<PortalTimeoutComponent>(args.Target, out var timeout))
+            return;
+
+        if (timeout.ExitPortal != ent.Owner)
+            return;
+
+        RefreshTimeout(args.Target, timeout);
     }
 
     private void OnTeleportRequest(Entity<PortalComponent> ent, ref TeleportRequestEvent args)
@@ -90,7 +95,10 @@ public abstract partial class SharedPortalSystem : EntitySystem
             return false;
 
         var destinationEntity = _random.Pick(link.LinkedEntities);
-        if (!Exists(destinationEntity) || TerminatingOrDeleted(destinationEntity))
+        if (!Exists(destinationEntity))
+            return false;
+
+        if (TerminatingOrDeleted(destinationEntity))
             return false;
 
         var destination = Transform(destinationEntity).Coordinates;
@@ -121,9 +129,8 @@ public abstract partial class SharedPortalSystem : EntitySystem
         }
         finally
         {
-            // A failed post-move effect must not remove protection at the exit.
-            if (timeoutSet && !moved && !TerminatingOrDeleted(target))
-                RestoreTimeout(target, previousExit);
+            if (timeoutSet)
+                RestoreTimeoutAfterFailedTeleport(target, previousExit, moved);
         }
     }
 

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
@@ -64,7 +64,7 @@ public abstract partial class SharedPortalSystem : EntitySystem
 
         if (TryComp<LinkedEntityComponent>(ent, out var link) && link.LinkedEntities.Count != 0)
         {
-            args.Handled = TryTeleportLinked(ent, link, args.Target);
+            args.Handled = TryTeleportLinked(ent, link, args.Target, args.TriggerEffects);
             return;
         }
 
@@ -75,11 +75,15 @@ public abstract partial class SharedPortalSystem : EntitySystem
             return;
 
         var randomDestination = FindRandomDestination(ent);
-        if (TryTeleport(ent, args.Target, randomDestination))
+        if (TryTeleport(ent, args.Target, randomDestination, args.TriggerEffects))
             args.Handled = true;
     }
 
-    private bool TryTeleportLinked(Entity<PortalComponent> ent, LinkedEntityComponent link, EntityUid target)
+    private bool TryTeleportLinked(
+        Entity<PortalComponent> ent,
+        LinkedEntityComponent link,
+        EntityUid target,
+        bool triggerEffects)
     {
         if (_net.IsClient && !CanPredictTeleport((ent, link)))
             return false;
@@ -89,13 +93,14 @@ public abstract partial class SharedPortalSystem : EntitySystem
             return false;
 
         var destination = Transform(destinationEntity).Coordinates;
-        return TryTeleport(ent, target, destination, destinationEntity);
+        return TryTeleport(ent, target, destination, triggerEffects, destinationEntity);
     }
 
     private bool TryTeleport(
         Entity<PortalComponent> ent,
         EntityUid target,
         EntityCoordinates destination,
+        bool triggerEffects,
         EntityUid? destinationEntity = null)
     {
         if (!TryValidateDestination(ent, destination, destinationEntity))
@@ -103,7 +108,7 @@ public abstract partial class SharedPortalSystem : EntitySystem
 
         var addedTimeout = AddTimeout(ent, target, destinationEntity);
         var source = Transform(target).Coordinates;
-        if (_teleport.TryTeleport(ent, target, destination))
+        if (_teleport.TryTeleport(ent, target, destination, triggerEffects))
         {
             LogTeleport(ent, target, source, destination);
             return true;

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
@@ -184,6 +184,7 @@ public abstract partial class SharedPortalSystem : EntitySystem
                 break;
         }
 
+        // If all attempts fail, use the last candidate even if it places the target inside a wall.
         return destination;
     }
 
@@ -198,6 +199,10 @@ public abstract partial class SharedPortalSystem : EntitySystem
     {
     }
 
+    /// <summary>
+    /// Clients can predict only a single linked exit that is available locally and outside nullspace.
+    /// Multiple exits require a random choice by the server.
+    /// </summary>
     private bool CanPredictTeleport(Entity<LinkedEntityComponent> portal)
     {
         if (portal.Comp.LinkedEntities.Count != 1)

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
@@ -2,6 +2,7 @@
 using Content.Shared.Popups;
 using Content.Shared.Teleportation.Components;
 using Content.Shared.Teleportation.Triggers;
+using Content.Shared.Whitelist;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
@@ -22,6 +23,7 @@ public abstract partial class SharedPortalSystem : EntitySystem
     [Dependency] private SharedTeleportSystem _teleport = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private CollisionTeleportTriggerSystem _collisionTrigger = default!;
+    [Dependency] private EntityWhitelistSystem _whitelist = default!;
 
     private const int MaxRandomTeleportAttempts = 20;
 
@@ -36,19 +38,34 @@ public abstract partial class SharedPortalSystem : EntitySystem
 
     private void OnTeleportUseAttempt(Entity<PortalComponent> ent, ref TeleportUseAttemptEvent args)
     {
+        if (args.Cancelled)
+            return;
+
         if (TryComp<PortalTimeoutComponent>(args.Target, out var timeout) && IsTimeoutActive(args.Target, timeout))
         {
-            args.Cancelled = true;
+            args.Cancel();
             return;
         }
-
-        if (ent.Comp.RandomTeleport)
-            return;
 
         if (TryComp<LinkedEntityComponent>(ent, out var link) && link.LinkedEntities.Count != 0)
             return;
 
-        args.Cancelled = true;
+        if (!ent.Comp.RandomTeleport)
+        {
+            args.Cancel();
+            return;
+        }
+
+        if (args.User == null)
+            return;
+
+        if (!_whitelist.CheckBoth(
+                args.User.Value,
+                blacklist: ent.Comp.UnlinkedUserBlacklist,
+                whitelist: ent.Comp.UnlinkedUserWhitelist))
+        {
+            args.Cancel("portal-component-unlinked-user-denied");
+        }
     }
 
     private void OnTeleportTriggerExited(Entity<PortalComponent> ent, ref TeleportTriggerExitedEvent args)

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
@@ -115,6 +115,9 @@ public abstract partial class SharedPortalSystem : EntitySystem
         if (!TryValidateDestination(ent, destination, destinationEntity))
             return false;
 
+        if (!TryValidateExit(target, destination, destinationEntity))
+            return false;
+
         var source = Transform(target).Coordinates;
         var previousExit = CompOrNull<PortalTimeoutComponent>(target)?.ExitPortal;
         var timeoutSet = destinationEntity is { } exit && SetPortalTimeout(target, exit);
@@ -132,6 +135,25 @@ public abstract partial class SharedPortalSystem : EntitySystem
             if (timeoutSet)
                 RestoreTimeoutAfterFailedTeleport(target, previousExit, moved);
         }
+    }
+
+    private bool TryValidateExit(EntityUid target, EntityCoordinates destination, EntityUid? exit)
+    {
+        if (exit == null)
+            return true;
+
+        var mapCoordinates = _transform.ToMapCoordinates(destination);
+        var targetTransform = Transform(target);
+        var rotation = _transform.GetWorldRotation(targetTransform);
+        // Bodies without local rotation follow the destination parent's rotation after reparenting.
+        if (targetTransform.NoLocalRotation)
+            rotation = _transform.GetWorldRotation(destination.EntityId);
+
+        if (!_teleport.IsDestinationBlocked(target, mapCoordinates, rotation, LookupFlags.Static))
+            return true;
+
+        _popup.PopupEntity(Loc.GetString("portal-component-exit-blocked"), target, target);
+        return false;
     }
 
     private bool TryValidateDestination(

--- a/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedPortalSystem.cs
@@ -36,7 +36,7 @@ public abstract partial class SharedPortalSystem : EntitySystem
 
     private void OnTeleportUseAttempt(Entity<PortalComponent> ent, ref TeleportUseAttemptEvent args)
     {
-        if (HasComp<PortalTimeoutComponent>(args.Target))
+        if (TryComp<PortalTimeoutComponent>(args.Target, out var timeout) && IsTimeoutActive(args.Target, timeout))
         {
             args.Cancelled = true;
             return;
@@ -53,8 +53,8 @@ public abstract partial class SharedPortalSystem : EntitySystem
 
     private void OnTeleportTriggerExited(Entity<PortalComponent> ent, ref TeleportTriggerExitedEvent args)
     {
-        if (TryComp<PortalTimeoutComponent>(args.Target, out var timeout) && timeout.EnteredPortal != ent)
-            RemCompDeferred<PortalTimeoutComponent>(args.Target);
+        if (TryComp<PortalTimeoutComponent>(args.Target, out var timeout) && timeout.ExitPortal == ent.Owner)
+            RefreshTimeout(args.Target, timeout);
     }
 
     private void OnTeleportRequest(Entity<PortalComponent> ent, ref TeleportRequestEvent args)
@@ -62,9 +62,11 @@ public abstract partial class SharedPortalSystem : EntitySystem
         if (args.Handled)
             return;
 
+        args.Handled = true;
+
         if (TryComp<LinkedEntityComponent>(ent, out var link) && link.LinkedEntities.Count != 0)
         {
-            args.Handled = TryTeleportLinked(ent, link, args.Target, args.TriggerEffects);
+            args.Succeeded = TryTeleportLinked(ent, link, args.Target, args.TriggerEffects);
             return;
         }
 
@@ -75,8 +77,7 @@ public abstract partial class SharedPortalSystem : EntitySystem
             return;
 
         var randomDestination = FindRandomDestination(ent);
-        if (TryTeleport(ent, args.Target, randomDestination, args.TriggerEffects))
-            args.Handled = true;
+        args.Succeeded = TryTeleport(ent, args.Target, randomDestination, args.TriggerEffects);
     }
 
     private bool TryTeleportLinked(
@@ -106,31 +107,24 @@ public abstract partial class SharedPortalSystem : EntitySystem
         if (!TryValidateDestination(ent, destination, destinationEntity))
             return false;
 
-        var addedTimeout = AddTimeout(ent, target, destinationEntity);
         var source = Transform(target).Coordinates;
-        if (_teleport.TryTeleport(ent, target, destination, triggerEffects))
+        var previousExit = CompOrNull<PortalTimeoutComponent>(target)?.ExitPortal;
+        var timeoutSet = destinationEntity is { } exit && SetPortalTimeout(target, exit);
+        var moved = false;
+        try
         {
+            if (!_teleport.TryTeleport(ent, target, destination, out moved, triggerEffects))
+                return false;
+
             LogTeleport(ent, target, source, destination);
             return true;
         }
-
-        if (addedTimeout)
-            RemComp<PortalTimeoutComponent>(target);
-
-        return false;
-    }
-
-    private bool AddTimeout(EntityUid portal, EntityUid target, EntityUid? destination)
-    {
-        // Only collision-triggered return trips need a timeout. Other targets may never raise an exit event.
-        if (destination is not { } exit || !HasComp<PortalComponent>(exit) || !_collisionTrigger.CanTrigger(exit, target))
-            return false;
-
-        var addedTimeout = !HasComp<PortalTimeoutComponent>(target);
-        var timeout = EnsureComp<PortalTimeoutComponent>(target);
-        timeout.EnteredPortal = portal;
-        Dirty(target, timeout);
-        return addedTimeout;
+        finally
+        {
+            // A failed post-move effect must not remove protection at the exit.
+            if (timeoutSet && !moved && !TerminatingOrDeleted(target))
+                RestoreTimeout(target, previousExit);
+        }
     }
 
     private bool TryValidateDestination(

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.Destination.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.Destination.cs
@@ -15,22 +15,22 @@ public sealed partial class SharedTeleportSystem
     /// <summary>
     /// Checks whether the entity would collide with another hard, collidable entity at the target coordinates.
     /// </summary>
-    /// <param name="user">The entity being checked.</param>
+    /// <param name="user">The entity being checked, with optional cached fixtures and physics components.</param>
     /// <param name="target">The map coordinates to check.</param>
     /// <param name="rotation">The entity's world rotation at the destination.</param>
     /// <param name="flags">Which types of obstacles to consider.</param>
-    /// <returns>Whether the destination is blocked.</returns>
+    /// <returns>Whether the destination is blocked. Returns false if either required component is missing.</returns>
     public bool IsDestinationBlocked(
-        EntityUid user,
+        Entity<FixturesComponent?, PhysicsComponent?> user,
         MapCoordinates target,
         Angle rotation,
         LookupFlags flags = LookupFlags.Dynamic | LookupFlags.Static)
     {
-        if (!TryComp<FixturesComponent>(user, out var fixtures))
+        if (!Resolve(user, ref user.Comp1, ref user.Comp2, logMissing: false))
             return false;
 
-        if (!TryComp<PhysicsComponent>(user, out var physics))
-            return false;
+        var fixtures = user.Comp1;
+        var physics = user.Comp2;
 
         if (!physics.CanCollide)
             return false;
@@ -55,10 +55,10 @@ public sealed partial class SharedTeleportSystem
 
             foreach (var other in _destinationIntersecting)
             {
-                if (other.Owner == user)
+                if (other.Owner == user.Owner)
                     continue;
 
-                if (_physics.IsCurrentlyHardCollidable((other.Owner, null, other.Comp), (user, fixtures, physics)))
+                if (_physics.IsCurrentlyHardCollidable((other.Owner, null, other.Comp), user))
                     return true;
             }
         }

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.Destination.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.Destination.cs
@@ -1,0 +1,68 @@
+using Robust.Shared.Map;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+
+namespace Content.Shared.Teleportation.Systems;
+
+public sealed partial class SharedTeleportSystem
+{
+    [Dependency] private EntityLookupSystem _lookup = default!;
+    [Dependency] private SharedPhysicsSystem _physics = default!;
+
+    private readonly HashSet<Entity<PhysicsComponent>> _destinationIntersecting = new();
+
+    /// <summary>
+    /// Checks whether the entity would collide with another hard, collidable entity at the target coordinates.
+    /// </summary>
+    /// <param name="user">The entity being checked.</param>
+    /// <param name="target">The map coordinates to check.</param>
+    /// <param name="rotation">The entity's world rotation at the destination.</param>
+    /// <param name="flags">Which types of obstacles to consider.</param>
+    /// <returns>Whether the destination is blocked.</returns>
+    public bool IsDestinationBlocked(
+        EntityUid user,
+        MapCoordinates target,
+        Angle rotation,
+        LookupFlags flags = LookupFlags.Dynamic | LookupFlags.Static)
+    {
+        if (!TryComp<FixturesComponent>(user, out var fixtures))
+            return false;
+
+        if (!TryComp<PhysicsComponent>(user, out var physics))
+            return false;
+
+        if (!physics.CanCollide)
+            return false;
+
+        if (!physics.Hard)
+            return false;
+
+        var destinationTransform = new Transform(target.Position, rotation);
+
+        foreach (var fixture in fixtures.Fixtures.Values)
+        {
+            if (!fixture.Hard)
+                continue;
+
+            _destinationIntersecting.Clear();
+            _lookup.GetEntitiesIntersecting(
+                target.MapId,
+                fixture.Shape,
+                destinationTransform,
+                _destinationIntersecting,
+                flags);
+
+            foreach (var other in _destinationIntersecting)
+            {
+                if (other.Owner == user)
+                    continue;
+
+                if (_physics.IsCurrentlyHardCollidable((other.Owner, null, other.Comp), (user, fixtures, physics)))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.Requests.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.Requests.cs
@@ -1,0 +1,61 @@
+using Content.Shared.Teleportation.Components;
+using Content.Shared.Teleportation.Triggers;
+using Robust.Shared.Network;
+
+namespace Content.Shared.Teleportation.Systems;
+
+public sealed partial class SharedTeleportSystem
+{
+    [Dependency] private INetManager _net = default!;
+
+    /// <summary>
+    /// Checks use restrictions without starting a teleport or running effects.
+    /// May also be used when collecting verbs.
+    /// </summary>
+    public TeleportUseAttemptEvent CheckTeleportUse(EntityUid teleporter, EntityUid target, EntityUid user)
+    {
+        var attempt = new TeleportUseAttemptEvent(target, user);
+
+        if (!Exists(teleporter) || TerminatingOrDeleted(teleporter) ||
+            !Exists(target) || TerminatingOrDeleted(target) || HasComp<TeleportingComponent>(target))
+        {
+            attempt.Cancelled = true;
+            return attempt;
+        }
+
+        RaiseLocalEvent(teleporter, ref attempt);
+        return attempt;
+    }
+
+    /// <summary>
+    /// Checks whether a teleporter can be used, then dispatches a request to its implementation.
+    /// The target remains protected from nested requests until all teleport events have finished.
+    /// </summary>
+    public bool RequestTeleport(EntityUid teleporter, EntityUid target, EntityUid user, bool triggerEffects = true)
+    {
+        var attempt = CheckTeleportUse(teleporter, target, user);
+        if (attempt.Cancelled)
+            return false;
+
+        try
+        {
+            AddComp<TeleportingComponent>(target);
+
+            var request = new TeleportRequestEvent(target, user, triggerEffects);
+            RaiseLocalEvent(teleporter, ref request);
+
+            if (!request.Handled && !_net.IsClient)
+            {
+                Log.Error($"Teleporter {ToPrettyString(teleporter)} couldn't teleport {ToPrettyString(target)} " +
+                          "because no teleport implementation handled the request");
+            }
+
+            return request.Handled;
+        }
+        finally
+        {
+            // Immediate removal also tolerates the target or marker being deleted by a handler.
+            RemComp<TeleportingComponent>(target);
+        }
+    }
+}

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.Requests.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.Requests.cs
@@ -12,7 +12,10 @@ public sealed partial class SharedTeleportSystem
     /// Checks use restrictions without starting a teleport or running effects.
     /// May also be used when collecting verbs.
     /// </summary>
-    public TeleportUseAttemptEvent CheckTeleportUse(EntityUid teleporter, EntityUid target, EntityUid user)
+    /// <param name="teleporter">The teleporter being activated.</param>
+    /// <param name="target">The entity to teleport.</param>
+    /// <param name="user">The explicit initiator, or null for automatic activation. A supplied initiator must still exist.</param>
+    public TeleportUseAttemptEvent CheckTeleportUse(EntityUid teleporter, EntityUid target, EntityUid? user)
     {
         var attempt = new TeleportUseAttemptEvent(target, user, Cancelled: true);
 
@@ -28,6 +31,12 @@ public sealed partial class SharedTeleportSystem
         if (TerminatingOrDeleted(target))
             return attempt;
 
+        if (user != null && !Exists(user.Value))
+            return attempt;
+
+        if (user != null && TerminatingOrDeleted(user.Value))
+            return attempt;
+
         if (HasComp<TeleportingComponent>(target))
             return attempt;
 
@@ -40,7 +49,11 @@ public sealed partial class SharedTeleportSystem
     /// Checks whether a teleporter can be used, then dispatches a request to its implementation.
     /// The target remains protected from nested requests until all teleport events have finished.
     /// </summary>
-    public bool RequestTeleport(EntityUid teleporter, EntityUid target, EntityUid user, bool triggerEffects = true)
+    /// <param name="teleporter">The teleporter being activated.</param>
+    /// <param name="target">The entity to teleport.</param>
+    /// <param name="user">The explicit initiator, or null for automatic activation.</param>
+    /// <param name="triggerEffects">Whether to run effects before and after movement.</param>
+    public bool RequestTeleport(EntityUid teleporter, EntityUid target, EntityUid? user, bool triggerEffects = true)
     {
         var attempt = CheckTeleportUse(teleporter, target, user);
         if (attempt.Cancelled)

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.Requests.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.Requests.cs
@@ -50,7 +50,7 @@ public sealed partial class SharedTeleportSystem
                           "because no teleport implementation handled the request");
             }
 
-            return request.Handled;
+            return request.Succeeded;
         }
         finally
         {

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.Requests.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.Requests.cs
@@ -14,15 +14,24 @@ public sealed partial class SharedTeleportSystem
     /// </summary>
     public TeleportUseAttemptEvent CheckTeleportUse(EntityUid teleporter, EntityUid target, EntityUid user)
     {
-        var attempt = new TeleportUseAttemptEvent(target, user);
+        var attempt = new TeleportUseAttemptEvent(target, user, Cancelled: true);
 
-        if (!Exists(teleporter) || TerminatingOrDeleted(teleporter) ||
-            !Exists(target) || TerminatingOrDeleted(target) || HasComp<TeleportingComponent>(target))
-        {
-            attempt.Cancelled = true;
+        if (!Exists(teleporter))
             return attempt;
-        }
 
+        if (TerminatingOrDeleted(teleporter))
+            return attempt;
+
+        if (!Exists(target))
+            return attempt;
+
+        if (TerminatingOrDeleted(target))
+            return attempt;
+
+        if (HasComp<TeleportingComponent>(target))
+            return attempt;
+
+        attempt.Cancelled = false;
         RaiseLocalEvent(teleporter, ref attempt);
         return attempt;
     }
@@ -44,11 +53,14 @@ public sealed partial class SharedTeleportSystem
             var request = new TeleportRequestEvent(target, user, triggerEffects);
             RaiseLocalEvent(teleporter, ref request);
 
-            if (!request.Handled && !_net.IsClient)
-            {
-                Log.Error($"Teleporter {ToPrettyString(teleporter)} couldn't teleport {ToPrettyString(target)} " +
-                          "because no teleport implementation handled the request");
-            }
+            if (request.Handled)
+                return request.Succeeded;
+
+            if (_net.IsClient)
+                return request.Succeeded;
+
+            Log.Error($"Teleporter {ToPrettyString(teleporter)} couldn't teleport {ToPrettyString(target)} " +
+                      "because no teleport implementation handled the request");
 
             return request.Succeeded;
         }

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
@@ -1,0 +1,85 @@
+using Content.Shared.Ghost.Components;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
+using Robust.Shared.Map;
+
+namespace Content.Shared.Teleportation.Systems;
+
+/// <summary>
+/// Moves entities to resolved destination coordinates and raises the common teleport lifecycle events.
+/// </summary>
+public sealed partial class SharedTeleportSystem : EntitySystem
+{
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private PullingSystem _pulling = default!;
+
+    /// <summary>
+    /// Attempts to move a target to already resolved destination coordinates.
+    /// </summary>
+    /// <param name="teleporter">The entity performing the teleportation.</param>
+    /// <param name="target">The entity to teleport.</param>
+    /// <param name="destination">The destination chosen by the teleport implementation.</param>
+    public bool TryTeleport(EntityUid teleporter, EntityUid target, EntityCoordinates destination)
+    {
+        if (!Exists(teleporter))
+            return false;
+
+        if (!Exists(target))
+            return false;
+
+        if (TerminatingOrDeleted(target))
+            return false;
+
+        if (!destination.IsValid(EntityManager))
+            return false;
+
+        var beforeTeleport = new BeforeTeleportEvent(target);
+        RaiseLocalEvent(teleporter, ref beforeTeleport);
+
+        StopPullingRelationships(target);
+        _transform.SetCoordinates(target, Transform(target), destination);
+
+        var targetTeleported = new TargetTeleportedEvent(target);
+        RaiseLocalEvent(teleporter, ref targetTeleported);
+
+        var teleported = new TeleportedEvent(teleporter);
+        RaiseLocalEvent(target, ref teleported);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to teleport an observer without invoking the regular teleport lifecycle.
+    /// </summary>
+    public bool TryTeleportGhost(EntityUid target, EntityCoordinates destination)
+    {
+        if (!HasComp<GhostComponent>(target))
+            return false;
+
+        if (TerminatingOrDeleted(target))
+            return false;
+
+        if (!destination.IsValid(EntityManager))
+            return false;
+
+        _transform.SetCoordinates(target, Transform(target), destination);
+        return true;
+    }
+
+    private void StopPullingRelationships(EntityUid target)
+    {
+        if (TryComp(target, out PullableComponent? targetPullable))
+            _pulling.TryStopPull(target, targetPullable);
+
+        if (!TryComp(target, out PullerComponent? targetPuller))
+            return;
+
+        if (targetPuller.Pulling is not { } pulledTarget)
+            return;
+
+        if (!TryComp(pulledTarget, out PullableComponent? pulledEntity))
+            return;
+
+        _pulling.TryStopPull(pulledTarget, pulledEntity);
+    }
+}

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Ghost.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Weapons.Misc;
@@ -8,7 +7,7 @@ using Robust.Shared.Physics.Systems;
 namespace Content.Shared.Teleportation.Systems;
 
 /// <summary>
-/// Moves entities to resolved destination coordinates and raises the common teleport lifecycle events.
+/// Moves entities to resolved destination coordinates, optionally raising the common teleport lifecycle events.
 /// </summary>
 public sealed partial class SharedTeleportSystem : EntitySystem
 {
@@ -17,7 +16,7 @@ public sealed partial class SharedTeleportSystem : EntitySystem
     [Dependency] private SharedJointSystem _joints = default!;
 
     /// <summary>
-    /// Attempts to move a target to already resolved destination coordinates.
+    /// Attempts to move a target and raise teleport lifecycle events on the teleporter and target.
     /// </summary>
     /// <param name="teleporter">The entity performing the teleportation.</param>
     /// <param name="target">The entity to teleport.</param>
@@ -27,20 +26,13 @@ public sealed partial class SharedTeleportSystem : EntitySystem
         if (!Exists(teleporter))
             return false;
 
-        if (!Exists(target))
-            return false;
-
-        if (TerminatingOrDeleted(target))
-            return false;
-
-        if (!destination.IsValid(EntityManager))
+        if (!CanTeleport(target, destination))
             return false;
 
         var beforeTeleport = new BeforeTeleportEvent(target);
         RaiseLocalEvent(teleporter, ref beforeTeleport);
 
-        StopSpatialRelationships(target);
-        _transform.SetCoordinates(target, Transform(target), destination);
+        Teleport(target, destination);
 
         var targetTeleported = new TargetTeleportedEvent(target);
         RaiseLocalEvent(teleporter, ref targetTeleported);
@@ -52,23 +44,27 @@ public sealed partial class SharedTeleportSystem : EntitySystem
     }
 
     /// <summary>
-    /// Attempts to teleport a ghost or spectral entity without invoking the regular teleport lifecycle.
+    /// Moves a target without raising teleport lifecycle events, including those that trigger sounds.
     /// Pulling and grappling relationships are still stopped before movement.
     /// </summary>
-    public bool TryTeleportGhost(EntityUid target, EntityCoordinates destination)
+    public bool TryTeleport(EntityUid target, EntityCoordinates destination)
     {
-        if (!HasComp<GhostComponent>(target) && !HasComp<SpectralComponent>(target))
+        if (!CanTeleport(target, destination))
             return false;
 
-        if (TerminatingOrDeleted(target))
-            return false;
+        Teleport(target, destination);
+        return true;
+    }
 
-        if (!destination.IsValid(EntityManager))
-            return false;
+    private bool CanTeleport(EntityUid target, EntityCoordinates destination)
+    {
+        return Exists(target) && !TerminatingOrDeleted(target) && destination.IsValid(EntityManager);
+    }
 
+    private void Teleport(EntityUid target, EntityCoordinates destination)
+    {
         StopSpatialRelationships(target);
         _transform.SetCoordinates(target, Transform(target), destination);
-        return true;
     }
 
     private void StopSpatialRelationships(EntityUid target)

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
@@ -1,7 +1,9 @@
 using Content.Shared.Ghost.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
+using Content.Shared.Weapons.Misc;
 using Robust.Shared.Map;
+using Robust.Shared.Physics.Systems;
 
 namespace Content.Shared.Teleportation.Systems;
 
@@ -12,6 +14,7 @@ public sealed partial class SharedTeleportSystem : EntitySystem
 {
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private PullingSystem _pulling = default!;
+    [Dependency] private SharedJointSystem _joints = default!;
 
     /// <summary>
     /// Attempts to move a target to already resolved destination coordinates.
@@ -36,7 +39,7 @@ public sealed partial class SharedTeleportSystem : EntitySystem
         var beforeTeleport = new BeforeTeleportEvent(target);
         RaiseLocalEvent(teleporter, ref beforeTeleport);
 
-        StopPullingRelationships(target);
+        StopSpatialRelationships(target);
         _transform.SetCoordinates(target, Transform(target), destination);
 
         var targetTeleported = new TargetTeleportedEvent(target);
@@ -49,11 +52,12 @@ public sealed partial class SharedTeleportSystem : EntitySystem
     }
 
     /// <summary>
-    /// Attempts to teleport an observer without invoking the regular teleport lifecycle.
+    /// Attempts to teleport a ghost or spectral entity without invoking the regular teleport lifecycle.
+    /// Pulling and grappling relationships are still stopped before movement.
     /// </summary>
     public bool TryTeleportGhost(EntityUid target, EntityCoordinates destination)
     {
-        if (!HasComp<GhostComponent>(target))
+        if (!HasComp<GhostComponent>(target) && !HasComp<SpectralComponent>(target))
             return false;
 
         if (TerminatingOrDeleted(target))
@@ -62,8 +66,17 @@ public sealed partial class SharedTeleportSystem : EntitySystem
         if (!destination.IsValid(EntityManager))
             return false;
 
+        StopSpatialRelationships(target);
         _transform.SetCoordinates(target, Transform(target), destination);
         return true;
+    }
+
+    private void StopSpatialRelationships(EntityUid target)
+    {
+        StopPullingRelationships(target);
+
+        // Do not leave a relayed physics joint spanning unrelated coordinates or maps after teleportation.
+        _joints.RemoveJoint(target, SharedGrapplingGunSystem.GrapplingJoint);
     }
 
     private void StopPullingRelationships(EntityUid target)

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
+using Content.Shared.Teleportation.Components;
 using Content.Shared.Weapons.Misc;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Systems;
@@ -7,7 +8,7 @@ using Robust.Shared.Physics.Systems;
 namespace Content.Shared.Teleportation.Systems;
 
 /// <summary>
-/// Moves entities to resolved destination coordinates, optionally raising the common teleport lifecycle events.
+/// Moves entities to resolved destination coordinates, with optional effects before and after movement.
 /// </summary>
 public sealed partial class SharedTeleportSystem : EntitySystem
 {
@@ -16,12 +17,15 @@ public sealed partial class SharedTeleportSystem : EntitySystem
     [Dependency] private SharedJointSystem _joints = default!;
 
     /// <summary>
-    /// Attempts to move a target and raise teleport lifecycle events on the teleporter and target.
+    /// Attempts to move a target, optionally triggering effects on the teleporter.
+    /// Always notifies the target with <see cref="TeleportedEvent"/> after successful movement.
+    /// Used by teleport implementations while handling a request dispatched by <see cref="RequestTeleport"/>.
     /// </summary>
     /// <param name="teleporter">The entity performing the teleportation.</param>
     /// <param name="target">The entity to teleport.</param>
     /// <param name="destination">The destination chosen by the teleport implementation.</param>
-    public bool TryTeleport(EntityUid teleporter, EntityUid target, EntityCoordinates destination)
+    /// <param name="triggerEffects">Whether to raise the pre-move and post-move effect events.</param>
+    internal bool TryTeleport(EntityUid teleporter, EntityUid target, EntityCoordinates destination, bool triggerEffects = true)
     {
         if (!Exists(teleporter))
             return false;
@@ -29,13 +33,19 @@ public sealed partial class SharedTeleportSystem : EntitySystem
         if (!CanTeleport(target, destination))
             return false;
 
-        var beforeTeleport = new BeforeTeleportEvent(target);
-        RaiseLocalEvent(teleporter, ref beforeTeleport);
+        if (triggerEffects)
+        {
+            var beforeTeleport = new BeforeTeleportEvent(target);
+            RaiseLocalEvent(teleporter, ref beforeTeleport);
+        }
 
         Teleport(target, destination);
 
-        var targetTeleported = new TargetTeleportedEvent(target);
-        RaiseLocalEvent(teleporter, ref targetTeleported);
+        if (triggerEffects)
+        {
+            var targetTeleported = new TargetTeleportedEvent(target);
+            RaiseLocalEvent(teleporter, ref targetTeleported);
+        }
 
         var teleported = new TeleportedEvent(teleporter);
         RaiseLocalEvent(target, ref teleported);
@@ -46,9 +56,13 @@ public sealed partial class SharedTeleportSystem : EntitySystem
     /// <summary>
     /// Moves a target without raising teleport lifecycle events, including those that trigger sounds.
     /// Pulling and grappling relationships are still stopped before movement.
+    /// Refuses to move a target while a teleport request is being processed.
     /// </summary>
     public bool TryTeleport(EntityUid target, EntityCoordinates destination)
     {
+        if (HasComp<TeleportingComponent>(target))
+            return false;
+
         if (!CanTeleport(target, destination))
             return false;
 

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
@@ -24,9 +24,12 @@ public sealed partial class SharedTeleportSystem : EntitySystem
     /// <param name="teleporter">The entity performing the teleportation.</param>
     /// <param name="target">The entity to teleport.</param>
     /// <param name="destination">The destination chosen by the teleport implementation.</param>
+    /// <param name="moved">Whether the target reached the destination, even if a later effect throws.</param>
     /// <param name="triggerEffects">Whether to raise the pre-move and post-move effect events.</param>
-    internal bool TryTeleport(EntityUid teleporter, EntityUid target, EntityCoordinates destination, bool triggerEffects = true)
+    internal bool TryTeleport(EntityUid teleporter, EntityUid target, EntityCoordinates destination, out bool moved, bool triggerEffects = true)
     {
+        moved = false;
+
         if (!Exists(teleporter))
             return false;
 
@@ -39,7 +42,25 @@ public sealed partial class SharedTeleportSystem : EntitySystem
             RaiseLocalEvent(teleporter, ref beforeTeleport);
         }
 
-        Teleport(target, destination);
+        // Effects may invalidate the target or destination without issuing another teleport request.
+        if (!CanTeleport(target, destination))
+            return false;
+
+        try
+        {
+            Teleport(target, destination);
+        }
+        finally
+        {
+            // SetCoordinates can raise movement handlers after changing the transform.
+            // Preserve the movement result even if one of those handlers throws.
+            moved = TryComp(target, out TransformComponent? transform) &&
+                    transform.ParentUid == destination.EntityId &&
+                    transform.LocalPosition.EqualsApprox(destination.Position);
+        }
+
+        if (!moved)
+            return false;
 
         if (triggerEffects)
         {

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
@@ -113,12 +113,13 @@ public sealed partial class SharedTeleportSystem : EntitySystem
         if (!TryComp(target, out PullerComponent? targetPuller))
             return;
 
-        if (targetPuller.Pulling is not { } pulledTarget)
+        var pulledTarget = targetPuller.Pulling;
+        if (pulledTarget == null)
             return;
 
         if (!TryComp(pulledTarget, out PullableComponent? pulledEntity))
             return;
 
-        _pulling.TryStopPull(pulledTarget, pulledEntity);
+        _pulling.TryStopPull(pulledTarget.Value, pulledEntity);
     }
 }

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
-using Content.Shared.Teleportation.Components;
 using Content.Shared.Weapons.Misc;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Systems;
@@ -18,7 +17,7 @@ public sealed partial class SharedTeleportSystem : EntitySystem
 
     /// <summary>
     /// Attempts to move a target, optionally triggering effects on the teleporter.
-    /// Always notifies the target with <see cref="TeleportedEvent"/> after successful movement.
+    /// Notifies the target with <see cref="TeleportedEvent"/> after successful movement, before post-move effects.
     /// Used by teleport implementations while handling a request dispatched by <see cref="RequestTeleport"/>.
     /// </summary>
     /// <param name="teleporter">The entity performing the teleportation.</param>
@@ -62,32 +61,22 @@ public sealed partial class SharedTeleportSystem : EntitySystem
         if (!moved)
             return false;
 
-        if (triggerEffects)
-        {
-            var targetTeleported = new TargetTeleportedEvent(target);
-            RaiseLocalEvent(teleporter, ref targetTeleported);
-        }
-
         var teleported = new TeleportedEvent(teleporter);
         RaiseLocalEvent(target, ref teleported);
 
-        return true;
-    }
+        if (!triggerEffects)
+            return true;
 
-    /// <summary>
-    /// Moves a target without raising teleport lifecycle events, including those that trigger sounds.
-    /// Pulling and grappling relationships are still stopped before movement.
-    /// Refuses to move a target while a teleport request is being processed.
-    /// </summary>
-    public bool TryTeleport(EntityUid target, EntityCoordinates destination)
-    {
-        if (HasComp<TeleportingComponent>(target))
-            return false;
+        // Notification handlers may delete either participant after the movement succeeded.
+        if (TerminatingOrDeleted(target))
+            return true;
 
-        if (!CanTeleport(target, destination))
-            return false;
+        if (TerminatingOrDeleted(teleporter))
+            return true;
 
-        Teleport(target, destination);
+        var targetTeleported = new TargetTeleportedEvent(target);
+        RaiseLocalEvent(teleporter, ref targetTeleported);
+
         return true;
     }
 

--- a/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SharedTeleportSystem.cs
@@ -82,7 +82,13 @@ public sealed partial class SharedTeleportSystem : EntitySystem
 
     private bool CanTeleport(EntityUid target, EntityCoordinates destination)
     {
-        return Exists(target) && !TerminatingOrDeleted(target) && destination.IsValid(EntityManager);
+        if (!Exists(target))
+            return false;
+
+        if (TerminatingOrDeleted(target))
+            return false;
+
+        return destination.IsValid(EntityManager);
     }
 
     private void Teleport(EntityUid target, EntityCoordinates destination)

--- a/Content.Shared/Teleportation/Systems/TeleportActionSystem.cs
+++ b/Content.Shared/Teleportation/Systems/TeleportActionSystem.cs
@@ -4,9 +4,6 @@ using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Popups;
 using Robust.Shared.Map;
-using Robust.Shared.Physics;
-using Robust.Shared.Physics.Components;
-using Robust.Shared.Physics.Systems;
 
 namespace Content.Shared.Teleportation.Systems;
 
@@ -16,15 +13,12 @@ namespace Content.Shared.Teleportation.Systems;
 /// </summary>
 public sealed partial class TeleportActionSystem : EntitySystem
 {
-    [Dependency] private EntityLookupSystem _lookup = default!;
-    [Dependency] private SharedPhysicsSystem _physics = default!;
+    [Dependency] private SharedTeleportSystem _teleport = default!;
     [Dependency] private ExamineSystemShared _examine = default!;
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private PullingSystem _pulling = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
-
-    private readonly HashSet<Entity<PhysicsComponent>> _intersecting = new();
 
     [SubscribeLocalEvent]
     private void OnTeleportAction(TeleportActionEvent args)
@@ -68,7 +62,7 @@ public sealed partial class TeleportActionSystem : EntitySystem
         var targetRotated = targetEntPosRot.WorldRotation.RotateVec(target.Position);
         var targetMapCoordinates = new MapCoordinates(targetEntPosRot.WorldPosition + targetRotated, targetXform.MapID);
 
-        if (IsDestinationBlocked(user, targetMapCoordinates, targetEntPosRot.WorldRotation))
+        if (_teleport.IsDestinationBlocked(user, targetMapCoordinates, targetEntPosRot.WorldRotation))
         {
             _popup.PopupEntity(Loc.GetString("teleport-action-popup-blocked"), user, user);
             return false;
@@ -94,60 +88,5 @@ public sealed partial class TeleportActionSystem : EntitySystem
 
         _transform.SetCoordinates(user, xform, destination);
         return true;
-    }
-
-    /// <summary>
-    /// Checks whether the entity would collide with another hard, collidable entity at the target coordinates.
-    /// </summary>
-    /// <param name="user">The entity being checked.</param>
-    /// <param name="target">The map coordinates to check.</param>
-    /// <param name="rotation">The rotation of the entity at the target coordinates.</param>
-    /// <param name="fixtures">The entity's fixtures component.</param>
-    /// <param name="physics">The entity's physics component.</param>
-    /// <returns>Whether the destination is blocked.</returns>
-    public bool IsDestinationBlocked(
-        EntityUid user,
-        MapCoordinates target,
-        Angle rotation,
-        FixturesComponent? fixtures = null,
-        PhysicsComponent? physics = null
-    )
-    {
-        if (!Resolve(user, ref fixtures, ref physics, false) ||
-            !physics.CanCollide ||
-            !physics.Hard)
-        {
-            return false;
-        }
-
-        var destinationTransform = new Transform(target.Position, rotation);
-
-        foreach (var fixture in fixtures.Fixtures.Values)
-        {
-            if (!fixture.Hard)
-                continue;
-
-            _intersecting.Clear();
-            _lookup.GetEntitiesIntersecting(
-                target.MapId,
-                fixture.Shape,
-                destinationTransform,
-                _intersecting,
-                LookupFlags.Dynamic | LookupFlags.Static
-            );
-
-            foreach (var other in _intersecting)
-            {
-                if (other.Owner == user)
-                    continue;
-
-                if (_physics.IsCurrentlyHardCollidable((other.Owner, null, other.Comp), (user, fixtures, physics)))
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 }

--- a/Content.Shared/Teleportation/TeleportEvents.cs
+++ b/Content.Shared/Teleportation/TeleportEvents.cs
@@ -1,0 +1,66 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Teleportation;
+
+/// <summary>
+/// Notifies a teleporter immediately before it moves a target.
+/// Raised on the teleporter entity.
+/// </summary>
+/// <param name="Target">The entity being teleported.</param>
+[ByRefEvent, Serializable]
+public record struct BeforeTeleportEvent(EntityUid Target);
+
+/// <summary>
+/// Passes a target and the user that activated the teleporter to a teleport implementation.
+/// Raised on the teleporter entity.
+/// </summary>
+/// <param name="Target">The entity to teleport.</param>
+/// <param name="User">The entity that activated the teleporter.</param>
+[ByRefEvent, Serializable]
+public record struct TeleportRequestEvent(EntityUid Target, EntityUid User)
+{
+    /// <summary>
+    /// Whether a teleport implementation successfully handled the request.
+    /// </summary>
+    public bool Handled;
+}
+
+/// <summary>
+/// Passes an observer to a teleport implementation without invoking the regular teleport lifecycle.
+/// Raised on the teleporter entity.
+/// </summary>
+/// <param name="Target">The observer to teleport.</param>
+[ByRefEvent, Serializable]
+public record struct GhostTeleportRequestEvent(EntityUid Target)
+{
+    /// <summary>
+    /// Whether a teleport implementation successfully handled the request.
+    /// </summary>
+    public bool Handled;
+}
+
+/// <summary>
+/// Notifies a teleporter that it has moved a target.
+/// Raised on the teleporter entity.
+/// </summary>
+/// <param name="Target">The entity that was teleported.</param>
+[ByRefEvent, Serializable]
+public record struct TargetTeleportedEvent(EntityUid Target);
+
+/// <summary>
+/// Notifies a target that it has been teleported.
+/// Raised on the teleported entity.
+/// </summary>
+/// <param name="Teleporter">The entity that performed the teleportation.</param>
+[ByRefEvent, Serializable]
+public record struct TeleportedEvent(EntityUid Teleporter);
+
+/// <summary>
+/// Checks whether a teleporter can be used.
+/// Raised on the teleporter entity.
+/// </summary>
+/// <param name="Target">The entity that would be teleported.</param>
+/// <param name="User">The entity that activates the teleporter.</param>
+/// <param name="Cancelled">Whether using the teleporter has been prevented.</param>
+[ByRefEvent, Serializable]
+public record struct TeleportUseAttemptEvent(EntityUid Target, EntityUid User, bool Cancelled = false);

--- a/Content.Shared/Teleportation/TeleportEvents.cs
+++ b/Content.Shared/Teleportation/TeleportEvents.cs
@@ -11,35 +11,6 @@ namespace Content.Shared.Teleportation;
 public record struct BeforeTeleportEvent(EntityUid Target);
 
 /// <summary>
-/// Passes a target and the user that activated the teleporter to a teleport implementation.
-/// Raised on the teleporter entity.
-/// </summary>
-/// <param name="Target">The entity to teleport.</param>
-/// <param name="User">The entity that activated the teleporter.</param>
-[ByRefEvent, Serializable]
-public record struct TeleportRequestEvent(EntityUid Target, EntityUid User)
-{
-    /// <summary>
-    /// Whether a teleport implementation successfully handled the request.
-    /// </summary>
-    public bool Handled;
-}
-
-/// <summary>
-/// Passes an observer to a teleport implementation without invoking the regular teleport lifecycle.
-/// Raised on the teleporter entity.
-/// </summary>
-/// <param name="Target">The observer to teleport.</param>
-[ByRefEvent, Serializable]
-public record struct GhostTeleportRequestEvent(EntityUid Target)
-{
-    /// <summary>
-    /// Whether a teleport implementation successfully handled the request.
-    /// </summary>
-    public bool Handled;
-}
-
-/// <summary>
 /// Notifies a teleporter that it has moved a target.
 /// Raised on the teleporter entity.
 /// </summary>
@@ -54,13 +25,3 @@ public record struct TargetTeleportedEvent(EntityUid Target);
 /// <param name="Teleporter">The entity that performed the teleportation.</param>
 [ByRefEvent, Serializable]
 public record struct TeleportedEvent(EntityUid Teleporter);
-
-/// <summary>
-/// Checks whether a teleporter can be used.
-/// Raised on the teleporter entity.
-/// </summary>
-/// <param name="Target">The entity that would be teleported.</param>
-/// <param name="User">The entity that activates the teleporter.</param>
-/// <param name="Cancelled">Whether using the teleporter has been prevented.</param>
-[ByRefEvent, Serializable]
-public record struct TeleportUseAttemptEvent(EntityUid Target, EntityUid User, bool Cancelled = false);

--- a/Content.Shared/Teleportation/TeleportEvents.cs
+++ b/Content.Shared/Teleportation/TeleportEvents.cs
@@ -3,16 +3,16 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.Teleportation;
 
 /// <summary>
-/// Notifies a teleporter immediately before it moves a target.
-/// Raised on the teleporter entity.
+/// Triggers effects immediately before a teleporter moves a target, after use checks have passed.
+/// Raised on the teleporter entity only when effects are enabled. Cannot cancel teleportation.
 /// </summary>
 /// <param name="Target">The entity being teleported.</param>
 [ByRefEvent, Serializable]
 public record struct BeforeTeleportEvent(EntityUid Target);
 
 /// <summary>
-/// Notifies a teleporter that it has moved a target.
-/// Raised on the teleporter entity.
+/// Triggers effects after a teleporter has moved a target.
+/// Raised on the teleporter entity only when effects are enabled. Cannot cancel teleportation.
 /// </summary>
 /// <param name="Target">The entity that was teleported.</param>
 [ByRefEvent, Serializable]
@@ -20,7 +20,8 @@ public record struct TargetTeleportedEvent(EntityUid Target);
 
 /// <summary>
 /// Notifies a target that it has been teleported.
-/// Raised on the teleported entity.
+/// Raised on the teleported entity even when effects are disabled.
+/// The low-level relocation overload without a teleporter does not raise this event.
 /// </summary>
 /// <param name="Teleporter">The entity that performed the teleportation.</param>
 [ByRefEvent, Serializable]

--- a/Content.Shared/Teleportation/TeleportEvents.cs
+++ b/Content.Shared/Teleportation/TeleportEvents.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Teleportation;
 /// </summary>
 /// <param name="Target">The entity being teleported.</param>
 [ByRefEvent, Serializable]
-public record struct BeforeTeleportEvent(EntityUid Target);
+public readonly record struct BeforeTeleportEvent(EntityUid Target);
 
 /// <summary>
 /// Triggers effects after a teleporter has moved a target and notified it with <see cref="TeleportedEvent"/>.
@@ -19,7 +19,7 @@ public record struct BeforeTeleportEvent(EntityUid Target);
 /// </summary>
 /// <param name="Target">The entity that was teleported.</param>
 [ByRefEvent, Serializable]
-public record struct TargetTeleportedEvent(EntityUid Target);
+public readonly record struct TargetTeleportedEvent(EntityUid Target);
 
 /// <summary>
 /// Notifies a target that it has been teleported.
@@ -28,4 +28,4 @@ public record struct TargetTeleportedEvent(EntityUid Target);
 /// </summary>
 /// <param name="Teleporter">The entity that performed the teleportation.</param>
 [ByRefEvent, Serializable]
-public record struct TeleportedEvent(EntityUid Teleporter);
+public readonly record struct TeleportedEvent(EntityUid Teleporter);

--- a/Content.Shared/Teleportation/TeleportEvents.cs
+++ b/Content.Shared/Teleportation/TeleportEvents.cs
@@ -2,6 +2,9 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Teleportation;
 
+// TODO: When an effect needs the original departure or arrival point, pass captured source and destination
+// coordinates in BeforeTeleportEvent and TargetTeleportedEvent instead of reading the target's current transform.
+
 /// <summary>
 /// Triggers effects immediately before a teleporter moves a target, after use checks have passed.
 /// Raised on the teleporter entity only when effects are enabled. Cannot cancel teleportation.
@@ -11,7 +14,7 @@ namespace Content.Shared.Teleportation;
 public record struct BeforeTeleportEvent(EntityUid Target);
 
 /// <summary>
-/// Triggers effects after a teleporter has moved a target.
+/// Triggers effects after a teleporter has moved a target and notified it with <see cref="TeleportedEvent"/>.
 /// Raised on the teleporter entity only when effects are enabled. Cannot cancel teleportation.
 /// </summary>
 /// <param name="Target">The entity that was teleported.</param>
@@ -21,7 +24,7 @@ public record struct TargetTeleportedEvent(EntityUid Target);
 /// <summary>
 /// Notifies a target that it has been teleported.
 /// Raised on the teleported entity even when effects are disabled.
-/// The low-level relocation overload without a teleporter does not raise this event.
+/// Raised before <see cref="TargetTeleportedEvent"/>, so a post-move effect cannot prevent this notification.
 /// </summary>
 /// <param name="Teleporter">The entity that performed the teleportation.</param>
 [ByRefEvent, Serializable]

--- a/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerComponent.cs
+++ b/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerComponent.cs
@@ -1,0 +1,34 @@
+using Content.Shared.Whitelist;
+
+namespace Content.Shared.Teleportation.Triggers;
+
+/// <summary>
+/// Requests teleportation when a target collides with a configured fixture.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CollisionTeleportTriggerComponent : Component
+{
+    /// <summary>
+    /// Fixture that triggers teleportation. Any fixture can trigger it when not specified.
+    /// </summary>
+    [DataField]
+    public string? TriggerFixtureId;
+
+    /// <summary>
+    /// Non-hard target fixtures that are allowed to trigger teleportation.
+    /// </summary>
+    [DataField]
+    public HashSet<string> AllowedNonHardTargetFixtureIds = new();
+
+    /// <summary>
+    /// Entities allowed to trigger teleportation.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? TargetWhitelist;
+
+    /// <summary>
+    /// Entities prevented from triggering teleportation.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? TargetBlacklist;
+}

--- a/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
@@ -1,5 +1,7 @@
 using Content.Shared.Whitelist;
 using Robust.Shared.Network;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Events;
 
@@ -25,13 +27,7 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
 
         var target = args.OtherEntity;
 
-        if (Transform(target).Anchored)
-            return;
-
-        if (_whitelist.IsWhitelistFail(ent.Comp.TargetWhitelist, target))
-            return;
-
-        if (_whitelist.IsWhitelistPass(ent.Comp.TargetBlacklist, target))
+        if (!IsTargetAllowed(ent.Comp, target))
             return;
 
         var attempt = new TeleportUseAttemptEvent(target, target);
@@ -62,18 +58,74 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
         RaiseLocalEvent(ent, ref exited);
     }
 
+    /// <summary>
+    /// Whether the target's fixtures and filters allow it to activate this trigger after teleporting here.
+    /// Does not check the teleport destination or current overlap.
+    /// </summary>
+    public bool CanTrigger(EntityUid teleporter, EntityUid target)
+    {
+        if (!TryComp<CollisionTeleportTriggerComponent>(teleporter, out var trigger) ||
+            !IsTargetAllowed(trigger, target) ||
+            !TryComp<PhysicsComponent>(teleporter, out var teleporterBody) || !teleporterBody.CanCollide ||
+            !TryComp<PhysicsComponent>(target, out var targetBody) || !targetBody.CanCollide ||
+            !TryComp<FixturesComponent>(teleporter, out var teleporterFixtures) ||
+            !TryComp<FixturesComponent>(target, out var targetFixtures))
+            return false;
+
+        foreach (var (teleporterId, teleporterFixture) in teleporterFixtures.Fixtures)
+        {
+            if (!IsTriggerFixture(trigger, teleporterId))
+                continue;
+
+            if (CanTriggerFixture(trigger, teleporterFixture, targetFixtures))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool CanTriggerFixture(
+        CollisionTeleportTriggerComponent component,
+        Fixture teleporterFixture,
+        FixturesComponent targetFixtures)
+    {
+        foreach (var (targetId, targetFixture) in targetFixtures.Fixtures)
+        {
+            if (!IsTargetFixtureAllowed(component, targetId, targetFixture))
+                continue;
+
+            if ((teleporterFixture.CollisionMask & targetFixture.CollisionLayer) != 0 ||
+                (targetFixture.CollisionMask & teleporterFixture.CollisionLayer) != 0)
+                return true;
+        }
+
+        return false;
+    }
+
+    private bool IsTargetAllowed(CollisionTeleportTriggerComponent component, EntityUid target)
+    {
+        return !Transform(target).Anchored &&
+               !_whitelist.IsWhitelistFail(component.TargetWhitelist, target) &&
+               !_whitelist.IsWhitelistPass(component.TargetBlacklist, target);
+    }
+
     private static bool IsTriggerCollision(
         CollisionTeleportTriggerComponent component,
         string teleporterFixtureId,
         string targetFixtureId,
         Fixture targetFixture)
     {
-        if (component.TriggerFixtureId is { } triggerFixtureId && teleporterFixtureId != triggerFixtureId)
-            return false;
+        return IsTriggerFixture(component, teleporterFixtureId) &&
+               IsTargetFixtureAllowed(component, targetFixtureId, targetFixture);
+    }
 
-        if (!targetFixture.Hard && !component.AllowedNonHardTargetFixtureIds.Contains(targetFixtureId))
-            return false;
+    private static bool IsTriggerFixture(CollisionTeleportTriggerComponent component, string fixtureId)
+    {
+        return component.TriggerFixtureId == null || component.TriggerFixtureId == fixtureId;
+    }
 
-        return true;
+    private static bool IsTargetFixtureAllowed(CollisionTeleportTriggerComponent component, string fixtureId, Fixture fixture)
+    {
+        return fixture.Hard || component.AllowedNonHardTargetFixtureIds.Contains(fixtureId);
     }
 }

--- a/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
@@ -1,0 +1,79 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.Network;
+using Robust.Shared.Physics.Dynamics;
+using Robust.Shared.Physics.Events;
+
+namespace Content.Shared.Teleportation.Triggers;
+
+public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
+{
+    [Dependency] private EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private INetManager _net = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CollisionTeleportTriggerComponent, StartCollideEvent>(OnStartCollide);
+        SubscribeLocalEvent<CollisionTeleportTriggerComponent, EndCollideEvent>(OnEndCollide);
+    }
+
+    private void OnStartCollide(Entity<CollisionTeleportTriggerComponent> ent, ref StartCollideEvent args)
+    {
+        if (!IsTriggerCollision(ent.Comp, args.OurFixtureId, args.OtherFixtureId, args.OtherFixture))
+            return;
+
+        var target = args.OtherEntity;
+
+        if (Transform(target).Anchored)
+            return;
+
+        if (_whitelist.IsWhitelistFail(ent.Comp.TargetWhitelist, target))
+            return;
+
+        if (_whitelist.IsWhitelistPass(ent.Comp.TargetBlacklist, target))
+            return;
+
+        var attempt = new TeleportUseAttemptEvent(target, target);
+        RaiseLocalEvent(ent, ref attempt);
+
+        if (attempt.Cancelled)
+            return;
+
+        var request = new TeleportRequestEvent(target, target);
+        RaiseLocalEvent(ent, ref request);
+
+        if (request.Handled)
+            return;
+
+        if (_net.IsClient)
+            return;
+
+        Log.Error($"CollisionTeleportTrigger on {ToPrettyString(ent)} couldn't teleport " +
+                  $"{ToPrettyString(target)} because no teleport implementation handled the request");
+    }
+
+    private void OnEndCollide(Entity<CollisionTeleportTriggerComponent> ent, ref EndCollideEvent args)
+    {
+        if (!IsTriggerCollision(ent.Comp, args.OurFixtureId, args.OtherFixtureId, args.OtherFixture))
+            return;
+
+        var exited = new TeleportTriggerExitedEvent(args.OtherEntity);
+        RaiseLocalEvent(ent, ref exited);
+    }
+
+    private static bool IsTriggerCollision(
+        CollisionTeleportTriggerComponent component,
+        string teleporterFixtureId,
+        string targetFixtureId,
+        Fixture targetFixture)
+    {
+        if (component.TriggerFixtureId is { } triggerFixtureId && teleporterFixtureId != triggerFixtureId)
+            return false;
+
+        if (!targetFixture.Hard && !component.AllowedNonHardTargetFixtureIds.Contains(targetFixtureId))
+            return false;
+
+        return true;
+    }
+}

--- a/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
@@ -1,9 +1,11 @@
 using Content.Shared.Teleportation.Systems;
 using Content.Shared.Whitelist;
+using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Events;
+using Robust.Shared.Physics.Systems;
 
 namespace Content.Shared.Teleportation.Triggers;
 
@@ -11,6 +13,7 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
 {
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
     [Dependency] private SharedTeleportSystem _teleport = default!;
+    [Dependency] private SharedPhysicsSystem _physics = default!;
 
     public override void Initialize()
     {
@@ -63,6 +66,65 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
 
             if (CanTriggerFixture(trigger, teleporterFixture, targetFixtures))
                 return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether the target overlaps the conservative world bounds of this trigger's fixtures.
+    /// Uses current geometry rather than physics contacts or collision eligibility, so temporarily
+    /// disabling collisions does not release a target that is still inside the exit.
+    /// Bounds can retain the block near the corners of rotated or non-rectangular shapes.
+    /// </summary>
+    public bool IsInsideTriggerBounds(EntityUid teleporter, EntityUid target)
+    {
+        if (!Exists(teleporter) || TerminatingOrDeleted(teleporter) ||
+            !Exists(target) || TerminatingOrDeleted(target) ||
+            !TryComp<CollisionTeleportTriggerComponent>(teleporter, out var trigger) ||
+            !TryComp<FixturesComponent>(teleporter, out var teleporterFixtures) ||
+            !TryComp<FixturesComponent>(target, out var targetFixtures) ||
+            !TryComp(teleporter, out TransformComponent? teleporterXform) ||
+            !TryComp(target, out TransformComponent? targetXform) ||
+            teleporterXform.MapID == MapId.Nullspace ||
+            teleporterXform.MapID != targetXform.MapID)
+            return false;
+
+        var teleporterTransform = _physics.GetPhysicsTransform(teleporter, teleporterXform);
+        var targetTransform = _physics.GetPhysicsTransform(target, targetXform);
+
+        foreach (var (teleporterId, teleporterFixture) in teleporterFixtures.Fixtures)
+        {
+            if (!IsTriggerFixture(trigger, teleporterId))
+                continue;
+
+            foreach (var (targetId, targetFixture) in targetFixtures.Fixtures)
+            {
+                if (!IsTargetFixtureAllowed(trigger, targetId, targetFixture))
+                    continue;
+
+                if (FixtureBoundsOverlap(teleporterFixture, targetFixture, teleporterTransform, targetTransform))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool FixtureBoundsOverlap(
+        Fixture teleporterFixture,
+        Fixture targetFixture,
+        Transform teleporterTransform,
+        Transform targetTransform)
+    {
+        for (var i = 0; i < teleporterFixture.Shape.ChildCount; i++)
+        {
+            var teleporterBounds = teleporterFixture.Shape.ComputeAABB(teleporterTransform, i);
+            for (var j = 0; j < targetFixture.Shape.ChildCount; j++)
+            {
+                if (teleporterBounds.Intersects(targetFixture.Shape.ComputeAABB(targetTransform, j)))
+                    return true;
+            }
         }
 
         return false;

--- a/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
@@ -1,5 +1,5 @@
+using Content.Shared.Teleportation.Systems;
 using Content.Shared.Whitelist;
-using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics;
@@ -10,7 +10,7 @@ namespace Content.Shared.Teleportation.Triggers;
 public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
 {
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
-    [Dependency] private INetManager _net = default!;
+    [Dependency] private SharedTeleportSystem _teleport = default!;
 
     public override void Initialize()
     {
@@ -30,23 +30,7 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
         if (!IsTargetAllowed(ent.Comp, target))
             return;
 
-        var attempt = new TeleportUseAttemptEvent(target, target);
-        RaiseLocalEvent(ent, ref attempt);
-
-        if (attempt.Cancelled)
-            return;
-
-        var request = new TeleportRequestEvent(target, target);
-        RaiseLocalEvent(ent, ref request);
-
-        if (request.Handled)
-            return;
-
-        if (_net.IsClient)
-            return;
-
-        Log.Error($"CollisionTeleportTrigger on {ToPrettyString(ent)} couldn't teleport " +
-                  $"{ToPrettyString(target)} because no teleport implementation handled the request");
+        _teleport.RequestTeleport(ent, target, target);
     }
 
     private void OnEndCollide(Entity<CollisionTeleportTriggerComponent> ent, ref EndCollideEvent args)

--- a/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
@@ -49,12 +49,12 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
     /// Whether the target's fixtures and filters allow it to activate this trigger after teleporting here.
     /// Does not check the teleport destination or current overlap.
     /// </summary>
-    public bool CanTrigger(EntityUid teleporter, EntityUid target)
+    public bool CanTrigger(Entity<CollisionTeleportTriggerComponent?> teleporter, EntityUid target)
     {
-        if (!TryComp<CollisionTeleportTriggerComponent>(teleporter, out var trigger))
+        if (!Resolve(teleporter, ref teleporter.Comp, logMissing: false))
             return false;
 
-        if (!IsTargetAllowed(trigger, target))
+        if (!IsTargetAllowed(teleporter.Comp, target))
             return false;
 
         if (!TryComp<PhysicsComponent>(teleporter, out var teleporterBody))
@@ -77,10 +77,10 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
 
         foreach (var (teleporterId, teleporterFixture) in teleporterFixtures.Fixtures)
         {
-            if (!IsTriggerFixture(trigger, teleporterId))
+            if (!IsTriggerFixture(teleporter.Comp, teleporterId))
                 continue;
 
-            if (CanTriggerFixture(trigger, teleporterFixture, targetFixtures))
+            if (CanTriggerFixture(teleporter.Comp, teleporterFixture, targetFixtures))
                 return true;
         }
 
@@ -93,8 +93,11 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
     /// disabling collisions does not release a target that is still inside the exit.
     /// Bounds can retain the block near the corners of rotated or non-rectangular shapes.
     /// </summary>
-    public bool IsInsideTriggerBounds(EntityUid teleporter, EntityUid target)
+    public bool IsInsideTriggerBounds(Entity<CollisionTeleportTriggerComponent?> teleporter, EntityUid target)
     {
+        if (!Resolve(teleporter, ref teleporter.Comp, logMissing: false))
+            return false;
+
         if (!Exists(teleporter))
             return false;
 
@@ -105,9 +108,6 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
             return false;
 
         if (TerminatingOrDeleted(target))
-            return false;
-
-        if (!TryComp<CollisionTeleportTriggerComponent>(teleporter, out var trigger))
             return false;
 
         if (!TryComp<FixturesComponent>(teleporter, out var teleporterFixtures))
@@ -133,12 +133,12 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
 
         foreach (var (teleporterId, teleporterFixture) in teleporterFixtures.Fixtures)
         {
-            if (!IsTriggerFixture(trigger, teleporterId))
+            if (!IsTriggerFixture(teleporter.Comp, teleporterId))
                 continue;
 
             foreach (var (targetId, targetFixture) in targetFixtures.Fixtures)
             {
-                if (!IsTargetFixtureAllowed(trigger, targetId, targetFixture))
+                if (!IsTargetFixtureAllowed(teleporter.Comp, targetId, targetFixture))
                     continue;
 
                 if (FixtureBoundsOverlap(teleporterFixture, targetFixture, teleporterTransform, targetTransform))

--- a/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
@@ -51,12 +51,28 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
     /// </summary>
     public bool CanTrigger(EntityUid teleporter, EntityUid target)
     {
-        if (!TryComp<CollisionTeleportTriggerComponent>(teleporter, out var trigger) ||
-            !IsTargetAllowed(trigger, target) ||
-            !TryComp<PhysicsComponent>(teleporter, out var teleporterBody) || !teleporterBody.CanCollide ||
-            !TryComp<PhysicsComponent>(target, out var targetBody) || !targetBody.CanCollide ||
-            !TryComp<FixturesComponent>(teleporter, out var teleporterFixtures) ||
-            !TryComp<FixturesComponent>(target, out var targetFixtures))
+        if (!TryComp<CollisionTeleportTriggerComponent>(teleporter, out var trigger))
+            return false;
+
+        if (!IsTargetAllowed(trigger, target))
+            return false;
+
+        if (!TryComp<PhysicsComponent>(teleporter, out var teleporterBody))
+            return false;
+
+        if (!teleporterBody.CanCollide)
+            return false;
+
+        if (!TryComp<PhysicsComponent>(target, out var targetBody))
+            return false;
+
+        if (!targetBody.CanCollide)
+            return false;
+
+        if (!TryComp<FixturesComponent>(teleporter, out var teleporterFixtures))
+            return false;
+
+        if (!TryComp<FixturesComponent>(target, out var targetFixtures))
             return false;
 
         foreach (var (teleporterId, teleporterFixture) in teleporterFixtures.Fixtures)
@@ -79,15 +95,37 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
     /// </summary>
     public bool IsInsideTriggerBounds(EntityUid teleporter, EntityUid target)
     {
-        if (!Exists(teleporter) || TerminatingOrDeleted(teleporter) ||
-            !Exists(target) || TerminatingOrDeleted(target) ||
-            !TryComp<CollisionTeleportTriggerComponent>(teleporter, out var trigger) ||
-            !TryComp<FixturesComponent>(teleporter, out var teleporterFixtures) ||
-            !TryComp<FixturesComponent>(target, out var targetFixtures) ||
-            !TryComp(teleporter, out TransformComponent? teleporterXform) ||
-            !TryComp(target, out TransformComponent? targetXform) ||
-            teleporterXform.MapID == MapId.Nullspace ||
-            teleporterXform.MapID != targetXform.MapID)
+        if (!Exists(teleporter))
+            return false;
+
+        if (TerminatingOrDeleted(teleporter))
+            return false;
+
+        if (!Exists(target))
+            return false;
+
+        if (TerminatingOrDeleted(target))
+            return false;
+
+        if (!TryComp<CollisionTeleportTriggerComponent>(teleporter, out var trigger))
+            return false;
+
+        if (!TryComp<FixturesComponent>(teleporter, out var teleporterFixtures))
+            return false;
+
+        if (!TryComp<FixturesComponent>(target, out var targetFixtures))
+            return false;
+
+        if (!TryComp(teleporter, out TransformComponent? teleporterXform))
+            return false;
+
+        if (!TryComp(target, out TransformComponent? targetXform))
+            return false;
+
+        if (teleporterXform.MapID == MapId.Nullspace)
+            return false;
+
+        if (teleporterXform.MapID != targetXform.MapID)
             return false;
 
         var teleporterTransform = _physics.GetPhysicsTransform(teleporter, teleporterXform);

--- a/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
@@ -188,9 +188,13 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
 
     private bool IsTargetAllowed(CollisionTeleportTriggerComponent component, EntityUid target)
     {
-        return !Transform(target).Anchored &&
-               !_whitelist.IsWhitelistFail(component.TargetWhitelist, target) &&
-               !_whitelist.IsWhitelistPass(component.TargetBlacklist, target);
+        if (Transform(target).Anchored)
+            return false;
+
+        if (_whitelist.IsWhitelistFail(component.TargetWhitelist, target))
+            return false;
+
+        return !_whitelist.IsWhitelistPass(component.TargetBlacklist, target);
     }
 
     private static bool IsTriggerCollision(

--- a/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/CollisionTeleportTriggerSystem.cs
@@ -33,7 +33,7 @@ public sealed partial class CollisionTeleportTriggerSystem : EntitySystem
         if (!IsTargetAllowed(ent.Comp, target))
             return;
 
-        _teleport.RequestTeleport(ent, target, target);
+        _teleport.RequestTeleport(ent, target, user: null);
     }
 
     private void OnEndCollide(Entity<CollisionTeleportTriggerComponent> ent, ref EndCollideEvent args)

--- a/Content.Shared/Teleportation/Triggers/TeleportOnVerbComponent.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportOnVerbComponent.cs
@@ -1,4 +1,6 @@
 using Content.Shared.Whitelist;
+using Robust.Shared.Serialization;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Teleportation.Triggers;
 
@@ -9,22 +11,49 @@ namespace Content.Shared.Teleportation.Triggers;
 public sealed partial class TeleportOnVerbComponent : Component
 {
     /// <summary>
-    /// Teleport behavior requested by this trigger.
+    /// Determines the verb menu and shortcut used to activate this trigger.
     /// </summary>
     [DataField]
-    public TeleportMode Mode = TeleportMode.Normal;
+    public TeleportVerbType VerbType;
 
     /// <summary>
     /// Text displayed for the teleport verb.
     /// </summary>
+    [DataField(required: true)]
+    public LocId VerbText;
+
+    /// <summary>
+    /// Optional icon and localized category for the verb.
+    /// </summary>
     [DataField]
-    public LocId VerbText = "portal-component-ghost-traverse";
+    public SpriteSpecifier? VerbIcon;
+
+    [DataField]
+    public LocId? VerbCategory;
+
+    /// <summary>
+    /// Ordering within the selected verb type. Higher priorities appear first.
+    /// </summary>
+    [DataField]
+    public int Priority;
 
     /// <summary>
     /// Description displayed while the teleport verb is available.
     /// </summary>
     [DataField]
     public LocId? EnabledMessage;
+
+    /// <summary>
+    /// Fallback description when teleportation is unavailable and no cancellation reason was supplied.
+    /// </summary>
+    [DataField]
+    public LocId? DisabledMessage;
+
+    /// <summary>
+    /// Hide unavailable verbs instead of displaying them disabled.
+    /// </summary>
+    [DataField]
+    public bool HideWhenDisabled;
 
     /// <summary>
     /// Entities allowed to use the teleport verb.
@@ -37,4 +66,13 @@ public sealed partial class TeleportOnVerbComponent : Component
     /// </summary>
     [DataField]
     public EntityWhitelist? UserBlacklist;
+}
+
+[Serializable, NetSerializable]
+public enum TeleportVerbType : byte
+{
+    Verb,
+    Alternative,
+    Interaction,
+    Activation,
 }

--- a/Content.Shared/Teleportation/Triggers/TeleportOnVerbComponent.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportOnVerbComponent.cs
@@ -1,0 +1,40 @@
+using Content.Shared.Whitelist;
+
+namespace Content.Shared.Teleportation.Triggers;
+
+/// <summary>
+/// Requests teleportation when an allowed user activates a verb on the teleporter.
+/// </summary>
+[RegisterComponent]
+public sealed partial class TeleportOnVerbComponent : Component
+{
+    /// <summary>
+    /// Teleport behavior requested by this trigger.
+    /// </summary>
+    [DataField]
+    public TeleportMode Mode = TeleportMode.Normal;
+
+    /// <summary>
+    /// Text displayed for the teleport verb.
+    /// </summary>
+    [DataField]
+    public LocId VerbText = "portal-component-ghost-traverse";
+
+    /// <summary>
+    /// Description displayed while the teleport verb is available.
+    /// </summary>
+    [DataField]
+    public LocId? EnabledMessage;
+
+    /// <summary>
+    /// Entities allowed to use the teleport verb.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? UserWhitelist;
+
+    /// <summary>
+    /// Entities prevented from using the teleport verb.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? UserBlacklist;
+}

--- a/Content.Shared/Teleportation/Triggers/TeleportOnVerbComponent.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportOnVerbComponent.cs
@@ -43,11 +43,14 @@ public sealed partial class TeleportOnVerbComponent : Component
     public LocId VerbText;
 
     /// <summary>
-    /// Optional icon and localized category for the verb.
+    /// Optional icon displayed for the verb.
     /// </summary>
     [DataField]
     public SpriteSpecifier? VerbIcon;
 
+    /// <summary>
+    /// Optional localization key for the verb's category name.
+    /// </summary>
     [DataField]
     public LocId? VerbCategory;
 

--- a/Content.Shared/Teleportation/Triggers/TeleportOnVerbComponent.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportOnVerbComponent.cs
@@ -24,6 +24,18 @@ public sealed partial class TeleportOnVerbComponent : Component
     public TeleportVerbType VerbType;
 
     /// <summary>
+    /// Require the user to pass the standard interaction blockers before offering this verb.
+    /// </summary>
+    [DataField]
+    public bool RequireCanInteract = true;
+
+    /// <summary>
+    /// Require the user to have a HandsComponent. Does not check hand count or whether a hand is empty.
+    /// </summary>
+    [DataField]
+    public bool RequireHands = true;
+
+    /// <summary>
     /// Text displayed for the teleport verb.
     /// </summary>
     [DataField(required: true)]

--- a/Content.Shared/Teleportation/Triggers/TeleportOnVerbComponent.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportOnVerbComponent.cs
@@ -11,6 +11,13 @@ namespace Content.Shared.Teleportation.Triggers;
 public sealed partial class TeleportOnVerbComponent : Component
 {
     /// <summary>
+    /// Whether this verb requests effects before and after teleportation.
+    /// Use checks and the successful teleport notification are unaffected.
+    /// </summary>
+    [DataField]
+    public bool TriggerEffects = true;
+
+    /// <summary>
     /// Determines the verb menu and shortcut used to activate this trigger.
     /// </summary>
     [DataField]

--- a/Content.Shared/Teleportation/Triggers/TeleportOnVerbComponent.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportOnVerbComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
@@ -7,7 +8,7 @@ namespace Content.Shared.Teleportation.Triggers;
 /// <summary>
 /// Requests teleportation when an allowed user activates a verb on the teleporter.
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class TeleportOnVerbComponent : Component
 {
     /// <summary>
@@ -26,13 +27,13 @@ public sealed partial class TeleportOnVerbComponent : Component
     /// <summary>
     /// Require the user to pass the standard interaction blockers before offering this verb.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool RequireCanInteract = true;
 
     /// <summary>
     /// Require the user to have a HandsComponent. Does not check hand count or whether a hand is empty.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool RequireHands = true;
 
     /// <summary>

--- a/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
@@ -1,0 +1,88 @@
+using Content.Shared.Verbs;
+using Content.Shared.Whitelist;
+using Robust.Shared.Network;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Teleportation.Triggers;
+
+public sealed partial class TeleportOnVerbSystem : EntitySystem
+{
+    [Dependency] private EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private INetManager _net = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TeleportOnVerbComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+    }
+
+    private void OnGetVerbs(Entity<TeleportOnVerbComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess)
+            return;
+
+        if (!IsUserAllowed(ent.Comp, args.User))
+            return;
+
+        var target = args.User;
+        var attempt = new TeleportUseAttemptEvent(target, target, Mode: ent.Comp.Mode);
+        RaiseLocalEvent(ent, ref attempt);
+
+        args.Verbs.Add(new AlternativeVerb
+        {
+            Priority = 11,
+            Act = () => RequestTeleport(ent, target),
+            Disabled = attempt.Cancelled,
+            Text = Loc.GetString(ent.Comp.VerbText),
+            Message = GetMessage(ent.Comp, attempt),
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/open.svg.192dpi.png"))
+        });
+    }
+
+    private void RequestTeleport(Entity<TeleportOnVerbComponent> ent, EntityUid target)
+    {
+        if (!IsUserAllowed(ent.Comp, target))
+            return;
+
+        var attempt = new TeleportUseAttemptEvent(target, target, Mode: ent.Comp.Mode);
+        RaiseLocalEvent(ent, ref attempt);
+
+        if (attempt.Cancelled)
+            return;
+
+        var request = new TeleportRequestEvent(target, target, ent.Comp.Mode);
+        RaiseLocalEvent(ent, ref request);
+
+        if (request.Handled)
+            return;
+
+        if (_net.IsClient)
+            return;
+
+        Log.Error($"TeleportOnVerb on {ToPrettyString(ent)} couldn't teleport {ToPrettyString(target)} " +
+                  "because no teleport implementation handled the request");
+    }
+
+    private bool IsUserAllowed(TeleportOnVerbComponent component, EntityUid user)
+    {
+        if (_whitelist.IsWhitelistFail(component.UserWhitelist, user))
+            return false;
+
+        if (_whitelist.IsWhitelistPass(component.UserBlacklist, user))
+            return false;
+
+        return true;
+    }
+
+    private string? GetMessage(TeleportOnVerbComponent component, TeleportUseAttemptEvent attempt)
+    {
+        if (attempt.CancelReason is { } cancelReason)
+            return Loc.GetString(cancelReason);
+
+        if (component.EnabledMessage is { } enabledMessage)
+            return Loc.GetString(enabledMessage);
+
+        return null;
+    }
+}

--- a/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
@@ -1,7 +1,6 @@
 using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
 using Robust.Shared.Network;
-using Robust.Shared.Utility;
 
 namespace Content.Shared.Teleportation.Triggers;
 
@@ -14,29 +13,43 @@ public sealed partial class TeleportOnVerbSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<TeleportOnVerbComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+        SubscribeVerb<Verb>(TeleportVerbType.Verb);
+        SubscribeVerb<AlternativeVerb>(TeleportVerbType.Alternative);
+        SubscribeVerb<InteractionVerb>(TeleportVerbType.Interaction);
+        SubscribeVerb<ActivationVerb>(TeleportVerbType.Activation);
     }
 
-    private void OnGetVerbs(Entity<TeleportOnVerbComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    private void SubscribeVerb<TVerb>(TeleportVerbType type) where TVerb : Verb, new()
     {
-        if (!args.CanAccess)
+        SubscribeLocalEvent<TeleportOnVerbComponent, GetVerbsEvent<TVerb>>(
+            (Entity<TeleportOnVerbComponent> ent, ref GetVerbsEvent<TVerb> args) => OnGetVerbs(ent, ref args, type));
+    }
+
+    private void OnGetVerbs<TVerb>(Entity<TeleportOnVerbComponent> ent, ref GetVerbsEvent<TVerb> args, TeleportVerbType type)
+        where TVerb : Verb, new()
+    {
+        if (ent.Comp.VerbType != type || !args.CanAccess)
             return;
 
         if (!IsUserAllowed(ent.Comp, args.User))
             return;
 
         var target = args.User;
-        var attempt = new TeleportUseAttemptEvent(target, target, Mode: ent.Comp.Mode);
+        var attempt = new TeleportUseAttemptEvent(target, target);
         RaiseLocalEvent(ent, ref attempt);
 
-        args.Verbs.Add(new AlternativeVerb
+        if (attempt.Cancelled && ent.Comp.HideWhenDisabled)
+            return;
+
+        args.Verbs.Add(new TVerb
         {
-            Priority = 11,
+            Priority = ent.Comp.Priority,
             Act = () => RequestTeleport(ent, target),
             Disabled = attempt.Cancelled,
             Text = Loc.GetString(ent.Comp.VerbText),
             Message = GetMessage(ent.Comp, attempt),
-            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/open.svg.192dpi.png"))
+            Icon = ent.Comp.VerbIcon,
+            Category = ent.Comp.VerbCategory is { } category ? new VerbCategory(category, null) : null,
         });
     }
 
@@ -45,13 +58,13 @@ public sealed partial class TeleportOnVerbSystem : EntitySystem
         if (!IsUserAllowed(ent.Comp, target))
             return;
 
-        var attempt = new TeleportUseAttemptEvent(target, target, Mode: ent.Comp.Mode);
+        var attempt = new TeleportUseAttemptEvent(target, target);
         RaiseLocalEvent(ent, ref attempt);
 
         if (attempt.Cancelled)
             return;
 
-        var request = new TeleportRequestEvent(target, target, ent.Comp.Mode);
+        var request = new TeleportRequestEvent(target, target);
         RaiseLocalEvent(ent, ref request);
 
         if (request.Handled)
@@ -66,23 +79,15 @@ public sealed partial class TeleportOnVerbSystem : EntitySystem
 
     private bool IsUserAllowed(TeleportOnVerbComponent component, EntityUid user)
     {
-        if (_whitelist.IsWhitelistFail(component.UserWhitelist, user))
-            return false;
-
-        if (_whitelist.IsWhitelistPass(component.UserBlacklist, user))
-            return false;
-
-        return true;
+        return !_whitelist.IsWhitelistFail(component.UserWhitelist, user) &&
+               !_whitelist.IsWhitelistPass(component.UserBlacklist, user);
     }
 
     private string? GetMessage(TeleportOnVerbComponent component, TeleportUseAttemptEvent attempt)
     {
-        if (attempt.CancelReason is { } cancelReason)
-            return Loc.GetString(cancelReason);
-
-        if (component.EnabledMessage is { } enabledMessage)
-            return Loc.GetString(enabledMessage);
-
-        return null;
+        var message = attempt.Cancelled
+            ? attempt.CancelReason ?? component.DisabledMessage
+            : component.EnabledMessage;
+        return message is { } key ? Loc.GetString(key) : null;
     }
 }

--- a/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
@@ -1,13 +1,13 @@
+using Content.Shared.Teleportation.Systems;
 using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
-using Robust.Shared.Network;
 
 namespace Content.Shared.Teleportation.Triggers;
 
 public sealed partial class TeleportOnVerbSystem : EntitySystem
 {
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
-    [Dependency] private INetManager _net = default!;
+    [Dependency] private SharedTeleportSystem _teleport = default!;
 
     public override void Initialize()
     {
@@ -35,8 +35,7 @@ public sealed partial class TeleportOnVerbSystem : EntitySystem
             return;
 
         var target = args.User;
-        var attempt = new TeleportUseAttemptEvent(target, target);
-        RaiseLocalEvent(ent, ref attempt);
+        var attempt = _teleport.CheckTeleportUse(ent, target, target);
 
         if (attempt.Cancelled && ent.Comp.HideWhenDisabled)
             return;
@@ -58,23 +57,7 @@ public sealed partial class TeleportOnVerbSystem : EntitySystem
         if (!IsUserAllowed(ent.Comp, target))
             return;
 
-        var attempt = new TeleportUseAttemptEvent(target, target);
-        RaiseLocalEvent(ent, ref attempt);
-
-        if (attempt.Cancelled)
-            return;
-
-        var request = new TeleportRequestEvent(target, target);
-        RaiseLocalEvent(ent, ref request);
-
-        if (request.Handled)
-            return;
-
-        if (_net.IsClient)
-            return;
-
-        Log.Error($"TeleportOnVerb on {ToPrettyString(ent)} couldn't teleport {ToPrettyString(target)} " +
-                  "because no teleport implementation handled the request");
+        _teleport.RequestTeleport(ent, target, target, ent.Comp.TriggerEffects);
     }
 
     private bool IsUserAllowed(TeleportOnVerbComponent component, EntityUid user)

--- a/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
@@ -22,16 +22,27 @@ public sealed partial class TeleportOnVerbSystem : EntitySystem
     private void SubscribeVerb<TVerb>(TeleportVerbType type, Func<TVerb> createVerb) where TVerb : Verb
     {
         SubscribeLocalEvent<TeleportOnVerbComponent, GetVerbsEvent<TVerb>>(
-            (Entity<TeleportOnVerbComponent> ent, ref GetVerbsEvent<TVerb> args) => OnGetVerbs(ent, ref args, type, createVerb));
+            (Entity<TeleportOnVerbComponent> ent, ref GetVerbsEvent<TVerb> args) =>
+                OnGetVerbs(ent, ref args, type, createVerb));
     }
 
-    private void OnGetVerbs<TVerb>(Entity<TeleportOnVerbComponent> ent, ref GetVerbsEvent<TVerb> args, TeleportVerbType type, Func<TVerb> createVerb)
+    private void OnGetVerbs<TVerb>(
+        Entity<TeleportOnVerbComponent> ent,
+        ref GetVerbsEvent<TVerb> args,
+        TeleportVerbType type,
+        Func<TVerb> createVerb)
         where TVerb : Verb
     {
         if (ent.Comp.VerbType != type)
             return;
 
         if (!args.CanAccess)
+            return;
+
+        if (ent.Comp.RequireCanInteract && !args.CanInteract)
+            return;
+
+        if (ent.Comp.RequireHands && args.Hands == null)
             return;
 
         if (!IsUserAllowed(ent.Comp, args.User))

--- a/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
@@ -61,7 +61,8 @@ public sealed partial class TeleportOnVerbSystem : EntitySystem
         verb.Text = Loc.GetString(ent.Comp.VerbText);
         verb.Message = GetMessage(ent.Comp, attempt);
         verb.Icon = ent.Comp.VerbIcon;
-        verb.Category = ent.Comp.VerbCategory is { } category ? new VerbCategory(category, null) : null;
+        var category = ent.Comp.VerbCategory;
+        verb.Category = category != null ? new VerbCategory(category.Value, null) : null;
         args.Verbs.Add(verb);
     }
 
@@ -86,6 +87,9 @@ public sealed partial class TeleportOnVerbSystem : EntitySystem
         var message = attempt.Cancelled
             ? attempt.CancelReason ?? component.DisabledMessage
             : component.EnabledMessage;
-        return message is { } key ? Loc.GetString(key) : null;
+        if (message == null)
+            return null;
+
+        return Loc.GetString(message.Value);
     }
 }

--- a/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
@@ -28,7 +28,10 @@ public sealed partial class TeleportOnVerbSystem : EntitySystem
     private void OnGetVerbs<TVerb>(Entity<TeleportOnVerbComponent> ent, ref GetVerbsEvent<TVerb> args, TeleportVerbType type)
         where TVerb : Verb, new()
     {
-        if (ent.Comp.VerbType != type || !args.CanAccess)
+        if (ent.Comp.VerbType != type)
+            return;
+
+        if (!args.CanAccess)
             return;
 
         if (!IsUserAllowed(ent.Comp, args.User))
@@ -62,8 +65,10 @@ public sealed partial class TeleportOnVerbSystem : EntitySystem
 
     private bool IsUserAllowed(TeleportOnVerbComponent component, EntityUid user)
     {
-        return !_whitelist.IsWhitelistFail(component.UserWhitelist, user) &&
-               !_whitelist.IsWhitelistPass(component.UserBlacklist, user);
+        if (_whitelist.IsWhitelistFail(component.UserWhitelist, user))
+            return false;
+
+        return !_whitelist.IsWhitelistPass(component.UserBlacklist, user);
     }
 
     private string? GetMessage(TeleportOnVerbComponent component, TeleportUseAttemptEvent attempt)

--- a/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportOnVerbSystem.cs
@@ -13,20 +13,20 @@ public sealed partial class TeleportOnVerbSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeVerb<Verb>(TeleportVerbType.Verb);
-        SubscribeVerb<AlternativeVerb>(TeleportVerbType.Alternative);
-        SubscribeVerb<InteractionVerb>(TeleportVerbType.Interaction);
-        SubscribeVerb<ActivationVerb>(TeleportVerbType.Activation);
+        SubscribeVerb(TeleportVerbType.Verb, () => new Verb());
+        SubscribeVerb(TeleportVerbType.Alternative, () => new AlternativeVerb());
+        SubscribeVerb(TeleportVerbType.Interaction, () => new InteractionVerb());
+        SubscribeVerb(TeleportVerbType.Activation, () => new ActivationVerb());
     }
 
-    private void SubscribeVerb<TVerb>(TeleportVerbType type) where TVerb : Verb, new()
+    private void SubscribeVerb<TVerb>(TeleportVerbType type, Func<TVerb> createVerb) where TVerb : Verb
     {
         SubscribeLocalEvent<TeleportOnVerbComponent, GetVerbsEvent<TVerb>>(
-            (Entity<TeleportOnVerbComponent> ent, ref GetVerbsEvent<TVerb> args) => OnGetVerbs(ent, ref args, type));
+            (Entity<TeleportOnVerbComponent> ent, ref GetVerbsEvent<TVerb> args) => OnGetVerbs(ent, ref args, type, createVerb));
     }
 
-    private void OnGetVerbs<TVerb>(Entity<TeleportOnVerbComponent> ent, ref GetVerbsEvent<TVerb> args, TeleportVerbType type)
-        where TVerb : Verb, new()
+    private void OnGetVerbs<TVerb>(Entity<TeleportOnVerbComponent> ent, ref GetVerbsEvent<TVerb> args, TeleportVerbType type, Func<TVerb> createVerb)
+        where TVerb : Verb
     {
         if (ent.Comp.VerbType != type)
             return;
@@ -43,16 +43,15 @@ public sealed partial class TeleportOnVerbSystem : EntitySystem
         if (attempt.Cancelled && ent.Comp.HideWhenDisabled)
             return;
 
-        args.Verbs.Add(new TVerb
-        {
-            Priority = ent.Comp.Priority,
-            Act = () => RequestTeleport(ent, target),
-            Disabled = attempt.Cancelled,
-            Text = Loc.GetString(ent.Comp.VerbText),
-            Message = GetMessage(ent.Comp, attempt),
-            Icon = ent.Comp.VerbIcon,
-            Category = ent.Comp.VerbCategory is { } category ? new VerbCategory(category, null) : null,
-        });
+        var verb = createVerb();
+        verb.Priority = ent.Comp.Priority;
+        verb.Act = () => RequestTeleport(ent, target);
+        verb.Disabled = attempt.Cancelled;
+        verb.Text = Loc.GetString(ent.Comp.VerbText);
+        verb.Message = GetMessage(ent.Comp, attempt);
+        verb.Icon = ent.Comp.VerbIcon;
+        verb.Category = ent.Comp.VerbCategory is { } category ? new VerbCategory(category, null) : null;
+        args.Verbs.Add(verb);
     }
 
     private void RequestTeleport(Entity<TeleportOnVerbComponent> ent, EntityUid target)

--- a/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
@@ -1,23 +1,4 @@
-using Robust.Shared.Serialization;
-
 namespace Content.Shared.Teleportation.Triggers;
-
-/// <summary>
-/// The requested teleport behavior, independent of the trigger that activated it.
-/// </summary>
-[Serializable, NetSerializable]
-public enum TeleportMode : byte
-{
-    /// <summary>
-    /// Regular teleportation, including lifecycle events and portal collision timeout protection.
-    /// </summary>
-    Normal,
-
-    /// <summary>
-    /// Explicit ghost traversal without the regular lifecycle or portal collision timeout.
-    /// </summary>
-    Ghost,
-}
 
 /// <summary>
 /// Passes a target and the user that activated the teleporter to a teleport implementation.
@@ -25,9 +6,8 @@ public enum TeleportMode : byte
 /// </summary>
 /// <param name="Target">The entity to teleport.</param>
 /// <param name="User">The entity that activated the teleporter.</param>
-/// <param name="Mode">The requested teleport behavior.</param>
 [ByRefEvent, Serializable]
-public record struct TeleportRequestEvent(EntityUid Target, EntityUid User, TeleportMode Mode = TeleportMode.Normal)
+public record struct TeleportRequestEvent(EntityUid Target, EntityUid User)
 {
     /// <summary>
     /// Whether a teleport implementation successfully handled the request.
@@ -36,7 +16,7 @@ public record struct TeleportRequestEvent(EntityUid Target, EntityUid User, Tele
 }
 
 /// <summary>
-/// Checks whether a teleporter can be used in the requested mode.
+/// Checks whether a teleporter can be used by the given target and user.
 /// Raised on the teleporter entity.
 /// Handlers must only update the cancellation state because this event can be raised while verbs are being collected.
 /// </summary>
@@ -44,14 +24,12 @@ public record struct TeleportRequestEvent(EntityUid Target, EntityUid User, Tele
 /// <param name="User">The entity that activates the teleporter.</param>
 /// <param name="Cancelled">Whether using the teleporter has been prevented.</param>
 /// <param name="CancelReason">Localization key explaining why the teleport is unavailable.</param>
-/// <param name="Mode">The requested teleport behavior; must match the subsequent request.</param>
 [ByRefEvent, Serializable]
 public record struct TeleportUseAttemptEvent(
     EntityUid Target,
     EntityUid User,
     bool Cancelled = false,
-    LocId? CancelReason = null,
-    TeleportMode Mode = TeleportMode.Normal);
+    LocId? CancelReason = null);
 
 /// <summary>
 /// Notifies a teleporter that a target has stopped colliding with its collision trigger.

--- a/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
@@ -1,0 +1,62 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Teleportation.Triggers;
+
+/// <summary>
+/// The requested teleport behavior, independent of the trigger that activated it.
+/// </summary>
+[Serializable, NetSerializable]
+public enum TeleportMode : byte
+{
+    /// <summary>
+    /// Regular teleportation, including lifecycle events and portal collision timeout protection.
+    /// </summary>
+    Normal,
+
+    /// <summary>
+    /// Explicit ghost traversal without the regular lifecycle or portal collision timeout.
+    /// </summary>
+    Ghost,
+}
+
+/// <summary>
+/// Passes a target and the user that activated the teleporter to a teleport implementation.
+/// Raised on the teleporter entity.
+/// </summary>
+/// <param name="Target">The entity to teleport.</param>
+/// <param name="User">The entity that activated the teleporter.</param>
+/// <param name="Mode">The requested teleport behavior.</param>
+[ByRefEvent, Serializable]
+public record struct TeleportRequestEvent(EntityUid Target, EntityUid User, TeleportMode Mode = TeleportMode.Normal)
+{
+    /// <summary>
+    /// Whether a teleport implementation successfully handled the request.
+    /// </summary>
+    public bool Handled;
+}
+
+/// <summary>
+/// Checks whether a teleporter can be used in the requested mode.
+/// Raised on the teleporter entity.
+/// Handlers must only update the cancellation state because this event can be raised while verbs are being collected.
+/// </summary>
+/// <param name="Target">The entity that would be teleported.</param>
+/// <param name="User">The entity that activates the teleporter.</param>
+/// <param name="Cancelled">Whether using the teleporter has been prevented.</param>
+/// <param name="CancelReason">Localization key explaining why the teleport is unavailable.</param>
+/// <param name="Mode">The requested teleport behavior; must match the subsequent request.</param>
+[ByRefEvent, Serializable]
+public record struct TeleportUseAttemptEvent(
+    EntityUid Target,
+    EntityUid User,
+    bool Cancelled = false,
+    LocId? CancelReason = null,
+    TeleportMode Mode = TeleportMode.Normal);
+
+/// <summary>
+/// Notifies a teleporter that a target has stopped colliding with its collision trigger.
+/// Raised on the teleporter entity.
+/// </summary>
+/// <param name="Target">The entity that left the trigger.</param>
+[ByRefEvent, Serializable]
+public record struct TeleportTriggerExitedEvent(EntityUid Target);

--- a/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
@@ -46,4 +46,4 @@ public record struct TeleportUseAttemptEvent(
 /// </summary>
 /// <param name="Target">The entity whose fixture contact ended.</param>
 [ByRefEvent, Serializable]
-public record struct TeleportTriggerExitedEvent(EntityUid Target);
+public readonly record struct TeleportTriggerExitedEvent(EntityUid Target);

--- a/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
@@ -6,10 +6,10 @@ namespace Content.Shared.Teleportation.Triggers;
 /// Triggers must use SharedTeleportSystem.RequestTeleport to run use checks and prevent nested requests.
 /// </summary>
 /// <param name="Target">The entity to teleport.</param>
-/// <param name="User">The entity that activated the teleporter.</param>
+/// <param name="User">The entity that explicitly activated the teleporter, or null for automatic activation.</param>
 /// <param name="TriggerEffects">Whether to run effects before and after movement. Does not bypass use checks.</param>
 [ByRefEvent, Serializable]
-public record struct TeleportRequestEvent(EntityUid Target, EntityUid User, bool TriggerEffects = true)
+public record struct TeleportRequestEvent(EntityUid Target, EntityUid? User, bool TriggerEffects = true)
 {
     /// <summary>
     /// Whether a teleport implementation accepted the request, even if teleportation failed.
@@ -29,15 +29,25 @@ public record struct TeleportRequestEvent(EntityUid Target, EntityUid User, bool
 /// Handlers must only update the cancellation state because this event can be raised while verbs are being collected.
 /// </summary>
 /// <param name="Target">The entity that would be teleported.</param>
-/// <param name="User">The entity that activates the teleporter.</param>
+/// <param name="User">The entity that explicitly activates the teleporter, or null for automatic activation.</param>
 /// <param name="Cancelled">Whether using the teleporter has been prevented.</param>
 /// <param name="CancelReason">Localization key explaining why the teleport is unavailable.</param>
 [ByRefEvent, Serializable]
 public record struct TeleportUseAttemptEvent(
     EntityUid Target,
-    EntityUid User,
+    EntityUid? User,
     bool Cancelled = false,
-    LocId? CancelReason = null);
+    LocId? CancelReason = null)
+{
+    /// <summary>
+    /// Cancels the attempt, preserving an explanation already provided by another handler.
+    /// </summary>
+    public void Cancel(LocId? reason = null)
+    {
+        Cancelled = true;
+        CancelReason ??= reason;
+    }
+}
 
 /// <summary>
 /// Notifies a teleporter that one eligible fixture contact with a target has ended.

--- a/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
@@ -3,11 +3,13 @@ namespace Content.Shared.Teleportation.Triggers;
 /// <summary>
 /// Passes a target and the user that activated the teleporter to a teleport implementation.
 /// Raised on the teleporter entity.
+/// Triggers must use SharedTeleportSystem.RequestTeleport to run use checks and prevent nested requests.
 /// </summary>
 /// <param name="Target">The entity to teleport.</param>
 /// <param name="User">The entity that activated the teleporter.</param>
+/// <param name="TriggerEffects">Whether to run effects before and after movement. Does not bypass use checks.</param>
 [ByRefEvent, Serializable]
-public record struct TeleportRequestEvent(EntityUid Target, EntityUid User)
+public record struct TeleportRequestEvent(EntityUid Target, EntityUid User, bool TriggerEffects = true)
 {
     /// <summary>
     /// Whether a teleport implementation successfully handled the request.

--- a/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
@@ -40,9 +40,10 @@ public record struct TeleportUseAttemptEvent(
     LocId? CancelReason = null);
 
 /// <summary>
-/// Notifies a teleporter that a target has stopped colliding with its collision trigger.
+/// Notifies a teleporter that one eligible fixture contact with a target has ended.
+/// The target may still overlap the trigger; handlers must check its bounds before treating this as an exit.
 /// Raised on the teleporter entity.
 /// </summary>
-/// <param name="Target">The entity that left the trigger.</param>
+/// <param name="Target">The entity whose fixture contact ended.</param>
 [ByRefEvent, Serializable]
 public record struct TeleportTriggerExitedEvent(EntityUid Target);

--- a/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
+++ b/Content.Shared/Teleportation/Triggers/TeleportTriggerEvents.cs
@@ -12,9 +12,15 @@ namespace Content.Shared.Teleportation.Triggers;
 public record struct TeleportRequestEvent(EntityUid Target, EntityUid User, bool TriggerEffects = true)
 {
     /// <summary>
-    /// Whether a teleport implementation successfully handled the request.
+    /// Whether a teleport implementation accepted the request, even if teleportation failed.
+    /// Set before execution to prevent another implementation from processing the same request.
     /// </summary>
     public bool Handled;
+
+    /// <summary>
+    /// Whether the implementation successfully completed the teleportation.
+    /// </summary>
+    public bool Succeeded;
 }
 
 /// <summary>

--- a/Resources/Locale/en-US/portal/portal.ftl
+++ b/Resources/Locale/en-US/portal/portal.ftl
@@ -4,6 +4,7 @@ portal-component-ghost-traverse = Traverse
 
 portal-component-no-linked-entities = Can't ghost traverse a portal that doesn't have exactly 1 linked portal
 portal-component-can-ghost-traverse = Teleport to the linked portal
+portal-component-unlinked-user-denied = You can't activate an unlinked portal.
 
 portal-component-invalid-configuration-fizzle = The portal fizzles out!
 portal-component-exit-blocked = The portal's exit is blocked!

--- a/Resources/Locale/en-US/portal/portal.ftl
+++ b/Resources/Locale/en-US/portal/portal.ftl
@@ -6,3 +6,4 @@ portal-component-no-linked-entities = Can't ghost traverse a portal that doesn't
 portal-component-can-ghost-traverse = Teleport to the linked portal
 
 portal-component-invalid-configuration-fizzle = The portal fizzles out!
+portal-component-exit-blocked = The portal's exit is blocked!

--- a/Resources/Prototypes/Entities/Effects/portal.yml
+++ b/Resources/Prototypes/Entities/Effects/portal.yml
@@ -1,6 +1,29 @@
 ﻿# Standing portals
 - type: entity
   abstract: true
+  id: BasePortalTeleportation
+  components:
+  - type: Portal
+  - type: CollisionTeleportTrigger
+    triggerFixtureId: portalFixture
+    allowedNonHardTargetFixtureIds:
+    - projectile
+    targetBlacklist:
+      tags:
+      - PreventPortalCollision
+  - type: TeleportSound
+    departureSound: /Audio/Effects/teleport_departure.ogg
+    arrivalSound: /Audio/Effects/teleport_arrival.ogg
+  - type: TeleportOnVerb
+    mode: Ghost
+    enabledMessage: portal-component-can-ghost-traverse
+    userWhitelist:
+      tags:
+      - AllowPortalTraversal
+
+- type: entity
+  abstract: true
+  parent: BasePortalTeleportation
   id: BasePortal
   name: bluespace portal
   description: Transports you to a linked destination!
@@ -25,7 +48,6 @@
         layer:
         - WallLayer
         hard: false
-  - type: Portal
   - type: PointLight
     radius: 3
     energy: 1
@@ -72,7 +94,7 @@
   name: shadow rift
   description: Looks unstable.
   components:
-  - type: Portal
+  - type: TeleportSound
     arrivalSound: /Audio/Items/hiss.ogg
     departureSound: /Audio/Items/hiss.ogg
   - type: Sprite

--- a/Resources/Prototypes/Entities/Effects/portal.yml
+++ b/Resources/Prototypes/Entities/Effects/portal.yml
@@ -15,8 +15,10 @@
     departureSound: /Audio/Effects/teleport_departure.ogg
     arrivalSound: /Audio/Effects/teleport_arrival.ogg
   - type: TeleportOnVerb
-    mode: Ghost
-    enabledMessage: portal-component-can-ghost-traverse
+    verbType: Alternative
+    verbText: portal-component-ghost-traverse
+    verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png
+    priority: 11
     userWhitelist:
       tags:
       - AllowPortalTraversal

--- a/Resources/Prototypes/Entities/Effects/portal.yml
+++ b/Resources/Prototypes/Entities/Effects/portal.yml
@@ -20,7 +20,6 @@
     requireHands: false
     verbType: Alternative
     verbText: portal-component-ghost-traverse
-    verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png
     priority: 11
     userWhitelist:
       tags:
@@ -63,6 +62,8 @@
   id: PortalRed
   description: This one looks more like a redspace portal.
   components:
+  - type: TeleportOnVerb
+    verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png
   - type: Sprite
     layers:
     - state: portal-red
@@ -73,6 +74,8 @@
   parent: BasePortal
   id: PortalBlue
   components:
+  - type: TeleportOnVerb
+    verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png
   - type: Sprite
     layers:
     - state: portal-blue
@@ -83,6 +86,8 @@
   parent: BasePortal
   id: PortalArtifact
   components:
+  - type: TeleportOnVerb
+    verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png
   - type: Sprite
     layers:
     - state: portal-artifact
@@ -99,6 +104,8 @@
   name: shadow rift
   description: Looks unstable.
   components:
+  - type: TeleportOnVerb
+    verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png
   - type: TeleportSound
     arrivalSound: /Audio/Items/hiss.ogg
     departureSound: /Audio/Items/hiss.ogg
@@ -140,6 +147,8 @@
   parent: BasePortalGateway
   id: PortalGatewayBlue
   components:
+  - type: TeleportOnVerb
+    verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png
   - type: Sprite
     color: SkyBlue
     layers:
@@ -151,6 +160,8 @@
   parent: BasePortalGateway
   id: PortalGatewayOrange
   components:
+  - type: TeleportOnVerb
+    verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png
   - type: Sprite
     color: OrangeRed
     layers:

--- a/Resources/Prototypes/Entities/Effects/portal.yml
+++ b/Resources/Prototypes/Entities/Effects/portal.yml
@@ -16,6 +16,8 @@
     arrivalSound: /Audio/Effects/teleport_arrival.ogg
   - type: TeleportOnVerb
     triggerEffects: false
+    requireCanInteract: false
+    requireHands: false
     verbType: Alternative
     verbText: portal-component-ghost-traverse
     verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png

--- a/Resources/Prototypes/Entities/Effects/portal.yml
+++ b/Resources/Prototypes/Entities/Effects/portal.yml
@@ -4,6 +4,9 @@
   id: BasePortalTeleportation
   components:
   - type: Portal
+    unlinkedUserBlacklist:
+      tags:
+      - AllowPortalTraversal
   - type: CollisionTeleportTrigger
     triggerFixtureId: portalFixture
     allowedNonHardTargetFixtureIds:

--- a/Resources/Prototypes/Entities/Effects/portal.yml
+++ b/Resources/Prototypes/Entities/Effects/portal.yml
@@ -15,6 +15,7 @@
     departureSound: /Audio/Effects/teleport_departure.ogg
     arrivalSound: /Audio/Effects/teleport_arrival.ogg
   - type: TeleportOnVerb
+    triggerEffects: false
     verbType: Alternative
     verbText: portal-component-ghost-traverse
     verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png

--- a/Resources/Prototypes/Entities/Structures/Machines/gateway.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gateway.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseStructure
+  parent: [ BaseStructure, BasePortalTeleportation ]
   id: Gateway
   name: gateway
   description: A mysterious gateway built by unknown hands, it allows for faster than light travel to far-flung locations.

--- a/Resources/Prototypes/Entities/Structures/Machines/gateway.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gateway.yml
@@ -4,6 +4,8 @@
   name: gateway
   description: A mysterious gateway built by unknown hands, it allows for faster than light travel to far-flung locations.
   components:
+  - type: TeleportOnVerb
+    verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png
   - type: Sprite
     sprite: Structures/Machines/gateway.rsi
     noRot: true

--- a/Resources/Prototypes/Entities/Structures/Machines/station_teleporter.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/station_teleporter.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ ConstructibleMachine, BaseMachinePowered ]
+  parent: [ ConstructibleMachine, BaseMachinePowered, BasePortalTeleportation ]
   id: StationTeleporter
   name: teleporter
   description: The peak of bluespace technology. A giant teleporter that allows you to travel vast distances in the blink of an eye.

--- a/Resources/Prototypes/Entities/Structures/Machines/station_teleporter.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/station_teleporter.yml
@@ -5,6 +5,8 @@
   description: The peak of bluespace technology. A giant teleporter that allows you to travel vast distances in the blink of an eye.
   suffix: Unknown Coordinates, Without Autolink
   components:
+  - type: TeleportOnVerb
+    verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png
   - type: Machine
     board: StationTeleporterMachineCircuitboard
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -275,7 +275,7 @@
 
 - type: entity
   id: AnomalyBluespace
-  parent: BaseAnomaly
+  parent: [ BaseAnomaly, BasePortalTeleportation ]
   suffix: Bluespace
   components:
   - type: Sprite
@@ -291,7 +291,6 @@
     color: "#00ccff"
     castShadows: false
   - type: BluespaceAnomaly
-  - type: Portal
   - type: Fixtures
     fixtures:
       fix1:
@@ -942,7 +941,7 @@
 
 - type: entity
   id: AnomalyShadow
-  parent: BaseAnomaly
+  parent: [ BaseAnomaly, BasePortalTeleportation ]
   suffix: Shadow
   components:
   - type: Sprite
@@ -988,7 +987,7 @@
         maxRange: 50
       spawns:
       - ShadowKudzu
-  - type: Portal
+  - type: TeleportSound
     arrivalSound: /Audio/Items/hiss.ogg
     departureSound: /Audio/Items/hiss.ogg
   - type: Tag

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -278,6 +278,8 @@
   parent: [ BaseAnomaly, BasePortalTeleportation ]
   suffix: Bluespace
   components:
+  - type: TeleportOnVerb
+    verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png
   - type: Sprite
     layers:
     - state: anom4
@@ -944,6 +946,8 @@
   parent: [ BaseAnomaly, BasePortalTeleportation ]
   suffix: Shadow
   components:
+  - type: TeleportOnVerb
+    verbIcon: /Textures/Interface/VerbIcons/open.svg.192dpi.png
   - type: Sprite
     sprite: Structures/Specific/Anomalies/shadow_anom.rsi
     layers:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Separates portal activation, destination selection, and movement into reusable systems. Collision and verb triggers now use a shared teleportation flow, with separate events for effects before and after movement.

Also fixes portal creation continuing after the hand teleporter leaves the user's hands, removes hand teleporter portals when their supporting tiles are removed, and prevents traversal into blocked linked exits.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

[YouTube video to grab attention](https://youtu.be/nTPIcaSE4nY)

Systems that need the same teleportation behavior can reuse it without inheriting portal-specific activation or destination logic. New triggers can define their own activation rules, and teleport implementations can choose their own destinations.

The shared movement flow provides one place to handle interactions such as pulling and grappling joints. Separate effect events allow systems to add sounds or other effects while supporting silent traversal for ghosts and revenants.

Gameplay fixes:

- Hand teleporter portal creation cancels when the device is dropped or taken from the user's hands.
- Hand teleporter portals close when their supporting tile is removed, including when the creating device no longer exists.
- Linked portals reject teleportation when solid static obstacles block the destination. This addresses teleportation into walls at linked exits; it does not guarantee an unobstructed destination for random teleportation. Related issue: [#28266](https://github.com/space-wizards/space-station-14/issues/28266).

## Technical details
<!-- Summary of code changes for easier review. -->

- Separates collision and verb triggers from destination selection and movement.
- Introduces `SharedTeleportSystem` for use checks, request dispatch, movement, and optional effects before and after teleportation.
- Keeps linked and random portal destination selection in `SharedPortalSystem`.
- Uses `TeleportingComponent` to prevent nested requests for the same target, with cleanup in `finally`.
- Uses `PortalTimeoutComponent` to block further portal use until the target leaves the exit's trigger bounds. This also protects the creator of a hand teleporter portal until they step out.
- Moves sound configuration into `TeleportSoundComponent`.
- Shares destination collision checks between portals and teleport actions. Linked portal exits check static obstacles.
- Adds `HandTeleporterPortalComponent` so tile-removal cleanup works independently of the creating device.
- Migrates portals, gateways, station teleporters, and spatial and shadow anomalies to the shared `BasePortalTeleportation` prototype.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Tested linked portal traversal with characters, items, and projectiles, including distant exits. Checked creator protection, leaving and re-entering an exit, and silent traversal for ghosts and revenants.

### Review instructions

- Use a hand teleporter to create an unlinked portal. Check random traversal through it, then create its linked exit and close the pair.
- Start creating a portal, then drop the hand teleporter or have it taken from your hands. Verify that creation cancels.
- Create a portal beneath yourself. Verify that it does not immediately teleport you, then step out and re-enter to check traversal.
- Traverse linked portals in both directions with characters, thrown items, and projectiles, including distant exits. Remain inside the exit briefly and verify that you are not immediately sent back. Leave and re-enter to verify that return traversal works.
- Remove the tile supporting a hand teleporter portal. Verify that the portal and its linked exit close. Repeat after deleting the creating device.
- Block a linked exit with a wall. Verify that traversal is rejected and the blocked-exit message appears. Remove the wall and verify that traversal works again.
- Use Traverse as a ghost and a revenant. Verify that no teleport departure or arrival sounds play.
- Change `requireCanInteract` and `requireHands` on `TeleportOnVerbComponent` independently. Verify that verb availability follows each configured restriction for an otherwise eligible user.
- Check spatial and shadow anomalies, gateways, and station teleporters. Verify their collision traversal, Traverse availability for eligible users, destination behavior, and configured teleport sounds.
- Check teleport actions after the destination collision check was moved into the shared system. Verify that blocked destinations are still rejected.

### Related issue testing and remaining observations

The reported behavior in the following issues was not reproduced during testing:

- [#24610](https://github.com/space-wizards/space-station-14/issues/24610)
- [#45640](https://github.com/space-wizards/space-station-14/issues/45640)
- [#31701](https://github.com/space-wizards/space-station-14/issues/31701)

The original behavior reported in [#31791](https://github.com/space-wizards/space-station-14/issues/31791) was also not reproduced. However, an intermittent prediction race involving item pickup and teleportation was observed.

These results alone do not establish that this PR fixes those issues.

The behavior reported in [#14892](https://github.com/space-wizards/space-station-14/issues/14892) remains unclear, so no conclusion is claimed for that issue.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

- `PortalComponent` no longer provides collision or verb activation on its own. Inherit from `BasePortalTeleportation` for standard portal behavior, or explicitly configure `CollisionTeleportTriggerComponent` and `TeleportOnVerbComponent`.
- `ArrivalSound` and `DepartureSound` have moved from `PortalComponent` to `TeleportSoundComponent`. Move YAML fields `arrivalSound` and `departureSound` from `Portal` to `TeleportSound`, and update C# references.
- `PortalTimeoutComponent.EnteredPortal` has been replaced with the non-nullable `ExitPortal` field. It identifies the exit whose trigger bounds the target must leave, rather than the entered portal. Update code that reads or sets this field to use the exit portal. Use `SharedPortalSystem.SetPortalTimeout` when applying portal protection; the absence of `PortalTimeoutComponent` represents no active protection.

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Maps, admin and rule changes should include a category header above the :cl: as per the guidelines.-->
:cl:
fix: Portal creation now cancels when the hand teleporter is dropped or taken from your hands.
fix: Hand teleporter portals now close when their supporting tile is removed.
fix: Linked portals now reject teleportation into walls or other solid static obstacles.
