### PR TITLE
Map weights

### DIFF
--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -156,8 +156,36 @@ public sealed partial class GameMapManager : IGameMapManager
 
     public void SelectMapRandom()
     {
+        _log.Info("Selecting a random map...");
         var maps = CurrentlyEligibleMaps().ToList();
-        _selectedMap = _random.Pick(maps);
+        if (maps.Count == 0)
+            return;
+
+        var totalWeight = maps.Sum(map => map.Weight);
+        _log.Info($"Total weight for {maps.Count}: {totalWeight}");
+        if (totalWeight == 0)
+        {
+            _selectedMap = _random.Pick(maps);
+            return;
+        }
+
+        var normalizedWeights = maps.Select(map => map.Weight / totalWeight);
+        var rand = _random.NextFloat();
+        _log.Info($"Normalized values for all maps: {normalizedWeights.Aggregate("", (acc, val) => $"{acc},{val}")}");
+        _log.Info($"Value selected for rolling random map is: {rand}");
+
+        foreach (var (index, weight) in normalizedWeights.Index())
+        {
+            rand -= weight;
+            if (rand <= 0)
+            {
+                _log.Info($"Selected: {maps[index].MapName}");
+                _selectedMap = maps[index];
+                return;
+            }
+        }
+        //Failsafe
+        _selectedMap = maps.Last();
     }
 
     public void SelectMapFromRotationQueue(bool markAsPlayed = false)

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -129,7 +129,7 @@ public sealed partial class CCVars
     ///     Is map rotation enabled?
     /// </summary>
     public static readonly CVarDef<bool>
-        GameMapRotation = CVarDef.Create("game.map_rotation", true, CVar.SERVERONLY);
+        GameMapRotation = CVarDef.Create("game.map_rotation", false, CVar.SERVERONLY);
 
     /// <summary>
     ///     If roles should be restricted based on time.

--- a/Content.Shared/Maps/GameMapPrototype.cs
+++ b/Content.Shared/Maps/GameMapPrototype.cs
@@ -24,6 +24,9 @@ public sealed partial class GameMapPrototype : IPrototype
     [DataField]
     public float MaxRandomOffset = 1000f;
 
+    [DataField]
+    public float Weight = 1.0f;
+
     /// <summary>
     /// Turns out some of the map files are actually secretly grids. Excellent. I love map loading code.
     /// </summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added map weights

## Why / Balance
This PR is designed to make maps with a special gimmick less likely to roll, allowing our players to view these maps as a novelty instead of an annoyance.


For a long time I've heard people complain about gimmicky maps which stray from the more popular, standard maps. While these maps had special charm, frequent and repeat rolling would eventually make players dislike the map, leading to it's eventual removal. 

This PR allows map creators to create more unique stations while accepting that the notion that their design decisions may make their map roll less frequently than others.

## Technical details
- New data field called `Weight` is added to to maps, to define a custom weight go to the map's prototype example: 
<img width="366" height="207" alt="image" src="https://github.com/user-attachments/assets/44178c9d-4203-4920-bdff-3939f8d82d0d" />

- To prevent from rolling a map more than once, a duplicate flag has been added. This works when selecting a map randomly or using weighted randomness.


- Method `SelectMapRandom()` has been updated to allow/disallow duplicates
- New method `SelectMapWeightedRandom()` has been created, much like `SelectMapRandom()` duplicates can be barred by the same flag.


## Test plan
Set the weight of a map really high to a value like 100, launch the client and server on release. Normalized values are logged as well as the selected map.


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
- `SelectMapByConfigRules()` has been updated to take in enum values.
- Boolean `MapRotationEnabled` has been replaced by the object `MapRotationConfig`

## Changelog
:cl:
- add: Maps now have weights, increasing or decreasing the probability of rolling a map.
- tweak: Rolling duplicate maps can now be enabled/disabled when picking a map randomly or using weights.

