### PR TITLE
Bugfix: Check component lifecycle in SharedInteractionSystem.OnMoveAttempt.

### DIFF
--- a/Content.Shared/Interaction/SharedInteractionSystem.Blocking.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.Blocking.cs
@@ -14,6 +14,7 @@ namespace Content.Shared.Interaction;
 /// </summary>
 public partial class SharedInteractionSystem
 {
+    [Dependency] EntityQuery<RelayInputMoverComponent> _relayInputMoverQuery;
     private void InitializeBlocking()
     {
         SubscribeLocalEvent<BlockMovementComponent, UpdateCanMoveEvent>(OnMoveAttempt);
@@ -42,10 +43,12 @@ public partial class SharedInteractionSystem
     private void OnMoveAttempt(EntityUid uid, BlockMovementComponent component, UpdateCanMoveEvent args)
     {
         // If we're relaying then don't cancel.
-        if (HasComp<RelayInputMoverComponent>(uid))
+        if (_relayInputMoverQuery.HasComp(uid))
             return;
 
-        args.Cancel(); // no more scurrying around
+        // Only handle events pre-shutdown.
+        if (component.LifeStage < ComponentLifeStage.Stopping)
+            args.Cancel();
     }
 
     private void CancellableInteractEvent(EntityUid uid, BlockMovementComponent component, CancellableEntityEventArgs args)

--- a/Content.Shared/Interaction/SharedInteractionSystem.Blocking.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.Blocking.cs
@@ -16,61 +16,59 @@ public partial class SharedInteractionSystem
 {
     [Dependency] EntityQuery<RelayInputMoverComponent> _relayInputMoverQuery;
 
-    private void InitializeBlocking()
-    {
-        SubscribeLocalEvent<BlockMovementComponent, UpdateCanMoveEvent>(OnMoveAttempt);
-        SubscribeLocalEvent<BlockMovementComponent, UseAttemptEvent>(CancelUseEvent);
-        SubscribeLocalEvent<BlockMovementComponent, InteractionAttemptEvent>(CancelInteractEvent);
-        SubscribeLocalEvent<BlockMovementComponent, DropAttemptEvent>(CancellableInteractEvent);
-        SubscribeLocalEvent<BlockMovementComponent, PickupAttemptEvent>(CancellableInteractEvent);
-        SubscribeLocalEvent<BlockMovementComponent, ChangeDirectionAttemptEvent>(CancelEvent);
-
-        SubscribeLocalEvent<BlockMovementComponent, ComponentStartup>(OnBlockingStartup);
-        SubscribeLocalEvent<BlockMovementComponent, ComponentShutdown>(OnBlockingShutdown);
-    }
-
+    [SubscribeLocalEvent]
     private void CancelInteractEvent(Entity<BlockMovementComponent> ent, ref InteractionAttemptEvent args)
     {
         if (ent.Comp.BlockInteraction)
             args.Cancelled = true;
     }
 
+    [SubscribeLocalEvent]
     private void CancelUseEvent(Entity<BlockMovementComponent> ent, ref UseAttemptEvent args)
     {
         if (ent.Comp.BlockUse)
             args.Cancel();
     }
 
-    private void OnMoveAttempt(EntityUid uid, BlockMovementComponent component, UpdateCanMoveEvent args)
+    [SubscribeLocalEvent]
+    private void OnMoveAttempt(Entity<BlockMovementComponent> ent, ref UpdateCanMoveEvent args)
     {
         // If we're relaying then don't cancel.
-        if (_relayInputMoverQuery.HasComp(uid))
+        if (_relayInputMoverQuery.HasComp(ent))
             return;
 
-        // Only handle events pre-shutdown.
-        if (component.LifeStage < ComponentLifeStage.Stopping)
-            args.Cancel();
+        args.Cancel();
     }
 
-    private void CancellableInteractEvent(EntityUid uid, BlockMovementComponent component, CancellableEntityEventArgs args)
+    [SubscribeLocalEvent]
+    private void OnDropAttempt(Entity<BlockMovementComponent> ent, ref DropAttemptEvent args)
     {
-        if (component.BlockInteraction)
+        if (ent.Comp.BlockInteraction)
             args.Cancel();
     }
 
-    private void CancelEvent(EntityUid uid, BlockMovementComponent component, CancellableEntityEventArgs args)
+    [SubscribeLocalEvent]
+    private void OnPickupAttempt(Entity<BlockMovementComponent> ent, ref PickupAttemptEvent args)
+    {
+        if (ent.Comp.BlockInteraction)
+            args.Cancel();
+    }
+
+    [SubscribeLocalEvent]
+    private void CancelEvent(Entity<BlockMovementComponent> ent, ref ChangeDirectionAttemptEvent args)
     {
         args.Cancel();
     }
 
-    private void OnBlockingStartup(EntityUid uid, BlockMovementComponent component, ComponentStartup args)
+    [SubscribeLocalEvent]
+    private void OnBlockingStartup(Entity<BlockMovementComponent> ent, ref ComponentStartup args)
     {
-        _actionBlockerSystem.UpdateCanMove(uid);
+        _actionBlockerSystem.UpdateCanMove(ent);
     }
 
-    private void OnBlockingShutdown(EntityUid uid, BlockMovementComponent component, ComponentShutdown args)
+    [SubscribeLocalEvent]
+    private void OnBlockingRemove(Entity<BlockMovementComponent> ent, ref ComponentRemove args)
     {
-        _actionBlockerSystem.UpdateCanMove(uid);
+        _actionBlockerSystem.UpdateCanMove(ent);
     }
 }
-

--- a/Content.Shared/Interaction/SharedInteractionSystem.Blocking.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.Blocking.cs
@@ -15,6 +15,7 @@ namespace Content.Shared.Interaction;
 public partial class SharedInteractionSystem
 {
     [Dependency] EntityQuery<RelayInputMoverComponent> _relayInputMoverQuery;
+
     private void InitializeBlocking()
     {
         SubscribeLocalEvent<BlockMovementComponent, UpdateCanMoveEvent>(OnMoveAttempt);

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -131,8 +131,6 @@ namespace Content.Shared.Interaction
                     CCVars.InteractionRateLimitAnnounceAdminsDelay,
                     RateLimitAlertAdmins)
             );
-
-            InitializeBlocking();
         }
 
         private void RateLimitAlertAdmins(ICommonSession session)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

~~Adds a component lifecycle check to SharedInteractionSystem.OnMoveAttempt so that entities having the BlockMovementComponent removed can move once again.~~ using componentremove

Moves a HasComp check to use an EntityQuery.

## Why / Balance

Resolves #45956.

## Technical details

~~Checking the component's LifeStage inside the UpdateCanMoveEvent handler, as it's being used directly inside of the ComponentShutdown handler.~~ using componentremove

~~Could apply this consistently to other handlers, but since the changed lines _directly affect the teardown_, this seems far more pressing.~~ using componentremove

## Test plan

1. Spawn a Urist.  Move around, you should be able to.
2. Add the BlockMovementComponent.
3. Try to move around, you shouldn't be able to.
4. Remove the BlockMovementComponent.
5. Move around, you should be able to.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

The test plan run on master vs. the head of this PR:

master (before)

https://github.com/user-attachments/assets/a625cd81-1bda-47bc-bc1f-6c9d09953e35

PR (after)

https://github.com/user-attachments/assets/96bfe751-5856-470e-8062-9b0fca4707bd

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Changelog
~~not player-facing as far as I'm aware~~ using componentremove